### PR TITLE
feat: implement lifecyclemodel build-resulting-process

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,21 @@ Current implementation choices:
 - `tiangong search flow`
 - `tiangong search process`
 - `tiangong search lifecyclemodel`
+- `tiangong lifecyclemodel build-resulting-process`
 - `tiangong publish run`
 - `tiangong validation run`
 - `tiangong admin embedding-run`
+
+## Planned command surface
+
+The `lifecyclemodel` namespace is now partially implemented. The remaining planned surface is:
+
+- `tiangong lifecyclemodel publish-resulting-process`
+- `tiangong lifecyclemodel auto-build`
+- `tiangong lifecyclemodel validate-build`
+- `tiangong lifecyclemodel publish-build`
+
+These remaining commands are intentionally not executable yet. They print an explicit `not implemented yet` message and exit with code `2` until the corresponding workflows are migrated into TypeScript.
 
 The stable launcher is `bin/tiangong.js`. It loads the compiled runtime at `dist/src/main.js`, while `npm start -- ...` rebuilds and dogfoods the same launcher path.
 
@@ -73,6 +85,7 @@ npm start -- --help
 npm start -- doctor
 npm start -- doctor --json
 npm start -- search flow --input ./request.json --dry-run
+npm start -- lifecyclemodel build-resulting-process --input ./request.json --json
 npm start -- publish run --input ./publish-request.json --dry-run
 npm start -- validation run --input-dir ./tidas-package --engine auto
 npm start -- admin embedding-run --input ./jobs.json --dry-run

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -30,6 +30,8 @@ tiangong
     flow
     process
     lifecyclemodel
+  lifecyclemodel
+    build-resulting-process
   publish
     run
   validation
@@ -40,15 +42,27 @@ tiangong
 
 对应关系：
 
-| CLI 命令                         | 当前后端能力                                         |
-| -------------------------------- | ---------------------------------------------------- |
-| `tiangong doctor`                | 本地环境诊断、`.env` 加载、统一 env 合同检查         |
-| `tiangong search flow`           | `flow_hybrid_search`                                 |
-| `tiangong search process`        | `process_hybrid_search`                              |
-| `tiangong search lifecyclemodel` | `lifecyclemodel_hybrid_search`                       |
-| `tiangong publish run`           | 本地 publish 契约归一化、dry-run/commit、report 输出 |
-| `tiangong validation run`        | 本地 `tidas-sdk` / `tidas-tools` 校验收口            |
-| `tiangong admin embedding-run`   | `embedding_ft`                                       |
+| CLI 命令 | 当前后端能力 |
+| --- | --- |
+| `tiangong doctor` | 本地环境诊断、`.env` 加载、统一 env 合同检查 |
+| `tiangong search flow` | `flow_hybrid_search` |
+| `tiangong search process` | `process_hybrid_search` |
+| `tiangong search lifecyclemodel` | `lifecyclemodel_hybrid_search` |
+| `tiangong lifecyclemodel build-resulting-process` | 本地 lifecycle model resulting process 聚合、内部 flow 抵消、artifact 输出 |
+| `tiangong publish run` | 本地 publish 契约归一化、dry-run/commit、report 输出 |
+| `tiangong validation run` | 本地 `tidas-sdk` / `tidas-tools` 校验收口 |
+| `tiangong admin embedding-run` | `embedding_ft` |
+
+此外，CLI 现在已经正式引入 `tiangong lifecyclemodel ...` 一级命名空间，其中：
+
+- `tiangong lifecyclemodel build-resulting-process` 已可执行
+- `publish-resulting-process`、`auto-build`、`validate-build`、`publish-build` 仍处于 planned 状态
+
+注意：
+
+- 已实现的 `build-resulting-process` 走本地优先、artifact-first 路径，不依赖 Python 或 MCP
+- 其余未实现的 `lifecyclemodel` 子命令仍只提供 help 和固定命名
+- 这样做的目的不是“假装已完成”，而是先固定命令树，再逐个把 workflow 迁入 TypeScript CLI
 
 ### 2.2 已经固定的工程约束
 

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -71,7 +71,7 @@
 | `embedding-ft` | 已有等价 CLI | shell wrapper | 只保留 skill 文档，调用 `tiangong admin embedding-run` | P0 |
 | `process-automated-builder` | 仍是重 workflow | shell + Python + LangGraph + MCP + OpenAI + AI edge search + TianGong unstructured | 迁成 `tiangong process ...` 主链 | P1 |
 | `lifecyclemodel-automated-builder` | 仍是重 workflow | shell + Python + MCP + OpenAI | 迁成 `tiangong lifecyclemodel ...` 主链 | P1 |
-| `lifecyclemodel-resulting-process-builder` | 仍是重 workflow | Python builder + 可选 MCP lookup | 迁成 `tiangong lifecyclemodel ...` 或 `tiangong process ...` 构建子命令 | P1 |
+| `lifecyclemodel-resulting-process-builder` | CLI 本地 build 已落地，skill 仍未切换 | Python builder + 可选 MCP lookup | 迁成 `skill -> tiangong lifecyclemodel build/publish-resulting-process` | P1 |
 | `lifecycleinventory-review` | 仍是 review workflow | Python review script | 迁成 `tiangong review process` | P2 |
 | `flow-governance-review` | 仍是治理 workflow | shell + 多个 Python helper + 可选 MCP | 迁成 `tiangong flow ...` / `tiangong review flow` | P2 |
 | `lifecyclemodel-recursive-orchestrator` | 仍是 orchestrator | Python orchestrator，串联多个技能 | 迁成 CLI 编排命令 | P3 |
@@ -91,36 +91,87 @@
 - “应该统一到 CLI”是目标态
 - “现在还有 Python / skills 逻辑”是现状债务
 
-## 6. 分批迁移清单
+## 6. 可执行迁移路线
 
-## Phase 0：冻结旧世界
+下面这部分不是“方向建议”，而是可以直接排期和建 issue 的执行顺序。
 
-- [ ] 明确宣布：不再新增 Python 业务 workflow
-- [ ] 明确宣布：不再新增 skill 自带 transport / env parsing
-- [ ] 明确宣布：不再新增基于 MCP 的 CLI 内部能力
+总原则只有一句：
+
+> 先让 CLI 成为唯一真实入口，再把每个 skill 逐个改成 `skill -> tiangong`，最后删除 Python / MCP / 旧 env 遗留层。
+
+### Phase 0：冻结旧世界
+
+目标：
+
+- 停止继续制造新的 Python / MCP 债务
+
+ToDo：
+
+- [ ] 明确宣布：不再新增任何 Python 业务 workflow
+- [ ] 明确宣布：不再新增任何 skill 自带 transport / env parsing
+- [ ] 明确宣布：不再新增任何基于 MCP 的 CLI 内部能力
 - [ ] 将 `tiangong-lca-skills` 中所有新需求默认路由到 CLI issue
+- [ ] 将“skills 最终只保留文档、示例、薄 wrapper”写成明确约束，而不是口头共识
 
-## Phase 1：清掉薄 remote 技能
+完成定义：
 
-这批已经有 CLI 对应能力，应该最先清掉。
+- [ ] 新需求默认先问“CLI 命令叫什么”，而不是“再加一个 skill 脚本吗”
+- [ ] 新提交里不再出现新的 Python workflow、MCP client、独立 env parser
+
+### Phase 1：收口 CLI 当前事实
+
+目标：
+
+- 先把 CLI 变成“诚实的入口”，避免命令帮助和真实能力脱节
+
+ToDo：
+
+- [x] 整理 `tiangong-lca-cli` 当前命令面，只保留真实可用命令，或把未实现命令明确标成 `planned`
+- [x] 决定 `lifecyclemodel` 是否作为 CLI 一级命名空间正式引入
+- [x] 把当前真实已实现能力和计划中能力分开写清楚
+- [x] 清理明显的文档残留，例如 `TIANGONG_CLI_DIR` -> `TIANGONG_LCA_CLI_DIR`
+- [x] 确保 agent 看完 `--help` 后不会误以为某个关键命令已经可用
+
+交付物：
+
+- [x] 更新后的 CLI help
+- [x] 更新后的 CLI 实施文档
+- [x] 更新后的 skills 说明文档
+
+完成定义：
+
+- [x] “命令面”与“实际实现”一致
+- [x] 当前阶段需要调用的能力，都能从 CLI 文档直接找到
+
+### Phase 2：清掉薄 remote skills
+
+目标：
+
+- 完成第一批已经有 CLI 等价能力的 skill 收口
+
+ToDo：
 
 - [x] `flow-hybrid-search` wrapper 改为只调用 `tiangong search flow`
 - [x] `process-hybrid-search` wrapper 改为只调用 `tiangong search process`
 - [x] `lifecyclemodel-hybrid-search` wrapper 改为只调用 `tiangong search lifecyclemodel`
 - [x] `embedding-ft` wrapper 改为只调用 `tiangong admin embedding-run`
-- [x] 删除这些 skill 中的旧 token / env 兼容文案
-- [x] 删除这些 skill 中的直接 `curl` / shell transport 逻辑
-- [x] 统一 skill 调用路径变量为 `TIANGONG_LCA_CLI_DIR`
+- [ ] 再做一轮 smoke check，确认这些 wrapper 不再保留旧 token / env / HTTP 分支
+- [x] 全量文档中统一 skill 调用路径变量为 `TIANGONG_LCA_CLI_DIR`
 
 完成定义：
 
 - [x] 调用链只剩 `skill -> tiangong`
 - [x] 不再出现 `TIANGONG_API_KEY`、`TIANGONG_LCA_APIKEY`、`SUPABASE_FUNCTIONS_URL` 之类旧名
 - [x] 不再出现 skill 自己解析 HTTP header / base URL
+- [ ] 这 4 个 skill 可以被视为“迁移模板”
 
-## Phase 2：先补 CLI 基础模块，再迁重 workflow
+### Phase 3：把 CLI 基础模块正式变成 workflow 依赖面
 
-在移植重 workflow 前，CLI 需要先有可复用的 TS 基础能力。
+目标：
+
+- 不再让重 workflow 自己管理运行态、artifact、校验、LLM、KB、OCR、publish
+
+当前已具备：
 
 - [x] `run` 基础模块：`run_id`、目录布局、manifest、resume 元数据
 - [x] `artifacts` 模块：统一 JSON / JSONL / audit / report 输出
@@ -128,41 +179,103 @@
 - [x] `http` / `rest-client` 模块：统一 REST 调用、重试、超时、错误格式
 - [x] `llm` 模块：统一模型调用抽象，不再直接暴露 `OPENAI_*`
 - [x] `kb-search` 模块：统一 `tiangong-ai-edge-function` 检索客户端
-- [x] `unstructured` 模块：统一 TianGong unstructured OCR / SI 解析客户端（当前使用 `/mineru_with_images`）
+- [x] `unstructured` 模块：统一 TianGong unstructured OCR / SI 解析客户端
 - [x] `publish` 模块：统一 dry-run / commit / publish report
 - [x] `validation` 模块：把 `tidas-sdk` / `tidas-tools` 校验调用收口到 CLI
 
+还需要做：
+
+- [ ] 明确哪些模块已经允许 workflow 直接依赖，哪些仍是内部预备模块
+- [ ] 为后续 workflow 命令确定稳定的输入输出契约
+- [ ] 确保未来不会再在 skill 里复制一份这些能力
+
 完成定义：
 
-- [x] 重 workflow 不再需要自己管理 env 解析
-- [x] 重 workflow 不再需要自己管理 artifact 目录约定
-- [x] 后续命令只是在复用 CLI 模块，而不是复制 Python 脚本
+- [ ] 重 workflow 迁移时，只需要编排 CLI 模块，而不需要重新设计 transport / cache / validation / publish
 
-当前落地点：
+### Phase 4：先迁 `lifecyclemodel-resulting-process-builder`
 
-- `tiangong publish run`：统一 publish request、bundle ingestion、dry-run / commit override、publish-report
-- `tiangong validation run`：统一 `tidas-sdk` / `tidas-tools` 报告形状与选择逻辑
-- `publish` 当前不会为了兼容旧实现而把 MCP 写库路径倒灌进 CLI；远端 commit 通过后续显式 executor 接入
+这一步不是因为它最重要，而是因为它最适合作为“第一个完整 CLI 化重 workflow 模板”。
 
-## Phase 3：迁 `process-automated-builder`
+当前状态：
 
-这是最高优先级的重 workflow。
+- `tiangong lifecyclemodel build-resulting-process` 已在 CLI 中落地，且通过 `npm run prepush:gate`
+- 仍未完成 `publish-resulting-process`、skill wrapper 收口、旧 Python 主入口删除
 
-建议目标命令：
+目标命令：
+
+- [x] `tiangong lifecyclemodel build-resulting-process`
+- [ ] `tiangong lifecyclemodel publish-resulting-process`
+
+ToDo：
+
+- [x] 在 CLI 中补齐 `lifecyclemodel` 顶层命名空间
+- [x] 将 lifecycle model 读取、拓扑解析、聚合投影逻辑迁到 TS
+- [x] 将 process catalog / local run 解析改为复用 CLI 模块
+- [ ] 将远程 process lookup 从可选 MCP lookup 改为直接 REST 查询
+- [ ] 保留 `publish-bundle.json` 契约，但发布入口统一走 CLI publish
+- [ ] skill wrapper 改为只调用 CLI
+- [ ] 删除 Python build / publish 主入口
+
+交付物：
+
+- [x] CLI 子命令实现
+- [x] CLI 测试
+- [x] 对应文档
+- [ ] skills 薄 wrapper
+
+完成定义：
+
+- [ ] 这个 skill 不再需要 Python builder
+- [ ] 这个 skill 不再需要 MCP lookup
+- [ ] 这个 skill 成为后续其它重 workflow CLI 化的参考模板
+
+### Phase 5：收口 publish / validation，清掉交付层并行实现
+
+目标：
+
+- 不再允许某个 skill 自带一套 publish 或 validation 逻辑
+
+ToDo：
+
+- [ ] 所有需要本地校验的 skill，统一改走 `tiangong validation run`
+- [ ] 所有需要 publish handoff 的 skill，统一改走 `tiangong publish run`
+- [ ] 若 `publish run` 还缺少远端 commit executor，则在 CLI 里补，不在 skills 里补
+- [ ] 将 `lca-publish-executor` 改成 CLI wrapper 或直接废弃
+- [ ] 明确 relation manifest / deferred publish / dry-run / commit 的唯一语义
+
+完成定义：
+
+- [ ] `lca-publish-executor` 不再是 Python publish contract layer
+- [ ] 没有任何 skill 再维护独立 publish 契约
+- [ ] 没有任何 skill 再自行判断用 `tidas-sdk` 还是 `tidas-tools`
+
+### Phase 6：迁 `process-automated-builder`
+
+这是最大的债务，也是最关键的主链迁移。
+
+目标命令：
 
 - [ ] `tiangong process auto-build`
 - [ ] `tiangong process resume-build`
 - [ ] `tiangong process publish-build`
 - [ ] `tiangong process batch-build`
 
+建议拆成 4 个连续小步骤，而不是一次性大迁移：
+
+- [ ] 6.1 先实现 `auto-build` 的本地产物路径，不做 publish
+- [ ] 6.2 再实现 `resume-build`，把 state-lock / run manifest 彻底收口到 CLI
+- [ ] 6.3 再实现 `publish-build`，接到统一 publish 模块
+- [ ] 6.4 最后实现 `batch-build`
+
 迁移内容：
 
 - [ ] 流程编排迁到 TS
 - [ ] flow search 改为直接 REST，而不是 MCP
-- [ ] publish 改为直接 REST，而不是 MCP CRUD
-- [ ] LLM 调用改为 CLI 自己的 provider abstraction
-- [ ] KB 检索改为 CLI 自己的 AI edge search client
-- [ ] unstructured 调用改为 CLI 自己的 client
+- [ ] publish 改为直接 REST / CLI publish，而不是 MCP CRUD
+- [ ] LLM 调用改为 CLI 的 provider abstraction
+- [ ] KB 检索改为 CLI 的 AI edge search client
+- [ ] unstructured 调用改为 CLI 的 client
 - [ ] 本地状态锁、cache、resume 逻辑迁到 CLI
 - [ ] 保留 artifact 契约，不保留 Python 实现
 
@@ -172,72 +285,90 @@
 - [ ] 对 LangGraph 的硬依赖
 - [ ] 对 `OPENAI_*`、`TIANGONG_LCA_REMOTE_*`、`TIANGONG_KB_REMOTE_*`、`TIANGONG_MINERU_WITH_IMAGE_*` 的依赖
 
-## Phase 4：迁 `lifecyclemodel-automated-builder`
+完成定义：
 
-建议目标命令：
+- [ ] `process-automated-builder` 只剩 `skill -> tiangong process ...`
+- [ ] agent 不再需要知道 LangGraph / MCP / OpenAI / MinerU 细节
+
+### Phase 7：迁 `lifecyclemodel-automated-builder`
+
+目标命令：
 
 - [ ] `tiangong lifecyclemodel auto-build`
 - [ ] `tiangong lifecyclemodel validate-build`
 - [ ] `tiangong lifecyclemodel publish-build`
 
-迁移内容：
+ToDo：
 
 - [ ] process discovery 改为 CLI 统一查询面
+- [ ] AI 选择逻辑改为 CLI LLM 模块
 - [ ] 本地 `json_ordered` 组装改为 TS
 - [ ] 本地校验改为 CLI 调用 `tidas-sdk` / `tidas-tools`
-- [ ] publish 改为直接 REST
+- [ ] publish 改为统一 publish 模块
 - [ ] 去掉只为 MCP insert 保留的分支
 
-## Phase 5：迁 `lifecyclemodel-resulting-process-builder`
+完成定义：
 
-建议目标命令：
+- [ ] lifecycle model 自动构建不再依赖 Python 和 MCP
+- [ ] 与 resulting-process / process build 的运行态契约一致
 
-- [ ] `tiangong lifecyclemodel build-resulting-process`
-- [ ] `tiangong lifecyclemodel publish-resulting-process`
+### Phase 8：迁 review / governance
 
-迁移内容：
+目标：
 
-- [ ] lifecycle model 读取、拓扑解析、聚合投影改为 TS
-- [ ] process catalog / local run 解析改为 CLI 模块
-- [ ] 远程 process lookup 改为直接 REST 查询
-- [ ] `publish-bundle.json` 生成契约保留，Python builder 删除
+- 把 review 与治理能力收口到统一 CLI，而不是分散脚本
 
-## Phase 6：迁 review / governance / publish
-
-这一批偏治理和交付层，复杂度高，但也最能体现 CLI 统一入口价值。
+ToDo：
 
 - [ ] `lifecycleinventory-review` -> `tiangong review process`
-- [ ] `flow-governance-review` -> `tiangong flow ...` / `tiangong review flow`
-- [ ] `lca-publish-executor` -> `tiangong publish ...`
+- [ ] `flow-governance-review` -> `tiangong review flow`
+- [ ] 视需要补 `tiangong flow get|list|remediate|publish-version|regen-product`
+- [ ] review 输出继续保持本地 artifact-first
+- [ ] 去掉 review 脚本中的直接 OpenAI / MCP 路径
 
-重点原则：
+完成定义：
 
-- [ ] review 输出保持本地 artifact-first
-- [ ] publish 统一 dry-run / commit 语义
-- [ ] 不再允许某个 skill 自带一套 publish 契约
+- [ ] review / governance 能力可以直接从 CLI 命令树被发现
+- [ ] agent 不再需要进入某个 skill 内部脚本目录才能执行治理任务
 
-## Phase 7：迁 orchestrator
+### Phase 9：最后迁 orchestrator
+
+只有在前面的构建、publish、review 子命令都稳定后，才应该做这一步。
+
+ToDo：
 
 - [ ] `lifecyclemodel-recursive-orchestrator` 迁成 CLI 编排命令
 - [ ] 所有子步骤只通过 `tiangong` 子命令调用
+- [ ] orchestrator 只负责编排，不再承载业务实现
 - [ ] 不再保留 Python orchestrator 作为总入口
 
