### PR TITLE
feat: add process batch-build orchestration

### DIFF
--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -18,6 +18,7 @@
 - `tiangong process auto-build`
 - `tiangong process resume-build`
 - `tiangong process publish-build`
+- `tiangong process batch-build`
 - `tiangong lifecyclemodel build-resulting-process`
 - `tiangong lifecyclemodel publish-resulting-process`
 - `tiangong publish run`
@@ -77,6 +78,7 @@ npm start -- search flow --input ./request.json --dry-run
 npm start -- process auto-build --input ./pff-request.json --json
 npm start -- process resume-build --run-id <run-id> --json
 npm start -- process publish-build --run-id <run-id> --json
+npm start -- process batch-build --input ./batch-request.json --json
 npm start -- lifecyclemodel build-resulting-process --input ./request.json --json
 npm start -- lifecyclemodel publish-resulting-process --run-dir ./runs/example --publish-processes --publish-relations --json
 npm start -- publish run --input ./publish-request.json --dry-run
@@ -123,9 +125,16 @@ npm start -- admin embedding-run --input ./jobs.json --dry-run
 
 这个命令当前只负责本地 publish handoff，不负责真正的远端 publish commit；真正的 dry-run / commit 边界仍由 `tiangong publish run` 负责。
 
-也就是说，下面这些还没有迁完：
+`tiangong process batch-build` 现在也已经进入可执行状态，负责：
 
-- `tiangong process batch-build`
+- 读取单个 batch manifest
+- 创建自包含的 batch root 和聚合 report 路径
+- 顺序复用 CLI 的 `process auto-build` 契约执行多个 item
+- 为每个 item 生成稳定的本地 run 目录
+- 在 batch report 中记录 per-item prepared / failed / skipped 结果
+- 为后续 `resume-build` / `publish-build` 保留明确的 `run_root`
+
+这个命令当前只负责本地 batch orchestration，不负责继续串接 resume / publish，也不负责远端 publish commit。
 
 `tiangong publish run` 现在已经成为统一 publish 契约入口，负责：
 
@@ -210,6 +219,7 @@ npm run build
 - `process-automated-builder` 已先迁入 `tiangong process auto-build` 本地 scaffold；剩余阶段继续按子命令切片迁移
 - `process-automated-builder` 的本地 resume handoff 也已迁入 `tiangong process resume-build`；后续阶段继续按子命令切片迁移
 - `process-automated-builder` 的本地 publish handoff 也已迁入 `tiangong process publish-build`
+- `process-automated-builder` 的本地 batch orchestration 也已迁入 `tiangong process batch-build`
 - 其余重型 workflow 先保留原执行器，但由 `tiangong` 统一调度
 - 所有新脚本优先使用统一环境变量名，不再扩散旧变量名
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Current implementation choices:
 - `tiangong process auto-build`
 - `tiangong process resume-build`
 - `tiangong process publish-build`
+- `tiangong process batch-build`
 - `tiangong lifecyclemodel build-resulting-process`
 - `tiangong lifecyclemodel publish-resulting-process`
 - `tiangong publish run`
@@ -34,7 +35,6 @@ The `lifecyclemodel` and `process` namespaces are now partially implemented. The
 - `tiangong lifecyclemodel validate-build`
 - `tiangong lifecyclemodel publish-build`
 - `tiangong process get`
-- `tiangong process batch-build`
 
 These remaining commands are intentionally not executable yet. They print an explicit `not implemented yet` message and exit with code `2` until the corresponding workflows are migrated into TypeScript.
 
@@ -93,6 +93,7 @@ npm start -- search flow --input ./request.json --dry-run
 npm start -- process auto-build --input ./pff-request.json --json
 npm start -- process resume-build --run-id <run-id> --json
 npm start -- process publish-build --run-id <run-id> --json
+npm start -- process batch-build --input ./batch-request.json --json
 npm start -- lifecyclemodel build-resulting-process --input ./request.json --json
 npm start -- lifecyclemodel publish-resulting-process --run-dir ./runs/example --publish-processes --publish-relations --json
 npm start -- publish run --input ./publish-request.json --dry-run
@@ -110,11 +111,15 @@ The command keeps the legacy per-run layout that later stages still expect, incl
 
 `tiangong process publish-build` is the third migrated `process_from_flow` slice. It reopens one existing local run by `--run-id` or `--run-dir`, validates `process_from_flow_state.json`, `agent_handoff_summary.json`, `run-manifest.json`, and `invocation-index.json`, collects canonical process/source datasets from `exports/` or state fallbacks, writes `stage_outputs/10_publish/publish-bundle.json`, `publish-request.json`, `publish-intent.json`, rewrites `agent_handoff_summary.json`, updates the run state and invocation index, and emits `process-publish-build-report.json`.
 
-`resume-build` and `publish-build` both still stop at the local handoff boundary. They do not execute remote publish CRUD or commit mode themselves; that boundary remains in `tiangong publish run`. `process batch-build` remains the next planned process slice.
+`tiangong process batch-build` is the fourth migrated `process_from_flow` slice. It reads one batch manifest, prepares a self-contained batch root, fans out multiple local `process auto-build` runs through the CLI-owned contract, writes a structured per-item aggregate report, and preserves deterministic item-level artifact paths for downstream `resume-build` or `publish-build` steps.
+
+`resume-build`, `publish-build`, and `batch-build` all still stop at local handoff boundaries. They do not execute remote publish CRUD or commit mode themselves; that boundary remains in `tiangong publish run`.
 
 ## Publish and validation
 
 `tiangong process publish-build` is the process-side local publish handoff command. It prepares the local bundle/request/intent artifacts expected by `tiangong publish run` without reintroducing Python, MCP, or legacy remote writers into the CLI.
+
+`tiangong process batch-build` is the process-side local batch orchestration command. It keeps batch execution file-first and JSON-first, reuses the single-run `process auto-build` contract for each item, and emits one batch report instead of pushing shell loops or Python coordinators back onto the caller.
 
 `tiangong lifecyclemodel publish-resulting-process` is the lifecyclemodel-side local publish handoff command. It reads a prior resulting-process run, writes `publish-bundle.json` and `publish-intent.json`, and preserves the old builder's artifact contract without reintroducing Python or MCP into the CLI.
 
@@ -129,6 +134,7 @@ node ./bin/tiangong.js doctor
 node ./bin/tiangong.js process auto-build --input ./pff-request.json --json
 node ./bin/tiangong.js process resume-build --run-id <run-id> --json
 node ./bin/tiangong.js process publish-build --run-id <run-id> --json
