### PR TITLE
feat: implement lifecyclemodel publish-resulting-process

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Current implementation choices:
 - `tiangong search process`
 - `tiangong search lifecyclemodel`
 - `tiangong lifecyclemodel build-resulting-process`
+- `tiangong lifecyclemodel publish-resulting-process`
 - `tiangong publish run`
 - `tiangong validation run`
 - `tiangong admin embedding-run`
@@ -26,7 +27,6 @@ Current implementation choices:
 
 The `lifecyclemodel` namespace is now partially implemented. The remaining planned surface is:
 
-- `tiangong lifecyclemodel publish-resulting-process`
 - `tiangong lifecyclemodel auto-build`
 - `tiangong lifecyclemodel validate-build`
 - `tiangong lifecyclemodel publish-build`
@@ -86,12 +86,15 @@ npm start -- doctor
 npm start -- doctor --json
 npm start -- search flow --input ./request.json --dry-run
 npm start -- lifecyclemodel build-resulting-process --input ./request.json --json
+npm start -- lifecyclemodel publish-resulting-process --run-dir ./runs/example --publish-processes --publish-relations --json
 npm start -- publish run --input ./publish-request.json --dry-run
 npm start -- validation run --input-dir ./tidas-package --engine auto
 npm start -- admin embedding-run --input ./jobs.json --dry-run
 ```
 
 ## Publish and validation
+
+`tiangong lifecyclemodel publish-resulting-process` is the lifecyclemodel-side local publish handoff command. It reads a prior resulting-process run, writes `publish-bundle.json` and `publish-intent.json`, and preserves the old builder's artifact contract without reintroducing Python or MCP into the CLI.
 
 `tiangong publish run` is the CLI-side publish contract boundary. It normalizes publish requests, ingests upstream `publish-bundle.json` inputs, writes `normalized-request.json`, `collected-inputs.json`, `relation-manifest.json`, and `publish-report.json`, and keeps commit-mode execution behind explicit executors instead of reintroducing MCP-specific logic into the CLI.
 

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -32,6 +32,7 @@ tiangong
     lifecyclemodel
   lifecyclemodel
     build-resulting-process
+    publish-resulting-process
   publish
     run
   validation
@@ -49,6 +50,7 @@ tiangong
 | `tiangong search process` | `process_hybrid_search` |
 | `tiangong search lifecyclemodel` | `lifecyclemodel_hybrid_search` |
 | `tiangong lifecyclemodel build-resulting-process` | 本地 lifecycle model resulting process 聚合、内部 flow 抵消、artifact 输出 |
+| `tiangong lifecyclemodel publish-resulting-process` | 读取 resulting-process run，生成 `publish-bundle.json` / `publish-intent.json` 本地交付物 |
 | `tiangong publish run` | 本地 publish 契约归一化、dry-run/commit、report 输出 |
 | `tiangong validation run` | 本地 `tidas-sdk` / `tidas-tools` 校验收口 |
 | `tiangong admin embedding-run` | `embedding_ft` |
@@ -56,11 +58,13 @@ tiangong
 此外，CLI 现在已经正式引入 `tiangong lifecyclemodel ...` 一级命名空间，其中：
 
 - `tiangong lifecyclemodel build-resulting-process` 已可执行
-- `publish-resulting-process`、`auto-build`、`validate-build`、`publish-build` 仍处于 planned 状态
+- `tiangong lifecyclemodel publish-resulting-process` 已可执行
+- `auto-build`、`validate-build`、`publish-build` 仍处于 planned 状态
 
 注意：
 
-- 已实现的 `build-resulting-process` 走本地优先、artifact-first 路径，不依赖 Python 或 MCP
+- 已实现的 `build-resulting-process` 和 `publish-resulting-process` 都走本地优先、artifact-first 路径，不依赖 Python 或 MCP
+- `publish-resulting-process` 当前负责生成本地 publish handoff 产物，还没有把提交语义直接并入 `publish run`
 - 其余未实现的 `lifecyclemodel` 子命令仍只提供 help 和固定命名
 - 这样做的目的不是“假装已完成”，而是先固定命令树，再逐个把 workflow 迁入 TypeScript CLI
 

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -71,7 +71,7 @@
 | `embedding-ft` | 已有等价 CLI | shell wrapper | 只保留 skill 文档，调用 `tiangong admin embedding-run` | P0 |
 | `process-automated-builder` | 仍是重 workflow | shell + Python + LangGraph + MCP + OpenAI + AI edge search + TianGong unstructured | 迁成 `tiangong process ...` 主链 | P1 |
 | `lifecyclemodel-automated-builder` | 仍是重 workflow | shell + Python + MCP + OpenAI | 迁成 `tiangong lifecyclemodel ...` 主链 | P1 |
-| `lifecyclemodel-resulting-process-builder` | CLI 本地 build 已落地，skill 仍未切换 | Python builder + 可选 MCP lookup | 迁成 `skill -> tiangong lifecyclemodel build/publish-resulting-process` | P1 |
+| `lifecyclemodel-resulting-process-builder` | CLI 本地 build/publish handoff 已落地，skill 仍未切换 | Python builder + 可选 MCP lookup | 迁成 `skill -> tiangong lifecyclemodel build/publish-resulting-process` | P1 |
 | `lifecycleinventory-review` | 仍是 review workflow | Python review script | 迁成 `tiangong review process` | P2 |
 | `flow-governance-review` | 仍是治理 workflow | shell + 多个 Python helper + 可选 MCP | 迁成 `tiangong flow ...` / `tiangong review flow` | P2 |
 | `lifecyclemodel-recursive-orchestrator` | 仍是 orchestrator | Python orchestrator，串联多个技能 | 迁成 CLI 编排命令 | P3 |
@@ -200,18 +200,20 @@ ToDo：
 当前状态：
 
 - `tiangong lifecyclemodel build-resulting-process` 已在 CLI 中落地，且通过 `npm run prepush:gate`
-- 仍未完成 `publish-resulting-process`、skill wrapper 收口、旧 Python 主入口删除
+- `tiangong lifecyclemodel publish-resulting-process` 已在 CLI 中落地，且通过 `npm run prepush:gate`
+- 仍未完成 skill wrapper 收口、旧 Python 主入口删除、远程 lookup 收口
 
 目标命令：
 
 - [x] `tiangong lifecyclemodel build-resulting-process`
-- [ ] `tiangong lifecyclemodel publish-resulting-process`
+- [x] `tiangong lifecyclemodel publish-resulting-process`
 
 ToDo：
 
 - [x] 在 CLI 中补齐 `lifecyclemodel` 顶层命名空间
 - [x] 将 lifecycle model 读取、拓扑解析、聚合投影逻辑迁到 TS
 - [x] 将 process catalog / local run 解析改为复用 CLI 模块
+- [x] 将 resulting-process publish handoff 生成迁到 TS CLI
 - [ ] 将远程 process lookup 从可选 MCP lookup 改为直接 REST 查询
 - [ ] 保留 `publish-bundle.json` 契约，但发布入口统一走 CLI publish
 - [ ] skill wrapper 改为只调用 CLI
@@ -429,13 +431,13 @@ ToDo：
 
 如果只按最短路径推进，下一轮建议严格做这 8 件事：
 
-当前已完成：1-4。
+当前已完成：1-5。
 
 1. 修 CLI help，让命令面和真实实现一致。
 2. 修 skills 文档中的 `TIANGONG_CLI_DIR` 残留。
 3. 正式引入 `tiangong lifecyclemodel ...` 命名空间。
 4. 先完成 `tiangong lifecyclemodel build-resulting-process`。
-5. 再完成 `tiangong lifecyclemodel publish-resulting-process`。
+5. 完成 `tiangong lifecyclemodel publish-resulting-process`。
 6. 把 `lifecyclemodel-resulting-process-builder` 改成薄 wrapper。
 7. 把 `lca-publish-executor` 收口到 `tiangong publish run`。
 8. 再进入 `tiangong process auto-build` 主链迁移。

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,11 @@ import {
   type LifecyclemodelResultingProcessReport,
   type RunLifecyclemodelResultingProcessOptions,
 } from './lib/lifecyclemodel-resulting-process.js';
+import {
+  runLifecyclemodelPublishResultingProcess,
+  type LifecyclemodelPublishResultingProcessReport,
+  type RunLifecyclemodelPublishResultingProcessOptions,
+} from './lib/lifecyclemodel-publish-resulting-process.js';
 import { runPublish, type PublishReport, type RunPublishOptions } from './lib/publish.js';
 import { executeRemoteCommand, getRemoteCommandHelp } from './lib/remote.js';
 import {
@@ -26,6 +31,9 @@ export type CliDeps = {
   runLifecyclemodelBuildResultingProcessImpl?: (
     options: RunLifecyclemodelResultingProcessOptions,
   ) => Promise<LifecyclemodelResultingProcessReport>;
+  runLifecyclemodelPublishResultingProcessImpl?: (
+    options: RunLifecyclemodelPublishResultingProcessOptions,
+  ) => Promise<LifecyclemodelPublishResultingProcessReport>;
 };
 
 export type CliResult = {
@@ -57,14 +65,14 @@ Commands:
 Implemented Commands:
   doctor     show environment diagnostics
   search     flow | process | lifecyclemodel
-  lifecyclemodel build-resulting-process
+  lifecyclemodel build-resulting-process | publish-resulting-process
   publish    run
   validation run
   admin      embedding-run
 
 Planned Surface (not implemented yet):
   auth       whoami | doctor-auth
-  lifecyclemodel publish-resulting-process | auto-build | validate-build | publish-build
+  lifecyclemodel auto-build | validate-build | publish-build
   review     flow | process
   flow       get | list | remediate | publish-version | regen-product
   process    get | auto-build | resume-build | publish-build | batch-build
@@ -165,15 +173,28 @@ Options:
 `.trim();
 }
 