-这一步必须放在前面重 workflow 完成后再做，否则只是把 Python 总控换个壳。
+完成定义：
 
-## Phase 8：删除遗留层
+- [ ] 总控层只编排 CLI
+- [ ] 没有新的“第二套入口”
+
+### Phase 10：删除遗留层
+
+目标：
+
+- 在代码层面真正完成“skills 全部只使用 CLI”
+
+ToDo：
 
 - [ ] 删除 skills 中的业务 Python 运行时
-- [ ] 删除 skills 中的业务 shell wrapper
-- [ ] 删除 skills 中的 transport/env parsing 逻辑
+- [ ] 删除 skills 中的业务 shell 实现，只保留薄 wrapper
+- [ ] 删除 skills 中的 transport / env parsing 逻辑
 - [ ] 删除 skills 中的 MCP-only 实现
 - [ ] 删除所有旧 env 名文档
 - [ ] 删除对 `TIANGONG_CLI_DIR` 旧变量名的依赖
+- [ ] 每个相关 repo merge 后，更新 `lca-workspace` 子模块指针
 
 最终 `skills` 仓库应只剩：
 
 - [ ] `SKILL.md`
 - [ ] 示例 request / assets
-- [ ] 对 `tiangong` 的单行调用
+- [ ] 参考文档
+- [ ] 对 `tiangong` 的薄调用
 
 ## 7. Env 收敛清单
 
@@ -272,10 +403,13 @@
 - [ ] `SUPABASE_FUNCTIONS_URL`
 - [ ] `SUPABASE_FUNCTION_REGION`
 - [ ] `OPENAI_*`
+- [ ] `LCA_OPENAI_*`
 - [ ] `TIANGONG_KB_*`（旧直连命名）
 - [ ] `TIANGONG_LCA_REMOTE_*`
 - [ ] `TIANGONG_KB_REMOTE_*`
 - [ ] `TIANGONG_MINERU_WITH_IMAGE_*`
+- [ ] `MINERU_*`
+- [ ] `MINERU_WITH_IMAGES_*`
 
 ## 8. 每个 Skill 的完成定义
 
@@ -285,31 +419,35 @@
 - [ ] skill 不再直接访问 REST / MCP
 - [ ] skill 不再解析 env
 - [ ] skill 不再持有独立 publish 逻辑
-- [ ] skill 调用统一 `tiangong` 命令
+- [ ] skill 只调用统一 `tiangong` 命令
 - [ ] 对应 CLI 子命令有测试
 - [ ] 对应 CLI 子命令有文档
 - [ ] 对应 CLI 子命令纳入 `npm run prepush:gate`
+- [ ] 对应 skill 文档已改成 CLI 用法
 
-## 9. 建议执行顺序
+## 9. 立即执行的短清单
 
-推荐严格按这个顺序推进：
+如果只按最短路径推进，下一轮建议严格做这 8 件事：
 
-1. 先清掉薄 remote skill
-2. 再补 CLI 基础模块
-3. 再迁 `process-automated-builder`
-4. 再迁 `lifecyclemodel-automated-builder`
-5. 再迁 `lifecyclemodel-resulting-process-builder`
-6. 再迁 review / governance / publish
-7. 最后迁 orchestrator
-8. 全量删除 Python 遗留层
+当前已完成：1-4。
 
-不建议的顺序：
+1. 修 CLI help，让命令面和真实实现一致。
+2. 修 skills 文档中的 `TIANGONG_CLI_DIR` 残留。
+3. 正式引入 `tiangong lifecyclemodel ...` 命名空间。
+4. 先完成 `tiangong lifecyclemodel build-resulting-process`。
+5. 再完成 `tiangong lifecyclemodel publish-resulting-process`。
+6. 把 `lifecyclemodel-resulting-process-builder` 改成薄 wrapper。
+7. 把 `lca-publish-executor` 收口到 `tiangong publish run`。
+8. 再进入 `tiangong process auto-build` 主链迁移。
 
-- 先迁 orchestrator
-- 先保留 Python 主逻辑，只包一层 TS 壳
-- 先统一文档，不统一执行面
+## 10. 不应该做的事
 
-## 10. 一句话标准
+- [ ] 不要先迁 orchestrator
+- [ ] 不要保留 Python 主逻辑，只包一层 TS 壳就算完成
+- [ ] 不要继续在 skills 里加新 env、新 transport、新 publish 约定
+- [ ] 不要为了兼容旧实现，把 MCP 重新带回 CLI
+
+## 11. 一句话标准
 
 判断迁移是否走在正确方向上，只问一句：
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,11 @@ import type { DotEnvLoadResult } from './lib/dotenv.js';
 import { CliError, toErrorPayload } from './lib/errors.js';
 import type { FetchLike } from './lib/http.js';
 import { stringifyJson } from './lib/io.js';