+node ./bin/tiangong.js process batch-build --input ./batch-request.json --json
 node ./dist/src/main.js doctor --json
 ```
 

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -34,6 +34,7 @@ tiangong
     auto-build
     resume-build
     publish-build
+    batch-build
   lifecyclemodel
     build-resulting-process
     publish-resulting-process
@@ -56,6 +57,7 @@ tiangong
 | `tiangong process auto-build` | 本地 `process_from_flow` intake、run-id 生成、artifact scaffold 预写 |
 | `tiangong process resume-build` | 本地 `process_from_flow` resume handoff、state-lock/manifest 收口、resume 元数据与报告输出 |
 | `tiangong process publish-build` | 本地 `process_from_flow` publish handoff、publish bundle/request/intent 产出、state/invocation/handoff 更新 |
+| `tiangong process batch-build` | 本地 `process_from_flow` batch manifest 编排、批量调用 auto-build、batch report 输出 |
 | `tiangong lifecyclemodel build-resulting-process` | 本地 lifecycle model resulting process 聚合、内部 flow 抵消、artifact 输出 |
 | `tiangong lifecyclemodel publish-resulting-process` | 读取 resulting-process run，生成 `publish-bundle.json` / `publish-intent.json` 本地交付物 |
 | `tiangong publish run` | 本地 publish 契约归一化、dry-run/commit、report 输出 |
@@ -73,7 +75,8 @@ tiangong
 - `tiangong process auto-build` 已可执行
 - `tiangong process resume-build` 已可执行
 - `tiangong process publish-build` 已可执行
-- `get`、`batch-build` 仍处于 planned 状态
+- `tiangong process batch-build` 已可执行
+- `get` 仍处于 planned 状态
 
 注意：
 
@@ -83,6 +86,8 @@ tiangong
 - `process resume-build` 当前只负责本地 resume handoff，不直接执行 route / split / exchange / QA / publish 阶段
 - 已实现的 `process publish-build` 继续保留同一套 run 布局，并把本地 publish-bundle/request/intent、state/invocation/handoff 更新统一收口到 CLI
 - `process publish-build` 当前只负责本地 publish handoff，不直接执行远端 publish commit 或数据库写入
+- 已实现的 `process batch-build` 继续走本地优先、artifact-first 路径，并把批量 item 编排、聚合 report、默认 run_dir 分配统一收口到 CLI
+- `process batch-build` 当前只负责本地 batch orchestration，不直接串接 resume / publish 或远端执行器
 - 已实现的 `build-resulting-process` 和 `publish-resulting-process` 都走本地优先、artifact-first 路径，不依赖 Python 或 MCP
 - `publish-resulting-process` 当前负责生成本地 publish handoff 产物，还没有把提交语义直接并入 `publish run`
 - 其余未实现的 `lifecyclemodel` / `process` 子命令仍只提供 help 和固定命名
@@ -240,6 +245,23 @@ tiangong admin embedding-run --input ./jobs.json --dry-run
 - 重新实现历史 MCP transport
 - `batch-build`
 
+`process batch-build` 现在固定的是“本地 process-from-flow batch orchestration 契约层”。
+
+它负责：
+
+- 读取单个 batch manifest
+- 生成 batch root、normalized request、invocation index、run manifest、aggregate report
+- 顺序复用 `process auto-build` 为多个 item 准备本地 run
+- 给每个 item 分配稳定的默认 `run_root`
+- 输出 per-item `prepared` / `failed` / `skipped` 状态
+- 为后续 `resume-build` / `publish-build` 保留明确的 `run_root`
+
+它现在还不负责：
+
+- 直接串接 `resume-build` / `publish-build`
+- 并发调度、daemon、远端 CRUD、历史 Python orchestrator 复刻
+- `process get`
+
 `publish run` 现在固定的是“稳定 publish 契约层”，不是历史 MCP 写库脚本的 TypeScript 复刻。
 
 它负责：
@@ -342,7 +364,7 @@ npm run prepush:gate
   - 已落地 `tiangong process auto-build`
   - 已落地 `tiangong process resume-build`
   - 已落地 `tiangong process publish-build`
-  - 仍待迁移 `batch-build`
+  - 已落地 `tiangong process batch-build`
 - `lifecycleinventory-review`
 - 其他重型 Python workflow
 
@@ -379,7 +401,7 @@ npm run prepush:gate
 
 ### Phase 2
 
-- 继续补齐 `process batch-build`
+- 切 `process-automated-builder` 到 CLI-only wrapper
 - 引入 `review` / `job` / `flow` / `process` 的更多业务子命令
 - 用 CLI 接管现有 workflow 的稳定 contract 层
 - 统一 run-dir / artifact / manifest 输入输出格式

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -69,7 +69,7 @@
 | `process-hybrid-search` | 已有等价 CLI | shell wrapper，历史 token/env 兼容 | 只保留 skill 文档，调用 `tiangong search process` | P0 |
 | `lifecyclemodel-hybrid-search` | 已有等价 CLI | shell wrapper，历史 token/env 兼容 | 只保留 skill 文档，调用 `tiangong search lifecyclemodel` | P0 |
 | `embedding-ft` | 已有等价 CLI | shell wrapper | 只保留 skill 文档，调用 `tiangong admin embedding-run` | P0 |
-| `process-automated-builder` | 已进入 CLI 化，6.1/6.2/6.3 已落地 | `tiangong process auto-build` / `resume-build` / `publish-build` + shell/Python/LangGraph/MCP/OpenAI/AI edge search/TianGong unstructured 遗留阶段 | 迁成 `tiangong process ...` 主链 | P1 |
+| `process-automated-builder` | 已进入 CLI 化，6.1/6.2/6.3/6.4 已落地 | `tiangong process auto-build` / `resume-build` / `publish-build` / `batch-build` + shell/Python/LangGraph/MCP/OpenAI/AI edge search/TianGong unstructured 遗留阶段 | 迁成 `tiangong process ...` 主链 | P1 |
 | `lifecyclemodel-automated-builder` | 仍是重 workflow | shell + Python + MCP + OpenAI | 迁成 `tiangong lifecyclemodel ...` 主链 | P1 |
 | `lifecyclemodel-resulting-process-builder` | CLI 本地 build/publish handoff 已落地，skill wrapper 已切换 | `skill -> tiangong lifecyclemodel build/publish-resulting-process` | 保持薄 wrapper，继续去掉遗留 lookup 分支 | P1 |
 | `lifecycleinventory-review` | 仍是 review workflow | Python review script | 迁成 `tiangong review process` | P2 |
@@ -262,20 +262,21 @@ ToDo：
 - [x] `tiangong process auto-build`
 - [x] `tiangong process resume-build`
 - [x] `tiangong process publish-build`
-- [ ] `tiangong process batch-build`
+- [x] `tiangong process batch-build`
 
 建议拆成 4 个连续小步骤，而不是一次性大迁移：
 
 - [x] 6.1 先实现 `auto-build` 的本地产物路径，不做 publish
 - [x] 6.2 再实现 `resume-build`，把 state-lock / run manifest 彻底收口到 CLI
 - [x] 6.3 再实现 `publish-build`，接到统一 publish 模块的本地 handoff 契约
-- [ ] 6.4 最后实现 `batch-build`
+- [x] 6.4 最后实现 `batch-build`
 
 迁移内容：
 
 - [x] intake request normalization / flow 归一化 / run-id / local artifact scaffold 迁到 TS CLI
 - [x] 本地状态锁、cache、resume handoff 逻辑迁到 CLI
 - [x] 本地 publish handoff、publish-bundle/request/intent 契约迁到 CLI
+- [x] 本地 batch manifest orchestration、aggregate report、default run_dir 分配迁到 CLI
 - [ ] 流程编排迁到 TS
 - [ ] flow search 改为直接 REST，而不是 MCP
 - [ ] publish 改为直接 REST / CLI publish，而不是 MCP CRUD
@@ -434,7 +435,7 @@ ToDo：
 
 如果只按最短路径推进，下一轮建议严格做这 8 件事：
 
-当前重点已经推进到第 8 项，且 `tiangong process auto-build` / `resume-build` / `publish-build`（Phase 6.1 / 6.2 / 6.3）已完成。
+当前重点已经推进到第 8 项，且 `tiangong process auto-build` / `resume-build` / `publish-build` / `batch-build`（Phase 6.1 / 6.2 / 6.3 / 6.4）已完成。
 
 1. 修 CLI help，让命令面和真实实现一致。
 2. 修 skills 文档中的 `TIANGONG_CLI_DIR` 残留。
@@ -443,7 +444,7 @@ ToDo：
 5. 完成 `tiangong lifecyclemodel publish-resulting-process`。
 6. 把 `lifecyclemodel-resulting-process-builder` 改成薄 wrapper。
 7. 把 `lca-publish-executor` 收口到 `tiangong publish run`。
-8. 继续推进 `tiangong process batch-build`，把批量 process build 编排面从遗留 workflow 收口到 CLI。
+8. 创建 follow-up skills child issue，把 `process-automated-builder` 切到 CLI-only 执行链。
 
 ## 10. 不应该做的事
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,11 @@ import {
   type RunProcessAutoBuildOptions,
 } from './lib/process-auto-build.js';
 import {
+  runProcessBatchBuild,
+  type ProcessBatchBuildReport,
+  type RunProcessBatchBuildOptions,
+} from './lib/process-batch-build.js';
+import {
   runProcessResumeBuild,
   type ProcessResumeBuildReport,
   type RunProcessResumeBuildOptions,
@@ -52,6 +57,9 @@ export type CliDeps = {
   runProcessAutoBuildImpl?: (
     options: RunProcessAutoBuildOptions,
   ) => Promise<ProcessAutoBuildReport>;
+  runProcessBatchBuildImpl?: (
+    options: RunProcessBatchBuildOptions,
+  ) => Promise<ProcessBatchBuildReport>;
   runProcessResumeBuildImpl?: (
     options: RunProcessResumeBuildOptions,
   ) => Promise<ProcessResumeBuildReport>;
@@ -89,7 +97,7 @@ Commands:
 Implemented Commands:
   doctor     show environment diagnostics
   search     flow | process | lifecyclemodel
-  process    auto-build | resume-build | publish-build
+  process    auto-build | resume-build | publish-build | batch-build
   lifecyclemodel build-resulting-process | publish-resulting-process
   publish    run
   validation run
@@ -100,7 +108,7 @@ Planned Surface (not implemented yet):
   lifecyclemodel auto-build | validate-build | publish-build
   review     flow | process
   flow       get | list | remediate | publish-version | regen-product
-  process    get | batch-build
+  process    get
   job        get | wait | logs
 
 Planned commands currently print an explicit "not implemented yet" message and exit with code 2.
@@ -112,6 +120,7 @@ Examples:
   tiangong process auto-build --input ./pff-request.json
   tiangong process resume-build --run-id <id>
   tiangong process publish-build --run-id <id>
+  tiangong process batch-build --input ./batch-request.json
   tiangong publish run --input ./publish-request.json --dry-run
   tiangong validation run --input-dir ./package --engine auto
   tiangong admin embedding-run --input ./jobs.json
@@ -270,6 +279,18 @@ Options:
 `.trim();
 }
 