+function renderLifecyclemodelPublishResultingProcessHelp(): string {
+  return `Usage:
+  tiangong lifecyclemodel publish-resulting-process --run-dir <dir> [options]
+
+Options:
+  --run-dir <dir>         Existing lifecyclemodel resulting-process run directory
+  --publish-processes     Include projected processes in publish-bundle.json
+  --publish-relations     Include lifecyclemodel/resulting-process relations in publish-bundle.json
+  --json                  Print compact JSON
+  -h, --help
+`.trim();
+}
+
 function renderLifecyclemodelHelp(): string {
   return `Usage:
   tiangong lifecyclemodel <subcommand> [options]
 
 Implemented Subcommands:
   build-resulting-process   Deterministically aggregate a lifecycle model into a resulting process bundle
+  publish-resulting-process Prepare publish-bundle.json and publish-intent.json from a prior resulting-process run
 
 Planned Subcommands:
-  publish-resulting-process Publish a previously built resulting process run through the unified publish layer
   auto-build                Assemble lifecycle models from discovered candidate processes
   validate-build            Re-run local validation on a lifecycle model build run
   publish-build             Publish a lifecycle model build run through the unified publish layer
@@ -186,17 +207,6 @@ Examples:
 }
 
 const lifecyclemodelPlannedHelp = {
-  'publish-resulting-process': `Usage:
-  tiangong lifecyclemodel publish-resulting-process --run-dir <dir> [options]
-
-Planned contract:
-  - read one prior resulting-process run directory
-  - ingest its publish handoff artifacts
-  - delegate commit semantics to the unified publish module
-
-Status:
-  Planned command. Execution is not implemented yet.
-`.trim(),
   'auto-build': `Usage:
   tiangong lifecyclemodel auto-build --input <file> [options]
 
@@ -490,6 +500,43 @@ function parseValidationFlags(args: string[]): {
   };
 }
 
+function parseLifecyclemodelPublishFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  runDir: string;
+  publishProcesses: boolean;
+  publishRelations: boolean;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        'run-dir': { type: 'string' },
+        'publish-processes': { type: 'boolean' },
+        'publish-relations': { type: 'boolean' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    runDir: typeof values['run-dir'] === 'string' ? values['run-dir'] : '',
+    publishProcesses: Boolean(values['publish-processes']),
+    publishRelations: Boolean(values['publish-relations']),
+  };
+}
+
 function parseLifecyclemodelBuildFlags(args: string[]): {
   help: boolean;
   json: boolean;
@@ -553,6 +600,8 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
     const validationImpl = deps.runValidationImpl ?? runValidation;
     const lifecyclemodelBuildImpl =
       deps.runLifecyclemodelBuildResultingProcessImpl ?? runLifecyclemodelBuildResultingProcess;
+    const lifecyclemodelPublishImpl =
+      deps.runLifecyclemodelPublishResultingProcessImpl ?? runLifecyclemodelPublishResultingProcess;
 
     if (flags.version) {
       return { exitCode: 0, stdout: '0.0.1\n', stderr: '' };
@@ -621,6 +670,29 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
       const report = await lifecyclemodelBuildImpl({
         inputPath: lifecyclemodelFlags.inputPath,
         outDir: lifecyclemodelFlags.outDir,
+      });
+
+      return {
+        exitCode: 0,
+        stdout: stringifyJson(report, lifecyclemodelFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'lifecyclemodel' && subcommand === 'publish-resulting-process') {
+      const lifecyclemodelFlags = parseLifecyclemodelPublishFlags(commandArgs);
+      if (lifecyclemodelFlags.help) {
+        return {
+          exitCode: 0,
+          stdout: `${renderLifecyclemodelPublishResultingProcessHelp()}\n`,
+          stderr: '',
+        };
+      }
+
+      const report = await lifecyclemodelPublishImpl({
+        runDir: lifecyclemodelFlags.runDir,
+        publishProcesses: lifecyclemodelFlags.publishProcesses,
+        publishRelations: lifecyclemodelFlags.publishRelations,
       });
 
       return {

--- a/src/lib/lifecyclemodel-publish-resulting-process.ts
+++ b/src/lib/lifecyclemodel-publish-resulting-process.ts
@@ -1,0 +1,162 @@
+import path from 'node:path';
+import { existsSync } from 'node:fs';
+import { readJsonArtifact, writeJsonArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+
+type JsonObject = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function ensureList<T = unknown>(value: unknown): T[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  return Array.isArray(value) ? (value as T[]) : ([value] as T[]);
+}
+
+function copyJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function nowIso(now: Date = new Date()): string {
+  return now.toISOString();
+}
+
+function requireRunDir(runDir: string): string {
+  if (!runDir.trim()) {
+    throw new CliError('Missing required --run-dir for lifecyclemodel publish-resulting-process.', {
+      code: 'LIFECYCLEMODEL_RUN_DIR_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  return path.resolve(runDir);
+}
+
+function readRequiredJsonObject(
+  filePath: string,
+  missingCode: string,
+  invalidCode: string,
+): JsonObject {
+  if (!existsSync(filePath)) {
+    throw new CliError(`Required lifecyclemodel artifact not found: ${filePath}`, {
+      code: missingCode,
+      exitCode: 2,
+    });
+  }
+
+  const value = readJsonArtifact(filePath);
+  if (!isRecord(value)) {
+    throw new CliError(`Expected lifecyclemodel artifact JSON object: ${filePath}`, {
+      code: invalidCode,
+      exitCode: 2,
+    });
+  }
+
+  return value;
+}
+
+export type LifecyclemodelPublishResultingProcessReport = {
+  generated_at_utc: string;
+  run_dir: string;
+  status: 'prepared_local_publish_bundle';
+  publish_processes: boolean;
+  publish_relations: boolean;
+  counts: {
+    projected_processes: number;
+    relations: number;
+  };
+  source_model: JsonObject;
+  files: {
+    projection_bundle: string;
+    projection_report: string;
+    publish_bundle: string;
+    publish_intent: string;
+  };
+};
+
+export type RunLifecyclemodelPublishResultingProcessOptions = {
+  runDir: string;
+  publishProcesses: boolean;
+  publishRelations: boolean;
+  now?: Date;
+};
+
+export async function runLifecyclemodelPublishResultingProcess(
+  options: RunLifecyclemodelPublishResultingProcessOptions,
+): Promise<LifecyclemodelPublishResultingProcessReport> {
+  const runDir = requireRunDir(options.runDir);
+  const generatedAtUtc = nowIso(options.now);
+  const projectionBundlePath = path.join(runDir, 'process-projection-bundle.json');
+  const projectionReportPath = path.join(runDir, 'projection-report.json');
+  const projectionBundle = readRequiredJsonObject(
+    projectionBundlePath,
+    'LIFECYCLEMODEL_PROJECTION_BUNDLE_MISSING',
+    'LIFECYCLEMODEL_PROJECTION_BUNDLE_NOT_OBJECT',
+  );
+  const projectionReport = readRequiredJsonObject(
+    projectionReportPath,
+    'LIFECYCLEMODEL_PROJECTION_REPORT_MISSING',
+    'LIFECYCLEMODEL_PROJECTION_REPORT_NOT_OBJECT',
+  );
+
+  const sourceModel = isRecord(projectionBundle.source_model)
+    ? copyJson(projectionBundle.source_model)
+    : {};
+  const projectedProcesses = options.publishProcesses
+    ? copyJson(ensureList(projectionBundle.projected_processes))
+    : [];
+  const relations = options.publishRelations
+    ? copyJson(ensureList(projectionBundle.relations))
+    : [];
+
+  const publishBundle = {
+    generated_at: generatedAtUtc,
+    run_dir: runDir,
+    source_model: sourceModel,
+    publish_processes: options.publishProcesses,
+    publish_relations: options.publishRelations,
+    status: 'prepared_local_publish_bundle' as const,
+    projected_processes: projectedProcesses,
+    relations,
+    report: copyJson(projectionReport),
+  };
+  const publishIntent = {
+    ok: true,
+    command: 'publish',
+    run_dir: runDir,
+    publish_processes: options.publishProcesses,
+    publish_relations: options.publishRelations,
+    status: 'prepared_local_publish_bundle' as const,
+  };
+
+  const publishBundlePath = writeJsonArtifact(
+    path.join(runDir, 'publish-bundle.json'),
+    publishBundle,
+  );
+  const publishIntentPath = writeJsonArtifact(
+    path.join(runDir, 'publish-intent.json'),
+    publishIntent,
+  );
+
+  return {
+    generated_at_utc: generatedAtUtc,
+    run_dir: runDir,
+    status: 'prepared_local_publish_bundle',
+    publish_processes: options.publishProcesses,
+    publish_relations: options.publishRelations,
+    counts: {
+      projected_processes: projectedProcesses.length,
+      relations: relations.length,
+    },
+    source_model: sourceModel,
+    files: {
+      projection_bundle: projectionBundlePath,
+      projection_report: projectionReportPath,
+      publish_bundle: publishBundlePath,
+      publish_intent: publishIntentPath,
+    },
+  };
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -38,6 +38,7 @@ test('executeCli prints main help when no command is given', async () => {
   assert.match(result.stdout, /Implemented Commands:/u);
   assert.match(result.stdout, /Planned Surface \(not implemented yet\):/u);
   assert.match(result.stdout, /lifecyclemodel build-resulting-process/u);
+  assert.match(result.stdout, /publish-resulting-process/u);
   assert.match(result.stdout, /exit with code 2/u);
   assert.equal(result.stderr, '');
 });
@@ -149,11 +150,12 @@ test('executeCli returns group help for search and admin namespaces', async () =
   assert.match(adminHelp.stdout, /tiangong admin embedding-run/u);
 });
 
-test('executeCli returns help for the lifecyclemodel namespace and planned subcommands', async () => {
+test('executeCli returns help for the lifecyclemodel namespace and implemented subcommands', async () => {
   const lifecyclemodelHelp = await executeCli(['lifecyclemodel'], makeDeps());
   assert.equal(lifecyclemodelHelp.exitCode, 0);
   assert.match(lifecyclemodelHelp.stdout, /tiangong lifecyclemodel <subcommand>/u);
   assert.match(lifecyclemodelHelp.stdout, /build-resulting-process/u);
+  assert.match(lifecyclemodelHelp.stdout, /publish-resulting-process/u);
 
   const buildHelp = await executeCli(
     ['lifecyclemodel', 'build-resulting-process', '--help'],
@@ -162,6 +164,18 @@ test('executeCli returns help for the lifecyclemodel namespace and planned subco
   assert.equal(buildHelp.exitCode, 0);
   assert.match(buildHelp.stdout, /tiangong lifecyclemodel build-resulting-process --input <file>/u);
   assert.doesNotMatch(buildHelp.stdout, /Planned command/u);
+
+  const publishHelp = await executeCli(
+    ['lifecyclemodel', 'publish-resulting-process', '--help'],
+    makeDeps(),
+  );
+  assert.equal(publishHelp.exitCode, 0);
+  assert.match(
+    publishHelp.stdout,
+    /tiangong lifecyclemodel publish-resulting-process --run-dir <dir>/u,
+  );
+  assert.match(publishHelp.stdout, /--publish-processes/u);
+  assert.doesNotMatch(publishHelp.stdout, /Planned command/u);
 });
 
 test('executeCli executes lifecyclemodel build-resulting-process with injected implementation', async () => {
@@ -216,6 +230,57 @@ test('executeCli executes lifecyclemodel build-resulting-process with injected i
     assert.equal(result.exitCode, 0);
     assert.match(result.stdout, /"status":"prepared_local_bundle"/u);
     assert.match(result.stdout, /"process_projection_bundle"/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli executes lifecyclemodel publish-resulting-process with injected implementation', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-publish-cli-'));
+
+  try {
+    const result = await executeCli(
+      [
+        'lifecyclemodel',
+        'publish-resulting-process',
+        '--json',
+        '--run-dir',
+        dir,
+        '--publish-processes',
+      ],
+      {
+        ...makeDeps(),
+        runLifecyclemodelPublishResultingProcessImpl: async (options) => {
+          assert.equal(options.runDir, dir);
+          assert.equal(options.publishProcesses, true);
+          assert.equal(options.publishRelations, false);
+          return {
+            generated_at_utc: '2026-03-29T00:00:00.000Z',
+            run_dir: dir,
+            status: 'prepared_local_publish_bundle',
+            publish_processes: true,
+            publish_relations: false,
+            counts: {
+              projected_processes: 1,
+              relations: 0,
+            },
+            source_model: {
+              id: 'lm-demo',
+            },
+            files: {
+              projection_bundle: path.join(dir, 'process-projection-bundle.json'),
+              projection_report: path.join(dir, 'projection-report.json'),
+              publish_bundle: path.join(dir, 'publish-bundle.json'),
+              publish_intent: path.join(dir, 'publish-intent.json'),
+            },
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /"status":"prepared_local_publish_bundle"/u);
+    assert.match(result.stdout, /"publish_bundle"/u);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -534,7 +599,7 @@ test('executeCli returns parsing errors for invalid publish and validation flags
   assert.match(validationResult.stderr, /INVALID_ARGS/u);
 });
 
-test('executeCli returns parsing errors for invalid lifecyclemodel build flags', async () => {
+test('executeCli returns parsing errors for invalid lifecyclemodel build and publish flags', async () => {
   const result = await executeCli(
     ['lifecyclemodel', 'build-resulting-process', '--bad-flag'],
     makeDeps(),
@@ -542,6 +607,14 @@ test('executeCli returns parsing errors for invalid lifecyclemodel build flags',
   assert.equal(result.exitCode, 2);
   assert.equal(result.stdout, '');
   assert.match(result.stderr, /INVALID_ARGS/u);
+
+  const publishResult = await executeCli(
+    ['lifecyclemodel', 'publish-resulting-process', '--bad-flag'],
+    makeDeps(),
+  );
+  assert.equal(publishResult.exitCode, 2);
+  assert.equal(publishResult.stdout, '');
+  assert.match(publishResult.stderr, /INVALID_ARGS/u);
 });
 
 test('executeCli executes validation run with injected implementation and report file', async () => {

--- a/test/lifecyclemodel-publish-resulting-process.test.ts
+++ b/test/lifecyclemodel-publish-resulting-process.test.ts
@@ -1,0 +1,300 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  runLifecyclemodelPublishResultingProcess,
+  type LifecyclemodelPublishResultingProcessReport,
+} from '../src/lib/lifecyclemodel-publish-resulting-process.js';
+import { CliError } from '../src/lib/errors.js';
+
+function writeJson(filePath: string, value: unknown): void {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function readJson<T>(filePath: string): T {
+  return JSON.parse(readFileSync(filePath, 'utf8')) as T;
+}
+
+function assertCliErrorCode(expectedCode: string) {
+  return (error: unknown): boolean => {
+    assert.ok(error instanceof CliError);
+    assert.equal(error.code, expectedCode);
+    return true;
+  };
+}
+
+test('runLifecyclemodelPublishResultingProcess writes publish bundle artifacts for selected payloads', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-publish-full-'));
+
+  writeJson(path.join(dir, 'process-projection-bundle.json'), {
+    source_model: {
+      id: 'lm-demo',
+      version: '00.00.001',
+    },
+    projected_processes: [{ id: 'proc-1' }, { id: 'proc-2' }],
+    relations: [{ id: 'rel-1' }],
+  });
+  writeJson(path.join(dir, 'projection-report.json'), {
+    status: 'prepared_local_bundle',
+  });
+
+  try {
+    const report = await runLifecyclemodelPublishResultingProcess({
+      runDir: dir,
+      publishProcesses: true,
+      publishRelations: true,
+      now: new Date('2026-03-29T00:00:00.000Z'),
+    });
+
+    assert.deepEqual(report, {
+      generated_at_utc: '2026-03-29T00:00:00.000Z',
+      run_dir: dir,
+      status: 'prepared_local_publish_bundle',
+      publish_processes: true,
+      publish_relations: true,
+      counts: {
+        projected_processes: 2,
+        relations: 1,
+      },
+      source_model: {
+        id: 'lm-demo',
+        version: '00.00.001',
+      },
+      files: {
+        projection_bundle: path.join(dir, 'process-projection-bundle.json'),
+        projection_report: path.join(dir, 'projection-report.json'),
+        publish_bundle: path.join(dir, 'publish-bundle.json'),
+        publish_intent: path.join(dir, 'publish-intent.json'),
+      },
+    } satisfies LifecyclemodelPublishResultingProcessReport);
+
+    assert.deepEqual(readJson(path.join(dir, 'publish-bundle.json')), {
+      generated_at: '2026-03-29T00:00:00.000Z',
+      run_dir: dir,
+      source_model: {
+        id: 'lm-demo',
+        version: '00.00.001',
+      },
+      publish_processes: true,
+      publish_relations: true,
+      status: 'prepared_local_publish_bundle',
+      projected_processes: [{ id: 'proc-1' }, { id: 'proc-2' }],
+      relations: [{ id: 'rel-1' }],
+      report: {
+        status: 'prepared_local_bundle',
+      },
+    });
+    assert.deepEqual(readJson(path.join(dir, 'publish-intent.json')), {
+      ok: true,
+      command: 'publish',
+      run_dir: dir,
+      publish_processes: true,
+      publish_relations: true,
+      status: 'prepared_local_publish_bundle',
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelPublishResultingProcess can independently disable projected process publishing', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-publish-relations-only-'));
+
+  writeJson(path.join(dir, 'process-projection-bundle.json'), {
+    source_model: {
+      id: 'lm-demo',
+    },
+    projected_processes: [{ id: 'proc-1' }],
+    relations: [{ id: 'rel-1' }],
+  });
+  writeJson(path.join(dir, 'projection-report.json'), {
+    status: 'prepared_local_bundle',
+  });
+
+  try {
+    const report = await runLifecyclemodelPublishResultingProcess({
+      runDir: dir,
+      publishProcesses: false,
+      publishRelations: true,
+    });
+
+    assert.deepEqual(report.counts, {
+      projected_processes: 0,
+      relations: 1,
+    });
+
+    assert.deepEqual(readJson(path.join(dir, 'publish-bundle.json')), {
+      generated_at: report.generated_at_utc,
+      run_dir: dir,
+      source_model: {
+        id: 'lm-demo',
+      },
+      publish_processes: false,
+      publish_relations: true,
+      status: 'prepared_local_publish_bundle',
+      projected_processes: [],
+      relations: [{ id: 'rel-1' }],
+      report: {
+        status: 'prepared_local_bundle',
+      },
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelPublishResultingProcess can independently disable relation publishing', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-publish-processes-only-'));
+
+  writeJson(path.join(dir, 'process-projection-bundle.json'), {
+    source_model: {
+      id: 'lm-demo',
+    },
+    projected_processes: [{ id: 'proc-1' }],
+    relations: [{ id: 'rel-1' }],
+  });
+  writeJson(path.join(dir, 'projection-report.json'), {
+    status: 'prepared_local_bundle',
+  });
+
+  try {
+    const report = await runLifecyclemodelPublishResultingProcess({
+      runDir: dir,
+      publishProcesses: true,
+      publishRelations: false,
+      now: new Date('2026-03-29T00:00:01.000Z'),
+    });
+
+    assert.deepEqual(report.counts, {
+      projected_processes: 1,
+      relations: 0,
+    });
+
+    assert.deepEqual(readJson(path.join(dir, 'publish-bundle.json')), {
+      generated_at: '2026-03-29T00:00:01.000Z',
+      run_dir: dir,
+      source_model: {
+        id: 'lm-demo',
+      },
+      publish_processes: true,
+      publish_relations: false,
+      status: 'prepared_local_publish_bundle',
+      projected_processes: [{ id: 'proc-1' }],
+      relations: [],
+      report: {
+        status: 'prepared_local_bundle',
+      },
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelPublishResultingProcess handles scalar and null projection entries', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-publish-scalar-'));
+
+  writeJson(path.join(dir, 'process-projection-bundle.json'), {
+    source_model: 'not-an-object',
+    projected_processes: { id: 'proc-scalar' },
+    relations: null,
+  });
+  writeJson(path.join(dir, 'projection-report.json'), {
+    status: 'prepared_local_bundle',
+  });
+
+  try {
+    const report = await runLifecyclemodelPublishResultingProcess({
+      runDir: dir,
+      publishProcesses: true,
+      publishRelations: true,
+    });
+
+    assert.deepEqual(report.source_model, {});
+    assert.deepEqual(report.counts, {
+      projected_processes: 1,
+      relations: 0,
+    });
+
+    assert.deepEqual(readJson(path.join(dir, 'publish-bundle.json')), {
+      generated_at: report.generated_at_utc,
+      run_dir: dir,
+      source_model: {},
+      publish_processes: true,
+      publish_relations: true,
+      status: 'prepared_local_publish_bundle',
+      projected_processes: [{ id: 'proc-scalar' }],
+      relations: [],
+      report: {
+        status: 'prepared_local_bundle',
+      },
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelPublishResultingProcess validates required run-dir and artifacts', async () => {
+  await assert.rejects(
+    () =>
+      runLifecyclemodelPublishResultingProcess({
+        runDir: '',
+        publishProcesses: true,
+        publishRelations: true,
+      }),
+    assertCliErrorCode('LIFECYCLEMODEL_RUN_DIR_REQUIRED'),
+  );
+
+  const missingBundleDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-publish-missing-bundle-'));
+  const invalidBundleDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-publish-invalid-bundle-'));
+  const invalidReportDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-publish-invalid-report-'));
+
+  writeJson(path.join(missingBundleDir, 'projection-report.json'), {
+    status: 'prepared_local_bundle',
+  });
+  writeJson(path.join(invalidBundleDir, 'process-projection-bundle.json'), []);
+  writeJson(path.join(invalidBundleDir, 'projection-report.json'), {
+    status: 'prepared_local_bundle',
+  });
+  writeJson(path.join(invalidReportDir, 'process-projection-bundle.json'), {
+    projected_processes: [],
+  });
+  writeJson(path.join(invalidReportDir, 'projection-report.json'), []);
+
+  try {
+    await assert.rejects(
+      () =>
+        runLifecyclemodelPublishResultingProcess({
+          runDir: missingBundleDir,
+          publishProcesses: true,
+          publishRelations: true,
+        }),
+      assertCliErrorCode('LIFECYCLEMODEL_PROJECTION_BUNDLE_MISSING'),
+    );
+
+    await assert.rejects(
+      () =>
+        runLifecyclemodelPublishResultingProcess({
+          runDir: invalidBundleDir,
+          publishProcesses: true,
+          publishRelations: true,
+        }),
+      assertCliErrorCode('LIFECYCLEMODEL_PROJECTION_BUNDLE_NOT_OBJECT'),
+    );
+
+    await assert.rejects(
+      () =>
+        runLifecyclemodelPublishResultingProcess({
+          runDir: invalidReportDir,
+          publishProcesses: true,
+          publishRelations: true,
+        }),
+      assertCliErrorCode('LIFECYCLEMODEL_PROJECTION_REPORT_NOT_OBJECT'),
+    );
+  } finally {
+    rmSync(missingBundleDir, { recursive: true, force: true });
+    rmSync(invalidBundleDir, { recursive: true, force: true });
+    rmSync(invalidReportDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #11

## Summary
- implement `tiangong lifecyclemodel publish-resulting-process` in the TypeScript CLI
- generate local `publish-bundle.json` and `publish-intent.json` artifacts from a prior resulting-process run
- update CLI help, tests, and migration docs to reflect the command as implemented

## Validation
- npm run prepush:gate

## Stack note
- this branch is intentionally stacked on #10 and currently targets `feature/issue-9`
- after #10 merges, rebase this branch onto `main` and retarget the PR