+import {
+  runLifecyclemodelBuildResultingProcess,
+  type LifecyclemodelResultingProcessReport,
+  type RunLifecyclemodelResultingProcessOptions,
+} from './lib/lifecyclemodel-resulting-process.js';
 import { runPublish, type PublishReport, type RunPublishOptions } from './lib/publish.js';
 import { executeRemoteCommand, getRemoteCommandHelp } from './lib/remote.js';
 import {
@@ -18,6 +23,9 @@ export type CliDeps = {
   fetchImpl: FetchLike;
   runPublishImpl?: (options: RunPublishOptions) => Promise<PublishReport>;
   runValidationImpl?: (options: RunValidationOptions) => Promise<ValidationRunReport>;
+  runLifecyclemodelBuildResultingProcessImpl?: (
+    options: RunLifecyclemodelResultingProcessOptions,
+  ) => Promise<LifecyclemodelResultingProcessReport>;
 };
 
 export type CliResult = {
@@ -46,16 +54,23 @@ Usage:
   tiangong <command> [subcommand] [options]
 
 Commands:
-  auth       whoami | doctor-auth
+Implemented Commands:
+  doctor     show environment diagnostics
   search     flow | process | lifecyclemodel
+  lifecyclemodel build-resulting-process
   publish    run
   validation run
+  admin      embedding-run
+
+Planned Surface (not implemented yet):
+  auth       whoami | doctor-auth
+  lifecyclemodel publish-resulting-process | auto-build | validate-build | publish-build
   review     flow | process
   flow       get | list | remediate | publish-version | regen-product
   process    get | auto-build | resume-build | publish-build | batch-build
   job        get | wait | logs
-  admin      embedding-run
-  doctor     show environment diagnostics
+
+Planned commands currently print an explicit "not implemented yet" message and exit with code 2.
 
 Examples:
   tiangong doctor
@@ -136,6 +151,93 @@ Options:
   --json               Print compact JSON
   -h, --help
 `.trim();
+}
+
+function renderLifecyclemodelBuildResultingProcessHelp(): string {
+  return `Usage:
+  tiangong lifecyclemodel build-resulting-process --input <file> [options]
+
+Options:
+  --input <file>     JSON request file
+  --out-dir <dir>    Override the default artifact output directory
+  --json             Print compact JSON
+  -h, --help
+`.trim();
+}
+
+function renderLifecyclemodelHelp(): string {
+  return `Usage:
+  tiangong lifecyclemodel <subcommand> [options]
+
+Implemented Subcommands:
+  build-resulting-process   Deterministically aggregate a lifecycle model into a resulting process bundle
+
+Planned Subcommands:
+  publish-resulting-process Publish a previously built resulting process run through the unified publish layer
+  auto-build                Assemble lifecycle models from discovered candidate processes
+  validate-build            Re-run local validation on a lifecycle model build run
+  publish-build             Publish a lifecycle model build run through the unified publish layer
+
+Examples:
+  tiangong lifecyclemodel --help
+  tiangong lifecyclemodel build-resulting-process --help
+  tiangong lifecyclemodel auto-build --help
+`.trim();
+}
+
+const lifecyclemodelPlannedHelp = {
+  'publish-resulting-process': `Usage:
+  tiangong lifecyclemodel publish-resulting-process --run-dir <dir> [options]
+
+Planned contract:
+  - read one prior resulting-process run directory
+  - ingest its publish handoff artifacts
+  - delegate commit semantics to the unified publish module
+
+Status:
+  Planned command. Execution is not implemented yet.
+`.trim(),
+  'auto-build': `Usage:
+  tiangong lifecyclemodel auto-build --input <file> [options]
+
+Planned contract:
+  - read one lifecycle model build manifest from --input
+  - discover candidate processes through CLI query surfaces
+  - assemble native json_ordered lifecycle model artifacts locally
+
+Status:
+  Planned command. Execution is not implemented yet.
+`.trim(),
+  'validate-build': `Usage:
+  tiangong lifecyclemodel validate-build --run-dir <dir> [options]
+
+Planned contract:
+  - load one lifecycle model build run directory
+  - re-run local validation through the unified validation module
+  - write a structured validation report into the run artifacts
+
+Status:
+  Planned command. Execution is not implemented yet.
+`.trim(),
+  'publish-build': `Usage:
+  tiangong lifecyclemodel publish-build --run-dir <dir> [options]
+
+Planned contract:
+  - load one lifecycle model build run directory
+  - publish lifecycle model artifacts through the unified publish module
+  - preserve dry-run and commit semantics from tiangong publish run
+
+Status:
+  Planned command. Execution is not implemented yet.
+`.trim(),
+} as const;
+
+type LifecyclemodelPlannedSubcommand = keyof typeof lifecyclemodelPlannedHelp;
+
+function isLifecyclemodelPlannedSubcommand(
+  value: string | null,
+): value is LifecyclemodelPlannedSubcommand {
+  return Boolean(value && value in lifecyclemodelPlannedHelp);
 }
 
 function renderDoctorText(report: ReturnType<typeof buildDoctorReport>): string {
@@ -388,6 +490,40 @@ function parseValidationFlags(args: string[]): {
   };
 }
 
+function parseLifecyclemodelBuildFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  inputPath: string;
+  outDir: string | null;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        input: { type: 'string' },
+        'out-dir': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    inputPath: typeof values.input === 'string' ? values.input : '',
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : null,
+  };
+}
+
 function plannedCommand(command: string, subcommand?: string): CliResult {
   const suffix = subcommand ? ` ${subcommand}` : '';
   return {
@@ -415,6 +551,8 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
     const { flags, command, subcommand, commandArgs } = parseCommandLine(argv);
     const publishImpl = deps.runPublishImpl ?? runPublish;
     const validationImpl = deps.runValidationImpl ?? runValidation;
+    const lifecyclemodelBuildImpl =
+      deps.runLifecyclemodelBuildResultingProcessImpl ?? runLifecyclemodelBuildResultingProcess;
 
     if (flags.version) {
       return { exitCode: 0, stdout: '0.0.1\n', stderr: '' };
@@ -464,6 +602,43 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
         }),
         stderr: '',
       };
+    }
+
+    if (command === 'lifecyclemodel' && !subcommand) {
+      return { exitCode: 0, stdout: `${renderLifecyclemodelHelp()}\n`, stderr: '' };
+    }
+
+    if (command === 'lifecyclemodel' && subcommand === 'build-resulting-process') {
+      const lifecyclemodelFlags = parseLifecyclemodelBuildFlags(commandArgs);
+      if (lifecyclemodelFlags.help) {
+        return {
+          exitCode: 0,
+          stdout: `${renderLifecyclemodelBuildResultingProcessHelp()}\n`,
+          stderr: '',
+        };
+      }
+
+      const report = await lifecyclemodelBuildImpl({
+        inputPath: lifecyclemodelFlags.inputPath,
+        outDir: lifecyclemodelFlags.outDir,
+      });
+
+      return {
+        exitCode: 0,
+        stdout: stringifyJson(report, lifecyclemodelFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'lifecyclemodel' && isLifecyclemodelPlannedSubcommand(subcommand)) {
+      if (commandArgs.includes('--help') || commandArgs.includes('-h')) {
+        return {
+          exitCode: 0,
+          stdout: `${lifecyclemodelPlannedHelp[subcommand]}\n`,
+          stderr: '',
+        };
+      }
+      return plannedCommand(command, subcommand);
     }
 
     if (command === 'admin' && !subcommand && commandArgs.includes('--help')) {

--- a/src/lib/lifecyclemodel-resulting-process.ts
+++ b/src/lib/lifecyclemodel-resulting-process.ts
@@ -1,0 +1,1541 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { writeJsonArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+import { readJsonInput } from './io.js';
+import { buildRunId, resolveRunLayout } from './run.js';
+
+type JsonObject = Record<string, unknown>;
+
+const DEFAULT_DATASET_VERSION = '00.00.001';
+const EPSILON = 1e-10;
+
+export type ProjectionMode = 'primary-only' | 'all-subproducts';
+export type PublishIntent = 'dry_run' | 'prepare_only' | 'publish';
+
+export type LifecyclemodelResultingProcessRequest = {
+  source_model: {
+    id: string | null;
+    version: string | null;
+    name: string | null;
+    json_ordered_path: string | null;
+    json_ordered: JsonObject | null;
+  };
+  projection: {
+    mode: ProjectionMode;
+    process_id: string | null;
+    process_version: string | null;
+    metadata_overrides: JsonObject;
+    attach_graph_snapshot: boolean;
+    attach_graph_snapshot_uri: string | null;
+  };
+  process_sources: {
+    process_catalog_path: string | null;
+    run_dirs: string[];
+    process_json_dirs: string[];
+    process_json_files: string[];
+    allow_remote_lookup: boolean;
+  };
+  publish: {
+    intent: PublishIntent;
+    prepare_process_payloads: boolean;
+    prepare_relation_payloads: boolean;
+  };
+};
+
+export type LifecyclemodelResultingProcessReport = {
+  generated_at_utc: string;
+  request_path: string;
+  out_dir: string;
+  status: string;
+  projected_process_count: number;
+  relation_count: number;
+  source_model: {
+    id: string;
+    version: string;
+    name: string;
+    json_ordered_path: string | null;
+    reference_to_resulting_process_id: string | null;
+    reference_to_resulting_process_version: string | null;
+    reference_process_instance_id: string | null;
+  };
+  files: {
+    normalized_request: string;
+    source_model_normalized: string;
+    source_model_summary: string;
+    projection_report: string;
+    process_projection_bundle: string;
+  };
+};
+
+export type RunLifecyclemodelResultingProcessOptions = {
+  inputPath: string;
+  outDir?: string | null;
+  now?: Date;
+};
+
+type ProcessRecord = {
+  processUuid: string;
+  version: string;
+  raw: JsonObject;
+  sourceLabel: string;
+  sourcePath: string | null;
+  referenceExchangeInternalId: string;
+  referenceFlowUuid: string;
+  referenceDirection: string;
+  referenceAmount: number;
+  inputAmounts: Record<string, number>;
+  outputAmounts: Record<string, number>;
+};
+
+type ProcessInstance = {
+  instance_id: string;
+  process_id: string;
+  process_version: string;
+  label: string;
+  multiplication_factor: number;
+  reference_to_process: JsonObject;
+  raw: JsonObject;
+};
+
+type Edge = {
+  edge_id: string;
+  from: string;
+  to: string;
+  exchange_id: string | null;
+  flow_uuid: string | null;
+};
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function ensureList<T = unknown>(value: unknown): T[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+
+  return Array.isArray(value) ? (value as T[]) : ([value] as T[]);
+}
+
+function copyJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function firstNonEmpty(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return null;
+}
+
+function uniqueStrings(values: Array<string | null | undefined>): string[] {
+  const unique: string[] = [];
+  const seen = new Set<string>();
+
+  values.forEach((value) => {
+    if (!value) {
+      return;
+    }
+
+    if (seen.has(value)) {
+      return;
+    }
+
+    seen.add(value);
+    unique.push(value);
+  });
+
+  return unique;
+}
+
+function sha256Text(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
+}
+
+function nowIso(now: Date = new Date()): string {
+  return now.toISOString();
+}
+
+function resolveInputPath(baseDir: string, value: string): string;
+function resolveInputPath(baseDir: string, value: unknown): string | null;
+function resolveInputPath(baseDir: string, value: unknown): string | null {
+  if (typeof value !== 'string' || !value.trim()) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.startsWith('file:')) {
+    return trimmed;
+  }
+
+  if (trimmed.includes('://')) {
+    return trimmed;
+  }
+
+  return path.resolve(baseDir, trimmed);
+}
+
+function resolveLocalPath(value: string, fieldName: string): string {
+  if (value.startsWith('file:')) {
+    return fileURLToPath(value);
+  }
+
+  if (value.includes('://')) {
+    throw new CliError(`${fieldName} must resolve to a local filesystem path.`, {
+      code: 'LIFECYCLEMODEL_LOCAL_PATH_REQUIRED',
+      exitCode: 2,
+      details: value,
+    });
+  }
+
+  return path.resolve(value);
+}
+
+function readJsonObject(filePath: string, code: string): JsonObject {
+  const value = readJsonInput(filePath);
+  if (!isRecord(value)) {
+    throw new CliError(`Expected a JSON object file: ${filePath}`, {
+      code,
+      exitCode: 2,
+    });
+  }
+
+  return value;
+}
+
+function toFiniteNumber(value: unknown, fieldName: string): number {
+  if (value === undefined || value === null || value === '') {
+    return 0;
+  }
+
+  const parsed = typeof value === 'number' ? value : Number(String(value));
+  if (!Number.isFinite(parsed)) {
+    throw new CliError(`Expected a numeric value for ${fieldName}.`, {
+      code: 'LIFECYCLEMODEL_INVALID_NUMBER',
+      exitCode: 2,
+      details: { fieldName, value },
+    });
+  }
+
+  return parsed;
+}
+
+function normalizeNumericOutput(value: number): number {
+  const rounded = Math.abs(value) < EPSILON ? 0 : Number.parseFloat(value.toFixed(12));
+  return rounded === 0 ? 0 : rounded;
+}
+
+function toBoolean(value: unknown, defaultValue: boolean): boolean {
+  if (value === undefined) {
+    return defaultValue;
+  }
+
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    if (value === 'true') {
+      return true;
+    }
+    if (value === 'false') {
+      return false;
+    }
+  }
+
+  return Boolean(value);
+}
+
+function normalizeStringArray(value: unknown, fieldName: string): string[] {
+  const items = ensureList(value);
+
+  return items.map((item, index) => {
+    if (typeof item !== 'string' || !item.trim()) {
+      throw new CliError(`Expected ${fieldName}[${index}] to be a non-empty string.`, {
+        code: 'LIFECYCLEMODEL_INVALID_STRING_ARRAY',
+        exitCode: 2,
+        details: { fieldName, value: item },
+      });
+    }
+
+    return item.trim();
+  });
+}
+
+function normalizeProjectionMode(value: unknown): ProjectionMode {
+  const mode = firstNonEmpty(value) ?? 'primary-only';
+  if (mode === 'primary-only' || mode === 'all-subproducts') {
+    return mode;
+  }
+
+  throw new CliError('projection.mode must be primary-only or all-subproducts.', {
+    code: 'LIFECYCLEMODEL_INVALID_PROJECTION_MODE',
+    exitCode: 2,
+    details: value,
+  });
+}
+
+function normalizePublishIntent(value: unknown): PublishIntent {
+  const intent = firstNonEmpty(value) ?? 'dry_run';
+  if (intent === 'dry_run' || intent === 'prepare_only' || intent === 'publish') {
+    return intent;
+  }
+
+  throw new CliError('publish.intent must be dry_run, prepare_only, or publish.', {
+    code: 'LIFECYCLEMODEL_INVALID_PUBLISH_INTENT',
+    exitCode: 2,
+    details: value,
+  });
+}
+
+function normalizeMetadataOverrides(value: unknown): JsonObject {
+  if (value === undefined) {
+    return {};
+  }
+
+  if (!isRecord(value)) {
+    throw new CliError('projection.metadata_overrides must be a JSON object when provided.', {
+      code: 'LIFECYCLEMODEL_INVALID_METADATA_OVERRIDES',
+      exitCode: 2,
+    });
+  }
+
+  return copyJson(value);
+}
+
+export function normalizeLifecyclemodelResultingProcessRequest(
+  input: unknown,
+  options: {
+    requestPath: string;
+  },
+): LifecyclemodelResultingProcessRequest {
+  if (!isRecord(input)) {
+    throw new CliError('Lifecyclemodel resulting-process request must be a JSON object.', {
+      code: 'LIFECYCLEMODEL_REQUEST_NOT_OBJECT',
+      exitCode: 2,
+    });
+  }
+
+  const baseDir = path.dirname(path.resolve(options.requestPath));
+  const sourceModelRaw = isRecord(input.source_model) ? input.source_model : {};
+  const projectionRaw = isRecord(input.projection) ? input.projection : {};
+  const processSourcesRaw = isRecord(input.process_sources) ? input.process_sources : {};
+  const publishRaw = isRecord(input.publish) ? input.publish : {};
+
+  const normalized: LifecyclemodelResultingProcessRequest = {
+    source_model: {
+      id: firstNonEmpty(sourceModelRaw.id),
+      version: firstNonEmpty(sourceModelRaw.version),
+      name: firstNonEmpty(sourceModelRaw.name),
+      json_ordered_path: resolveInputPath(baseDir, sourceModelRaw.json_ordered_path),
+      json_ordered: isRecord(sourceModelRaw.json_ordered)
+        ? copyJson(sourceModelRaw.json_ordered)
+        : null,
+    },
+    projection: {
+      mode: normalizeProjectionMode(projectionRaw.mode),
+      process_id: firstNonEmpty(projectionRaw.process_id),
+      process_version: firstNonEmpty(projectionRaw.process_version),
+      metadata_overrides: normalizeMetadataOverrides(projectionRaw.metadata_overrides),
+      attach_graph_snapshot: toBoolean(projectionRaw.attach_graph_snapshot, false),
+      attach_graph_snapshot_uri: resolveInputPath(baseDir, projectionRaw.attach_graph_snapshot_uri),
+    },
+    process_sources: {
+      process_catalog_path: (() => {
+        const resolved = resolveInputPath(baseDir, processSourcesRaw.process_catalog_path);
+        return resolved ? resolveLocalPath(resolved, 'process_sources.process_catalog_path') : null;
+      })(),
+      run_dirs: normalizeStringArray(processSourcesRaw.run_dirs, 'process_sources.run_dirs').map(
+        (item) => resolveLocalPath(resolveInputPath(baseDir, item), 'process_sources.run_dirs'),
+      ),
+      process_json_dirs: normalizeStringArray(
+        processSourcesRaw.process_json_dirs,
+        'process_sources.process_json_dirs',
+      ).map((item) =>
+        resolveLocalPath(resolveInputPath(baseDir, item), 'process_sources.process_json_dirs'),
+      ),
+      process_json_files: normalizeStringArray(
+        processSourcesRaw.process_json_files,
+        'process_sources.process_json_files',
+      ).map((item) =>
+        resolveLocalPath(resolveInputPath(baseDir, item), 'process_sources.process_json_files'),
+      ),
+      allow_remote_lookup: toBoolean(
+        processSourcesRaw.allow_remote_lookup ?? processSourcesRaw.allow_mcp_lookup,
+        false,
+      ),
+    },
+    publish: {
+      intent: normalizePublishIntent(publishRaw.intent),
+      prepare_process_payloads: toBoolean(publishRaw.prepare_process_payloads, true),
+      prepare_relation_payloads: toBoolean(publishRaw.prepare_relation_payloads, true),
+    },
+  };
+
+  if (
+    !normalized.source_model.id &&
+    !normalized.source_model.json_ordered &&
+    !normalized.source_model.json_ordered_path
+  ) {
+    throw new CliError(
+      'source_model must include at least one of id, json_ordered, or json_ordered_path.',
+      {
+        code: 'LIFECYCLEMODEL_SOURCE_MODEL_REQUIRED',
+        exitCode: 2,
+      },
+    );
+  }
+
+  if (!normalized.process_sources.process_catalog_path) {
+    normalized.process_sources.process_catalog_path = autoDetectProcessCatalogPath(
+      normalized.source_model.json_ordered_path,
+    );
+  }
+
+  if (normalized.process_sources.process_json_dirs.length === 0) {
+    normalized.process_sources.process_json_dirs = autoDetectProcessJsonDirs(
+      normalized.source_model.json_ordered_path,
+    );
+  }
+
+  return normalized;
+}
+
+function lifecyclemodelRoot(model: JsonObject): JsonObject {
+  return isRecord(model.lifeCycleModelDataSet)
+    ? (model.lifeCycleModelDataSet as JsonObject)
+    : model;
+}
+
+function processDatasetRoot(payload: JsonObject): JsonObject {
+  if (isRecord(payload.processDataSet)) {
+    return payload.processDataSet;
+  }
+
+  for (const key of ['json_ordered', 'json'] as const) {
+    const nested = payload[key];
+    if (isRecord(nested) && isRecord(nested.processDataSet)) {
+      return nested.processDataSet;
+    }
+  }
+
+  throw new CliError('Process payload does not contain processDataSet.', {
+    code: 'LIFECYCLEMODEL_PROCESS_DATASET_REQUIRED',
+    exitCode: 2,
+  });
+}
+
+function resolveNameField(namePayload: unknown): string | null {
+  if (typeof namePayload === 'string') {
+    return namePayload.trim() || null;
+  }
+
+  if (Array.isArray(namePayload)) {
+    for (const item of namePayload) {
+      const resolved = resolveNameField(item);
+      if (resolved) {
+        return resolved;
+      }
+    }
+    return null;
+  }
+
+  if (!isRecord(namePayload)) {
+    return null;
+  }
+
+  const direct = firstNonEmpty(namePayload['@index'], namePayload['#text'], namePayload.text);
+  if (direct) {
+    return direct;
+  }
+
+  for (const key of ['baseName', 'shortName', 'name'] as const) {
+    const nested = namePayload[key];
+    if (isRecord(nested)) {
+      const nestedText = firstNonEmpty(nested['@index'], nested['#text'], nested.text);
+      if (nestedText) {
+        return nestedText;
+      }
+    }
+
+    const resolved = firstNonEmpty(nested);
+    if (resolved) {
+      return resolved;
+    }
+  }
+
+  return null;
+}
+
+function normalizedNameInfo(namePayload: unknown, fallbackText: string): JsonObject {
+  if (isRecord(namePayload) && Object.keys(namePayload).length > 0) {
+    return copyJson(namePayload);
+  }
+
+  return {
+    baseName: [
+      {
+        '@xml:lang': 'en',
+        '#text': resolveNameField(namePayload) ?? fallbackText,
+      },
+    ],
+  };
+}
+
+function multilangFromText(enText: string, zhText: string): JsonObject[] {
+  return [
+    {
+      '@xml:lang': 'en',
+      '#text': enText,
+    },
+    {
+      '@xml:lang': 'zh',
+      '#text': zhText,
+    },
+  ];
+}
+
+function modelDatasetVersion(model: JsonObject): string | null {
+  const root = lifecyclemodelRoot(model);
+  const administrative = isRecord(root.administrativeInformation)
+    ? root.administrativeInformation
+    : {};
+  const publication = isRecord(administrative.publicationAndOwnership)
+    ? administrative.publicationAndOwnership
+    : isRecord(administrative['common:publicationAndOwnership'])
+      ? (administrative['common:publicationAndOwnership'] as JsonObject)
+      : {};
+
+  return firstNonEmpty(publication['common:dataSetVersion']);
+}
+
+function modelIdentifier(
+  model: JsonObject,
+  sourceModel: LifecyclemodelResultingProcessRequest['source_model'],
+): {
+  id: string;
+  version: string;
+  name: string;
+} {
+  const root = lifecyclemodelRoot(model);
+  const info = isRecord(root.lifeCycleModelInformation) ? root.lifeCycleModelInformation : {};
+  const dataInfo = isRecord(info.dataSetInformation) ? info.dataSetInformation : {};
+  const modelId =
+    firstNonEmpty(
+      sourceModel.id,
+      dataInfo['common:UUID'],
+      root['@id'],
+      root.id,
+      dataInfo.identifierOfSubDataSet,
+    ) ?? `lm-${sha256Text(JSON.stringify(model)).slice(0, 12)}`;
+  const version =
+    firstNonEmpty(
+      sourceModel.version,
+      modelDatasetVersion(model),
+      root['@version'],
+      root.version,
+      dataInfo['@version'],
+    ) ?? DEFAULT_DATASET_VERSION;
+  const name =
+    firstNonEmpty(sourceModel.name, resolveNameField(dataInfo.name), root.name) ?? modelId;
+
+  return {
+    id: modelId,
+    version,
+    name,
+  };
+}
+
+function extractProcessInstances(model: JsonObject): ProcessInstance[] {
+  const root = lifecyclemodelRoot(model);
+  const info = isRecord(root.lifeCycleModelInformation) ? root.lifeCycleModelInformation : {};
+  const technology = isRecord(info.technology)
+    ? info.technology
+    : isRecord(root.technology)
+      ? root.technology
+      : {};
+  const processes = isRecord(technology.processes) ? technology.processes : {};
+  const instances = ensureList<JsonObject>(processes.processInstance);
+
+  return instances.filter(isRecord).map((item, index) => {
+    const ref = isRecord(item.referenceToProcess) ? item.referenceToProcess : {};
+    return {
+      instance_id:
+        firstNonEmpty(item['@dataSetInternalID'], item['@id'], item.id) ?? `pi-${index + 1}`,
+      process_id: firstNonEmpty(ref['@refObjectId'], ref.id, ref.processId) ?? `proc-${index + 1}`,
+      process_version: firstNonEmpty(ref['@version'], ref.version) ?? DEFAULT_DATASET_VERSION,
+      label:
+        firstNonEmpty(
+          resolveNameField(ref['common:shortDescription']),
+          resolveNameField(ref.shortDescription),
+          resolveNameField(ref.name),
+          ref['@refObjectId'],
+        ) ?? `process-${index + 1}`,
+      multiplication_factor: normalizeNumericOutput(
+        toFiniteNumber(item['@multiplicationFactor'], 'processInstance.@multiplicationFactor'),
+      ),
+      reference_to_process: copyJson(ref),
+      raw: copyJson(item),
+    };
+  });
+}
+
+function extractEdges(model: JsonObject): Edge[] {
+  const edges: Edge[] = [];
+
+  extractProcessInstances(model).forEach((instance) => {
+    const connections = isRecord(instance.raw.connections) ? instance.raw.connections : {};
+    const outputs = ensureList<JsonObject>(connections.outputExchange);
+
+    outputs.filter(isRecord).forEach((exchange, edgeIndex) => {
+      const downstreamItems = ensureList<JsonObject>(exchange.downstreamProcess).filter(isRecord);
+      downstreamItems.forEach((downstream, downstreamIndex) => {
+        const downstreamId = firstNonEmpty(
+          downstream['@refObjectId'],
+          downstream['@id'],
+          downstream.id,
+          exchange.downstreamProcessId,
+        );
+        if (!downstreamId) {
+          return;
+        }
+
+        edges.push({
+          edge_id:
+            firstNonEmpty(exchange['@id'], exchange.id) ??
+            `${instance.instance_id}-edge-${edgeIndex + 1}-${downstreamIndex + 1}`,
+          from: instance.instance_id,
+          to: downstreamId,
+          exchange_id: firstNonEmpty(exchange['@id'], exchange.id),
+          flow_uuid: firstNonEmpty(
+            exchange['@flowUUID'],
+            downstream['@flowUUID'],
+            exchange.flowUUID,
+          ),
+        });
+      });
+    });
+  });
+
+  return edges;
+}
+
+function processReferencePairs(model: JsonObject): Array<{ process_id: string; version: string }> {
+  const seen = new Set<string>();
+  const pairs: Array<{ process_id: string; version: string }> = [];
+
+  extractProcessInstances(model).forEach((instance) => {
+    const key = `${instance.process_id}@${instance.process_version}`;
+    if (seen.has(key)) {
+      return;
+    }
+
+    seen.add(key);
+    pairs.push({
+      process_id: instance.process_id,
+      version: instance.process_version,
+    });
+  });
+
+  return pairs;
+}
+
+function parseProcessRecord(
+  payload: JsonObject,
+  options: {
+    sourceLabel: string;
+    sourcePath: string | null;
+  },
+): ProcessRecord {
+  const dataset = processDatasetRoot(payload);
+  const info = isRecord(dataset.processInformation) ? dataset.processInformation : {};
+  const dataInfo = isRecord(info.dataSetInformation) ? info.dataSetInformation : {};
+  const administrative = isRecord(dataset.administrativeInformation)
+    ? dataset.administrativeInformation
+    : {};
+  const publication = isRecord(administrative.publicationAndOwnership)
+    ? administrative.publicationAndOwnership
+    : {};
+  const processUuid = firstNonEmpty(dataInfo['common:UUID']);
+  if (!processUuid) {
+    throw new CliError(`processDataSet missing common:UUID from ${options.sourceLabel}`, {
+      code: 'LIFECYCLEMODEL_PROCESS_UUID_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  const version = firstNonEmpty(publication['common:dataSetVersion']) ?? DEFAULT_DATASET_VERSION;
+  const quantitativeReference = isRecord(info.quantitativeReference)
+    ? info.quantitativeReference
+    : {};
+  const referenceInternalId = firstNonEmpty(quantitativeReference.referenceToReferenceFlow);
+  const exchangesWrapper = isRecord(dataset.exchanges) ? dataset.exchanges : {};
+  const exchanges = ensureList<JsonObject>(exchangesWrapper.exchange).filter(isRecord);
+  const referenceExchange = exchanges.find(
+    (item) => String(item['@dataSetInternalID'] ?? '') === String(referenceInternalId ?? ''),
+  );
+
+  if (!referenceExchange) {
+    throw new CliError(
+      `reference exchange ${referenceInternalId ?? '(missing)'} not found for process ${processUuid}`,
+      {
+        code: 'LIFECYCLEMODEL_REFERENCE_EXCHANGE_NOT_FOUND',
+        exitCode: 2,
+      },
+    );
+  }
+
+  const inputAmounts: Record<string, number> = {};
+  const outputAmounts: Record<string, number> = {};
+
+  exchanges.forEach((exchange) => {
+    const flowRef = isRecord(exchange.referenceToFlowDataSet)
+      ? exchange.referenceToFlowDataSet
+      : {};
+    const flowUuid = firstNonEmpty(flowRef['@refObjectId']);
+    const direction = firstNonEmpty(exchange.exchangeDirection) ?? '';
+    if (!flowUuid) {
+      return;
+    }
+
+    const amount = normalizeNumericOutput(
+      toFiniteNumber(exchange.meanAmount ?? exchange.resultingAmount, 'exchange amount'),
+    );
+
+    if (direction === 'Input') {
+      inputAmounts[flowUuid] = normalizeNumericOutput((inputAmounts[flowUuid] ?? 0) + amount);
+    } else if (direction === 'Output') {
+      outputAmounts[flowUuid] = normalizeNumericOutput((outputAmounts[flowUuid] ?? 0) + amount);
+    }
+  });
+
+  const referenceFlow = isRecord(referenceExchange.referenceToFlowDataSet)
+    ? referenceExchange.referenceToFlowDataSet
+    : {};
+
+  return {
+    processUuid,
+    version,
+    raw: {
+      processDataSet: dataset,
+    },
+    sourceLabel: options.sourceLabel,
+    sourcePath: options.sourcePath,
+    referenceExchangeInternalId: String(referenceInternalId ?? ''),
+    referenceFlowUuid: firstNonEmpty(referenceFlow['@refObjectId']) ?? '',
+    referenceDirection: firstNonEmpty(referenceExchange.exchangeDirection) ?? '',
+    referenceAmount: normalizeNumericOutput(
+      toFiniteNumber(
+        referenceExchange.meanAmount ?? referenceExchange.resultingAmount,
+        'reference amount',
+      ),
+    ),
+    inputAmounts,
+    outputAmounts,
+  };
+}
+
+function autoDetectProcessCatalogPath(modelPath: string | null): string | null {
+  if (!modelPath) {
+    return null;
+  }
+
+  const resolved = PathSafe.resolve(modelPath);
+  if (!resolved) {
+    return null;
+  }
+
+  if (path.basename(path.dirname(resolved)) !== 'lifecyclemodels') {
+    return null;
+  }
+
+  const tidasBundleDir = path.dirname(path.dirname(resolved));
+  if (path.basename(tidasBundleDir) !== 'tidas_bundle') {
+    return null;
+  }
+
+  const candidate = path.join(path.dirname(tidasBundleDir), 'process-catalog.json');
+  return existsSync(candidate) ? candidate : null;
+}
+
+function autoDetectProcessJsonDirs(modelPath: string | null): string[] {
+  if (!modelPath) {
+    return [];
+  }
+
+  const resolved = PathSafe.resolve(modelPath);
+  if (!resolved) {
+    return [];
+  }
+
+  const candidates = [path.join(path.dirname(resolved), 'processes')];
+
+  if (path.basename(path.dirname(resolved)) === 'lifecyclemodels') {
+    candidates.push(path.join(path.dirname(path.dirname(resolved)), 'processes'));
+  }
+
+  const stem = path.basename(resolved, path.extname(resolved));
+  if (stem.endsWith('-model')) {
+    const prefix = stem.slice(0, -'-model'.length).trim();
+    if (prefix) {
+      candidates.push(path.join(path.dirname(resolved), `${prefix}-processes`));
+    }
+  }
+  if (stem.endsWith('_model')) {
+    const prefix = stem.slice(0, -'_model'.length).trim();
+    if (prefix) {
+      candidates.push(path.join(path.dirname(resolved), `${prefix}_processes`));
+    }
+  }
+
+  return uniqueStrings(candidates.filter((candidate) => existsSync(candidate)));
+}
+
+const PathSafe = {
+  resolve(value: string): string | null {
+    try {
+      return resolveLocalPath(value, 'path');
+    } catch {
+      return null;
+    }
+  },
+};
+
+function processSourceDirs(request: LifecyclemodelResultingProcessRequest): string[] {
+  const dirs = [...request.process_sources.process_json_dirs];
+
+  request.process_sources.run_dirs.forEach((runDir) => {
+    const candidate = path.join(runDir, 'exports', 'processes');
+    if (existsSync(candidate)) {
+      dirs.push(candidate);
+    }
+  });
+
+  if (request.process_sources.process_catalog_path) {
+    try {
+      const payload = JSON.parse(
+        readFileSync(request.process_sources.process_catalog_path, 'utf8'),
+      ) as unknown;
+      ensureList<JsonObject>(payload)
+        .filter(isRecord)
+        .forEach((item) => {
+          const sourceLabel = firstNonEmpty(item.source_label);
+          if (!sourceLabel) {
+            return;
+          }
+          const candidate = path.join(sourceLabel, 'exports', 'processes');
+          if (existsSync(candidate)) {
+            dirs.push(candidate);
+          }
+        });
+    } catch {
+      // Keep local process resolution best-effort for catalog expansion.
+    }
+  }
+
+  return uniqueStrings(dirs);
+}
+
+function locateLocalProcessFile(
+  processId: string,
+  version: string,
+  options: {
+    processDirs: string[];
+    processFiles: string[];
+  },
+): string | null {
+  const targetFileName = `${processId}_${version}.json`;
+
+  for (const directory of options.processDirs) {
+    const candidate = path.join(directory, targetFileName);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  for (const filePath of options.processFiles) {
+    if (existsSync(filePath) && path.basename(filePath) === targetFileName) {
+      return filePath;
+    }
+  }
+
+  return null;
+}
+
+function resolveProcessRecords(
+  request: LifecyclemodelResultingProcessRequest,
+  options: {
+    sourceModelJson: JsonObject;
+  },
+): {
+  records: Record<string, ProcessRecord>;
+  resolutionSummary: JsonObject;
+} {
+  const requiredPairs = processReferencePairs(options.sourceModelJson);
+  const processFiles = request.process_sources.process_json_files;
+  const processDirs = processSourceDirs(request);
+  const records: Record<string, ProcessRecord> = {};
+  const resolutionItems: JsonObject[] = [];
+  const unresolved: Array<{ process_id: string; version: string }> = [];
+
+  requiredPairs.forEach(({ process_id, version }) => {
+    const localPath = locateLocalProcessFile(process_id, version, {
+      processDirs,
+      processFiles,
+    });
+
+    if (localPath) {
+      const record = parseProcessRecord(
+        readJsonObject(localPath, 'LIFECYCLEMODEL_PROCESS_FILE_NOT_OBJECT'),
+        {
+          sourceLabel: path.dirname(localPath),
+          sourcePath: localPath,
+        },
+      );
+      records[`${process_id}@${version}`] = record;
+      resolutionItems.push({
+        process_id,
+        version,
+        resolution: 'local_file',
+        source_path: localPath,
+      });
+      return;
+    }
+
+    unresolved.push({ process_id, version });
+  });
+
+  if (unresolved.length > 0) {
+    if (request.process_sources.allow_remote_lookup) {
+      throw new CliError(
+        'Remote process lookup is not implemented in the CLI yet. Provide local process_sources.run_dirs, process_json_dirs, or process_json_files.',
+        {
+          code: 'LIFECYCLEMODEL_REMOTE_LOOKUP_NOT_IMPLEMENTED',
+          exitCode: 2,
+          details: unresolved,
+        },
+      );
+    }
+
+    const missing = unresolved.map((item) => `${item.process_id}@${item.version}`).join(', ');
+    throw new CliError(
+      `Could not resolve referenced process datasets for lifecycle model: ${missing}.`,
+      {
+        code: 'LIFECYCLEMODEL_PROCESS_RESOLUTION_FAILED',
+        exitCode: 2,
+      },
+    );
+  }
+
+  return {
+    records,
+    resolutionSummary: {
+      required_process_count: requiredPairs.length,
+      resolved_process_count: Object.keys(records).length,
+      local_process_dir_count: processDirs.length,
+      explicit_process_file_count: processFiles.length,
+      remote_resolution_count: 0,
+      items: resolutionItems,
+    },
+  };
+}
+
+function loadSourceModel(request: LifecyclemodelResultingProcessRequest): {
+  sourceModelJson: JsonObject;
+  modelPath: string | null;
+} {
+  if (request.source_model.json_ordered) {
+    return {
+      sourceModelJson: copyJson(request.source_model.json_ordered),
+      modelPath: null,
+    };
+  }
+
+  if (!request.source_model.json_ordered_path) {
+    throw new CliError('source_model must include json_ordered or json_ordered_path.', {
+      code: 'LIFECYCLEMODEL_SOURCE_MODEL_PATH_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  const localPath = resolveLocalPath(
+    request.source_model.json_ordered_path,
+    'source_model.json_ordered_path',
+  );
+
+  return {
+    sourceModelJson: readJsonObject(localPath, 'LIFECYCLEMODEL_SOURCE_MODEL_NOT_OBJECT'),
+    modelPath: localPath,
+  };
+}
+
+function referenceToResultingProcess(model: JsonObject): {
+  id: string | null;
+  version: string | null;
+} {
+  const root = lifecyclemodelRoot(model);
+  const info = isRecord(root.lifeCycleModelInformation) ? root.lifeCycleModelInformation : {};
+  const dataInfo = isRecord(info.dataSetInformation) ? info.dataSetInformation : {};
+  const ref = isRecord(dataInfo.referenceToResultingProcess)
+    ? dataInfo.referenceToResultingProcess
+    : {};
+
+  return {
+    id: firstNonEmpty(ref['@refObjectId'], ref.id),
+    version: firstNonEmpty(ref['@version'], ref.version),
+  };
+}
+
+function referenceProcessInstanceId(model: JsonObject): string | null {
+  const root = lifecyclemodelRoot(model);
+  const info = isRecord(root.lifeCycleModelInformation) ? root.lifeCycleModelInformation : {};
+  const quantitative = isRecord(info.quantitativeReference) ? info.quantitativeReference : {};
+  const ref = quantitative.referenceToReferenceProcess;
+  return isRecord(ref) ? firstNonEmpty(ref['@refObjectId'], ref.id) : firstNonEmpty(ref);
+}
+
+function chooseReferenceInstance(
+  processInstances: ProcessInstance[],
+  requestedInstanceId: string | null,
+): ProcessInstance {
+  const directMatch = requestedInstanceId
+    ? processInstances.find((item) => item.instance_id === requestedInstanceId)
+    : null;
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const scaled = processInstances.find((item) => item.multiplication_factor > 0);
+  if (scaled) {
+    return scaled;
+  }
+
+  const fallback = processInstances[0];
+  if (!fallback) {
+    throw new CliError('Lifecycle model does not contain any process instances.', {
+      code: 'LIFECYCLEMODEL_PROCESS_INSTANCES_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  return fallback;
+}
+
+function cloneExchangeWithAmount(
+  exchange: JsonObject,
+  amount: number,
+  internalId: string,
+  options: {
+    quantitativeReference: boolean;
+  },
+): JsonObject {
+  const cloned = copyJson(exchange);
+  cloned['@dataSetInternalID'] = internalId;
+  const normalizedAmount = normalizeNumericOutput(amount);
+  cloned.meanAmount = normalizedAmount;
+  if ('resultingAmount' in cloned) {
+    cloned.resultingAmount = normalizedAmount;
+  }
+  cloned.quantitativeReference = options.quantitativeReference;
+  return cloned;
+}
+
+function buildResultingProcessPayload(options: {
+  sourceModelId: string;
+  sourceModelVersion: string;
+  sourceModelName: string;
+  sourceModelNameInfo: JsonObject;
+  processId: string;
+  processVersion: string;
+  role: 'primary';
+  projectionSignature: string;
+  processInstances: ProcessInstance[];
+  edges: Edge[];
+  processRecords: Record<string, ProcessRecord>;
+  referenceProcessInstanceId: string | null;
+  metadataOverrides: JsonObject;
+  attachGraphSnapshotUri: string | null;
+}): JsonObject {
+  const chosenInstance = chooseReferenceInstance(
+    options.processInstances,
+    options.referenceProcessInstanceId,
+  );
+  const chosenKey = `${chosenInstance.process_id}@${chosenInstance.process_version}`;
+  const finalRecord = options.processRecords[chosenKey];
+  const finalProcess = copyJson(finalRecord.raw);
+  const finalDataset = processDatasetRoot(finalProcess);
+  const totals = new Map<string, { amount: number; exchange: JsonObject }>();
+
+  options.processInstances.forEach((instance) => {
+    if (instance.multiplication_factor === 0) {
+      return;
+    }
+
+    const record = options.processRecords[`${instance.process_id}@${instance.process_version}`];
+    const recordDataset = processDatasetRoot(record.raw);
+    const exchangesWrapper = isRecord(recordDataset.exchanges)
+      ? (recordDataset.exchanges as JsonObject)
+      : {};
+    const exchanges = ensureList<JsonObject>(exchangesWrapper.exchange).filter(isRecord);
+
+    exchanges.forEach((exchange) => {
+      const flowRef = isRecord(exchange.referenceToFlowDataSet)
+        ? exchange.referenceToFlowDataSet
+        : {};
+      const flowUuid = firstNonEmpty(flowRef['@refObjectId']);
+      const direction = firstNonEmpty(exchange.exchangeDirection);
+
+      if (!flowUuid || (direction !== 'Input' && direction !== 'Output')) {
+        return;
+      }
+
+      const key = `${flowUuid}\u0000${direction}`;
+      const scaledAmount =
+        toFiniteNumber(exchange.meanAmount ?? exchange.resultingAmount, 'exchange amount') *
+        instance.multiplication_factor;
+      const existing = totals.get(key);
+      if (existing) {
+        existing.amount = normalizeNumericOutput(existing.amount + scaledAmount);
+        return;
+      }
+
+      totals.set(key, {
+        amount: normalizeNumericOutput(scaledAmount),
+        exchange: copyJson(exchange),
+      });
+    });
+  });
+
+  const instanceById = new Map(options.processInstances.map((item) => [item.instance_id, item]));
+  options.edges.forEach((edge) => {
+    if (!edge.flow_uuid) {
+      return;
+    }
+
+    const downstreamInstance = instanceById.get(edge.to);
+    if (!downstreamInstance) {
+      return;
+    }
+
+    const downstreamRecord =
+      options.processRecords[
+        `${downstreamInstance.process_id}@${downstreamInstance.process_version}`
+      ];
+    if (!downstreamRecord) {
+      return;
+    }
+
+    const internalAmount =
+      (downstreamRecord.inputAmounts[edge.flow_uuid] ?? 0) *
+      downstreamInstance.multiplication_factor;
+
+    ['Output', 'Input'].forEach((direction) => {
+      const key = `${edge.flow_uuid}\u0000${direction}`;
+      const existing = totals.get(key);
+      if (!existing) {
+        return;
+      }
+
+      existing.amount = normalizeNumericOutput(existing.amount - internalAmount);
+    });
+  });
+
+  const exchangeItems: JsonObject[] = [];
+  let nextInternalId = 1;
+  let referenceExchangeInternalId = '';
+  const sortedEntries = [...totals.entries()].sort((left, right) =>
+    left[0].localeCompare(right[0]),
+  );
+
+  sortedEntries.forEach(([key, payload]) => {
+    if (payload.amount <= 0) {
+      return;
+    }
+
+    const [flowUuid, direction] = key.split('\u0000');
+    const quantitativeReference =
+      flowUuid === finalRecord.referenceFlowUuid &&
+      direction === (finalRecord.referenceDirection || 'Output') &&
+      !referenceExchangeInternalId;
+
+    const internalId = String(nextInternalId);
+    nextInternalId += 1;
+    if (quantitativeReference) {
+      referenceExchangeInternalId = internalId;
+    }
+
+    exchangeItems.push(
+      cloneExchangeWithAmount(payload.exchange, payload.amount, internalId, {
+        quantitativeReference,
+      }),
+    );
+  });
+
+  if (!referenceExchangeInternalId) {
+    throw new CliError(
+      `Could not build resulting process reference exchange for lifecycle model ${options.sourceModelId}.`,
+      {
+        code: 'LIFECYCLEMODEL_REFERENCE_OUTPUT_REQUIRED',
+        exitCode: 2,
+      },
+    );
+  }
+
+  const processInformation = isRecord(finalDataset.processInformation)
+    ? (finalDataset.processInformation as JsonObject)
+    : {};
+  finalDataset.processInformation = processInformation;
+  const dataInfo = isRecord(processInformation.dataSetInformation)
+    ? (processInformation.dataSetInformation as JsonObject)
+    : {};
+  processInformation.dataSetInformation = dataInfo;
+  dataInfo['common:UUID'] = options.processId;
+  dataInfo.name = copyJson(options.sourceModelNameInfo);
+  const generalComment = ensureList<JsonObject>(dataInfo['common:generalComment']).filter(isRecord);
+  generalComment.push(
+    ...multilangFromText(
+      `Local ${options.role} resulting process generated from lifecycle model ${options.sourceModelId}; exchanges are aggregated from included processes with internal linked flows cancelled.`,
+      `本地为生命周期模型 ${options.sourceModelId} 生成的 ${options.role} resulting process；其 exchanges 由包含过程聚合并抵消内部连接 flow 后得到。`,
+    ),
+  );
+  dataInfo['common:generalComment'] = generalComment;
+
+  const quantitativeReference = isRecord(processInformation.quantitativeReference)
+    ? (processInformation.quantitativeReference as JsonObject)
+    : {};
+  processInformation.quantitativeReference = quantitativeReference;
+  quantitativeReference.referenceToReferenceFlow = referenceExchangeInternalId;
+
+  const technology = isRecord(processInformation.technology)
+    ? (processInformation.technology as JsonObject)
+    : {};
+  processInformation.technology = technology;
+  const includedRefs = options.processInstances.map((item) => copyJson(item.reference_to_process));
+  if (includedRefs.length > 0) {
+    technology.referenceToIncludedProcesses =
+      includedRefs.length === 1 ? includedRefs[0] : includedRefs;
+  }
+
+  finalDataset.exchanges = {
+    exchange: exchangeItems.length === 1 ? exchangeItems[0] : exchangeItems,
+  };
+
+  const administrative = isRecord(finalDataset.administrativeInformation)
+    ? (finalDataset.administrativeInformation as JsonObject)
+    : {};
+  finalDataset.administrativeInformation = administrative;
+  const publication = isRecord(administrative.publicationAndOwnership)
+    ? (administrative.publicationAndOwnership as JsonObject)
+    : {};
+  administrative.publicationAndOwnership = publication;
+  publication['common:dataSetVersion'] = options.processVersion;
+  publication['common:permanentDataSetURI'] =
+    `https://local.tiangong.invalid/processes/${options.processId}?version=${options.processVersion}`;
+
+  const modellingAndValidation = isRecord(finalDataset.modellingAndValidation)
+    ? (finalDataset.modellingAndValidation as JsonObject)
+    : {};
+  finalDataset.modellingAndValidation = modellingAndValidation;
+  const lciMethod = isRecord(modellingAndValidation.LCIMethodAndAllocation)
+    ? (modellingAndValidation.LCIMethodAndAllocation as JsonObject)
+    : {};
+  modellingAndValidation.LCIMethodAndAllocation = lciMethod;
+  const typeOfDataSet =
+    firstNonEmpty(options.metadataOverrides.type_of_data_set) ?? 'partly terminated system';
+  lciMethod.typeOfDataSet = typeOfDataSet;
+
+  dataInfo.generatedFromLifecycleModel = {
+    id: options.sourceModelId,
+    version: options.sourceModelVersion,
+    role: options.role,
+  };
+
+  const metadata: JsonObject = {
+    generated_from_lifecyclemodel_id: options.sourceModelId,
+    generated_from_lifecyclemodel_version: options.sourceModelVersion,
+    projection_role: options.role,
+    projection_signature: options.projectionSignature,
+    type_of_data_set: typeOfDataSet,
+    ...copyJson(options.metadataOverrides),
+  };
+  if (options.attachGraphSnapshotUri) {
+    metadata.graph_snapshot_uri = options.attachGraphSnapshotUri;
+  }
+
+  finalProcess.projectionMetadata = metadata;
+  finalProcess.topologySummary = {
+    process_instance_count: options.processInstances.length,
+    edge_count: options.edges.length,
+  };
+
+  return finalProcess;
+}
+
+function buildProjectionBundle(options: {
+  request: LifecyclemodelResultingProcessRequest;
+  sourceModelJson: JsonObject;
+  modelPath: string | null;
+}): {
+  bundle: JsonObject;
+  report: JsonObject;
+  sourceModelSummary: {
+    id: string;
+    version: string;
+    name: string;
+    json_ordered_path: string | null;
+    reference_to_resulting_process_id: string | null;
+    reference_to_resulting_process_version: string | null;
+    reference_process_instance_id: string | null;
+    resolved_process_summary: JsonObject;
+  };
+} {
+  const root = lifecyclemodelRoot(options.sourceModelJson);
+  const modelInfo = isRecord(root.lifeCycleModelInformation) ? root.lifeCycleModelInformation : {};
+  const modelDataInfo = isRecord(modelInfo.dataSetInformation) ? modelInfo.dataSetInformation : {};
+  const modelIdentity = modelIdentifier(options.sourceModelJson, options.request.source_model);
+  const sourceModelNameInfo = normalizedNameInfo(modelDataInfo.name, modelIdentity.name);
+  const processInstances = extractProcessInstances(options.sourceModelJson);
+  const edges = extractEdges(options.sourceModelJson);
+  const processResolution = resolveProcessRecords(options.request, {
+    sourceModelJson: options.sourceModelJson,
+  });
+  const referenceProcess = referenceToResultingProcess(options.sourceModelJson);
+  const referenceProcessInstance = referenceProcessInstanceId(options.sourceModelJson);
+  const signatureSeed = {
+    source_model_id: modelIdentity.id,
+    source_model_version: modelIdentity.version,
+    projection_mode: options.request.projection.mode,
+    process_instances: processInstances.map((item) => ({
+      instance_id: item.instance_id,
+      process_id: item.process_id,
+      process_version: item.process_version,
+    })),
+    edges,
+  };
+  const projectionSignature = `sha256:${sha256Text(JSON.stringify(signatureSeed))}`;
+  const primaryProcessId =
+    options.request.projection.process_id ??
+    referenceProcess.id ??
+    `${modelIdentity.id}-resulting-process`;
+  const primaryProcessVersion =
+    options.request.projection.process_version ?? referenceProcess.version ?? modelIdentity.version;
+  const notes = [
+    'This command materializes a deterministic resulting processDataSet by aggregating included process exchanges and cancelling internal linked flows.',
+    'Remote writes remain gated behind an explicit publish layer.',
+  ];
+
+  const primaryPayload = buildResultingProcessPayload({
+    sourceModelId: modelIdentity.id,
+    sourceModelVersion: modelIdentity.version,
+    sourceModelName: modelIdentity.name,
+    sourceModelNameInfo,
+    processId: primaryProcessId,
+    processVersion: primaryProcessVersion,
+    role: 'primary',
+    projectionSignature,
+    processInstances,
+    edges,
+    processRecords: processResolution.records,
+    referenceProcessInstanceId: referenceProcessInstance,
+    metadataOverrides: options.request.projection.metadata_overrides,
+    attachGraphSnapshotUri: options.request.projection.attach_graph_snapshot_uri,
+  });
+
+  if (options.request.projection.mode === 'all-subproducts') {
+    const jsonTg = isRecord(root.json_tg) ? root.json_tg : {};
+    const submodels = ensureList<JsonObject>(jsonTg.submodels).filter(isRecord);
+    notes.push(
+      submodels.length > 0
+        ? 'Subproduct projection was requested, but this lifecycle model only carries submodel metadata and no submodel-specific topology slices; only the primary aggregated resulting process was emitted.'
+        : 'Subproduct projection was requested, but the lifecycle model does not expose submodel topology metadata; only the primary aggregated resulting process was emitted.',
+    );
+  }
+
+  const sourceModelSummary = {
+    id: modelIdentity.id,
+    version: modelIdentity.version,
+    name: modelIdentity.name,
+    json_ordered_path: options.modelPath,
+    reference_to_resulting_process_id: referenceProcess.id,
+    reference_to_resulting_process_version: referenceProcess.version,
+    reference_process_instance_id: referenceProcessInstance,
+    resolved_process_summary: processResolution.resolutionSummary,
+  };
+
+  const report = {
+    generated_at: nowIso(),
+    status:
+      options.request.publish.intent === 'publish'
+        ? 'projected_local_bundle'
+        : 'prepared_local_bundle',
+    source_model: sourceModelSummary,
+    projection_mode: options.request.projection.mode,
+    node_count: processInstances.length,
+    edge_count: edges.length,
+    reference_process_instance_id: referenceProcessInstance,
+    process_instance_preview: processInstances.slice(0, 10).map((item) => ({
+      instance_id: item.instance_id,
+      process_id: item.process_id,
+      label: item.label,
+    })),
+    edge_preview: edges.slice(0, 10),
+    projection_signature: projectionSignature,
+    attach_graph_snapshot_uri: options.request.projection.attach_graph_snapshot_uri,
+    resolved_process_summary: processResolution.resolutionSummary,
+    projected_process_count: 1,
+    notes,
+  };
+
+  const bundle = {
+    source_model: sourceModelSummary,
+    projected_processes: [
+      {
+        role: 'primary',
+        id: primaryProcessId,
+        version: primaryProcessVersion,
+        name: modelIdentity.name,
+        json_ordered: primaryPayload,
+        metadata: primaryPayload.projectionMetadata,
+      },
+    ],
+    relations: [
+      {
+        lifecyclemodel_id: modelIdentity.id,
+        lifecyclemodel_version: modelIdentity.version,
+        resulting_process_id: primaryProcessId,
+        resulting_process_version: primaryProcessVersion,
+        projection_role: 'primary',
+        projection_signature: projectionSignature,
+        is_primary: true,
+      },
+    ],
+    report,
+    projection: {
+      mode: options.request.projection.mode,
+      metadata_overrides: options.request.projection.metadata_overrides,
+      attach_graph_snapshot_uri: options.request.projection.attach_graph_snapshot_uri,
+    },
+  };
+
+  return {
+    bundle,
+    report,
+    sourceModelSummary,
+  };
+}
+
+function defaultOutDir(requestPath: string, subject: string, now: Date = new Date()): string {
+  const requestDir = path.dirname(path.resolve(requestPath));
+  const runId = buildRunId({
+    namespace: 'lifecyclemodel_resulting_process',
+    subject,
+    operation: 'build',
+    now,
+  });
+
+  return resolveRunLayout(
+    path.join(requestDir, 'artifacts'),
+    'lifecyclemodel_resulting_process',
+    runId,
+  ).runRoot;
+}
+
+export async function runLifecyclemodelBuildResultingProcess(
+  options: RunLifecyclemodelResultingProcessOptions,
+): Promise<LifecyclemodelResultingProcessReport> {
+  const requestPath = path.resolve(options.inputPath);
+  const input = readJsonInput(requestPath);
+  const normalizedRequest = normalizeLifecyclemodelResultingProcessRequest(input, {
+    requestPath,
+  });
+  const sourceModel = loadSourceModel(normalizedRequest);
+  const modelIdentity = modelIdentifier(
+    sourceModel.sourceModelJson,
+    normalizedRequest.source_model,
+  );
+  const outDir = options.outDir
+    ? path.resolve(options.outDir)
+    : defaultOutDir(requestPath, modelIdentity.id, options.now);
+  const projection = buildProjectionBundle({
+    request: normalizedRequest,
+    sourceModelJson: sourceModel.sourceModelJson,
+    modelPath: sourceModel.modelPath,
+  });
+
+  const files = {
+    normalized_request: writeJsonArtifact(
+      path.join(outDir, 'request.normalized.json'),
+      normalizedRequest,
+    ),
+    source_model_normalized: writeJsonArtifact(
+      path.join(outDir, 'source-model.normalized.json'),
+      sourceModel.sourceModelJson,
+    ),
+    source_model_summary: writeJsonArtifact(
+      path.join(outDir, 'source-model.summary.json'),
+      projection.sourceModelSummary,
+    ),
+    projection_report: writeJsonArtifact(
+      path.join(outDir, 'projection-report.json'),
+      projection.report,
+    ),
+    process_projection_bundle: writeJsonArtifact(
+      path.join(outDir, 'process-projection-bundle.json'),
+      projection.bundle,
+    ),
+  };
+
+  return {
+    generated_at_utc: nowIso(options.now),
+    request_path: requestPath,
+    out_dir: outDir,
+    status: String(projection.report.status),
+    projected_process_count: 1,
+    relation_count: 1,
+    source_model: {
+      id: projection.sourceModelSummary.id,
+      version: projection.sourceModelSummary.version,
+      name: projection.sourceModelSummary.name,
+      json_ordered_path: projection.sourceModelSummary.json_ordered_path,
+      reference_to_resulting_process_id:
+        projection.sourceModelSummary.reference_to_resulting_process_id,
+      reference_to_resulting_process_version:
+        projection.sourceModelSummary.reference_to_resulting_process_version,
+      reference_process_instance_id: projection.sourceModelSummary.reference_process_instance_id,
+    },
+    files,
+  };
+}
+
+// Exposed for deterministic unit coverage of internal lifecyclemodel fallback logic.
+export const __testInternals = {
+  uniqueStrings,
+  toFiniteNumber,
+  normalizeNumericOutput,
+  toBoolean,
+  resolveNameField,
+  normalizedNameInfo,
+  modelIdentifier,
+  extractProcessInstances,
+  extractEdges,
+  processReferencePairs,
+  parseProcessRecord,
+  autoDetectProcessCatalogPath,
+  autoDetectProcessJsonDirs,
+  processSourceDirs,
+  locateLocalProcessFile,
+  loadSourceModel,
+  referenceToResultingProcess,
+  referenceProcessInstanceId,
+  chooseReferenceInstance,
+  cloneExchangeWithAmount,
+  buildResultingProcessPayload,
+  buildProjectionBundle,
+  defaultOutDir,
+};

--- a/test/artifacts.test.ts
+++ b/test/artifacts.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSyn
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import { loadDistModule } from './helpers/load-dist-module.js';
 import {
   readJsonArtifact,
   readJsonLinesArtifact,
@@ -10,6 +11,10 @@ import {
   writeJsonLinesArtifact,
   writeTextArtifact,
 } from '../src/lib/artifacts.js';
+
+async function loadDistArtifactsModule(): Promise<typeof import('../src/lib/artifacts.js')> {
+  return loadDistModule('src/lib/artifacts.js');
+}
 
 test('writeTextArtifact writes plain text and creates parent directories', () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-artifacts-text-'));
@@ -112,6 +117,28 @@ test('readJsonLinesArtifact skips blank lines and throws on invalid JSONL', () =
       () => readJsonLinesArtifact(invalidPath),
       /Artifact file contains invalid JSONL at line 2/u,
     );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('artifact helpers behave the same from the built dist module', async () => {
+  const artifacts = await loadDistArtifactsModule();
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-artifacts-dist-'));
+  const textPath = path.join(dir, 'nested', 'artifact.txt');
+  const jsonPath = path.join(dir, 'artifact.json');
+  const jsonlPath = path.join(dir, 'artifact.jsonl');
+
+  try {
+    assert.equal(artifacts.writeTextArtifact(textPath, 'hello\n'), textPath);
+    assert.equal(readFileSync(textPath, 'utf8'), 'hello\n');
+
+    artifacts.writeJsonArtifact(jsonPath, { hello: 'world' }, true);
+    assert.deepEqual(artifacts.readJsonArtifact(jsonPath), { hello: 'world' });
+
+    artifacts.writeJsonLinesArtifact(jsonlPath, { id: 1 });
+    artifacts.writeJsonLinesArtifact(jsonlPath, [{ id: 2 }], { append: true });
+    assert.deepEqual(artifacts.readJsonLinesArtifact(jsonlPath), [{ id: 1 }, { id: 2 }]);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -35,6 +35,10 @@ test('executeCli prints main help when no command is given', async () => {
   const result = await executeCli([], makeDeps());
   assert.equal(result.exitCode, 0);
   assert.match(result.stdout, /Unified TianGong command entrypoint/u);
+  assert.match(result.stdout, /Implemented Commands:/u);
+  assert.match(result.stdout, /Planned Surface \(not implemented yet\):/u);
+  assert.match(result.stdout, /lifecyclemodel build-resulting-process/u);
+  assert.match(result.stdout, /exit with code 2/u);
   assert.equal(result.stderr, '');
 });
 
@@ -143,6 +147,78 @@ test('executeCli returns group help for search and admin namespaces', async () =
   const adminHelp = await executeCli(['admin', '--help'], makeDeps());
   assert.equal(adminHelp.exitCode, 0);
   assert.match(adminHelp.stdout, /tiangong admin embedding-run/u);
+});
+
+test('executeCli returns help for the lifecyclemodel namespace and planned subcommands', async () => {
+  const lifecyclemodelHelp = await executeCli(['lifecyclemodel'], makeDeps());
+  assert.equal(lifecyclemodelHelp.exitCode, 0);
+  assert.match(lifecyclemodelHelp.stdout, /tiangong lifecyclemodel <subcommand>/u);
+  assert.match(lifecyclemodelHelp.stdout, /build-resulting-process/u);
+
+  const buildHelp = await executeCli(
+    ['lifecyclemodel', 'build-resulting-process', '--help'],
+    makeDeps(),
+  );
+  assert.equal(buildHelp.exitCode, 0);
+  assert.match(buildHelp.stdout, /tiangong lifecyclemodel build-resulting-process --input <file>/u);
+  assert.doesNotMatch(buildHelp.stdout, /Planned command/u);
+});
+
+test('executeCli executes lifecyclemodel build-resulting-process with injected implementation', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-cli-'));
+  const inputPath = path.join(dir, 'request.json');
+  writeFileSync(inputPath, '{"source_model":{"json_ordered_path":"./model.json"}}', 'utf8');
+
+  try {
+    const result = await executeCli(
+      [
+        'lifecyclemodel',
+        'build-resulting-process',
+        '--json',
+        '--input',
+        inputPath,
+        '--out-dir',
+        './out',
+      ],
+      {
+        ...makeDeps(),
+        runLifecyclemodelBuildResultingProcessImpl: async (options) => {
+          assert.equal(options.inputPath, inputPath);
+          assert.equal(options.outDir, './out');
+          return {
+            generated_at_utc: '2026-03-29T00:00:00.000Z',
+            request_path: inputPath,
+            out_dir: path.join(dir, 'out'),
+            status: 'prepared_local_bundle',
+            projected_process_count: 1,
+            relation_count: 1,
+            source_model: {
+              id: 'lm-demo',
+              version: '00.00.001',
+              name: 'Demo model',
+              json_ordered_path: path.join(dir, 'model.json'),
+              reference_to_resulting_process_id: 'proc-demo',
+              reference_to_resulting_process_version: '00.00.001',
+              reference_process_instance_id: '1',
+            },
+            files: {
+              normalized_request: path.join(dir, 'out', 'request.normalized.json'),
+              source_model_normalized: path.join(dir, 'out', 'source-model.normalized.json'),
+              source_model_summary: path.join(dir, 'out', 'source-model.summary.json'),
+              projection_report: path.join(dir, 'out', 'projection-report.json'),
+              process_projection_bundle: path.join(dir, 'out', 'process-projection-bundle.json'),
+            },
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /"status":"prepared_local_bundle"/u);
+    assert.match(result.stdout, /"process_projection_bundle"/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test('executeCli keeps subcommand --json inside remote command parsing', async () => {
@@ -458,6 +534,16 @@ test('executeCli returns parsing errors for invalid publish and validation flags
   assert.match(validationResult.stderr, /INVALID_ARGS/u);
 });
 
+test('executeCli returns parsing errors for invalid lifecyclemodel build flags', async () => {
+  const result = await executeCli(
+    ['lifecyclemodel', 'build-resulting-process', '--bad-flag'],
+    makeDeps(),
+  );
+  assert.equal(result.exitCode, 2);
+  assert.equal(result.stdout, '');
+  assert.match(result.stderr, /INVALID_ARGS/u);
+});
+
 test('executeCli executes validation run with injected implementation and report file', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-validation-cli-'));
 
@@ -570,6 +656,21 @@ test('executeCli returns planned command message for unimplemented command', asy
   assert.equal(result.exitCode, 2);
   assert.equal(result.stdout, '');
   assert.match(result.stderr, /not implemented yet/u);
+});
+
+test('executeCli returns planned command message for lifecyclemodel subcommands after help is introduced', async () => {
+  const result = await executeCli(['lifecyclemodel', 'auto-build'], makeDeps());
+  assert.equal(result.exitCode, 2);
+  assert.equal(result.stdout, '');
+  assert.match(result.stderr, /Command 'lifecyclemodel auto-build'/u);
+});
+
+test('executeCli returns dedicated help for planned lifecyclemodel subcommands', async () => {
+  const result = await executeCli(['lifecyclemodel', 'auto-build', '--help'], makeDeps());
+  assert.equal(result.exitCode, 0);
+  assert.match(result.stdout, /Planned contract:/u);
+  assert.match(result.stdout, /discover candidate processes/u);
+  assert.equal(result.stderr, '');
 });
 
 test('executeCli returns planned command message when a command is missing a subcommand', async () => {

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,6 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { loadDistModule } from './helpers/load-dist-module.js';
 import { CliError, toErrorPayload } from '../src/lib/errors.js';
+
+async function loadDistErrorsModule(): Promise<typeof import('../src/lib/errors.js')> {
+  return loadDistModule('src/lib/errors.js');
+}
 
 test('CliError stores code, exitCode, and details', () => {
   const error = new CliError('boom', {
@@ -50,6 +55,17 @@ test('toErrorPayload handles CliError, Error, and unknown values', () => {
     error: {
       code: 'UNKNOWN_THROWN_VALUE',
       message: 'weird',
+    },
+  });
+});
+
+test('error helpers behave the same from the built dist module', async () => {
+  const errors = await loadDistErrorsModule();
+
+  assert.deepEqual(errors.toErrorPayload(new errors.CliError('boom', { code: 'DIST_ERROR' })), {
+    error: {
+      code: 'DIST_ERROR',
+      message: 'boom',
     },
   });
 });

--- a/test/helpers/load-dist-module.ts
+++ b/test/helpers/load-dist-module.ts
@@ -1,0 +1,7 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export async function loadDistModule<T>(relativePath: string): Promise<T> {
+  const moduleUrl = pathToFileURL(path.join(process.cwd(), 'dist', relativePath)).href;
+  return (await import(moduleUrl)) as T;
+}

--- a/test/io.test.ts
+++ b/test/io.test.ts
@@ -3,7 +3,12 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { loadDistModule } from './helpers/load-dist-module.js';
 import { readJsonInput, stringifyJson } from '../src/lib/io.js';
+
+async function loadDistIoModule(): Promise<typeof import('../src/lib/io.js')> {
+  return loadDistModule('src/lib/io.js');
+}
 
 test('readJsonInput reads valid json files', () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-io-valid-'));
@@ -35,4 +40,10 @@ test('readJsonInput throws for missing and invalid files', () => {
 test('stringifyJson supports pretty and compact output', () => {
   assert.equal(stringifyJson({ hello: 'world' }, false), '{\n  "hello": "world"\n}\n');
   assert.equal(stringifyJson({ hello: 'world' }, true), '{"hello":"world"}\n');
+});
+
+test('io helpers behave the same from the built dist module', async () => {
+  const io = await loadDistIoModule();
+
+  assert.equal(io.stringifyJson({ hello: 'world' }, true), '{"hello":"world"}\n');
 });

--- a/test/lifecyclemodel-resulting-process.test.ts
+++ b/test/lifecyclemodel-resulting-process.test.ts
@@ -1,0 +1,2088 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { loadDistModule } from './helpers/load-dist-module.js';
+import { executeCli } from '../src/cli.js';
+import { CliError } from '../src/lib/errors.js';
+import {
+  __testInternals,
+  normalizeLifecyclemodelResultingProcessRequest,
+  runLifecyclemodelBuildResultingProcess,
+  type LifecyclemodelResultingProcessRequest,
+} from '../src/lib/lifecyclemodel-resulting-process.js';
+
+type JsonRecord = Record<string, unknown>;
+type PublicationKey = 'publicationAndOwnership' | 'common:publicationAndOwnership';
+
+const VERSION = '00.00.001';
+
+async function loadDistLifecyclemodelModule(): Promise<
+  typeof import('../src/lib/lifecyclemodel-resulting-process.js')
+> {
+  return loadDistModule('src/lib/lifecyclemodel-resulting-process.js');
+}
+
+async function loadDistLifecyclemodelTestInternals(): Promise<typeof __testInternals> {
+  const module = await loadDistLifecyclemodelModule();
+  return module.__testInternals;
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function writeText(filePath: string, text: string): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, text, 'utf8');
+}
+
+function readJson<T>(filePath: string): T {
+  return JSON.parse(readFileSync(filePath, 'utf8')) as T;
+}
+
+function assertCliErrorSync(
+  runner: () => unknown,
+  expectedCode: string,
+  expectedMessage?: RegExp,
+): void {
+  assert.throws(runner, (error) => {
+    assert.ok(error instanceof CliError);
+    assert.equal(error.code, expectedCode);
+    if (expectedMessage) {
+      assert.match(error.message, expectedMessage);
+    }
+    return true;
+  });
+}
+
+async function assertCliErrorAsync(
+  runner: () => Promise<unknown>,
+  expectedCode: string,
+  expectedMessage?: RegExp,
+): Promise<void> {
+  await assert.rejects(runner, (error) => {
+    assert.ok(error instanceof CliError);
+    assert.equal(error.code, expectedCode);
+    if (expectedMessage) {
+      assert.match(error.message, expectedMessage);
+    }
+    return true;
+  });
+}
+
+function createExchange(options: {
+  internalId: string;
+  flowId?: string | null;
+  direction?: string;
+  meanAmount?: number | string;
+  resultingAmount?: number | string;
+}): JsonRecord {
+  const exchange: JsonRecord = {
+    '@dataSetInternalID': options.internalId,
+    exchangeDirection: options.direction ?? 'Output',
+  };
+
+  if (options.flowId !== undefined) {
+    exchange.referenceToFlowDataSet =
+      options.flowId === null
+        ? {}
+        : {
+            '@refObjectId': options.flowId,
+            '@type': 'flow data set',
+          };
+  }
+  if (options.meanAmount !== undefined) {
+    exchange.meanAmount = options.meanAmount;
+  }
+  if (options.resultingAmount !== undefined) {
+    exchange.resultingAmount = options.resultingAmount;
+  }
+
+  return exchange;
+}
+
+function createProcessPayload(options: {
+  id?: string;
+  version?: string;
+  name?: unknown;
+  referenceInternalId: string;
+  exchanges: JsonRecord[] | JsonRecord;
+  wrap?: 'json_ordered' | 'json' | null;
+  includeAdministrative?: boolean;
+  includeModelling?: boolean;
+  publicationKey?: PublicationKey;
+  generalComment?: unknown;
+}): JsonRecord {
+  const dataSetInformation: JsonRecord = {};
+  if (options.id !== undefined) {
+    dataSetInformation['common:UUID'] = options.id;
+  }
+  if (options.name !== undefined) {
+    dataSetInformation.name = options.name;
+  }
+  if (options.generalComment !== undefined) {
+    dataSetInformation['common:generalComment'] = options.generalComment;
+  }
+
+  const dataset: JsonRecord = {
+    processInformation: {
+      dataSetInformation,
+      quantitativeReference: {
+        referenceToReferenceFlow: options.referenceInternalId,
+      },
+    },
+    exchanges: {
+      exchange: options.exchanges,
+    },
+  };
+
+  if (options.includeAdministrative !== false) {
+    dataset.administrativeInformation = {
+      [options.publicationKey ?? 'publicationAndOwnership']: {
+        'common:dataSetVersion': options.version ?? VERSION,
+      },
+    };
+  }
+
+  if (options.includeModelling !== false) {
+    dataset.modellingAndValidation = {
+      LCIMethodAndAllocation: {
+        typeOfDataSet: 'Unit process, single operation',
+      },
+    };
+  }
+
+  const directPayload = {
+    processDataSet: dataset,
+  };
+
+  if (options.wrap === 'json_ordered') {
+    return { json_ordered: directPayload };
+  }
+  if (options.wrap === 'json') {
+    return { json: directPayload };
+  }
+
+  return directPayload;
+}
+
+function createOutputExchange(options: {
+  id?: string;
+  flowId?: string | null;
+  downstreamId?: string | null;
+  downstreamFlowId?: string | null;
+}): JsonRecord {
+  const downstreamProcess: JsonRecord = {};
+  if (options.downstreamId !== undefined && options.downstreamId !== null) {
+    downstreamProcess['@id'] = options.downstreamId;
+  }
+  if (options.downstreamFlowId !== undefined && options.downstreamFlowId !== null) {
+    downstreamProcess['@flowUUID'] = options.downstreamFlowId;
+  }
+
+  const exchange: JsonRecord = {
+    downstreamProcess,
+  };
+  if (options.id) {
+    exchange['@id'] = options.id;
+  }
+  if (options.flowId !== undefined && options.flowId !== null) {
+    exchange['@flowUUID'] = options.flowId;
+  }
+
+  return exchange;
+}
+
+function createProcessInstance(options: {
+  instanceId: string;
+  processId: string;
+  version?: string;
+  factor?: string | number;
+  shortDescription?: unknown;
+  name?: unknown;
+  outputExchange?: JsonRecord[] | JsonRecord;
+}): JsonRecord {
+  const referenceToProcess: JsonRecord = {
+    '@refObjectId': options.processId,
+    '@version': options.version ?? VERSION,
+  };
+  if (options.shortDescription !== undefined) {
+    referenceToProcess['common:shortDescription'] = options.shortDescription;
+  }
+  if (options.name !== undefined) {
+    referenceToProcess.name = options.name;
+  }
+
+  return {
+    '@dataSetInternalID': options.instanceId,
+    '@multiplicationFactor': String(options.factor ?? '1'),
+    referenceToProcess,
+    connections: {
+      outputExchange: options.outputExchange ?? [],
+    },
+  };
+}
+
+function createLifecycleModel(options: {
+  id?: string;
+  version?: string;
+  namePayload?: unknown;
+  referenceToResultingProcess?: JsonRecord | null;
+  referenceProcessInstance?: unknown;
+  instances?: JsonRecord[] | JsonRecord;
+  includeWrapper?: boolean;
+  technologyInRoot?: boolean;
+  publicationKey?: PublicationKey;
+  jsonTgSubmodels?: unknown;
+}): JsonRecord {
+  const lifeCycleModelInformation: JsonRecord = {
+    dataSetInformation: {
+      'common:UUID': options.id ?? 'lm-demo',
+    },
+    quantitativeReference: {},
+  };
+
+  if (options.namePayload !== undefined) {
+    (lifeCycleModelInformation.dataSetInformation as JsonRecord).name = options.namePayload;
+  }
+  if (
+    options.referenceToResultingProcess !== undefined &&
+    options.referenceToResultingProcess !== null
+  ) {
+    (lifeCycleModelInformation.dataSetInformation as JsonRecord).referenceToResultingProcess =
+      options.referenceToResultingProcess;
+  }
+  if (options.referenceProcessInstance !== undefined) {
+    (lifeCycleModelInformation.quantitativeReference as JsonRecord).referenceToReferenceProcess =
+      options.referenceProcessInstance;
+  }
+  if (!options.technologyInRoot) {
+    lifeCycleModelInformation.technology = {
+      processes: {
+        processInstance: options.instances ?? [],
+      },
+    };
+  }
+
+  const root: JsonRecord = {
+    '@id': options.id ?? 'lm-demo',
+    '@version': options.version ?? VERSION,
+    lifeCycleModelInformation,
+    administrativeInformation: {
+      [options.publicationKey ?? 'publicationAndOwnership']: {
+        'common:dataSetVersion': options.version ?? VERSION,
+      },
+    },
+  };
+
+  if (options.technologyInRoot) {
+    root.technology = {
+      processes: {
+        processInstance: options.instances ?? [],
+      },
+    };
+  }
+  if (options.jsonTgSubmodels !== undefined) {
+    root.json_tg = {
+      submodels: options.jsonTgSubmodels,
+    };
+  }
+
+  return options.includeWrapper === false ? root : { lifeCycleModelDataSet: root };
+}
+
+test('normalizeLifecyclemodelResultingProcessRequest resolves paths and auto-detects process sources', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-normalize-'));
+  const modelPath = path.join(dir, 'tidas_bundle', 'lifecyclemodels', 'battery-model.json');
+  const localProcessesDir = path.join(dir, 'tidas_bundle', 'lifecyclemodels', 'processes');
+  const siblingProcessesDir = path.join(dir, 'tidas_bundle', 'processes');
+  const stemProcessesDir = path.join(dir, 'tidas_bundle', 'lifecyclemodels', 'battery-processes');
+  const catalogPath = path.join(dir, 'process-catalog.json');
+  const explicitJsonFile = path.join(dir, 'processes', `proc-demo_${VERSION}.json`);
+  const requestPath = path.join(dir, 'request.json');
+
+  writeJson(modelPath, createLifecycleModel({ instances: [] }));
+  mkdirSync(localProcessesDir, { recursive: true });
+  mkdirSync(siblingProcessesDir, { recursive: true });
+  mkdirSync(stemProcessesDir, { recursive: true });
+  writeJson(catalogPath, []);
+  writeJson(explicitJsonFile, {});
+
+  try {
+    const distModule = await loadDistLifecyclemodelModule();
+    const normalized = normalizeLifecyclemodelResultingProcessRequest(
+      {
+        source_model: {
+          json_ordered_path: pathToFileURL(modelPath).href,
+        },
+        projection: {
+          attach_graph_snapshot: 'true',
+          attach_graph_snapshot_uri: 'https://example.com/snapshots/model.png',
+        },
+        process_sources: {
+          run_dirs: './runs/demo-run',
+          process_json_files: './processes/proc-demo_00.00.001.json',
+          allow_mcp_lookup: 'true',
+        },
+      },
+      {
+        requestPath,
+      },
+    );
+
+    assert.equal(normalized.source_model.json_ordered_path, pathToFileURL(modelPath).href);
+    assert.equal(normalized.projection.mode, 'primary-only');
+    assert.equal(normalized.projection.attach_graph_snapshot, true);
+    assert.equal(
+      normalized.projection.attach_graph_snapshot_uri,
+      'https://example.com/snapshots/model.png',
+    );
+    assert.equal(normalized.process_sources.process_catalog_path, catalogPath);
+    assert.deepEqual(
+      normalized.process_sources.process_json_dirs.sort(),
+      [localProcessesDir, siblingProcessesDir, stemProcessesDir].sort(),
+    );
+    assert.deepEqual(normalized.process_sources.run_dirs, [path.join(dir, 'runs', 'demo-run')]);
+    assert.deepEqual(normalized.process_sources.process_json_files, [
+      path.join(dir, 'processes', 'proc-demo_00.00.001.json'),
+    ]);
+    assert.equal(normalized.process_sources.allow_remote_lookup, true);
+    assert.equal(normalized.publish.intent, 'dry_run');
+    assert.equal(normalized.publish.prepare_process_payloads, true);
+    assert.equal(normalized.publish.prepare_relation_payloads, true);
+
+    const normalizedFromFileUrls = normalizeLifecyclemodelResultingProcessRequest(
+      {
+        source_model: {
+          id: 'lm-file-urls',
+        },
+        process_sources: {
+          process_json_dirs: [pathToFileURL(localProcessesDir).href],
+          process_json_files: pathToFileURL(explicitJsonFile).href,
+        },
+        publish: {
+          prepare_process_payloads: false,
+          prepare_relation_payloads: false,
+        },
+      },
+      {
+        requestPath,
+      },
+    );
+    assert.deepEqual(normalizedFromFileUrls.process_sources.process_json_dirs, [localProcessesDir]);
+    assert.deepEqual(normalizedFromFileUrls.process_sources.process_json_files, [explicitJsonFile]);
+    assert.equal(normalizedFromFileUrls.publish.prepare_process_payloads, false);
+    assert.equal(normalizedFromFileUrls.publish.prepare_relation_payloads, false);
+
+    const normalizedFromDist = distModule.normalizeLifecyclemodelResultingProcessRequest(
+      {
+        source_model: {
+          json_ordered_path: pathToFileURL(modelPath).href,
+        },
+        process_sources: {
+          run_dirs: ['./runs/demo-run'],
+        },
+      },
+      {
+        requestPath,
+      },
+    );
+    assert.deepEqual(normalizedFromDist.process_sources.run_dirs, [
+      path.join(dir, 'runs', 'demo-run'),
+    ]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('normalizeLifecyclemodelResultingProcessRequest rejects malformed request shapes', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-normalize-errors-'));
+  const requestPath = path.join(dir, 'request.json');
+
+  try {
+    assertCliErrorSync(
+      () => normalizeLifecyclemodelResultingProcessRequest([], { requestPath }),
+      'LIFECYCLEMODEL_REQUEST_NOT_OBJECT',
+    );
+    assertCliErrorSync(
+      () => normalizeLifecyclemodelResultingProcessRequest({}, { requestPath }),
+      'LIFECYCLEMODEL_SOURCE_MODEL_REQUIRED',
+    );
+    assertCliErrorSync(
+      () =>
+        normalizeLifecyclemodelResultingProcessRequest(
+          {
+            source_model: {
+              json_ordered_path: 'https://example.com/model.json',
+            },
+            process_sources: {
+              process_catalog_path: 'https://example.com/process-catalog.json',
+            },
+          },
+          { requestPath },
+        ),
+      'LIFECYCLEMODEL_LOCAL_PATH_REQUIRED',
+    );
+    assertCliErrorSync(
+      () =>
+        normalizeLifecyclemodelResultingProcessRequest(
+          {
+            source_model: {
+              id: 'lm-demo',
+            },
+            process_sources: {
+              process_json_files: [42],
+            },
+          },
+          { requestPath },
+        ),
+      'LIFECYCLEMODEL_INVALID_STRING_ARRAY',
+    );
+    assertCliErrorSync(
+      () =>
+        normalizeLifecyclemodelResultingProcessRequest(
+          {
+            source_model: {
+              id: 'lm-demo',
+            },
+            projection: {
+              mode: 'invalid',
+            },
+          },
+          { requestPath },
+        ),
+      'LIFECYCLEMODEL_INVALID_PROJECTION_MODE',
+    );
+    assertCliErrorSync(
+      () =>
+        normalizeLifecyclemodelResultingProcessRequest(
+          {
+            source_model: {
+              id: 'lm-demo',
+            },
+            publish: {
+              intent: 'ship-it',
+            },
+          },
+          { requestPath },
+        ),
+      'LIFECYCLEMODEL_INVALID_PUBLISH_INTENT',
+    );
+    assertCliErrorSync(
+      () =>
+        normalizeLifecyclemodelResultingProcessRequest(
+          {
+            source_model: {
+              id: 'lm-demo',
+            },
+            projection: {
+              metadata_overrides: [],
+            },
+          },
+          { requestPath },
+        ),
+      'LIFECYCLEMODEL_INVALID_METADATA_OVERRIDES',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelBuildResultingProcess builds and aggregates a resulting process bundle', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-build-success-'));
+  const procCellPath = path.join(dir, 'inputs', `proc-cell-module_${VERSION}.json`);
+  const runDir = path.join(dir, 'runs', 'local-run');
+  const procPackPath = path.join(
+    runDir,
+    'exports',
+    'processes',
+    `proc-pack-assembly_${VERSION}.json`,
+  );
+  const snapshotPath = path.join(dir, 'snapshot.png');
+  const catalogPath = path.join(dir, 'process-catalog.json');
+  const requestPath = path.join(dir, 'request.json');
+  const outDir = path.join(dir, 'out');
+  const now = new Date('2026-03-29T00:00:00.000Z');
+
+  const model = createLifecycleModel({
+    id: 'lm-demo-battery-pack',
+    version: VERSION,
+    namePayload: 'Battery pack model',
+    referenceProcessInstance: '2',
+    includeWrapper: false,
+    instances: [
+      createProcessInstance({
+        instanceId: '1',
+        processId: 'proc-cell-module',
+        shortDescription: [
+          {
+            '@xml:lang': 'en',
+            '#text': 'Cell module assembly',
+          },
+        ],
+        outputExchange: [
+          createOutputExchange({
+            id: 'edge-cell-to-pack',
+            flowId: 'flow-cell-module',
+            downstreamId: '2',
+            downstreamFlowId: 'flow-cell-module',
+          }),
+          createOutputExchange({
+            id: 'edge-ghost',
+            flowId: 'flow-ghost',
+            downstreamId: '999',
+          }),
+          createOutputExchange({
+            id: 'edge-without-flow',
+            downstreamId: '2',
+          }),
+        ],
+      }),
+      createProcessInstance({
+        instanceId: '2',
+        processId: 'proc-pack-assembly',
+        shortDescription: [
+          {
+            '@xml:lang': 'en',
+            '#text': 'Pack assembly',
+          },
+        ],
+        outputExchange: [],
+      }),
+      createProcessInstance({
+        instanceId: '3',
+        processId: 'proc-pack-assembly',
+        factor: '0',
+        shortDescription: [
+          {
+            '@xml:lang': 'en',
+            '#text': 'Pack assembly duplicate',
+          },
+        ],
+      }),
+    ],
+  });
+
+  writeJson(
+    procCellPath,
+    createProcessPayload({
+      id: 'proc-cell-module',
+      referenceInternalId: '2',
+      wrap: 'json_ordered',
+      name: {
+        baseName: [
+          {
+            '@xml:lang': 'en',
+            '#text': 'Cell module assembly',
+          },
+        ],
+      },
+      generalComment: [
+        {
+          '@xml:lang': 'en',
+          '#text': 'Cell module comment',
+        },
+      ],
+      exchanges: [
+        createExchange({
+          internalId: '1',
+          flowId: 'flow-electricity',
+          direction: 'Input',
+          meanAmount: 5,
+          resultingAmount: 5,
+        }),
+        createExchange({
+          internalId: '1b',
+          flowId: 'flow-electricity',
+          direction: 'Input',
+          resultingAmount: 0.5,
+        }),
+        createExchange({
+          internalId: '1c',
+          flowId: null,
+          direction: 'Input',
+          meanAmount: 99,
+        }),
+        createExchange({
+          internalId: '1d',
+          flowId: 'flow-ignored',
+          direction: 'Other',
+          meanAmount: 2,
+        }),
+        createExchange({
+          internalId: '2',
+          flowId: 'flow-cell-module',
+          direction: 'Output',
+          meanAmount: 1,
+          resultingAmount: 1,
+        }),
+      ],
+    }),
+  );
+  writeJson(
+    procPackPath,
+    createProcessPayload({
+      id: 'proc-pack-assembly',
+      referenceInternalId: '3',
+      name: {
+        baseName: [
+          {
+            '@xml:lang': 'en',
+            '#text': 'Pack assembly',
+          },
+        ],
+      },
+      generalComment: [
+        {
+          '@xml:lang': 'en',
+          '#text': 'Pack assembly comment',
+        },
+      ],
+      exchanges: [
+        createExchange({
+          internalId: '1',
+          flowId: 'flow-cell-module',
+          direction: 'Input',
+          meanAmount: 1,
+          resultingAmount: 1,
+        }),
+        createExchange({
+          internalId: '2',
+          flowId: 'flow-bms',
+          direction: 'Input',
+          meanAmount: 1,
+          resultingAmount: 1,
+        }),
+        createExchange({
+          internalId: '3',
+          flowId: 'flow-battery-pack',
+          direction: 'Output',
+          resultingAmount: 1,
+        }),
+      ],
+    }),
+  );
+  writeJson(catalogPath, [
+    {
+      source_label: runDir,
+    },
+    {
+      ignored: true,
+    },
+  ]);
+  writeText(snapshotPath, 'binary');
+  writeJson(requestPath, {
+    source_model: {
+      json_ordered: model,
+    },
+    projection: {
+      mode: 'primary-only',
+      process_id: 'proc-demo-battery-pack-primary',
+      process_version: VERSION,
+      metadata_overrides: {
+        type_of_data_set: 'partly terminated system',
+        projection_source: 'unit-test',
+      },
+      attach_graph_snapshot_uri: pathToFileURL(snapshotPath).href,
+    },
+    process_sources: {
+      process_catalog_path: catalogPath,
+      run_dirs: [runDir],
+      process_json_files: [procCellPath],
+      allow_remote_lookup: false,
+    },
+    publish: {
+      intent: 'prepare_only',
+      prepare_process_payloads: true,
+      prepare_relation_payloads: true,
+    },
+  });
+
+  try {
+    const report = await runLifecyclemodelBuildResultingProcess({
+      inputPath: requestPath,
+      outDir,
+      now,
+    });
+
+    assert.equal(report.generated_at_utc, now.toISOString());
+    assert.equal(report.out_dir, outDir);
+    assert.equal(report.status, 'prepared_local_bundle');
+    assert.equal(report.projected_process_count, 1);
+    assert.equal(report.relation_count, 1);
+    assert.equal(report.source_model.id, 'lm-demo-battery-pack');
+    assert.equal(report.source_model.json_ordered_path, null);
+
+    const normalizedRequest = readJson<JsonRecord>(report.files.normalized_request);
+    const projectionReport = readJson<JsonRecord>(report.files.projection_report);
+    const bundle = readJson<JsonRecord>(report.files.process_projection_bundle);
+
+    assert.equal(
+      (normalizedRequest.process_sources as JsonRecord).process_catalog_path,
+      catalogPath,
+    );
+    assert.equal(projectionReport.node_count as number, 3);
+    assert.equal(projectionReport.edge_count as number, 3);
+
+    const projectedProcess = ((bundle.projected_processes as JsonRecord[])[0] as JsonRecord)
+      .json_ordered as JsonRecord;
+    const processDataSet = projectedProcess.processDataSet as JsonRecord;
+    const processInformation = processDataSet.processInformation as JsonRecord;
+    const dataSetInformation = processInformation.dataSetInformation as JsonRecord;
+    const quantitativeReference = processInformation.quantitativeReference as JsonRecord;
+    const technology = processInformation.technology as JsonRecord;
+    const metadata = projectedProcess.projectionMetadata as JsonRecord;
+    const exchangesWrapper = processDataSet.exchanges as JsonRecord;
+    const exchanges = exchangesWrapper.exchange as JsonRecord[];
+    const flowIds = exchanges.map((item) => {
+      const referenceToFlow = item.referenceToFlowDataSet as JsonRecord;
+      return referenceToFlow['@refObjectId'];
+    });
+
+    assert.equal(dataSetInformation['common:UUID'], 'proc-demo-battery-pack-primary');
+    assert.equal(quantitativeReference.referenceToReferenceFlow, '1');
+    assert.deepEqual(flowIds, ['flow-battery-pack', 'flow-bms', 'flow-electricity']);
+    assert.deepEqual(
+      exchanges.map((item) => [item.exchangeDirection, item.meanAmount]),
+      [
+        ['Output', 1],
+        ['Input', 1],
+        ['Input', 5.5],
+      ],
+    );
+    assert.equal((exchanges[0] as JsonRecord).quantitativeReference, true);
+    assert.equal((exchanges[2] as JsonRecord).quantitativeReference, false);
+    assert.equal(metadata.graph_snapshot_uri, pathToFileURL(snapshotPath).href);
+    assert.equal(metadata.projection_source, 'unit-test');
+    assert.equal(metadata.type_of_data_set, 'partly terminated system');
+    assert.deepEqual(projectedProcess.topologySummary, {
+      process_instance_count: 3,
+      edge_count: 3,
+    });
+    assert.equal((technology.referenceToIncludedProcesses as JsonRecord[]).length, 3);
+    assert.equal((dataSetInformation['common:generalComment'] as JsonRecord[]).length, 3);
+    assert.equal(
+      ((processDataSet.modellingAndValidation as JsonRecord).LCIMethodAndAllocation as JsonRecord)
+        .typeOfDataSet,
+      'partly terminated system',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelBuildResultingProcess auto-detects process dirs and writes a default run directory', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-autodetect-'));
+  const modelPath = path.join(dir, 'tidas_bundle', 'lifecyclemodels', 'solo_model.json');
+  const processDir = path.join(dir, 'tidas_bundle', 'lifecyclemodels', 'solo_processes');
+  const processPath = path.join(processDir, `proc-solo_${VERSION}.json`);
+  const catalogPath = path.join(dir, 'process-catalog.json');
+  const requestPath = path.join(dir, 'request.json');
+  const now = new Date('2026-03-29T01:02:03.000Z');
+
+  writeJson(
+    modelPath,
+    createLifecycleModel({
+      id: 'lm-solo',
+      version: VERSION,
+      namePayload: {
+        shortName: {
+          '#text': 'Solo model',
+        },
+      },
+      referenceToResultingProcess: {
+        id: 'proc-solo-result',
+        version: VERSION,
+      },
+      referenceProcessInstance: {
+        id: 'solo-inst',
+      },
+      technologyInRoot: true,
+      publicationKey: 'common:publicationAndOwnership',
+      jsonTgSubmodels: [
+        {
+          id: 'submodel-1',
+        },
+      ],
+      instances: createProcessInstance({
+        instanceId: 'solo-inst',
+        processId: 'proc-solo',
+        factor: 2,
+        name: 'Solo process',
+      }),
+    }),
+  );
+  writeJson(
+    processPath,
+    createProcessPayload({
+      id: 'proc-solo',
+      referenceInternalId: '1',
+      wrap: 'json',
+      includeAdministrative: false,
+      includeModelling: false,
+      exchanges: createExchange({
+        internalId: '1',
+        flowId: 'flow-solo-product',
+        direction: 'Output',
+        meanAmount: 1,
+      }),
+    }),
+  );
+  writeText(catalogPath, 'not-json');
+  writeJson(requestPath, {
+    source_model: {
+      json_ordered_path: './tidas_bundle/lifecyclemodels/solo_model.json',
+    },
+    projection: {
+      mode: 'all-subproducts',
+    },
+    process_sources: {
+      allow_mcp_lookup: 'false',
+    },
+    publish: {
+      intent: 'publish',
+    },
+  });
+
+  try {
+    const report = await runLifecyclemodelBuildResultingProcess({
+      inputPath: requestPath,
+      now,
+    });
+
+    assert.match(report.out_dir, /artifacts\/lifecyclemodel_resulting_process\//u);
+    assert.equal(report.status, 'projected_local_bundle');
+    assert.equal(report.source_model.id, 'lm-solo');
+    assert.equal(report.source_model.name, 'Solo model');
+    assert.equal(report.source_model.reference_to_resulting_process_id, 'proc-solo-result');
+    assert.equal(report.source_model.reference_process_instance_id, 'solo-inst');
+
+    const normalizedRequest = readJson<JsonRecord>(report.files.normalized_request);
+    const projectionReport = readJson<JsonRecord>(report.files.projection_report);
+    const bundle = readJson<JsonRecord>(report.files.process_projection_bundle);
+
+    assert.equal(
+      (normalizedRequest.process_sources as JsonRecord).process_catalog_path,
+      catalogPath,
+    );
+    assert.deepEqual((normalizedRequest.process_sources as JsonRecord).process_json_dirs, [
+      processDir,
+    ]);
+    assert.equal(projectionReport.status as string, 'projected_local_bundle');
+    assert.match(
+      (projectionReport.notes as string[])[2] as string,
+      /only carries submodel metadata/u,
+    );
+
+    const projectedProcess = ((bundle.projected_processes as JsonRecord[])[0] as JsonRecord)
+      .json_ordered as JsonRecord;
+    const processDataSet = projectedProcess.processDataSet as JsonRecord;
+    const exchanges = (processDataSet.exchanges as JsonRecord).exchange as JsonRecord;
+    const processInformation = processDataSet.processInformation as JsonRecord;
+    const technology = processInformation.technology as JsonRecord;
+    const metadata = projectedProcess.projectionMetadata as JsonRecord;
+
+    assert.equal(
+      (processInformation.dataSetInformation as JsonRecord)['common:UUID'] as string,
+      'proc-solo-result',
+    );
+    assert.equal(exchanges.meanAmount, 2);
+    assert.equal(exchanges.resultingAmount, undefined);
+    assert.equal(
+      (exchanges.referenceToFlowDataSet as JsonRecord)['@refObjectId'] as string,
+      'flow-solo-product',
+    );
+    assert.equal(
+      (technology.referenceToIncludedProcesses as JsonRecord)['@refObjectId'] as string,
+      'proc-solo',
+    );
+    assert.equal(metadata.graph_snapshot_uri, undefined);
+    assert.equal(metadata.type_of_data_set, 'partly terminated system');
+    assert.equal(
+      ((processDataSet.modellingAndValidation as JsonRecord).LCIMethodAndAllocation as JsonRecord)
+        .typeOfDataSet,
+      'partly terminated system',
+    );
+    assert.equal(
+      ((bundle.projected_processes as JsonRecord[])[0] as JsonRecord).id,
+      'proc-solo-result',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelBuildResultingProcess rejects unresolved process lookups and invalid source payloads', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-build-errors-a-'));
+  const modelPath = path.join(dir, 'model.json');
+  const requestPath = path.join(dir, 'request.json');
+
+  writeJson(
+    modelPath,
+    createLifecycleModel({
+      id: 'lm-errors',
+      version: VERSION,
+      namePayload: 'Error model',
+      referenceProcessInstance: '1',
+      instances: createProcessInstance({
+        instanceId: '1',
+        processId: 'proc-missing',
+      }),
+    }),
+  );
+
+  try {
+    writeJson(requestPath, {
+      source_model: {
+        id: 'lm-only',
+      },
+    });
+    await assertCliErrorAsync(
+      () => runLifecyclemodelBuildResultingProcess({ inputPath: requestPath }),
+      'LIFECYCLEMODEL_SOURCE_MODEL_PATH_REQUIRED',
+    );
+
+    writeJson(requestPath, {
+      source_model: {
+        json_ordered_path: 'https://example.com/model.json',
+      },
+    });
+    await assertCliErrorAsync(
+      () => runLifecyclemodelBuildResultingProcess({ inputPath: requestPath }),
+      'LIFECYCLEMODEL_LOCAL_PATH_REQUIRED',
+    );
+
+    writeJson(modelPath, []);
+    writeJson(requestPath, {
+      source_model: {
+        json_ordered_path: './model.json',
+      },
+    });
+    await assertCliErrorAsync(
+      () => runLifecyclemodelBuildResultingProcess({ inputPath: requestPath }),
+      'LIFECYCLEMODEL_SOURCE_MODEL_NOT_OBJECT',
+    );
+
+    writeJson(
+      modelPath,
+      createLifecycleModel({
+        id: 'lm-errors',
+        version: VERSION,
+        namePayload: 'Error model',
+        referenceProcessInstance: '1',
+        instances: createProcessInstance({
+          instanceId: '1',
+          processId: 'proc-missing',
+        }),
+      }),
+    );
+    writeJson(requestPath, {
+      source_model: {
+        json_ordered_path: './model.json',
+      },
+      process_sources: {
+        allow_remote_lookup: false,
+      },
+    });
+    await assertCliErrorAsync(
+      () => runLifecyclemodelBuildResultingProcess({ inputPath: requestPath }),
+      'LIFECYCLEMODEL_PROCESS_RESOLUTION_FAILED',
+    );
+
+    writeJson(requestPath, {
+      source_model: {
+        json_ordered_path: './model.json',
+      },
+      process_sources: {
+        allow_remote_lookup: true,
+      },
+    });
+    await assertCliErrorAsync(
+      () => runLifecyclemodelBuildResultingProcess({ inputPath: requestPath }),
+      'LIFECYCLEMODEL_REMOTE_LOOKUP_NOT_IMPLEMENTED',
+    );
+
+    writeJson(requestPath, {
+      source_model: {
+        json_ordered_path: './model.json',
+      },
+      process_sources: {
+        process_json_files: ['./proc-missing_00.00.001.json'],
+      },
+    });
+    writeJson(path.join(dir, `proc-missing_${VERSION}.json`), []);
+    await assertCliErrorAsync(
+      () => runLifecyclemodelBuildResultingProcess({ inputPath: requestPath }),
+      'LIFECYCLEMODEL_PROCESS_FILE_NOT_OBJECT',
+    );
+
+    writeJson(path.join(dir, `proc-missing_${VERSION}.json`), {
+      json_ordered: {},
+    });
+    await assertCliErrorAsync(
+      () => runLifecyclemodelBuildResultingProcess({ inputPath: requestPath }),
+      'LIFECYCLEMODEL_PROCESS_DATASET_REQUIRED',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelBuildResultingProcess rejects invalid process payload semantics and missing topology', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-build-errors-b-'));
+  const requestPath = path.join(dir, 'request.json');
+  const modelPath = path.join(dir, 'model.json');
+  const processPath = path.join(dir, `proc-error_${VERSION}.json`);
+
+  try {
+    writeJson(
+      modelPath,
+      createLifecycleModel({
+        id: 'lm-invalid',
+        version: VERSION,
+        namePayload: 'Invalid model',
+        referenceProcessInstance: '1',
+        instances: createProcessInstance({
+          instanceId: '1',
+          processId: 'proc-error',
+          factor: 'bad-number',
+        }),
+      }),
+    );
+    writeJson(requestPath, {
+      source_model: {
+        json_ordered_path: './model.json',
+      },
+      process_sources: {
+        process_json_files: ['./proc-error_00.00.001.json'],
+      },
+    });
+    writeJson(
+      processPath,
+      createProcessPayload({
+        id: 'proc-error',
+        referenceInternalId: '1',
+        exchanges: createExchange({
+          internalId: '1',
+          flowId: 'flow-product',
+          direction: 'Output',
+          meanAmount: 1,
+        }),
+      }),
+    );
+    await assertCliErrorAsync(
+      () => runLifecyclemodelBuildResultingProcess({ inputPath: requestPath }),
+      'LIFECYCLEMODEL_INVALID_NUMBER',
+    );
+
+    writeJson(
+      modelPath,
+      createLifecycleModel({
+        id: 'lm-invalid',
+        version: VERSION,
+        namePayload: 'Invalid model',
+        referenceProcessInstance: '1',
+        instances: createProcessInstance({
+          instanceId: '1',
+          processId: 'proc-error',
+        }),
+      }),
+    );
+    writeJson(
+      processPath,
+      createProcessPayload({
+        referenceInternalId: '1',
+        exchanges: createExchange({
+          internalId: '1',
+          flowId: 'flow-product',
+          direction: 'Output',
+          meanAmount: 1,
+        }),
+      }),
+    );
+    await assertCliErrorAsync(
+      () => runLifecyclemodelBuildResultingProcess({ inputPath: requestPath }),
+      'LIFECYCLEMODEL_PROCESS_UUID_REQUIRED',
+    );
+
+    writeJson(
+      processPath,
+      createProcessPayload({
+        id: 'proc-error',
+        referenceInternalId: '999',
+        exchanges: createExchange({
+          internalId: '1',
+          flowId: 'flow-product',
+          direction: 'Output',
+          meanAmount: 1,
+        }),
+      }),
+    );
+    await assertCliErrorAsync(
+      () => runLifecyclemodelBuildResultingProcess({ inputPath: requestPath }),
+      'LIFECYCLEMODEL_REFERENCE_EXCHANGE_NOT_FOUND',
+    );
+
+    writeJson(
+      modelPath,
+      createLifecycleModel({
+        id: 'lm-empty',
+        version: VERSION,
+        namePayload: 'Empty model',
+        referenceProcessInstance: '1',
+        instances: [],
+      }),
+    );
+    writeJson(requestPath, {
+      source_model: {
+        json_ordered_path: './model.json',
+      },
+    });
+    await assertCliErrorAsync(
+      () => runLifecyclemodelBuildResultingProcess({ inputPath: requestPath }),
+      'LIFECYCLEMODEL_PROCESS_INSTANCES_REQUIRED',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelBuildResultingProcess rejects projections without an external reference output', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-build-errors-c-'));
+  const requestPath = path.join(dir, 'request.json');
+  const modelPath = path.join(dir, 'model.json');
+  const upstreamPath = path.join(dir, `proc-upstream_${VERSION}.json`);
+  const downstreamPath = path.join(dir, `proc-downstream_${VERSION}.json`);
+
+  writeJson(
+    modelPath,
+    createLifecycleModel({
+      id: 'lm-no-reference-output',
+      version: VERSION,
+      namePayload: 'No external reference output',
+      referenceProcessInstance: '1',
+      instances: [
+        createProcessInstance({
+          instanceId: '1',
+          processId: 'proc-upstream',
+          shortDescription: 'Upstream',
+          outputExchange: createOutputExchange({
+            id: 'edge-upstream-downstream',
+            flowId: 'flow-intermediate',
+            downstreamId: '2',
+            downstreamFlowId: 'flow-intermediate',
+          }),
+        }),
+        createProcessInstance({
+          instanceId: '2',
+          processId: 'proc-downstream',
+          shortDescription: 'Downstream',
+        }),
+      ],
+    }),
+  );
+  writeJson(
+    upstreamPath,
+    createProcessPayload({
+      id: 'proc-upstream',
+      referenceInternalId: '1',
+      exchanges: createExchange({
+        internalId: '1',
+        flowId: 'flow-intermediate',
+        direction: 'Output',
+        meanAmount: 1,
+      }),
+    }),
+  );
+  writeJson(
+    downstreamPath,
+    createProcessPayload({
+      id: 'proc-downstream',
+      referenceInternalId: '2',
+      exchanges: [
+        createExchange({
+          internalId: '1',
+          flowId: 'flow-intermediate',
+          direction: 'Input',
+          meanAmount: 1,
+        }),
+        createExchange({
+          internalId: '2',
+          flowId: 'flow-final',
+          direction: 'Output',
+          meanAmount: 1,
+        }),
+      ],
+    }),
+  );
+  writeJson(requestPath, {
+    source_model: {
+      json_ordered_path: './model.json',
+    },
+    process_sources: {
+      process_json_files: ['./proc-upstream_00.00.001.json', './proc-downstream_00.00.001.json'],
+      allow_remote_lookup: false,
+    },
+  });
+
+  try {
+    await assertCliErrorAsync(
+      () => runLifecyclemodelBuildResultingProcess({ inputPath: requestPath }),
+      'LIFECYCLEMODEL_REFERENCE_OUTPUT_REQUIRED',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli can run lifecyclemodel build-resulting-process end to end', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-cli-e2e-'));
+  const modelPath = path.join(dir, 'model.json');
+  const processPath = path.join(dir, `proc-cli_${VERSION}.json`);
+  const requestPath = path.join(dir, 'request.json');
+
+  writeJson(
+    modelPath,
+    createLifecycleModel({
+      id: 'lm-cli',
+      version: VERSION,
+      namePayload: 'CLI model',
+      referenceProcessInstance: {
+        '@refObjectId': 'cli-inst',
+      },
+      referenceToResultingProcess: {
+        '@refObjectId': 'proc-cli-result',
+        '@version': VERSION,
+      },
+      instances: createProcessInstance({
+        instanceId: 'cli-inst',
+        processId: 'proc-cli',
+        name: {
+          name: {
+            text: 'CLI process',
+          },
+        },
+      }),
+    }),
+  );
+  writeJson(
+    processPath,
+    createProcessPayload({
+      id: 'proc-cli',
+      referenceInternalId: '1',
+      exchanges: createExchange({
+        internalId: '1',
+        flowId: 'flow-cli-product',
+        direction: 'Output',
+        meanAmount: 1,
+      }),
+    }),
+  );
+  writeJson(requestPath, {
+    source_model: {
+      json_ordered_path: './model.json',
+    },
+    process_sources: {
+      process_json_files: ['./proc-cli_00.00.001.json'],
+      allow_mcp_lookup: 'false',
+    },
+    publish: {
+      intent: 'dry_run',
+    },
+  });
+
+  try {
+    const result = await executeCli(
+      ['lifecyclemodel', 'build-resulting-process', '--input', requestPath, '--json'],
+      {
+        env: process.env,
+        dotEnvStatus: {
+          loaded: false,
+          path: '/tmp/.env',
+          count: 0,
+        },
+        fetchImpl: async () => ({
+          ok: true,
+          status: 200,
+          headers: {
+            get: () => 'application/json',
+          },
+          text: async () => '{}',
+        }),
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stderr, '');
+
+    const payload = JSON.parse(result.stdout) as JsonRecord;
+    assert.equal(payload.status, 'prepared_local_bundle');
+    assert.equal(payload.projected_process_count, 1);
+    assert.equal((payload.source_model as JsonRecord).reference_process_instance_id, 'cli-inst');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('lifecyclemodel internal helpers cover primitive fallback branches', async () => {
+  const internals = await loadDistLifecyclemodelTestInternals();
+
+  assert.deepEqual(internals.uniqueStrings([null, 'a', 'a', 'b']), ['a', 'b']);
+  assert.equal(internals.toFiniteNumber(undefined, 'missing-number'), 0);
+  assert.equal(internals.normalizeNumericOutput(-0), 0);
+  assert.equal(internals.toBoolean('false', true), false);
+  assert.equal(internals.toBoolean('fallback-true', false), true);
+  assert.equal(internals.resolveNameField('  trimmed  '), 'trimmed');
+  assert.equal(internals.resolveNameField('   '), null);
+  assert.equal(internals.resolveNameField([{ '#text': 'from-array' }]), 'from-array');
+  assert.equal(internals.resolveNameField([{ unused: true }]), null);
+  assert.equal(internals.resolveNameField({ shortName: { '#text': 'short-name' } }), 'short-name');
+  assert.equal(internals.resolveNameField({ name: 'plain-name' }), 'plain-name');
+  assert.deepEqual(internals.normalizedNameInfo({}, 'fallback-name'), {
+    baseName: [
+      {
+        '@xml:lang': 'en',
+        '#text': 'fallback-name',
+      },
+    ],
+  });
+
+  const fallbackIdentity = internals.modelIdentifier(
+    {},
+    {
+      id: null,
+      version: null,
+      name: null,
+      json_ordered_path: null,
+      json_ordered: null,
+    },
+  );
+  assert.match(fallbackIdentity.id, /^lm-[0-9a-f]{12}$/u);
+  assert.equal(fallbackIdentity.version, VERSION);
+  assert.equal(fallbackIdentity.name, fallbackIdentity.id);
+
+  assert.deepEqual(internals.referenceToResultingProcess({}), {
+    id: null,
+    version: null,
+  });
+  assert.equal(internals.referenceProcessInstanceId({}), null);
+});
+
+test('lifecyclemodel internal helpers cover extraction, parsing, and discovery fallbacks', async () => {
+  const internals = await loadDistLifecyclemodelTestInternals();
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-internals-'));
+  const modelPath = path.join(dir, 'alt', 'custom', 'model.json');
+  const requestModelPath = path.join(dir, 'embedded-model.json');
+  const runDir = path.join(dir, 'run-source');
+  const catalogPath = path.join(dir, 'catalog.json');
+  const explicitFile = path.join(dir, `proc-explicit_${VERSION}.json`);
+  const processDir = path.join(runDir, 'exports', 'processes');
+  const fromDir = path.join(processDir, `proc-dir_${VERSION}.json`);
+
+  mkdirSync(path.dirname(modelPath), { recursive: true });
+  writeText(modelPath, '{}');
+  writeJson(requestModelPath, createLifecycleModel({ instances: [] }));
+  mkdirSync(processDir, { recursive: true });
+  writeJson(fromDir, {});
+  writeJson(explicitFile, {});
+  writeJson(catalogPath, [
+    {
+      source_label: runDir,
+    },
+    {
+      source_label: '',
+    },
+  ]);
+
+  try {
+    const extractedInstances = internals.extractProcessInstances({
+      technology: {
+        processes: {
+          processInstance: [
+            {},
+            {
+              '@dataSetInternalID': 'second',
+              referenceToProcess: {
+                '@refObjectId': 'proc-duplicate',
+              },
+            },
+            {
+              '@dataSetInternalID': 'third',
+              referenceToProcess: {
+                '@refObjectId': 'proc-duplicate',
+              },
+            },
+          ],
+        },
+      },
+    });
+    assert.deepEqual(
+      extractedInstances.map((item) => ({
+        instance_id: item.instance_id,
+        process_id: item.process_id,
+        version: item.process_version,
+        label: item.label,
+        factor: item.multiplication_factor,
+      })),
+      [
+        {
+          instance_id: 'pi-1',
+          process_id: 'proc-1',
+          version: VERSION,
+          label: 'process-1',
+          factor: 0,
+        },
+        {
+          instance_id: 'second',
+          process_id: 'proc-duplicate',
+          version: VERSION,
+          label: 'proc-duplicate',
+          factor: 0,
+        },
+        {
+          instance_id: 'third',
+          process_id: 'proc-duplicate',
+          version: VERSION,
+          label: 'proc-duplicate',
+          factor: 0,
+        },
+      ],
+    );
+    assert.deepEqual(internals.extractProcessInstances({}), []);
+    assert.deepEqual(
+      internals.processReferencePairs({
+        technology: {
+          processes: {
+            processInstance: [
+              {
+                '@dataSetInternalID': 'one',
+                referenceToProcess: {
+                  '@refObjectId': 'proc-a',
+                },
+              },
+              {
+                '@dataSetInternalID': 'two',
+                referenceToProcess: {
+                  '@refObjectId': 'proc-a',
+                },
+              },
+            ],
+          },
+        },
+      }),
+      [{ process_id: 'proc-a', version: VERSION }],
+    );
+
+    assert.deepEqual(
+      internals.extractEdges({
+        technology: {
+          processes: {
+            processInstance: {
+              '@dataSetInternalID': 'proc-edge',
+              referenceToProcess: {
+                '@refObjectId': 'proc-edge',
+              },
+              connections: {
+                outputExchange: [
+                  {
+                    downstreamProcess: {},
+                  },
+                  {
+                    flowUUID: 'flow-edge',
+                    downstreamProcess: {
+                      '@id': 'downstream',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+      [
+        {
+          edge_id: 'proc-edge-edge-2-1',
+          from: 'proc-edge',
+          to: 'downstream',
+          exchange_id: null,
+          flow_uuid: 'flow-edge',
+        },
+      ],
+    );
+    assert.deepEqual(
+      internals.extractEdges({
+        technology: {
+          processes: {
+            processInstance: {
+              '@dataSetInternalID': 'proc-no-connections',
+              referenceToProcess: {
+                '@refObjectId': 'proc-no-connections',
+              },
+            },
+          },
+        },
+      }),
+      [],
+    );
+
+    const parsedRecord = internals.parseProcessRecord(
+      {
+        processDataSet: {
+          processInformation: {
+            dataSetInformation: {
+              'common:UUID': 'proc-parse',
+            },
+            quantitativeReference: {
+              referenceToReferenceFlow: '1',
+            },
+          },
+          exchanges: {
+            exchange: [
+              {
+                '@dataSetInternalID': '1',
+              },
+              {
+                '@dataSetInternalID': '2',
+                referenceToFlowDataSet: {
+                  '@refObjectId': 'flow-input',
+                },
+                exchangeDirection: 'Input',
+              },
+            ],
+          },
+        },
+      },
+      {
+        sourceLabel: 'parse-test',
+        sourcePath: null,
+      },
+    );
+    assert.equal(parsedRecord.version, VERSION);
+    assert.equal(parsedRecord.referenceFlowUuid, '');
+    assert.equal(parsedRecord.referenceDirection, '');
+    assert.equal(parsedRecord.referenceAmount, 0);
+    assert.equal(parsedRecord.inputAmounts['flow-input'], 0);
+
+    const blankReferenceRecord = internals.parseProcessRecord(
+      {
+        processDataSet: {
+          processInformation: {
+            dataSetInformation: {
+              'common:UUID': 'proc-blank',
+            },
+          },
+          exchanges: {
+            exchange: {
+              exchangeDirection: 'Output',
+              referenceToFlowDataSet: {
+                '@refObjectId': 'flow-blank',
+              },
+            },
+          },
+        },
+      },
+      {
+        sourceLabel: 'blank-reference',
+        sourcePath: null,
+      },
+    );
+    assert.equal(blankReferenceRecord.referenceExchangeInternalId, '');
+    assert.equal(blankReferenceRecord.referenceFlowUuid, 'flow-blank');
+
+    assert.throws(
+      () =>
+        internals.parseProcessRecord(
+          {
+            processDataSet: {},
+          },
+          {
+            sourceLabel: 'missing-info',
+            sourcePath: null,
+          },
+        ),
+      (error) => {
+        assert.equal((error as { code?: string }).code, 'LIFECYCLEMODEL_PROCESS_UUID_REQUIRED');
+        return true;
+      },
+    );
+    assert.throws(
+      () =>
+        internals.parseProcessRecord(
+          {
+            processDataSet: {
+              processInformation: {
+                dataSetInformation: {
+                  'common:UUID': 'proc-missing-reference',
+                },
+              },
+            },
+          },
+          {
+            sourceLabel: 'missing-reference',
+            sourcePath: null,
+          },
+        ),
+      (error) => {
+        assert.equal(
+          (error as { code?: string }).code,
+          'LIFECYCLEMODEL_REFERENCE_EXCHANGE_NOT_FOUND',
+        );
+        assert.match(String((error as { message?: string }).message), /\(missing\)/u);
+        return true;
+      },
+    );
+
+    assert.equal(internals.autoDetectProcessCatalogPath(null), null);
+    assert.equal(internals.autoDetectProcessCatalogPath(modelPath), null);
+    const notBundleModelPath = path.join(
+      dir,
+      'not-bundle',
+      'lifecyclemodels',
+      'battery-model.json',
+    );
+    writeText(notBundleModelPath, '{}');
+    assert.equal(internals.autoDetectProcessCatalogPath(notBundleModelPath), null);
+    const bundleModelPath = path.join(
+      dir,
+      'bundle-missing',
+      'tidas_bundle',
+      'lifecyclemodels',
+      'battery_model.json',
+    );
+    writeText(bundleModelPath, '{}');
+    assert.equal(internals.autoDetectProcessCatalogPath(bundleModelPath), null);
+    assert.deepEqual(internals.autoDetectProcessJsonDirs('https://example.com/model.json'), []);
+    assert.deepEqual(internals.autoDetectProcessJsonDirs(null), []);
+
+    const requestLike: LifecyclemodelResultingProcessRequest = {
+      source_model: {
+        id: null,
+        version: null,
+        name: null,
+        json_ordered_path: pathToFileURL(requestModelPath).href,
+        json_ordered: null,
+      },
+      projection: {
+        mode: 'primary-only',
+        process_id: null,
+        process_version: null,
+        metadata_overrides: {},
+        attach_graph_snapshot: false,
+        attach_graph_snapshot_uri: null,
+      },
+      process_sources: {
+        process_catalog_path: catalogPath,
+        run_dirs: [runDir, path.join(dir, 'missing-run')],
+        process_json_dirs: [processDir],
+        process_json_files: [explicitFile],
+        allow_remote_lookup: false,
+      },
+      publish: {
+        intent: 'dry_run',
+        prepare_process_payloads: true,
+        prepare_relation_payloads: true,
+      },
+    };
+
+    assert.deepEqual(internals.processSourceDirs(requestLike).sort(), [processDir].sort());
+    assert.equal(
+      internals.locateLocalProcessFile('proc-dir', VERSION, {
+        processDirs: [processDir],
+        processFiles: [],
+      }),
+      fromDir,
+    );
+    assert.equal(
+      internals.locateLocalProcessFile('proc-explicit', VERSION, {
+        processDirs: [],
+        processFiles: [explicitFile],
+      }),
+      explicitFile,
+    );
+    assert.equal(
+      internals.locateLocalProcessFile('proc-missing', VERSION, {
+        processDirs: [],
+        processFiles: [],
+      }),
+      null,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('lifecyclemodel internal builders cover fallback-only branches', async () => {
+  const internals = await loadDistLifecyclemodelTestInternals();
+
+  const directChoice = internals.chooseReferenceInstance(
+    [
+      {
+        instance_id: 'a',
+        process_id: 'proc-a',
+        process_version: VERSION,
+        label: 'A',
+        multiplication_factor: 0,
+        reference_to_process: {},
+        raw: {},
+      },
+      {
+        instance_id: 'b',
+        process_id: 'proc-b',
+        process_version: VERSION,
+        label: 'B',
+        multiplication_factor: 2,
+        reference_to_process: {},
+        raw: {},
+      },
+    ],
+    null,
+  );
+  assert.equal(directChoice.instance_id, 'b');
+
+  const fallbackChoice = internals.chooseReferenceInstance(
+    [
+      {
+        instance_id: 'fallback',
+        process_id: 'proc-fallback',
+        process_version: VERSION,
+        label: 'Fallback',
+        multiplication_factor: 0,
+        reference_to_process: {},
+        raw: {},
+      },
+    ],
+    null,
+  );
+  assert.equal(fallbackChoice.instance_id, 'fallback');
+
+  assert.deepEqual(
+    internals.cloneExchangeWithAmount(
+      {
+        referenceToFlowDataSet: {
+          '@refObjectId': 'flow-direct',
+        },
+      },
+      3,
+      '12',
+      {
+        quantitativeReference: false,
+      },
+    ),
+    {
+      '@dataSetInternalID': '12',
+      referenceToFlowDataSet: {
+        '@refObjectId': 'flow-direct',
+      },
+      meanAmount: 3,
+      quantitativeReference: false,
+    },
+  );
+
+  const builtProcess = internals.buildResultingProcessPayload({
+    sourceModelId: 'lm-internal',
+    sourceModelVersion: VERSION,
+    sourceModelName: 'Internal',
+    sourceModelNameInfo: {
+      baseName: [
+        {
+          '@xml:lang': 'en',
+          '#text': 'Internal',
+        },
+      ],
+    },
+    processId: 'proc-built',
+    processVersion: VERSION,
+    role: 'primary',
+    projectionSignature: 'sha256:internal',
+    processInstances: [
+      {
+        instance_id: 'a',
+        process_id: 'proc-a',
+        process_version: VERSION,
+        label: 'A',
+        multiplication_factor: 1,
+        reference_to_process: {},
+        raw: {},
+      },
+      {
+        instance_id: 'b',
+        process_id: 'proc-b',
+        process_version: VERSION,
+        label: 'B',
+        multiplication_factor: 0,
+        reference_to_process: {},
+        raw: {},
+      },
+      {
+        instance_id: 'c',
+        process_id: 'proc-c',
+        process_version: VERSION,
+        label: 'C',
+        multiplication_factor: 1,
+        reference_to_process: {},
+        raw: {},
+      },
+    ],
+    edges: [
+      {
+        edge_id: 'missing-instance',
+        from: 'a',
+        to: 'missing',
+        exchange_id: null,
+        flow_uuid: 'flow-ghost',
+      },
+      {
+        edge_id: 'missing-record',
+        from: 'a',
+        to: 'b',
+        exchange_id: null,
+        flow_uuid: 'flow-ghost',
+      },
+      {
+        edge_id: 'missing-total',
+        from: 'a',
+        to: 'c',
+        exchange_id: null,
+        flow_uuid: 'flow-ghost',
+      },
+      {
+        edge_id: 'missing-input-amount',
+        from: 'a',
+        to: 'c',
+        exchange_id: null,
+        flow_uuid: 'flow-no-input',
+      },
+    ],
+    processRecords: {
+      [`proc-a@${VERSION}`]: {
+        processUuid: 'proc-a',
+        version: VERSION,
+        raw: {
+          processDataSet: {
+            processInformation: {
+              technology: {
+                existingTechnologyNote: 'kept',
+              },
+            },
+            exchanges: {
+              exchange: [
+                {
+                  referenceToFlowDataSet: {
+                    '@refObjectId': 'flow-built',
+                  },
+                  exchangeDirection: 'Output',
+                  meanAmount: 1,
+                },
+                {
+                  exchangeDirection: 'Input',
+                },
+              ],
+            },
+          },
+        },
+        sourceLabel: 'internal',
+        sourcePath: null,
+        referenceExchangeInternalId: '1',
+        referenceFlowUuid: 'flow-built',
+        referenceDirection: '',
+        referenceAmount: 1,
+        inputAmounts: {},
+        outputAmounts: {
+          'flow-built': 1,
+        },
+      },
+      [`proc-c@${VERSION}`]: {
+        processUuid: 'proc-c',
+        version: VERSION,
+        raw: {
+          processDataSet: {},
+        },
+        sourceLabel: 'internal',
+        sourcePath: null,
+        referenceExchangeInternalId: '1',
+        referenceFlowUuid: 'flow-unused',
+        referenceDirection: 'Output',
+        referenceAmount: 0,
+        inputAmounts: {
+          'flow-ghost': 1,
+        },
+        outputAmounts: {},
+      },
+    },
+    referenceProcessInstanceId: null,
+    metadataOverrides: {},
+    attachGraphSnapshotUri: null,
+  });
+  const builtDataset = (builtProcess.processDataSet as JsonRecord).processInformation as JsonRecord;
+  assert.equal(
+    (((builtProcess.processDataSet as JsonRecord).exchanges as JsonRecord).exchange as JsonRecord)
+      .meanAmount,
+    1,
+  );
+  assert.equal((builtDataset.quantitativeReference as JsonRecord).referenceToReferenceFlow, '1');
+  assert.equal(
+    ((builtDataset.technology as JsonRecord).referenceToIncludedProcesses as JsonRecord[]).length,
+    3,
+  );
+  assert.equal((builtDataset.technology as JsonRecord).existingTechnologyNote, 'kept');
+  assert.equal(
+    (
+      ((builtProcess.processDataSet as JsonRecord).administrativeInformation as JsonRecord)
+        .publicationAndOwnership as JsonRecord
+    )['common:dataSetVersion'],
+    VERSION,
+  );
+  assert.equal(
+    (
+      ((builtProcess.processDataSet as JsonRecord).modellingAndValidation as JsonRecord)
+        .LCIMethodAndAllocation as JsonRecord
+    ).typeOfDataSet,
+    'partly terminated system',
+  );
+
+  const builtWithoutProcessInformation = internals.buildResultingProcessPayload({
+    sourceModelId: 'lm-no-process-info',
+    sourceModelVersion: VERSION,
+    sourceModelName: 'No Process Info',
+    sourceModelNameInfo: {
+      baseName: [
+        {
+          '@xml:lang': 'en',
+          '#text': 'No Process Info',
+        },
+      ],
+    },
+    processId: 'proc-no-process-info',
+    processVersion: VERSION,
+    role: 'primary',
+    projectionSignature: 'sha256:no-process-info',
+    processInstances: [
+      {
+        instance_id: 'solo',
+        process_id: 'proc-solo',
+        process_version: VERSION,
+        label: 'Solo',
+        multiplication_factor: 1,
+        reference_to_process: {},
+        raw: {},
+      },
+    ],
+    edges: [],
+    processRecords: {
+      [`proc-solo@${VERSION}`]: {
+        processUuid: 'proc-solo',
+        version: VERSION,
+        raw: {
+          processDataSet: {
+            exchanges: {
+              exchange: {
+                referenceToFlowDataSet: {
+                  '@refObjectId': 'flow-solo',
+                },
+                exchangeDirection: 'Output',
+                meanAmount: 1,
+              },
+            },
+          },
+        },
+        sourceLabel: 'internal',
+        sourcePath: null,
+        referenceExchangeInternalId: '1',
+        referenceFlowUuid: 'flow-solo',
+        referenceDirection: 'Output',
+        referenceAmount: 1,
+        inputAmounts: {},
+        outputAmounts: {
+          'flow-solo': 1,
+        },
+      },
+    },
+    referenceProcessInstanceId: 'solo',
+    metadataOverrides: {},
+    attachGraphSnapshotUri: null,
+  });
+  assert.equal(
+    (
+      (
+        (builtWithoutProcessInformation.processDataSet as JsonRecord)
+          .processInformation as JsonRecord
+      ).quantitativeReference as JsonRecord
+    ).referenceToReferenceFlow,
+    '1',
+  );
+
+  const projectionDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-projection-internal-'));
+  const projectionProcessPath = path.join(projectionDir, `proc-one_${VERSION}.json`);
+  writeJson(
+    projectionProcessPath,
+    createProcessPayload({
+      id: 'proc-one',
+      referenceInternalId: '1',
+      exchanges: createExchange({
+        internalId: '1',
+        flowId: 'flow-projection',
+        direction: 'Output',
+        meanAmount: 1,
+      }),
+    }),
+  );
+
+  try {
+    const projection = internals.buildProjectionBundle({
+      request: {
+        source_model: {
+          id: null,
+          version: null,
+          name: null,
+          json_ordered_path: null,
+          json_ordered: null,
+        },
+        projection: {
+          mode: 'all-subproducts',
+          process_id: null,
+          process_version: null,
+          metadata_overrides: {},
+          attach_graph_snapshot: false,
+          attach_graph_snapshot_uri: null,
+        },
+        process_sources: {
+          process_catalog_path: null,
+          run_dirs: [],
+          process_json_dirs: [],
+          process_json_files: [projectionProcessPath],
+          allow_remote_lookup: false,
+        },
+        publish: {
+          intent: 'dry_run',
+          prepare_process_payloads: true,
+          prepare_relation_payloads: true,
+        },
+      } satisfies LifecyclemodelResultingProcessRequest,
+      sourceModelJson: {
+        technology: {
+          processes: {
+            processInstance: createProcessInstance({
+              instanceId: 'projection-inst',
+              processId: 'proc-one',
+              factor: 1,
+            }),
+          },
+        },
+      },
+      modelPath: null,
+    });
+
+    const projectedProcess = (projection.bundle.projected_processes as JsonRecord[])[0];
+    assert.equal(projectedProcess.id, `${projection.sourceModelSummary.id}-resulting-process`);
+    assert.match(
+      (projection.report.notes as string[])[2] as string,
+      /does not expose submodel topology metadata/u,
+    );
+  } finally {
+    rmSync(projectionDir, { recursive: true, force: true });
+  }
+});

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'no
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import { loadDistModule } from './helpers/load-dist-module.js';
 import {
   buildResumeMetadata,
   buildRunId,
@@ -14,6 +15,10 @@ import {
   sanitizeRunToken,
   writeLatestRunId,
 } from '../src/lib/run.js';
+
+async function loadDistRunModule(): Promise<typeof import('../src/lib/run.js')> {
+  return loadDistModule('src/lib/run.js');
+}
 
 test('sanitizeRunToken normalizes user input and preserves fallback behavior', () => {
   assert.equal(sanitizeRunToken('Flow Search / CN'), 'flow_search_cn');
@@ -166,4 +171,56 @@ test('buildRunManifest and buildResumeMetadata emit deterministic metadata paylo
       resumedAt: '2026-03-28T08:50:00.000Z',
     },
   );
+});
+
+test('run helpers behave the same from the built dist module', async () => {
+  const run = await loadDistRunModule();
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-run-dist-'));
+  const now = new Date('2026-03-28T09:00:00.000Z');
+
+  try {
+    assert.equal(run.sanitizeRunToken('Flow Search / CN'), 'flow_search_cn');
+    assert.equal(run.buildUtcTimestamp(now), '20260328T090000Z');
+
+    const runId = run.buildRunId({
+      namespace: 'Flow Search',
+      subject: 'Battery Pack',
+      operation: 'Build',
+      now,
+      suffix: 'custom-id',
+    });
+    assert.equal(runId, 'flow_search_battery_pack_build_20260328T090000Z_custom_id');
+
+    const layout = run.ensureRunLayout(run.resolveRunLayout(dir, 'Flow Search', 'run-dist'));
+    assert.equal(existsSync(layout.cacheDir), true);
+
+    run.writeLatestRunId(layout, 'run-dist-2');
+    assert.equal(run.readLatestRunId(layout.collectionDir), 'run-dist-2');
+
+    const manifest = run.buildRunManifest({
+      layout,
+      command: ['tiangong', 'flow', 'search'],
+      cwd: '/tmp/workspace',
+      createdAt: now,
+    });
+    assert.equal(manifest.cwd, '/tmp/workspace');
+    assert.equal(manifest.createdAt, now.toISOString());
+
+    const resumeMetadata = run.buildResumeMetadata({
+      runId: 'run-dist',
+      resumedFrom: 'step-02',
+      checkpoint: 'checkpoint-a',
+      attempt: 3,
+      resumedAt: now,
+    });
+    assert.deepEqual(resumeMetadata, {
+      runId: 'run-dist',
+      resumedFrom: 'step-02',
+      checkpoint: 'checkpoint-a',
+      attempt: 3,
+      resumedAt: now.toISOString(),
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Closes #9

## Summary
- Implement the TypeScript lifecyclemodel resulting-process projection pipeline in tiangong-lca-cli.
- Expose tiangong lifecyclemodel build-resulting-process and write normalized request, source model, projection report, and bundle artifacts.
- Sync README and Chinese implementation docs so build-resulting-process is marked implemented while the remaining lifecyclemodel commands stay planned.

## Key Decisions
- Keep the build path local-first and deterministic instead of reintroducing MCP or Python into the CLI.
- Fail explicit remote lookup requests with LIFECYCLEMODEL_REMOTE_LOOKUP_NOT_IMPLEMENTED until a direct REST lookup path is intentionally added.
- Add built-dist parity tests where needed so c8 source-map accounting still reaches the repo's 100% gate.

## Validation
- npm run prepush:gate

## Risks / Rollback
- Low to medium: new command surface and projection logic are fully covered, but publish-resulting-process is still not implemented.

## Workspace Integration
- Requires a later lca-workspace submodule bump after merge.