+function renderProcessBatchBuildHelp(): string {
+  return `Usage:
+  tiangong process batch-build --input <file> [options]
+
+Options:
+  --input <file>     JSON batch manifest file
+  --out-dir <dir>    Override the batch artifact output directory
+  --json             Print compact JSON
+  -h, --help
+`.trim();
+}
+
 function renderProcessHelp(): string {
   return `Usage:
   tiangong process <subcommand> [options]
@@ -278,16 +299,17 @@ Implemented Subcommands:
   auto-build   Prepare a local process-from-flow run scaffold and artifact workspace
   resume-build Prepare a local resume handoff from one existing process build run
   publish-build Prepare publish handoff artifacts from one existing process build run
+  batch-build  Run multiple process auto-build requests through one batch-oriented CLI surface
 
 Planned Subcommands:
   get          Load one process dataset or process build run summary
-  batch-build  Run multiple process build requests through one batch-oriented CLI surface
 
 Examples:
   tiangong process --help
   tiangong process auto-build --help
   tiangong process resume-build --run-id <id> --help
   tiangong process publish-build --run-id <id> --help
+  tiangong process batch-build --input ./batch-request.json --help
 `.trim();
 }
 
@@ -786,6 +808,40 @@ function parseProcessPublishBuildFlags(args: string[]): {
   };
 }
 
+function parseProcessBatchBuildFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  inputPath: string;
+  outDir: string | null;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        input: { type: 'string' },
+        'out-dir': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    inputPath: typeof values.input === 'string' ? values.input : '',
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : null,
+  };
+}
+
 function plannedCommand(command: string, subcommand?: string): CliResult {
   const suffix = subcommand ? ` ${subcommand}` : '';
   return {
@@ -818,6 +874,7 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
     const lifecyclemodelPublishImpl =
       deps.runLifecyclemodelPublishResultingProcessImpl ?? runLifecyclemodelPublishResultingProcess;
     const processAutoBuildImpl = deps.runProcessAutoBuildImpl ?? runProcessAutoBuild;
+    const processBatchBuildImpl = deps.runProcessBatchBuildImpl ?? runProcessBatchBuild;
     const processResumeBuildImpl = deps.runProcessResumeBuildImpl ?? runProcessResumeBuild;
     const processPublishBuildImpl = deps.runProcessPublishBuildImpl ?? runProcessPublishBuild;
 
@@ -996,6 +1053,28 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
 
       return {
         exitCode: 0,
+        stdout: stringifyJson(report, processFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'process' && subcommand === 'batch-build') {
+      const processFlags = parseProcessBatchBuildFlags(commandArgs);
+      if (processFlags.help) {
+        return {
+          exitCode: 0,
+          stdout: `${renderProcessBatchBuildHelp()}\n`,
+          stderr: '',
+        };
+      }
+
+      const report = await processBatchBuildImpl({
+        inputPath: processFlags.inputPath,
+        outDir: processFlags.outDir,
+      });
+
+      return {
+        exitCode: report.status === 'completed_with_failures' ? 1 : 0,
         stdout: stringifyJson(report, processFlags.json),
         stderr: '',
       };

--- a/src/lib/process-auto-build.ts
+++ b/src/lib/process-auto-build.ts
@@ -131,6 +131,9 @@ export type RunProcessAutoBuildOptions = {
   outDir?: string | null;
   now?: Date;
   cwd?: string;
+  inputValue?: unknown;
+  requestIdOverride?: string;
+  runIdOverride?: string;
 };
 
 type ProcessAutoBuildStage = {
@@ -883,7 +886,13 @@ function buildReport(
 
 export function normalizeProcessAutoBuildRequest(
   input: unknown,
-  options: { inputPath: string; outDir?: string | null; now?: Date },
+  options: {
+    inputPath: string;
+    outDir?: string | null;
+    now?: Date;
+    requestIdOverride?: string;
+    runIdOverride?: string;
+  },
 ): NormalizedProcessAutoBuildRequest {
   const request = requiredRequestObject(input);
   const requestDir = path.dirname(path.resolve(options.inputPath));
@@ -893,6 +902,7 @@ export function normalizeProcessAutoBuildRequest(
   const { flowDataset, wrapper } = extractFlowDatasetRoot(flowPayload);
   const flowSummary = extractFlowSummary(flowDataset, wrapper);
   const runId =
+    nonEmptyString(options.runIdOverride) ??
     nonEmptyString(request.run_id) ??
     buildProcessAutoBuildRunId(flowFile, operation, flowSummary, options.now);
   const runRoot = resolveRunRoot(requestDir, runId, options.outDir, request.workspace_run_root);
@@ -901,7 +911,10 @@ export function normalizeProcessAutoBuildRequest(
   return {
     schema_version: 1,
     request_path: path.resolve(options.inputPath),
-    request_id: nonEmptyString(request.request_id) ?? `pff-${runId}`,
+    request_id:
+      nonEmptyString(options.requestIdOverride) ??
+      nonEmptyString(request.request_id) ??
+      `pff-${runId}`,
     flow_file: flowFile,
     flow_summary: flowSummary,
     flow_dataset: flowDataset,
@@ -920,12 +933,14 @@ export function normalizeProcessAutoBuildRequest(
 export async function runProcessAutoBuild(
   options: RunProcessAutoBuildOptions,
 ): Promise<ProcessAutoBuildReport> {
-  const input = readJsonInput(options.inputPath);
+  const input = options.inputValue ?? readJsonInput(options.inputPath);
   const now = options.now ?? new Date();
   const normalized = normalizeProcessAutoBuildRequest(input, {
     inputPath: options.inputPath,
     outDir: options.outDir,
     now,
+    requestIdOverride: options.requestIdOverride,
+    runIdOverride: options.runIdOverride,
   });
   const layout = buildLayout(normalized.run_root, normalized.run_id);
   const flowArtifactPath = path.join(layout.inputsDir, path.basename(normalized.flow_file));

--- a/src/lib/process-batch-build.ts
+++ b/src/lib/process-batch-build.ts
@@ -1,0 +1,617 @@
+import { existsSync, mkdirSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { readJsonInput } from './io.js';
+import { writeJsonArtifact } from './artifacts.js';
+import { CliError, toErrorPayload, type ErrorPayload } from './errors.js';
+import {
+  normalizeProcessAutoBuildRequest,
+  runProcessAutoBuild,
+  type ProcessAutoBuildReport,
+} from './process-auto-build.js';
+import {
+  buildRunId,
+  buildRunManifest,
+  ensureRunLayout,
+  sanitizeRunToken,
+  writeLatestRunId,
+  type RunLayout,
+} from './run.js';
+
+type JsonRecord = Record<string, unknown>;
+
+type ProcessBatchBuildStatus = 'completed' | 'completed_with_failures';
+type ProcessBatchBuildItemStatus = 'prepared' | 'failed' | 'skipped';
+
+type ProcessBatchBuildManifestItem = {
+  item_id: string;
+  input_path: string;
+  out_dir: string;
+};
+
+export type ProcessBatchBuildLayout = RunLayout & {
+  requestDir: string;
+  runsDir: string;
+  requestSnapshotPath: string;
+  normalizedRequestPath: string;
+  invocationIndexPath: string;
+  runManifestPath: string;
+  reportPath: string;
+};
+
+export type NormalizedProcessBatchBuildRequest = {
+  schema_version: 1;
+  manifest_path: string;
+  batch_id: string;
+  batch_root: string;
+  continue_on_error: boolean;
+  items: ProcessBatchBuildManifestItem[];
+};
+
+export type ProcessBatchBuildItemReport = {
+  item_id: string;
+  index: number;
+  input_path: string;
+  out_dir: string;
+  status: ProcessBatchBuildItemStatus;
+  run_id: string | null;
+  run_root: string | null;
+  request_id: string | null;
+  files: {
+    request_snapshot: string | null;
+    report: string | null;
+    state: string | null;
+    handoff_summary: string | null;
+    run_manifest: string | null;
+  };
+  error: ErrorPayload['error'] | null;
+};
+
+export type ProcessBatchBuildReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: ProcessBatchBuildStatus;
+  manifest_path: string;
+  batch_id: string;
+  batch_root: string;
+  continue_on_error: boolean;
+  counts: {
+    total: number;
+    prepared: number;
+    failed: number;
+    skipped: number;
+  };
+  files: {
+    request_snapshot: string;
+    normalized_request: string;
+    invocation_index: string;
+    run_manifest: string;
+    report: string;
+  };
+  items: ProcessBatchBuildItemReport[];
+  next_actions: string[];
+};
+
+export type RunProcessBatchBuildOptions = {
+  inputPath: string;
+  outDir?: string | null;
+  now?: Date;
+  cwd?: string;
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized || null;
+}
+
+function normalizeBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function requiredRequestObject(input: unknown): JsonRecord {
+  if (!isRecord(input)) {
+    throw new CliError('process batch-build request must be a JSON object.', {
+      code: 'PROCESS_BATCH_BUILD_REQUEST_INVALID',
+      exitCode: 2,
+    });
+  }
+
+  return input;
+}
+
+function resolveBatchRoot(
+  manifestDir: string,
+  batchId: string,
+  outDirOverride: string | null | undefined,
+  requestOutDir: unknown,
+): string {
+  const override = nonEmptyString(outDirOverride);
+  if (override) {
+    return path.resolve(manifestDir, override);
+  }
+
+  const requestValue = nonEmptyString(requestOutDir);
+  if (requestValue) {
+    return path.resolve(manifestDir, requestValue);
+  }
+
+  return path.join(manifestDir, 'artifacts', 'process_batch', batchId);
+}
+
+function buildLayout(batchRoot: string, batchId: string): ProcessBatchBuildLayout {
+  const collectionDir = path.dirname(batchRoot);
+  const layout: RunLayout = {
+    namespace: 'process_batch',
+    runId: batchId,
+    artifactsRoot: path.dirname(collectionDir),
+    collectionDir,
+    runRoot: batchRoot,
+    cacheDir: path.join(batchRoot, 'cache'),
+    inputsDir: path.join(batchRoot, 'request'),
+    outputsDir: path.join(batchRoot, 'runs'),
+    reportsDir: path.join(batchRoot, 'reports'),
+    logsDir: path.join(batchRoot, 'logs'),
+    manifestsDir: path.join(batchRoot, 'manifests'),
+    latestRunIdPath: path.join(collectionDir, '.latest_run_id'),
+  };
+
+  return {
+    ...layout,
+    requestDir: path.join(batchRoot, 'request'),
+    runsDir: path.join(batchRoot, 'runs'),
+    requestSnapshotPath: path.join(batchRoot, 'request', 'batch-request.json'),
+    normalizedRequestPath: path.join(batchRoot, 'request', 'request.normalized.json'),
+    invocationIndexPath: path.join(batchRoot, 'manifests', 'invocation-index.json'),
+    runManifestPath: path.join(batchRoot, 'manifests', 'run-manifest.json'),
+    reportPath: path.join(batchRoot, 'reports', 'process-batch-build-report.json'),
+  };
+}
+
+function ensureEmptyRunRoot(runRoot: string): void {
+  if (!existsSync(runRoot)) {
+    return;
+  }
+
+  const entries = readdirSync(runRoot);
+  if (entries.length > 0) {
+    throw new CliError(`process batch-build run root already exists and is not empty: ${runRoot}`, {
+      code: 'PROCESS_BATCH_BUILD_RUN_EXISTS',
+      exitCode: 2,
+    });
+  }
+}
+
+function ensureProcessBatchBuildLayout(layout: ProcessBatchBuildLayout): void {
+  ensureRunLayout(layout);
+  [layout.requestDir, layout.runsDir].forEach((dirPath) => {
+    mkdirSync(dirPath, { recursive: true });
+  });
+}
+
+function normalizeBatchId(inputPath: string, request: JsonRecord, now: Date): string {
+  const explicit = nonEmptyString(request.batch_id);
+  if (explicit) {
+    return explicit;
+  }
+
+  return buildRunId({
+    namespace: 'process_batch',
+    subject: path.basename(inputPath, path.extname(inputPath)),
+    operation: 'build',
+    now,
+  });
+}
+
+function normalizeItemId(
+  request: JsonRecord,
+  inputPath: string,
+  index: number,
+  seenIds: Set<string>,
+): string {
+  const explicit = nonEmptyString(request.item_id);
+  const baseId = sanitizeRunToken(
+    explicit ?? path.basename(inputPath, path.extname(inputPath)),
+    `item_${index + 1}`,
+  );
+
+  if (explicit) {
+    if (seenIds.has(baseId)) {
+      throw new CliError(`Duplicate process batch-build item_id: ${baseId}`, {
+        code: 'PROCESS_BATCH_BUILD_ITEM_DUPLICATE',
+        exitCode: 2,
+      });
+    }
+
+    seenIds.add(baseId);
+    return baseId;
+  }
+
+  if (!seenIds.has(baseId)) {
+    seenIds.add(baseId);
+    return baseId;
+  }
+
+  let suffix = 2;
+  while (seenIds.has(`${baseId}_${suffix}`)) {
+    suffix += 1;
+  }
+
+  const deduped = `${baseId}_${suffix}`;
+  seenIds.add(deduped);
+  return deduped;
+}
+
+function normalizeItems(
+  value: unknown,
+  manifestDir: string,
+  batchRoot: string,
+): ProcessBatchBuildManifestItem[] {
+  if (!Array.isArray(value)) {
+    throw new CliError('process batch-build items must be an array.', {
+      code: 'PROCESS_BATCH_BUILD_REQUEST_INVALID',
+      exitCode: 2,
+    });
+  }
+
+  if (value.length === 0) {
+    throw new CliError('process batch-build items must not be empty.', {
+      code: 'PROCESS_BATCH_BUILD_REQUEST_INVALID',
+      exitCode: 2,
+    });
+  }
+
+  const seenIds = new Set<string>();
+
+  return value.map((entry, index) => {
+    const request = typeof entry === 'string' ? { input_path: entry } : entry;
+    if (!isRecord(request)) {
+      throw new CliError('process batch-build items entries must be strings or objects.', {
+        code: 'PROCESS_BATCH_BUILD_REQUEST_INVALID',
+        exitCode: 2,
+        details: { index },
+      });
+    }
+
+    const inputValue = nonEmptyString(request.input_path);
+    if (!inputValue) {
+      throw new CliError("process batch-build items[] is missing 'input_path'.", {
+        code: 'PROCESS_BATCH_BUILD_REQUEST_INVALID',
+        exitCode: 2,
+        details: { index },
+      });
+    }
+
+    const inputPath = path.resolve(manifestDir, inputValue);
+    const itemId = normalizeItemId(request, inputPath, index, seenIds);
+    const explicitOutDir = nonEmptyString(request.out_dir);
+    const outDir = explicitOutDir
+      ? path.resolve(manifestDir, explicitOutDir)
+      : path.join(batchRoot, 'runs', `${String(index + 1).padStart(3, '0')}_${itemId}`);
+
+    return {
+      item_id: itemId,
+      input_path: inputPath,
+      out_dir: outDir,
+    };
+  });
+}
+
+export function normalizeProcessBatchBuildRequest(
+  input: unknown,
+  options: {
+    inputPath: string;
+    outDir?: string | null;
+    now?: Date;
+  },
+): NormalizedProcessBatchBuildRequest {
+  const request = requiredRequestObject(input);
+  const manifestPath = path.resolve(options.inputPath);
+  const manifestDir = path.dirname(manifestPath);
+  const now = options.now ?? new Date();
+  const batchId = normalizeBatchId(manifestPath, request, now);
+  const batchRoot = resolveBatchRoot(manifestDir, batchId, options.outDir, request.out_dir);
+
+  return {
+    schema_version: 1,
+    manifest_path: manifestPath,
+    batch_id: batchId,
+    batch_root: batchRoot,
+    continue_on_error: normalizeBoolean(request.continue_on_error, true),
+    items: normalizeItems(request.items, manifestDir, batchRoot),
+  };
+}
+
+function buildInvocationIndex(
+  normalized: NormalizedProcessBatchBuildRequest,
+  options: RunProcessBatchBuildOptions,
+  layout: ProcessBatchBuildLayout,
+  now: Date,
+): JsonRecord {
+  const command = ['process', 'batch-build', '--input', options.inputPath];
+  if (options.outDir) {
+    command.push('--out-dir', options.outDir);
+  }
+
+  return {
+    schema_version: 1,
+    invocations: [
+      {
+        command,
+        cwd: options.cwd ?? process.cwd(),
+        created_at: now.toISOString(),
+        manifest_path: normalized.manifest_path,
+        batch_id: normalized.batch_id,
+        report_path: layout.reportPath,
+      },
+    ],
+  };
+}
+
+function buildNextActions(layout: ProcessBatchBuildLayout): string[] {
+  return [
+    `inspect: ${layout.normalizedRequestPath}`,
+    `inspect: ${layout.reportPath}`,
+    `future: consume items[].run_root for downstream resume-build or publish-build steps`,
+  ];
+}
+
+function buildPreparedItemResult(
+  item: ProcessBatchBuildManifestItem,
+  index: number,
+  report: ProcessAutoBuildReport,
+): ProcessBatchBuildItemReport {
+  return {
+    item_id: item.item_id,
+    index,
+    input_path: item.input_path,
+    out_dir: item.out_dir,
+    status: 'prepared',
+    run_id: report.run_id,
+    run_root: report.run_root,
+    request_id: report.request_id,
+    files: {
+      request_snapshot: report.files.request_snapshot,
+      report: report.files.report,
+      state: report.files.state,
+      handoff_summary: report.files.handoff_summary,
+      run_manifest: report.files.run_manifest,
+    },
+    error: null,
+  };
+}
+
+function buildFailedItemResult(
+  item: ProcessBatchBuildManifestItem,
+  index: number,
+  error: unknown,
+): ProcessBatchBuildItemReport {
+  return {
+    item_id: item.item_id,
+    index,
+    input_path: item.input_path,
+    out_dir: item.out_dir,
+    status: 'failed',
+    run_id: null,
+    run_root: null,
+    request_id: null,
+    files: {
+      request_snapshot: null,
+      report: null,
+      state: null,
+      handoff_summary: null,
+      run_manifest: null,
+    },
+    error: toErrorPayload(error).error,
+  };
+}
+
+function buildSkippedItemResult(
+  item: ProcessBatchBuildManifestItem,
+  index: number,
+): ProcessBatchBuildItemReport {
+  return {
+    item_id: item.item_id,
+    index,
+    input_path: item.input_path,
+    out_dir: item.out_dir,
+    status: 'skipped',
+    run_id: null,
+    run_root: null,
+    request_id: null,
+    files: {
+      request_snapshot: null,
+      report: null,
+      state: null,
+      handoff_summary: null,
+      run_manifest: null,
+    },
+    error: null,
+  };
+}
+
+function buildReport(
+  normalized: NormalizedProcessBatchBuildRequest,
+  layout: ProcessBatchBuildLayout,
+  items: ProcessBatchBuildItemReport[],
+  now: Date,
+): ProcessBatchBuildReport {
+  const counts = items.reduce(
+    (summary, item) => {
+      summary.total += 1;
+      if (item.status === 'prepared') {
+        summary.prepared += 1;
+      } else if (item.status === 'failed') {
+        summary.failed += 1;
+      } else {
+        summary.skipped += 1;
+      }
+
+      return summary;
+    },
+    {
+      total: 0,
+      prepared: 0,
+      failed: 0,
+      skipped: 0,
+    },
+  );
+
+  return {
+    schema_version: 1,
+    generated_at_utc: now.toISOString(),
+    status: counts.failed > 0 ? 'completed_with_failures' : 'completed',
+    manifest_path: normalized.manifest_path,
+    batch_id: normalized.batch_id,
+    batch_root: normalized.batch_root,
+    continue_on_error: normalized.continue_on_error,
+    counts,
+    files: {
+      request_snapshot: layout.requestSnapshotPath,
+      normalized_request: layout.normalizedRequestPath,
+      invocation_index: layout.invocationIndexPath,
+      run_manifest: layout.runManifestPath,
+      report: layout.reportPath,
+    },
+    items,
+    next_actions: buildNextActions(layout),
+  };
+}
+
+function resolveItemOverrides(
+  itemInput: unknown,
+  item: ProcessBatchBuildManifestItem,
+  index: number,
+  now: Date,
+): {
+  runIdOverride?: string;
+  requestIdOverride?: string;
+  finalRunId: string | null;
+} {
+  if (!isRecord(itemInput)) {
+    return {
+      finalRunId: null,
+    };
+  }
+
+  const explicitRunId = nonEmptyString(itemInput.run_id);
+  const explicitRequestId = nonEmptyString(itemInput.request_id);
+  if (explicitRunId) {
+    return {
+      finalRunId: explicitRunId,
+      requestIdOverride: explicitRequestId ? undefined : `pff-${explicitRunId}`,
+    };
+  }
+
+  const preview = normalizeProcessAutoBuildRequest(itemInput, {
+    inputPath: item.input_path,
+    outDir: item.out_dir,
+    now,
+  });
+  const runIdOverride = `${preview.run_id}_b${String(index + 1).padStart(3, '0')}`;
+
+  return {
+    runIdOverride,
+    requestIdOverride: explicitRequestId ?? `pff-${runIdOverride}`,
+    finalRunId: runIdOverride,
+  };
+}
+
+export async function runProcessBatchBuild(
+  options: RunProcessBatchBuildOptions,
+): Promise<ProcessBatchBuildReport> {
+  const input = readJsonInput(options.inputPath);
+  const now = options.now ?? new Date();
+  const normalized = normalizeProcessBatchBuildRequest(input, {
+    inputPath: options.inputPath,
+    outDir: options.outDir,
+    now,
+  });
+  const layout = buildLayout(normalized.batch_root, normalized.batch_id);
+
+  ensureEmptyRunRoot(layout.runRoot);
+  ensureProcessBatchBuildLayout(layout);
+
+  writeJsonArtifact(layout.requestSnapshotPath, input);
+  writeJsonArtifact(layout.normalizedRequestPath, normalized);
+  writeJsonArtifact(
+    layout.invocationIndexPath,
+    buildInvocationIndex(normalized, options, layout, now),
+  );
+  writeJsonArtifact(
+    layout.runManifestPath,
+    buildRunManifest({
+      layout,
+      command: options.outDir
+        ? ['process', 'batch-build', '--input', options.inputPath, '--out-dir', options.outDir]
+        : ['process', 'batch-build', '--input', options.inputPath],
+      cwd: options.cwd,
+      createdAt: now,
+    }),
+  );
+
+  const seenRunIds = new Set<string>();
+  const items: ProcessBatchBuildItemReport[] = [];
+  let stopAfterFailure = false;
+
+  for (const [index, item] of normalized.items.entries()) {
+    if (stopAfterFailure) {
+      items.push(buildSkippedItemResult(item, index));
+      continue;
+    }
+
+    try {
+      const itemInput = readJsonInput(item.input_path);
+      const overrides = resolveItemOverrides(itemInput, item, index, now);
+
+      if (overrides.finalRunId && seenRunIds.has(overrides.finalRunId)) {
+        throw new CliError(`Duplicate process batch-build run_id: ${overrides.finalRunId}`, {
+          code: 'PROCESS_BATCH_BUILD_RUN_ID_DUPLICATE',
+          exitCode: 2,
+          details: { itemId: item.item_id, index },
+        });
+      }
+
+      if (overrides.finalRunId) {
+        seenRunIds.add(overrides.finalRunId);
+      }
+
+      const report = await runProcessAutoBuild({
+        inputPath: item.input_path,
+        inputValue: itemInput,
+        outDir: item.out_dir,
+        now,
+        cwd: options.cwd,
+        requestIdOverride: overrides.requestIdOverride,
+        runIdOverride: overrides.runIdOverride,
+      });
+      items.push(buildPreparedItemResult(item, index, report));
+    } catch (error) {
+      items.push(buildFailedItemResult(item, index, error));
+      if (!normalized.continue_on_error) {
+        stopAfterFailure = true;
+      }
+    }
+  }
+
+  const report = buildReport(normalized, layout, items, now);
+  writeJsonArtifact(layout.reportPath, report);
+  writeLatestRunId(layout, normalized.batch_id);
+  return report;
+}
+
+export const __testInternals = {
+  buildLayout,
+  resolveBatchRoot,
+  normalizeItems,
+  normalizeProcessBatchBuildRequest,
+  buildInvocationIndex,
+  buildNextActions,
+  buildReport,
+};

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -186,6 +186,7 @@ test('executeCli returns help for the process namespace and implemented subcomma
   assert.match(processHelp.stdout, /auto-build/u);
   assert.match(processHelp.stdout, /resume-build/u);
   assert.match(processHelp.stdout, /publish-build/u);
+  assert.match(processHelp.stdout, /batch-build/u);
 
   const autoBuildHelp = await executeCli(['process', 'auto-build', '--help'], makeDeps());
   assert.equal(autoBuildHelp.exitCode, 0);
@@ -210,6 +211,12 @@ test('executeCli returns help for the process namespace and implemented subcomma
   );
   assert.match(publishBuildHelp.stdout, /--run-dir/u);
   assert.doesNotMatch(publishBuildHelp.stdout, /Planned command/u);
+
+  const batchBuildHelp = await executeCli(['process', 'batch-build', '--help'], makeDeps());
+  assert.equal(batchBuildHelp.exitCode, 0);
+  assert.match(batchBuildHelp.stdout, /tiangong process batch-build --input <file>/u);
+  assert.match(batchBuildHelp.stdout, /--out-dir/u);
+  assert.doesNotMatch(batchBuildHelp.stdout, /Planned command/u);
 });
 
 test('executeCli executes lifecyclemodel build-resulting-process with injected implementation', async () => {
@@ -632,6 +639,120 @@ test('executeCli executes process publish-build with run-dir only', async () => 
   }
 });
 
+test('executeCli executes process batch-build with injected implementation', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-batch-build-cli-'));
+  const inputPath = path.join(dir, 'batch-request.json');
+  writeFileSync(inputPath, '{"items":["./request-a.json"]}', 'utf8');
+
+  try {
+    const result = await executeCli(
+      ['process', 'batch-build', '--json', '--input', inputPath, '--out-dir', './batch-root'],
+      {
+        ...makeDeps(),
+        runProcessBatchBuildImpl: async (options) => {
+          assert.equal(options.inputPath, inputPath);
+          assert.equal(options.outDir, './batch-root');
+          return {
+            schema_version: 1,
+            generated_at_utc: '2026-03-29T00:22:00.000Z',
+            status: 'completed',
+            manifest_path: inputPath,
+            batch_id: 'batch-1',
+            batch_root: path.join(dir, 'batch-root'),
+            continue_on_error: true,
+            counts: {
+              total: 1,
+              prepared: 1,
+              failed: 0,
+              skipped: 0,
+            },
+            files: {
+              request_snapshot: path.join(dir, 'batch-root', 'request', 'batch-request.json'),
+              normalized_request: path.join(
+                dir,
+                'batch-root',
+                'request',
+                'request.normalized.json',
+              ),
+              invocation_index: path.join(dir, 'batch-root', 'manifests', 'invocation-index.json'),
+              run_manifest: path.join(dir, 'batch-root', 'manifests', 'run-manifest.json'),
+              report: path.join(dir, 'batch-root', 'reports', 'process-batch-build-report.json'),
+            },
+            items: [
+              {
+                item_id: 'request_a',
+                index: 0,
+                input_path: path.join(dir, 'request-a.json'),
+                out_dir: path.join(dir, 'batch-root', 'runs', '001_request_a'),
+                status: 'prepared',
+                run_id: 'run-1',
+                run_root: path.join(dir, 'batch-root', 'runs', '001_request_a'),
+                request_id: 'req-1',
+                files: {
+                  request_snapshot: path.join(dir, 'item', 'request.json'),
+                  report: path.join(dir, 'item', 'report.json'),
+                  state: path.join(dir, 'item', 'state.json'),
+                  handoff_summary: path.join(dir, 'item', 'handoff.json'),
+                  run_manifest: path.join(dir, 'item', 'run-manifest.json'),
+                },
+                error: null,
+              },
+            ],
+            next_actions: ['inspect: report'],
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /"status":"completed"/u);
+    assert.match(result.stdout, /"batch_id":"batch-1"/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli maps process batch-build failures to exit code 1', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-batch-build-cli-failure-'));
+  const inputPath = path.join(dir, 'batch-request.json');
+  writeFileSync(inputPath, '{"items":["./request-a.json"]}', 'utf8');
+
+  try {
+    const result = await executeCli(['process', 'batch-build', '--input', inputPath], {
+      ...makeDeps(),
+      runProcessBatchBuildImpl: async () => ({
+        schema_version: 1,
+        generated_at_utc: '2026-03-29T00:23:00.000Z',
+        status: 'completed_with_failures',
+        manifest_path: inputPath,
+        batch_id: 'batch-2',
+        batch_root: path.join(dir, 'batch-root'),
+        continue_on_error: true,
+        counts: {
+          total: 1,
+          prepared: 0,
+          failed: 1,
+          skipped: 0,
+        },
+        files: {
+          request_snapshot: path.join(dir, 'batch-root', 'request', 'batch-request.json'),
+          normalized_request: path.join(dir, 'batch-root', 'request', 'request.normalized.json'),
+          invocation_index: path.join(dir, 'batch-root', 'manifests', 'invocation-index.json'),
+          run_manifest: path.join(dir, 'batch-root', 'manifests', 'run-manifest.json'),
+          report: path.join(dir, 'batch-root', 'reports', 'process-batch-build-report.json'),
+        },
+        items: [],
+        next_actions: ['inspect: report'],
+      }),
+    });
+
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stdout, /completed_with_failures/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('executeCli keeps subcommand --json inside remote command parsing', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-search-json-'));
   const inputPath = path.join(dir, 'request.json');
@@ -945,7 +1066,7 @@ test('executeCli returns parsing errors for invalid publish and validation flags
   assert.match(validationResult.stderr, /INVALID_ARGS/u);
 });
 
-test('executeCli returns parsing errors for invalid lifecyclemodel build, process build, resume, and publish-build flags', async () => {
+test('executeCli returns parsing errors for invalid lifecyclemodel build, process build, resume, publish-build, and batch-build flags', async () => {
   const result = await executeCli(
     ['lifecyclemodel', 'build-resulting-process', '--bad-flag'],
     makeDeps(),
@@ -982,6 +1103,11 @@ test('executeCli returns parsing errors for invalid lifecyclemodel build, proces
   assert.equal(processPublishResult.exitCode, 2);
   assert.equal(processPublishResult.stdout, '');
   assert.match(processPublishResult.stderr, /INVALID_ARGS/u);
+
+  const processBatchResult = await executeCli(['process', 'batch-build', '--bad-flag'], makeDeps());
+  assert.equal(processBatchResult.exitCode, 2);
+  assert.equal(processBatchResult.stdout, '');
+  assert.match(processBatchResult.stderr, /INVALID_ARGS/u);
 });
 
 test('executeCli executes validation run with injected implementation and report file', async () => {
@@ -1106,10 +1232,10 @@ test('executeCli returns planned command message for lifecyclemodel subcommands 
 });
 
 test('executeCli returns planned command message for process subcommands after help is introduced', async () => {
-  const result = await executeCli(['process', 'batch-build'], makeDeps());
+  const result = await executeCli(['process', 'get'], makeDeps());
   assert.equal(result.exitCode, 2);
   assert.equal(result.stdout, '');
-  assert.match(result.stderr, /Command 'process batch-build'/u);
+  assert.match(result.stderr, /Command 'process get'/u);
 });
 
 test('executeCli returns dedicated help for planned lifecyclemodel subcommands', async () => {
@@ -1121,9 +1247,9 @@ test('executeCli returns dedicated help for planned lifecyclemodel subcommands',
 });
 
 test('executeCli returns dedicated help for planned process subcommands', async () => {
-  const result = await executeCli(['process', 'batch-build', '--help'], makeDeps());
+  const result = await executeCli(['process', 'get', '--help'], makeDeps());
   assert.equal(result.exitCode, 0);
-  assert.match(result.stdout, /tiangong process batch-build --input <file>/u);
+  assert.match(result.stdout, /tiangong process get --id <process-id>/u);
   assert.match(result.stdout, /Execution is not implemented yet/u);
   assert.equal(result.stderr, '');
 });

--- a/test/process-batch-build.test.ts
+++ b/test/process-batch-build.test.ts
@@ -1,0 +1,525 @@
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { __testInternals, runProcessBatchBuild } from '../src/lib/process-batch-build.js';
+
+function writeJson(filePath: string, value: unknown): void {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function readJson<T = Record<string, unknown>>(filePath: string): T {
+  return JSON.parse(readFileSync(filePath, 'utf8')) as T;
+}
+
+function bundledFlowPayload(): Record<string, unknown> {
+  return readJson(
+    path.resolve(process.cwd(), '../tidas-sdk/test-data/tidas-example-flow.json'),
+  ) as Record<string, unknown>;
+}
+
+function writeFlowFixture(dir: string): string {
+  const filePath = path.join(dir, '01211_3a8d74d8_reference-flow.json');
+  writeJson(filePath, bundledFlowPayload());
+  return filePath;
+}
+
+function writeProcessRequest(
+  dir: string,
+  fileName: string,
+  options?: {
+    flowPath?: string;
+    overrides?: Record<string, unknown>;
+  },
+): string {
+  const flowPath = options?.flowPath ?? writeFlowFixture(dir);
+  const requestPath = path.join(dir, fileName);
+  writeJson(requestPath, {
+    flow_file: `./${path.basename(flowPath)}`,
+    ...(options?.overrides ?? {}),
+  });
+  return requestPath;
+}
+
+test('runProcessBatchBuild prepares multiple process auto-build runs from one batch manifest', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-batch-build-success-'));
+  const flowPath = writeFlowFixture(dir);
+  writeProcessRequest(dir, 'request-a.json', {
+    flowPath,
+  });
+  writeProcessRequest(dir, 'request-b.json', {
+    flowPath,
+  });
+  const manifestPath = path.join(dir, 'batch-request.json');
+  const explicitRunRoot = path.join(dir, 'custom-run-root');
+  writeJson(manifestPath, {
+    batch_id: 'batch-demo',
+    out_dir: './batch-artifacts',
+    items: [
+      './request-a.json',
+      {
+        input_path: './request-b.json',
+        item_id: 'second-item',
+        out_dir: './custom-run-root',
+      },
+    ],
+  });
+
+  try {
+    const report = await runProcessBatchBuild({
+      inputPath: manifestPath,
+      now: new Date('2026-03-29T07:00:00Z'),
+      cwd: '/tmp/process-batch-build-success',
+    });
+
+    assert.equal(report.status, 'completed');
+    assert.equal(report.batch_id, 'batch-demo');
+    assert.equal(realpathSync(report.batch_root), realpathSync(path.join(dir, 'batch-artifacts')));
+    assert.equal(report.continue_on_error, true);
+    assert.deepEqual(report.counts, {
+      total: 2,
+      prepared: 2,
+      failed: 0,
+      skipped: 0,
+    });
+    assert.equal(existsSync(report.files.request_snapshot), true);
+    assert.equal(existsSync(report.files.normalized_request), true);
+    assert.equal(existsSync(report.files.invocation_index), true);
+    assert.equal(existsSync(report.files.run_manifest), true);
+    assert.equal(existsSync(report.files.report), true);
+
+    const firstItem = report.items[0];
+    assert.equal(firstItem?.status, 'prepared');
+    assert.equal(firstItem?.run_id?.endsWith('_b001'), true);
+    assert.equal(firstItem?.request_id, `pff-${firstItem?.run_id}`);
+    assert.equal(
+      realpathSync(firstItem?.run_root ?? ''),
+      realpathSync(path.join(report.batch_root, 'runs', '001_request_a')),
+    );
+
+    const secondItem = report.items[1];
+    assert.equal(secondItem?.status, 'prepared');
+    assert.equal(secondItem?.run_id?.endsWith('_b002'), true);
+    assert.equal(realpathSync(secondItem?.run_root ?? ''), realpathSync(explicitRunRoot));
+    assert.equal(existsSync(secondItem?.files.report ?? ''), true);
+
+    const invocationIndex = readJson<{
+      invocations: Array<Record<string, unknown>>;
+    }>(report.files.invocation_index);
+    assert.equal(invocationIndex.invocations.length, 1);
+    assert.deepEqual(invocationIndex.invocations[0]?.command, [
+      'process',
+      'batch-build',
+      '--input',
+      manifestPath,
+    ]);
+
+    const normalizedRequest = readJson<Record<string, unknown>>(report.files.normalized_request);
+    assert.equal(normalizedRequest.batch_id, 'batch-demo');
+    assert.equal((normalizedRequest.items as unknown[]).length, 2);
+
+    const persistedReport = readJson(report.files.report);
+    assert.deepEqual(persistedReport, report);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessBatchBuild supports partial failures when continue_on_error is true', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-batch-build-continue-'));
+  const flowPath = writeFlowFixture(dir);
+  writeProcessRequest(dir, 'request-a.json', {
+    flowPath,
+  });
+  writeProcessRequest(dir, 'request-b.json', {
+    flowPath,
+    overrides: {
+      request_id: 'req-custom',
+    },
+  });
+  const manifestPath = path.join(dir, 'batch-request.json');
+  writeJson(manifestPath, {
+    batch_id: 'batch-continue',
+    items: ['./request-a.json', './missing.json', './request-b.json'],
+  });
+
+  try {
+    const report = await runProcessBatchBuild({
+      inputPath: manifestPath,
+      now: new Date('2026-03-29T07:30:00Z'),
+      cwd: '/tmp/process-batch-build-continue',
+    });
+
+    assert.equal(report.status, 'completed_with_failures');
+    assert.deepEqual(report.counts, {
+      total: 3,
+      prepared: 2,
+      failed: 1,
+      skipped: 0,
+    });
+    assert.equal(report.items[0]?.status, 'prepared');
+    assert.equal(report.items[1]?.status, 'failed');
+    assert.equal(report.items[1]?.error?.code, 'INPUT_NOT_FOUND');
+    assert.equal(report.items[2]?.status, 'prepared');
+    assert.equal(report.items[2]?.request_id, 'req-custom');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessBatchBuild stops after the first failure when continue_on_error is false', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-batch-build-stop-'));
+  const flowPath = writeFlowFixture(dir);
+  writeProcessRequest(dir, 'request-a.json', {
+    flowPath,
+  });
+  writeProcessRequest(dir, 'request-c.json', {
+    flowPath,
+  });
+  const manifestPath = path.join(dir, 'batch-request.json');
+  writeJson(manifestPath, {
+    batch_id: 'batch-stop',
+    continue_on_error: false,
+    items: ['./request-a.json', './missing.json', './request-c.json'],
+  });
+
+  try {
+    const report = await runProcessBatchBuild({
+      inputPath: manifestPath,
+      now: new Date('2026-03-29T08:00:00Z'),
+      cwd: '/tmp/process-batch-build-stop',
+    });
+
+    assert.equal(report.status, 'completed_with_failures');
+    assert.deepEqual(report.counts, {
+      total: 3,
+      prepared: 1,
+      failed: 1,
+      skipped: 1,
+    });
+    assert.equal(report.items[0]?.status, 'prepared');
+    assert.equal(report.items[1]?.status, 'failed');
+    assert.equal(report.items[2]?.status, 'skipped');
+    assert.equal(existsSync(path.join(report.batch_root, 'runs', '003_request_c')), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessBatchBuild records explicit CLI outDir and handles non-object item requests', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-batch-build-cli-outdir-'));
+  const flowPath = writeFlowFixture(dir);
+  writeProcessRequest(dir, 'request-a.json', {
+    flowPath,
+    overrides: {
+      run_id: 'cli-fixed-run',
+      request_id: 'cli-fixed-request',
+    },
+  });
+  const invalidRequestPath = path.join(dir, 'request-invalid.json');
+  writeJson(invalidRequestPath, 'not-an-object');
+  const manifestPath = path.join(dir, 'batch-request.json');
+  const explicitBatchRoot = path.join(dir, 'cli-batch-root');
+  writeJson(manifestPath, {
+    batch_id: 'batch-cli-outdir',
+    items: ['./request-a.json', './request-invalid.json'],
+  });
+
+  try {
+    const report = await runProcessBatchBuild({
+      inputPath: manifestPath,
+      outDir: explicitBatchRoot,
+      now: new Date('2026-03-29T08:15:00Z'),
+      cwd: '/tmp/process-batch-build-cli-outdir',
+    });
+
+    assert.equal(report.status, 'completed_with_failures');
+    assert.equal(realpathSync(report.batch_root), realpathSync(explicitBatchRoot));
+    assert.equal(report.items[0]?.status, 'prepared');
+    assert.equal(report.items[0]?.run_id, 'cli-fixed-run');
+    assert.equal(report.items[0]?.request_id, 'cli-fixed-request');
+    assert.equal(report.items[1]?.status, 'failed');
+    assert.equal(report.items[1]?.error?.code, 'PROCESS_AUTO_BUILD_REQUEST_INVALID');
+
+    const runManifest = readJson<{
+      command: string[];
+      layout: {
+        runRoot: string;
+      };
+    }>(report.files.run_manifest);
+    assert.deepEqual(runManifest.command, [
+      'process',
+      'batch-build',
+      '--input',
+      manifestPath,
+      '--out-dir',
+      explicitBatchRoot,
+    ]);
+    assert.equal(realpathSync(runManifest.layout.runRoot), realpathSync(explicitBatchRoot));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessBatchBuild rejects invalid manifests and duplicate runtime identifiers', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-batch-build-invalid-'));
+  const flowPath = writeFlowFixture(dir);
+  writeProcessRequest(dir, 'request-a.json', {
+    flowPath,
+    overrides: {
+      run_id: 'fixed-run',
+    },
+  });
+  writeProcessRequest(dir, 'request-b.json', {
+    flowPath,
+    overrides: {
+      run_id: 'fixed-run',
+    },
+  });
+
+  try {
+    const invalidRootPath = path.join(dir, 'invalid-root.json');
+    writeJson(invalidRootPath, 'not-an-object');
+    await assert.rejects(
+      () => runProcessBatchBuild({ inputPath: invalidRootPath }),
+      /request must be a JSON object/u,
+    );
+
+    const missingItemsPath = path.join(dir, 'missing-items.json');
+    writeJson(missingItemsPath, {});
+    await assert.rejects(
+      () => runProcessBatchBuild({ inputPath: missingItemsPath }),
+      /items must be an array/u,
+    );
+
+    const emptyItemsPath = path.join(dir, 'empty-items.json');
+    writeJson(emptyItemsPath, {
+      items: [],
+    });
+    await assert.rejects(
+      () => runProcessBatchBuild({ inputPath: emptyItemsPath }),
+      /items must not be empty/u,
+    );
+
+    const badItemPath = path.join(dir, 'bad-item.json');
+    writeJson(badItemPath, {
+      items: [true],
+    });
+    await assert.rejects(
+      () => runProcessBatchBuild({ inputPath: badItemPath }),
+      /entries must be strings or objects/u,
+    );
+
+    const missingInputPath = path.join(dir, 'missing-input.json');
+    writeJson(missingInputPath, {
+      items: [{}],
+    });
+    await assert.rejects(
+      () => runProcessBatchBuild({ inputPath: missingInputPath }),
+      /missing 'input_path'/u,
+    );
+
+    const duplicateItemIdPath = path.join(dir, 'duplicate-item-id.json');
+    writeJson(duplicateItemIdPath, {
+      items: [
+        { input_path: './request-a.json', item_id: 'same' },
+        { input_path: './request-b.json', item_id: 'same' },
+      ],
+    });
+    await assert.rejects(
+      () => runProcessBatchBuild({ inputPath: duplicateItemIdPath }),
+      /Duplicate process batch-build item_id/u,
+    );
+
+    const duplicateRunIdPath = path.join(dir, 'duplicate-run-id.json');
+    writeJson(duplicateRunIdPath, {
+      batch_id: 'batch-duplicate-runid',
+      items: ['./request-a.json', './request-b.json'],
+    });
+    const duplicateRunIdReport = await runProcessBatchBuild({
+      inputPath: duplicateRunIdPath,
+      now: new Date('2026-03-29T08:30:00Z'),
+      cwd: '/tmp/process-batch-build-duplicate-runid',
+    });
+    assert.equal(duplicateRunIdReport.status, 'completed_with_failures');
+    assert.equal(duplicateRunIdReport.items[0]?.status, 'prepared');
+    assert.equal(duplicateRunIdReport.items[1]?.status, 'failed');
+    assert.equal(
+      duplicateRunIdReport.items[1]?.error?.code,
+      'PROCESS_BATCH_BUILD_RUN_ID_DUPLICATE',
+    );
+
+    const existingRootPath = path.join(dir, 'existing-root.json');
+    const existingRootDir = path.join(dir, 'existing-root');
+    mkdirSync(existingRootDir, { recursive: true });
+    writeFileSync(path.join(existingRootDir, 'keep.txt'), 'busy', 'utf8');
+    writeJson(existingRootPath, {
+      batch_id: 'batch-existing-root',
+      out_dir: './existing-root',
+      items: ['./request-a.json'],
+    });
+    await assert.rejects(
+      () => runProcessBatchBuild({ inputPath: existingRootPath }),
+      /run root already exists and is not empty/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('process batch-build internals cover layout, normalization, and helper fallbacks', () => {
+  const layout = __testInternals.buildLayout('/tmp/process-batch/batch-1', 'batch-1');
+  assert.equal(layout.runId, 'batch-1');
+  assert.equal(layout.requestSnapshotPath, '/tmp/process-batch/batch-1/request/batch-request.json');
+
+  assert.equal(
+    __testInternals.resolveBatchRoot('/tmp/work', 'batch-1', './override', null),
+    path.resolve('/tmp/work', './override'),
+  );
+  assert.equal(
+    __testInternals.resolveBatchRoot('/tmp/work', 'batch-1', null, './request-root'),
+    path.resolve('/tmp/work', './request-root'),
+  );
+  assert.equal(
+    __testInternals.resolveBatchRoot('/tmp/work', 'batch-1', '   ', './request-root'),
+    path.resolve('/tmp/work', './request-root'),
+  );
+
+  const normalized = __testInternals.normalizeProcessBatchBuildRequest(
+    {
+      batch_id: 'batch-inline',
+      continue_on_error: false,
+      items: ['./request-a.json', './request-a.json'],
+    },
+    {
+      inputPath: '/tmp/work/batch-request.json',
+      outDir: './batch-root',
+      now: new Date('2026-03-29T09:00:00Z'),
+    },
+  );
+  assert.equal(normalized.batch_id, 'batch-inline');
+  assert.equal(normalized.continue_on_error, false);
+  assert.equal(normalized.items[0]?.item_id, 'request_a');
+  assert.equal(normalized.items[1]?.item_id, 'request_a_2');
+
+  const normalizedWithoutNow = __testInternals.normalizeProcessBatchBuildRequest(
+    {
+      batch_id: 'batch-inline-default-now',
+      items: ['./request-a.json'],
+    },
+    {
+      inputPath: '/tmp/work/batch-request.json',
+    },
+  );
+  assert.equal(normalizedWithoutNow.batch_id, 'batch-inline-default-now');
+
+  const normalizedWithOccupiedSuffix = __testInternals.normalizeProcessBatchBuildRequest(
+    {
+      batch_id: 'batch-inline-loop',
+      items: [
+        './request-a.json',
+        {
+          input_path: './request-b.json',
+          item_id: 'request_a_2',
+        },
+        './request-a.json',
+      ],
+    },
+    {
+      inputPath: '/tmp/work/batch-request.json',
+      now: new Date('2026-03-29T09:05:00Z'),
+    },
+  );
+  assert.equal(normalizedWithOccupiedSuffix.items[2]?.item_id, 'request_a_3');
+
+  const invocationIndex = __testInternals.buildInvocationIndex(
+    normalized,
+    {
+      inputPath: '/tmp/work/batch-request.json',
+      outDir: './batch-root',
+      cwd: '/tmp/workspace',
+    },
+    layout,
+    new Date('2026-03-29T09:10:00Z'),
+  ) as {
+    invocations: Array<Record<string, unknown>>;
+  };
+  assert.deepEqual(invocationIndex.invocations[0]?.command, [
+    'process',
+    'batch-build',
+    '--input',
+    '/tmp/work/batch-request.json',
+    '--out-dir',
+    './batch-root',
+  ]);
+
+  const invocationIndexWithoutCwd = __testInternals.buildInvocationIndex(
+    normalized,
+    {
+      inputPath: '/tmp/work/batch-request.json',
+    },
+    layout,
+    new Date('2026-03-29T09:15:00Z'),
+  ) as {
+    invocations: Array<Record<string, unknown>>;
+  };
+  assert.equal(invocationIndexWithoutCwd.invocations[0]?.cwd, process.cwd());
+
+  const report = __testInternals.buildReport(
+    normalized,
+    layout,
+    [
+      {
+        item_id: 'request_a',
+        index: 0,
+        input_path: '/tmp/work/request-a.json',
+        out_dir: '/tmp/work/batch-root/runs/001_request_a',
+        status: 'prepared',
+        run_id: 'run-1',
+        run_root: '/tmp/work/batch-root/runs/001_request_a',
+        request_id: 'req-1',
+        files: {
+          request_snapshot: '/tmp/work/req.json',
+          report: '/tmp/work/report.json',
+          state: '/tmp/work/state.json',
+          handoff_summary: '/tmp/work/handoff.json',
+          run_manifest: '/tmp/work/run-manifest.json',
+        },
+        error: null,
+      },
+      {
+        item_id: 'request_b',
+        index: 1,
+        input_path: '/tmp/work/request-b.json',
+        out_dir: '/tmp/work/batch-root/runs/002_request_b',
+        status: 'skipped',
+        run_id: null,
+        run_root: null,
+        request_id: null,
+        files: {
+          request_snapshot: null,
+          report: null,
+          state: null,
+          handoff_summary: null,
+          run_manifest: null,
+        },
+        error: null,
+      },
+    ],
+    new Date('2026-03-29T09:20:00Z'),
+  );
+  assert.equal(report.status, 'completed');
+  assert.equal(report.counts.skipped, 1);
+
+  const nextActions = __testInternals.buildNextActions(layout);
+  assert.match(nextActions[2] ?? '', /consume items\[\]\.run_root/u);
+});


### PR DESCRIPTION
Closes #16

## Summary
- Add the executable `tiangong process batch-build --input <file>` command and the local manifest/report contract.
- Reuse the existing process auto-build contract for each item and emit deterministic per-item plus aggregate batch artifacts.
- Update CLI help, tests, and migration docs so the batch path is explicit and stays Python-free inside the CLI.

## Key Decisions
- Keep the slice local-first and file-first; do not reintroduce MCP, Python orchestration, or generic workflow layers into the CLI runtime.
- Base this PR on `feature/issue-15` because the current process command slices are still stacked and this diff should stay scoped to issue #16 only.
- When item requests do not provide an explicit `run_id`, derive a per-item override with a batch suffix; explicit duplicate `run_id` values fail deterministically.

## Validation
- npm run lint
- npm test
- npm run test:coverage
- npm run test:coverage:assert-full
- npm run prepush:gate

## Risks / Rollback
- This is a stacked PR on top of `feature/issue-15`; review and merge order must preserve the current branch dependency or the branch must be rebased later.

## Follow-ups
- After the process command stack lands, switch the remaining skill-side batch wrapper logic to this CLI entrypoint in a later tracked slice.

## Workspace Integration
- Requires a later `lca-workspace` submodule bump after the CLI stack merges to the default branch.