### PR TITLE
feat: implement process auto-build local artifact path

### DIFF
--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -15,6 +15,9 @@
 - `tiangong search flow`
 - `tiangong search process`
 - `tiangong search lifecyclemodel`
+- `tiangong process auto-build`
+- `tiangong lifecyclemodel build-resulting-process`
+- `tiangong lifecyclemodel publish-resulting-process`
 - `tiangong publish run`
 - `tiangong validation run`
 - `tiangong admin embedding-run`
@@ -69,12 +72,33 @@ npm start -- --help
 npm start -- doctor
 npm start -- doctor --json
 npm start -- search flow --input ./request.json --dry-run
+npm start -- process auto-build --input ./pff-request.json --json
+npm start -- lifecyclemodel build-resulting-process --input ./request.json --json
+npm start -- lifecyclemodel publish-resulting-process --run-dir ./runs/example --publish-processes --publish-relations --json
 npm start -- publish run --input ./publish-request.json --dry-run
 npm start -- validation run --input-dir ./tidas-package --engine auto
 npm start -- admin embedding-run --input ./jobs.json --dry-run
 ```
 
-## publish / validation 边界
+## process / publish / validation 边界
+
+`tiangong process auto-build` 现在已经承担 `process_from_flow` 主链的第一个 CLI 切片，负责：
+
+- 读取单个 process-from-flow request
+- 解析 `flow_file` 指向的 ILCD flow JSON
+- 生成兼容旧工作流的 `run_id`
+- 创建本地 `artifacts/process_from_flow/<run_id>/` 运行骨架
+- 预写 `cache/process_from_flow_state.json`
+- 预写 `cache/agent_handoff_summary.json`
+- 产出 request / flow / assembly / lineage / invocation / run manifest / report
+
+这个命令当前只负责本地 intake 与 scaffold，不负责继续执行后续工作流阶段。
+
+也就是说，下面这些还没有迁完：
+
+- `tiangong process resume-build`
+- `tiangong process publish-build`
+- `tiangong process batch-build`
 
 `tiangong publish run` 现在已经成为统一 publish 契约入口，负责：
 
@@ -156,7 +180,8 @@ npm run build
 当前建议：
 
 - 轻量远程 skill 直接调用 `tiangong search ...` 或 `tiangong admin ...`
-- 重型 Python workflow 先保留原执行器，但由 `tiangong` 统一调度
+- `process-automated-builder` 已先迁入 `tiangong process auto-build` 本地 scaffold；剩余阶段继续按子命令切片迁移
+- 其余重型 workflow 先保留原执行器，但由 `tiangong` 统一调度
 - 所有新脚本优先使用统一环境变量名，不再扩散旧变量名
 
 ## 当前目录约定

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Current implementation choices:
 - `tiangong search flow`
 - `tiangong search process`
 - `tiangong search lifecyclemodel`
+- `tiangong process auto-build`
 - `tiangong lifecyclemodel build-resulting-process`
 - `tiangong lifecyclemodel publish-resulting-process`
 - `tiangong publish run`
@@ -25,11 +26,15 @@ Current implementation choices:
 
 ## Planned command surface
 
-The `lifecyclemodel` namespace is now partially implemented. The remaining planned surface is:
+The `lifecyclemodel` and `process` namespaces are now partially implemented. The remaining workflow migration surface is:
 
 - `tiangong lifecyclemodel auto-build`
 - `tiangong lifecyclemodel validate-build`
 - `tiangong lifecyclemodel publish-build`
+- `tiangong process get`
+- `tiangong process resume-build`
+- `tiangong process publish-build`
+- `tiangong process batch-build`
 
 These remaining commands are intentionally not executable yet. They print an explicit `not implemented yet` message and exit with code `2` until the corresponding workflows are migrated into TypeScript.
 
@@ -85,12 +90,21 @@ npm start -- --help
 npm start -- doctor
 npm start -- doctor --json
 npm start -- search flow --input ./request.json --dry-run
+npm start -- process auto-build --input ./pff-request.json --json
 npm start -- lifecyclemodel build-resulting-process --input ./request.json --json
 npm start -- lifecyclemodel publish-resulting-process --run-dir ./runs/example --publish-processes --publish-relations --json
 npm start -- publish run --input ./publish-request.json --dry-run
 npm start -- validation run --input-dir ./tidas-package --engine auto
 npm start -- admin embedding-run --input ./jobs.json --dry-run
 ```
+
+## Process build scaffold
+
+`tiangong process auto-build` is the first migrated `process_from_flow` slice. It reads one request JSON from `--input`, loads the referenced ILCD flow dataset from `flow_file`, preserves the old run id contract (`pfw_<flow_code>_<flow_uuid8>_<operation>_<UTC_TIMESTAMP>`), and writes a local run scaffold under `artifacts/process_from_flow/<run_id>/` or `--out-dir`.
+
+The command keeps the legacy per-run layout that later stages still expect, including `input/`, `exports/processes/`, `exports/sources/`, `cache/process_from_flow_state.json`, and `cache/agent_handoff_summary.json`. It also adds CLI-owned manifests such as the normalized request snapshot, flow summary, assembly plan, lineage manifest, invocation index, run manifest, and a compact report artifact.
+
+This command does not yet execute the downstream workflow stages. `resume-build`, `publish-build`, and `batch-build` remain separate planned slices.
 
 ## Publish and validation
 
@@ -104,6 +118,7 @@ Run the built artifact directly:
 
 ```bash
 node ./bin/tiangong.js doctor
+node ./bin/tiangong.js process auto-build --input ./pff-request.json --json
 node ./dist/src/main.js doctor --json
 ```
 
@@ -112,7 +127,8 @@ node ./dist/src/main.js doctor --json
 `tiangong-lca-skills` should converge on this CLI instead of keeping separate transport scripts. The current migration strategy is:
 
 - thin remote wrappers move first
-- heavier Python workflows stay in place temporarily
+- local artifact-first workflow slices move into the CLI incrementally
+- remaining heavier workflow stages stay in place temporarily until the matching CLI subcommands exist
 - future skill execution should call `tiangong` as the stable entrypoint
 
 ## Docs

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -30,6 +30,8 @@ tiangong
     flow
     process
     lifecyclemodel
+  process
+    auto-build
   lifecyclemodel
     build-resulting-process
     publish-resulting-process
@@ -49,6 +51,7 @@ tiangong
 | `tiangong search flow` | `flow_hybrid_search` |
 | `tiangong search process` | `process_hybrid_search` |
 | `tiangong search lifecyclemodel` | `lifecyclemodel_hybrid_search` |
+| `tiangong process auto-build` | 本地 `process_from_flow` intake、run-id 生成、artifact scaffold 预写 |
 | `tiangong lifecyclemodel build-resulting-process` | 本地 lifecycle model resulting process 聚合、内部 flow 抵消、artifact 输出 |
 | `tiangong lifecyclemodel publish-resulting-process` | 读取 resulting-process run，生成 `publish-bundle.json` / `publish-intent.json` 本地交付物 |
 | `tiangong publish run` | 本地 publish 契约归一化、dry-run/commit、report 输出 |
@@ -61,11 +64,18 @@ tiangong
 - `tiangong lifecyclemodel publish-resulting-process` 已可执行
 - `auto-build`、`validate-build`、`publish-build` 仍处于 planned 状态
 
+`tiangong process ...` 也已经开始承接 `process_from_flow` 主链迁移，其中：
+
+- `tiangong process auto-build` 已可执行
+- `get`、`resume-build`、`publish-build`、`batch-build` 仍处于 planned 状态
+
 注意：
 
+- 已实现的 `process auto-build` 保留了旧 `artifacts/process_from_flow/<run_id>/`、`cache/process_from_flow_state.json`、`cache/agent_handoff_summary.json` 等运行布局
+- `process auto-build` 当前只负责本地 request intake、flow 归一化、run scaffold 和 manifest/report 预写，不继续执行后续阶段
 - 已实现的 `build-resulting-process` 和 `publish-resulting-process` 都走本地优先、artifact-first 路径，不依赖 Python 或 MCP
 - `publish-resulting-process` 当前负责生成本地 publish handoff 产物，还没有把提交语义直接并入 `publish run`
-- 其余未实现的 `lifecyclemodel` 子命令仍只提供 help 和固定命名
+- 其余未实现的 `lifecyclemodel` / `process` 子命令仍只提供 help 和固定命名
 - 这样做的目的不是“假装已完成”，而是先固定命令树，再逐个把 workflow 迁入 TypeScript CLI
 
 ### 2.2 已经固定的工程约束
@@ -160,7 +170,25 @@ tiangong admin embedding-run --input ./jobs.json --dry-run
 
 而不是长自然语言参数和不稳定的 shell 拼接。
 
-### 4.4 publish 和 validation 的当前边界
+### 4.4 process / publish / validation 的当前边界
+
+`process auto-build` 现在固定的是“本地 process-from-flow intake 与 scaffold 契约层”。
+
+它负责：
+
+- 读取单个 request JSON
+- 解析 `flow_file` 指向的 ILCD flow payload
+- 兼容旧 `pfw_<flow_code>_<flow_uuid8>_<operation>_<UTC_TIMESTAMP>` run-id 规则
+- 创建本地 run root、`input/`、`exports/`、`cache/`、`reports/` 等目录
+- 预写 `process_from_flow_state.json`
+- 预写 `agent_handoff_summary.json`
+- 写出 normalized request、flow summary、assembly plan、lineage manifest、invocation index、run manifest、report
+
+它现在还不负责：
+
+- 执行 route / split / exchange / QA / publish 等后续阶段
+- 远程检索、LLM、OCR、publish commit
+- `resume-build`、`publish-build`、`batch-build`
 
 `publish run` 现在固定的是“稳定 publish 契约层”，不是历史 MCP 写库脚本的 TypeScript 复刻。
 
@@ -256,11 +284,13 @@ npm run prepush:gate
 | `lifecyclemodel-hybrid-search` | `tiangong search lifecyclemodel` |
 | `embedding-ft`                 | `tiangong admin embedding-run`   |
 
-### 7.3 暂不全量重写的对象
+### 7.3 已启动但未完成迁移的对象
 
-这类能力先不做 JS/TS 全量重写：
+这类能力已经进入 CLI 迁移路线，但还没有完全变成纯 TS 主链：
 
 - `process-automated-builder`
+  - 已落地 `tiangong process auto-build`
+  - 仍待迁移 `resume-build`、`publish-build`、`batch-build`
 - `lifecycleinventory-review`
 - 其他重型 Python workflow
 
@@ -297,13 +327,15 @@ npm run prepush:gate
 
 ### Phase 2
 
+- 继续补齐 `process resume-build` / `publish-build` / `batch-build`
 - 引入 `review` / `job` / `flow` / `process` 的更多业务子命令
-- 用 CLI 调度现有 Python workflow
+- 用 CLI 接管现有 workflow 的稳定 contract 层
 - 统一 run-dir / artifact / manifest 输入输出格式
 
 ### Phase 3
 
-- 把重型 workflow 中真正稳定的远程能力逐步服务化
+- 把重型 workflow 中真正稳定的执行阶段逐步迁成纯 TS CLI
+- 把其中适合服务化的远程能力逐步服务化
 - 继续减少 skill 仓库里的 transport logic
 - 让 agent 主要理解 `tiangong` 命令树，而不是 repo 内部脚本细节
 

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -69,9 +69,9 @@
 | `process-hybrid-search` | 已有等价 CLI | shell wrapper，历史 token/env 兼容 | 只保留 skill 文档，调用 `tiangong search process` | P0 |
 | `lifecyclemodel-hybrid-search` | 已有等价 CLI | shell wrapper，历史 token/env 兼容 | 只保留 skill 文档，调用 `tiangong search lifecyclemodel` | P0 |
 | `embedding-ft` | 已有等价 CLI | shell wrapper | 只保留 skill 文档，调用 `tiangong admin embedding-run` | P0 |
-| `process-automated-builder` | 仍是重 workflow | shell + Python + LangGraph + MCP + OpenAI + AI edge search + TianGong unstructured | 迁成 `tiangong process ...` 主链 | P1 |
+| `process-automated-builder` | 已进入 CLI 化，6.1 已落地 | `tiangong process auto-build` + shell/Python/LangGraph/MCP/OpenAI/AI edge search/TianGong unstructured 遗留阶段 | 迁成 `tiangong process ...` 主链 | P1 |
 | `lifecyclemodel-automated-builder` | 仍是重 workflow | shell + Python + MCP + OpenAI | 迁成 `tiangong lifecyclemodel ...` 主链 | P1 |
-| `lifecyclemodel-resulting-process-builder` | CLI 本地 build/publish handoff 已落地，skill 仍未切换 | Python builder + 可选 MCP lookup | 迁成 `skill -> tiangong lifecyclemodel build/publish-resulting-process` | P1 |
+| `lifecyclemodel-resulting-process-builder` | CLI 本地 build/publish handoff 已落地，skill wrapper 已切换 | `skill -> tiangong lifecyclemodel build/publish-resulting-process` | 保持薄 wrapper，继续去掉遗留 lookup 分支 | P1 |
 | `lifecycleinventory-review` | 仍是 review workflow | Python review script | 迁成 `tiangong review process` | P2 |
 | `flow-governance-review` | 仍是治理 workflow | shell + 多个 Python helper + 可选 MCP | 迁成 `tiangong flow ...` / `tiangong review flow` | P2 |
 | `lifecyclemodel-recursive-orchestrator` | 仍是 orchestrator | Python orchestrator，串联多个技能 | 迁成 CLI 编排命令 | P3 |
@@ -90,6 +90,7 @@
 
 - “应该统一到 CLI”是目标态
 - “现在还有 Python / skills 逻辑”是现状债务
+- 但 `process_from_flow` 的 intake/scaffold 已经开始被 CLI 接管，后续应该沿同一路径继续削减遗留层
 
 ## 6. 可执行迁移路线
 
@@ -258,20 +259,21 @@ ToDo：
 
 目标命令：
 
-- [ ] `tiangong process auto-build`
+- [x] `tiangong process auto-build`
 - [ ] `tiangong process resume-build`
 - [ ] `tiangong process publish-build`
 - [ ] `tiangong process batch-build`
 
 建议拆成 4 个连续小步骤，而不是一次性大迁移：
 
-- [ ] 6.1 先实现 `auto-build` 的本地产物路径，不做 publish
+- [x] 6.1 先实现 `auto-build` 的本地产物路径，不做 publish
 - [ ] 6.2 再实现 `resume-build`，把 state-lock / run manifest 彻底收口到 CLI
 - [ ] 6.3 再实现 `publish-build`，接到统一 publish 模块
 - [ ] 6.4 最后实现 `batch-build`
 
 迁移内容：
 
+- [x] intake request normalization / flow 归一化 / run-id / local artifact scaffold 迁到 TS CLI
 - [ ] 流程编排迁到 TS
 - [ ] flow search 改为直接 REST，而不是 MCP
 - [ ] publish 改为直接 REST / CLI publish，而不是 MCP CRUD
@@ -431,7 +433,7 @@ ToDo：
 
 如果只按最短路径推进，下一轮建议严格做这 8 件事：
 
-当前已完成：1-5。
+当前重点已经推进到第 8 项，且 `tiangong process auto-build` / Phase 6.1 已完成。
 
 1. 修 CLI help，让命令面和真实实现一致。
 2. 修 skills 文档中的 `TIANGONG_CLI_DIR` 残留。
@@ -440,7 +442,7 @@ ToDo：
 5. 完成 `tiangong lifecyclemodel publish-resulting-process`。
 6. 把 `lifecyclemodel-resulting-process-builder` 改成薄 wrapper。
 7. 把 `lca-publish-executor` 收口到 `tiangong publish run`。
-8. 再进入 `tiangong process auto-build` 主链迁移。
+8. 继续推进 `tiangong process resume-build`，把后续阶段执行面从遗留 workflow 收口到 CLI。
 
 ## 10. 不应该做的事
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,11 @@ import {
   type LifecyclemodelPublishResultingProcessReport,
   type RunLifecyclemodelPublishResultingProcessOptions,
 } from './lib/lifecyclemodel-publish-resulting-process.js';
+import {
+  runProcessAutoBuild,
+  type ProcessAutoBuildReport,
+  type RunProcessAutoBuildOptions,
+} from './lib/process-auto-build.js';
 import { runPublish, type PublishReport, type RunPublishOptions } from './lib/publish.js';
 import { executeRemoteCommand, getRemoteCommandHelp } from './lib/remote.js';
 import {
@@ -34,6 +39,9 @@ export type CliDeps = {
   runLifecyclemodelPublishResultingProcessImpl?: (
     options: RunLifecyclemodelPublishResultingProcessOptions,
   ) => Promise<LifecyclemodelPublishResultingProcessReport>;
+  runProcessAutoBuildImpl?: (
+    options: RunProcessAutoBuildOptions,
+  ) => Promise<ProcessAutoBuildReport>;
 };
 
 export type CliResult = {
@@ -65,6 +73,7 @@ Commands:
 Implemented Commands:
   doctor     show environment diagnostics
   search     flow | process | lifecyclemodel
+  process    auto-build
   lifecyclemodel build-resulting-process | publish-resulting-process
   publish    run
   validation run
@@ -84,6 +93,7 @@ Examples:
   tiangong doctor
   tiangong search flow --input ./request.json
   tiangong search process --input ./request.json --dry-run
+  tiangong process auto-build --input ./pff-request.json
   tiangong publish run --input ./publish-request.json --dry-run
   tiangong validation run --input-dir ./package --engine auto
   tiangong admin embedding-run --input ./jobs.json
@@ -206,6 +216,38 @@ Examples:
 `.trim();
 }
 
+function renderProcessAutoBuildHelp(): string {
+  return `Usage:
+  tiangong process auto-build --input <file> [options]
+
+Options:
+  --input <file>     JSON request file
+  --out-dir <dir>    Override the default run root directory
+  --json             Print compact JSON
+  -h, --help
+`.trim();
+}
+
+function renderProcessHelp(): string {
+  return `Usage:
+  tiangong process <subcommand> [options]
+
+Implemented Subcommands:
+  auto-build   Prepare a local process-from-flow run scaffold and artifact workspace
+
+Planned Subcommands:
+  get          Load one process dataset or process build run summary
+  resume-build Resume a prepared process build run and continue execution stages
+  publish-build Publish a process build run through the unified publish layer
+  batch-build  Run multiple process build requests through one batch-oriented CLI surface
+
+Examples:
+  tiangong process --help
+  tiangong process auto-build --help
+  tiangong process resume-build --help
+`.trim();
+}
+
 const lifecyclemodelPlannedHelp = {
   'auto-build': `Usage:
   tiangong lifecyclemodel auto-build --input <file> [options]
@@ -242,12 +284,60 @@ Status:
 `.trim(),
 } as const;
 
+const processPlannedHelp = {
+  get: `Usage:
+  tiangong process get --id <process-id> [options]
+
+Planned contract:
+  - load one process dataset or process build run summary by identifier
+  - keep read-only access distinct from build/publish workflows
+
+Status:
+  Planned command. Execution is not implemented yet.
+`.trim(),
+  'resume-build': `Usage:
+  tiangong process resume-build --run-id <id> [options]
+
+Planned contract:
+  - load one prepared process auto-build run
+  - continue stage execution from the persisted local state under artifacts/process_from_flow/<run_id>
+
+Status:
+  Planned command. Execution is not implemented yet.
+`.trim(),
+  'publish-build': `Usage:
+  tiangong process publish-build --run-id <id> [options]
+
+Planned contract:
+  - load one completed process build run
+  - generate publish handoff artifacts and later commit through the unified publish layer
+
+Status:
+  Planned command. Execution is not implemented yet.
+`.trim(),
+  'batch-build': `Usage:
+  tiangong process batch-build --input <file> [options]
+
+Planned contract:
+  - process multiple process auto-build requests from one batch manifest
+  - preserve isolated run directories and state locks per request
+
+Status:
+  Planned command. Execution is not implemented yet.
+`.trim(),
+} as const;
+
 type LifecyclemodelPlannedSubcommand = keyof typeof lifecyclemodelPlannedHelp;
+type ProcessPlannedSubcommand = keyof typeof processPlannedHelp;
 
 function isLifecyclemodelPlannedSubcommand(
   value: string | null,
 ): value is LifecyclemodelPlannedSubcommand {
   return Boolean(value && value in lifecyclemodelPlannedHelp);
+}
+
+function isProcessPlannedSubcommand(value: string | null): value is ProcessPlannedSubcommand {
+  return Boolean(value && value in processPlannedHelp);
 }
 
 function renderDoctorText(report: ReturnType<typeof buildDoctorReport>): string {
@@ -571,6 +661,40 @@ function parseLifecyclemodelBuildFlags(args: string[]): {
   };
 }
 
+function parseProcessAutoBuildFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  inputPath: string;
+  outDir: string | null;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        input: { type: 'string' },
+        'out-dir': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    inputPath: typeof values.input === 'string' ? values.input : '',
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : null,
+  };
+}
+
 function plannedCommand(command: string, subcommand?: string): CliResult {
   const suffix = subcommand ? ` ${subcommand}` : '';
   return {
@@ -602,6 +726,7 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
       deps.runLifecyclemodelBuildResultingProcessImpl ?? runLifecyclemodelBuildResultingProcess;
     const lifecyclemodelPublishImpl =
       deps.runLifecyclemodelPublishResultingProcessImpl ?? runLifecyclemodelPublishResultingProcess;
+    const processAutoBuildImpl = deps.runProcessAutoBuildImpl ?? runProcessAutoBuild;
 
     if (flags.version) {
       return { exitCode: 0, stdout: '0.0.1\n', stderr: '' };
@@ -707,6 +832,43 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
         return {
           exitCode: 0,
           stdout: `${lifecyclemodelPlannedHelp[subcommand]}\n`,
+          stderr: '',
+        };
+      }
+      return plannedCommand(command, subcommand);
+    }
+
+    if (command === 'process' && !subcommand) {
+      return { exitCode: 0, stdout: `${renderProcessHelp()}\n`, stderr: '' };
+    }
+
+    if (command === 'process' && subcommand === 'auto-build') {
+      const processFlags = parseProcessAutoBuildFlags(commandArgs);
+      if (processFlags.help) {
+        return {
+          exitCode: 0,
+          stdout: `${renderProcessAutoBuildHelp()}\n`,
+          stderr: '',
+        };
+      }
+
+      const report = await processAutoBuildImpl({
+        inputPath: processFlags.inputPath,
+        outDir: processFlags.outDir,
+      });
+
+      return {
+        exitCode: 0,
+        stdout: stringifyJson(report, processFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'process' && isProcessPlannedSubcommand(subcommand)) {
+      if (commandArgs.includes('--help') || commandArgs.includes('-h')) {
+        return {
+          exitCode: 0,
+          stdout: `${processPlannedHelp[subcommand]}\n`,
           stderr: '',
         };
       }

--- a/src/lib/process-auto-build.ts
+++ b/src/lib/process-auto-build.ts
@@ -1,0 +1,1006 @@
+import { copyFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { writeJsonArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+import { readJsonInput } from './io.js';
+import {
+  buildRunManifest,
+  buildUtcTimestamp,
+  ensureRunLayout,
+  type RunLayout,
+  sanitizeRunToken,
+  writeLatestRunId,
+} from './run.js';
+import { withStateFileLock } from './state-lock.js';
+
+type JsonRecord = Record<string, unknown>;
+
+export type ProcessAutoBuildOperation = 'produce' | 'treat';
+export type ProcessAutoBuildSourceInputType = 'local_file' | 'local_text';
+
+export type ProcessAutoBuildSourcePolicy = {
+  step1_route: {
+    preferred: string[];
+    fallback: string;
+  };
+  step2_process_split: {
+    preferred: string[];
+    fallback: string;
+  };
+  step3b_exchange_values: {
+    preferred: string[];
+    require_numeric_evidence: boolean;
+    allow_estimation: boolean;
+  };
+};
+
+export type ProcessAutoBuildFlowSummary = {
+  wrapper: 'flowDataSet' | 'direct';
+  uuid: string | null;
+  version: string | null;
+  base_name: string | null;
+  permanent_uri: string | null;
+};
+
+export type NormalizedProcessAutoBuildSourceInput = {
+  source_id: string;
+  type: ProcessAutoBuildSourceInputType;
+  source_path: string;
+  artifact_path: string;
+  artifact_file_name: string;
+  intended_roles: string[];
+};
+
+export type NormalizedProcessAutoBuildRequest = {
+  schema_version: 1;
+  request_path: string;
+  request_id: string;
+  flow_file: string;
+  flow_summary: ProcessAutoBuildFlowSummary;
+  flow_dataset: JsonRecord;
+  operation: ProcessAutoBuildOperation;
+  run_id: string;
+  run_root: string;
+  source_inputs: NormalizedProcessAutoBuildSourceInput[];
+  source_policy: ProcessAutoBuildSourcePolicy;
+};
+
+export type ProcessAutoBuildLayout = RunLayout & {
+  requestDir: string;
+  evidenceDir: string;
+  evidenceIncomingDir: string;
+  evidenceNormalizedDir: string;
+  evidenceTextDir: string;
+  evidenceStructuredDir: string;
+  stageOutputsDir: string;
+  reviewsDir: string;
+  requestSnapshotPath: string;
+  normalizedRequestPath: string;
+  sourcePolicyPath: string;
+  flowSummaryPath: string;
+  inputManifestPath: string;
+  assemblyPlanPath: string;
+  lineageManifestPath: string;
+  invocationIndexPath: string;
+  runManifestPath: string;
+  reportPath: string;
+  statePath: string;
+  handoffSummaryPath: string;
+  processExportsDir: string;
+  sourceExportsDir: string;
+};
+
+export type ProcessAutoBuildReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: 'prepared_local_process_auto_build_run';
+  request_path: string;
+  request_id: string;
+  run_id: string;
+  run_root: string;
+  operation: ProcessAutoBuildOperation;
+  flow: {
+    source_path: string;
+    artifact_path: string;
+    wrapper: 'flowDataSet' | 'direct';
+    uuid: string | null;
+    version: string | null;
+    base_name: string | null;
+  };
+  source_input_count: number;
+  stage_count: number;
+  files: {
+    request_snapshot: string;
+    normalized_request: string;
+    source_policy: string;
+    flow_summary: string;
+    input_manifest: string;
+    assembly_plan: string;
+    lineage_manifest: string;
+    invocation_index: string;
+    run_manifest: string;
+    state: string;
+    handoff_summary: string;
+    report: string;
+  };
+  next_actions: string[];
+};
+
+export type RunProcessAutoBuildOptions = {
+  inputPath: string;
+  outDir?: string | null;
+  now?: Date;
+  cwd?: string;
+};
+
+type ProcessAutoBuildStage = {
+  id: string;
+  title: string;
+  output: string;
+  createsCandidatesDir: boolean;
+  modules: string[];
+};
+
+const DEFAULT_SOURCE_POLICY: ProcessAutoBuildSourcePolicy = {
+  step1_route: {
+    preferred: ['user_bundle', 'kb_bundle'],
+    fallback: 'expert_judgement',
+  },
+  step2_process_split: {
+    preferred: ['user_bundle.process_split', 'si_bundle', 'kb_bundle.process_split'],
+    fallback: 'expert_judgement',
+  },
+  step3b_exchange_values: {
+    preferred: ['user_bundle.exchange_values', 'si_bundle', 'kb_bundle.exchange_values'],
+    require_numeric_evidence: true,
+    allow_estimation: true,
+  },
+};
+
+const PROCESS_AUTO_BUILD_STAGES: ProcessAutoBuildStage[] = [
+  {
+    id: '01_route',
+    title: 'Route planning',
+    output: 'stage_outputs/01_route/route_plan.json',
+    createsCandidatesDir: true,
+    modules: ['kb-search', 'llm'],
+  },
+  {
+    id: '02_process_split',
+    title: 'Process chain split',
+    output: 'stage_outputs/02_process_split/process_chain.json',
+    createsCandidatesDir: true,
+    modules: ['llm'],
+  },
+  {
+    id: '03_exchange_plan',
+    title: 'Exchange planning',
+    output: 'stage_outputs/03_exchange_plan/exchange_plan.json',
+    createsCandidatesDir: false,
+    modules: ['llm'],
+  },
+  {
+    id: '04_exchange_values',
+    title: 'Exchange value extraction',
+    output: 'stage_outputs/04_exchange_values/exchange_values.json',
+    createsCandidatesDir: true,
+    modules: ['unstructured', 'kb-search', 'llm'],
+  },
+  {
+    id: '05_chain_review',
+    title: 'Chain review',
+    output: 'stage_outputs/05_chain_review/chain_review.json',
+    createsCandidatesDir: false,
+    modules: ['llm'],
+  },
+  {
+    id: '06_flow_match',
+    title: 'Flow matching',
+    output: 'stage_outputs/06_flow_match/flow_match_bundle.json',
+    createsCandidatesDir: false,
+    modules: ['search:flow', 'llm'],
+  },
+  {
+    id: '07_source_build',
+    title: 'Source dataset build',
+    output: 'stage_outputs/07_source_build/source_bundle.json',
+    createsCandidatesDir: false,
+    modules: ['validation'],
+  },
+  {
+    id: '08_process_build',
+    title: 'Process dataset build',
+    output: 'stage_outputs/08_process_build/process_bundle.json',
+    createsCandidatesDir: false,
+    modules: ['validation', 'llm'],
+  },
+  {
+    id: '09_qa',
+    title: 'QA and balance review',
+    output: 'stage_outputs/09_qa/qa_bundle.json',
+    createsCandidatesDir: false,
+    modules: ['validation', 'llm'],
+  },
+  {
+    id: '10_publish',
+    title: 'Publish handoff',
+    output: 'stage_outputs/10_publish/publish_bundle.json',
+    createsCandidatesDir: false,
+    modules: ['publish'],
+  },
+];
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized || null;
+}
+
+function extractText(value: unknown): string | null {
+  const direct = nonEmptyString(value);
+  if (direct) {
+    return direct;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const extracted = extractText(item);
+      if (extracted) {
+        return extracted;
+      }
+    }
+    return null;
+  }
+
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  if ('#text' in value) {
+    return nonEmptyString(value['#text']);
+  }
+
+  return null;
+}
+
+function requiredRequestObject(input: unknown): JsonRecord {
+  if (!isRecord(input)) {
+    throw new CliError('process auto-build request must be a JSON object.', {
+      code: 'PROCESS_AUTO_BUILD_REQUEST_INVALID',
+      exitCode: 2,
+    });
+  }
+
+  return input;
+}
+
+function requiredRequestString(input: JsonRecord, key: string): string {
+  const value = nonEmptyString(input[key]);
+  if (!value) {
+    throw new CliError(`process auto-build request is missing '${key}'.`, {
+      code: 'PROCESS_AUTO_BUILD_REQUEST_INVALID',
+      exitCode: 2,
+      details: { key },
+    });
+  }
+
+  return value;
+}
+
+function normalizeOperation(value: unknown): ProcessAutoBuildOperation {
+  const normalized = nonEmptyString(value);
+  if (!normalized) {
+    return 'produce';
+  }
+  if (normalized === 'produce' || normalized === 'treat') {
+    return normalized;
+  }
+
+  throw new CliError("process auto-build operation must be 'produce' or 'treat'.", {
+    code: 'PROCESS_AUTO_BUILD_OPERATION_INVALID',
+    exitCode: 2,
+    details: normalized,
+  });
+}
+
+function normalizePreferredList(value: unknown, fallback: string[]): string[] {
+  if (!Array.isArray(value)) {
+    return [...fallback];
+  }
+
+  const normalized = value
+    .map((entry) => nonEmptyString(entry))
+    .filter((entry): entry is string => Boolean(entry));
+
+  return normalized.length ? normalized : [...fallback];
+}
+
+function normalizeBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function buildDefaultSourcePolicy(): ProcessAutoBuildSourcePolicy {
+  return {
+    step1_route: {
+      preferred: [...DEFAULT_SOURCE_POLICY.step1_route.preferred],
+      fallback: DEFAULT_SOURCE_POLICY.step1_route.fallback,
+    },
+    step2_process_split: {
+      preferred: [...DEFAULT_SOURCE_POLICY.step2_process_split.preferred],
+      fallback: DEFAULT_SOURCE_POLICY.step2_process_split.fallback,
+    },
+    step3b_exchange_values: {
+      preferred: [...DEFAULT_SOURCE_POLICY.step3b_exchange_values.preferred],
+      require_numeric_evidence:
+        DEFAULT_SOURCE_POLICY.step3b_exchange_values.require_numeric_evidence,
+      allow_estimation: DEFAULT_SOURCE_POLICY.step3b_exchange_values.allow_estimation,
+    },
+  };
+}
+
+function normalizeSourcePolicy(value: unknown): ProcessAutoBuildSourcePolicy {
+  if (!isRecord(value)) {
+    return buildDefaultSourcePolicy();
+  }
+
+  const defaults = buildDefaultSourcePolicy();
+  const step1Route = isRecord(value.step1_route) ? value.step1_route : {};
+  const step2ProcessSplit = isRecord(value.step2_process_split) ? value.step2_process_split : {};
+  const step3ExchangeValues = isRecord(value.step3b_exchange_values)
+    ? value.step3b_exchange_values
+    : {};
+
+  return {
+    step1_route: {
+      preferred: normalizePreferredList(step1Route.preferred, defaults.step1_route.preferred),
+      fallback: nonEmptyString(step1Route.fallback) ?? DEFAULT_SOURCE_POLICY.step1_route.fallback,
+    },
+    step2_process_split: {
+      preferred: normalizePreferredList(
+        step2ProcessSplit.preferred,
+        defaults.step2_process_split.preferred,
+      ),
+      fallback:
+        nonEmptyString(step2ProcessSplit.fallback) ??
+        DEFAULT_SOURCE_POLICY.step2_process_split.fallback,
+    },
+    step3b_exchange_values: {
+      preferred: normalizePreferredList(
+        step3ExchangeValues.preferred,
+        defaults.step3b_exchange_values.preferred,
+      ),
+      require_numeric_evidence: normalizeBoolean(
+        step3ExchangeValues.require_numeric_evidence,
+        DEFAULT_SOURCE_POLICY.step3b_exchange_values.require_numeric_evidence,
+      ),
+      allow_estimation: normalizeBoolean(
+        step3ExchangeValues.allow_estimation,
+        DEFAULT_SOURCE_POLICY.step3b_exchange_values.allow_estimation,
+      ),
+    },
+  };
+}
+
+function extractFlowDatasetRoot(payload: unknown): {
+  flowPayload: JsonRecord;
+  flowDataset: JsonRecord;
+  wrapper: 'flowDataSet' | 'direct';
+} {
+  if (!isRecord(payload)) {
+    throw new CliError('process auto-build flow file must contain a JSON object.', {
+      code: 'PROCESS_AUTO_BUILD_FLOW_INVALID',
+      exitCode: 2,
+    });
+  }
+
+  if (isRecord(payload.flowDataSet)) {
+    return {
+      flowPayload: payload,
+      flowDataset: payload.flowDataSet,
+      wrapper: 'flowDataSet',
+    };
+  }
+
+  return {
+    flowPayload: payload,
+    flowDataset: payload,
+    wrapper: 'direct',
+  };
+}
+
+function extractFlowSummary(
+  flowDataset: JsonRecord,
+  wrapper: 'flowDataSet' | 'direct',
+): ProcessAutoBuildFlowSummary {
+  const flowInformation = isRecord(flowDataset.flowInformation) ? flowDataset.flowInformation : {};
+  const dataSetInformation = isRecord(flowInformation.dataSetInformation)
+    ? flowInformation.dataSetInformation
+    : {};
+  const administrativeInformation = isRecord(flowDataset.administrativeInformation)
+    ? flowDataset.administrativeInformation
+    : {};
+  const publicationAndOwnership = isRecord(administrativeInformation.publicationAndOwnership)
+    ? administrativeInformation.publicationAndOwnership
+    : {};
+  const name = isRecord(dataSetInformation.name) ? dataSetInformation.name : {};
+
+  return {
+    wrapper,
+    uuid:
+      nonEmptyString(dataSetInformation['common:UUID']) ??
+      nonEmptyString(flowDataset['@id']) ??
+      null,
+    version:
+      nonEmptyString(publicationAndOwnership['common:dataSetVersion']) ??
+      nonEmptyString(flowDataset['@version']) ??
+      null,
+    base_name: extractText(name.baseName),
+    permanent_uri: nonEmptyString(publicationAndOwnership['common:permanentDataSetURI']) ?? null,
+  };
+}
+
+function runIdToken(value: string | null | undefined, fallback: string): string {
+  return sanitizeRunToken(value ?? '', fallback);
+}
+
+function buildProcessAutoBuildRunId(
+  flowFilePath: string,
+  operation: ProcessAutoBuildOperation,
+  summary: ProcessAutoBuildFlowSummary,
+  now: Date = new Date(),
+): string {
+  const stem = path.basename(flowFilePath, path.extname(flowFilePath));
+  const parts = stem.split('_');
+  const flowCode = runIdToken(parts[0] || summary.base_name || summary.uuid, 'flow');
+  const flowUuidShort = runIdToken(parts[1] || summary.uuid, 'unknown').slice(0, 8);
+  const operationToken = operation === 'treat' ? 'treat' : 'produce';
+
+  return `pfw_${flowCode}_${flowUuidShort}_${operationToken}_${buildUtcTimestamp(now)}`;
+}
+
+function resolveRunRoot(
+  requestDir: string,
+  runId: string,
+  outDirOverride: string | null | undefined,
+  requestRunRoot: unknown,
+): string {
+  const override = nonEmptyString(outDirOverride);
+  if (override) {
+    return path.resolve(requestDir, override);
+  }
+
+  const requestValue = nonEmptyString(requestRunRoot);
+  if (requestValue) {
+    return path.resolve(requestDir, requestValue);
+  }
+
+  return path.join(requestDir, 'artifacts', 'process_from_flow', runId);
+}
+
+function normalizeSourceInputType(value: unknown): ProcessAutoBuildSourceInputType {
+  const normalized = nonEmptyString(value);
+  if (normalized === 'local_file' || normalized === 'local_text') {
+    return normalized;
+  }
+
+  throw new CliError(
+    "process auto-build source_inputs[].type must be 'local_file' or 'local_text'.",
+    {
+      code: 'PROCESS_AUTO_BUILD_SOURCE_INVALID',
+      exitCode: 2,
+      details: { value },
+    },
+  );
+}
+
+function normalizeIntendedRoles(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((entry) => nonEmptyString(entry))
+    .filter((entry): entry is string => Boolean(entry));
+}
+
+function normalizeSourceInputs(
+  value: unknown,
+  requestDir: string,
+  evidenceIncomingDir: string,
+): NormalizedProcessAutoBuildSourceInput[] {
+  if (value === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new CliError('process auto-build source_inputs must be an array when provided.', {
+      code: 'PROCESS_AUTO_BUILD_SOURCE_INVALID',
+      exitCode: 2,
+    });
+  }
+
+  const seenIds = new Set<string>();
+
+  return value.map((entry, index) => {
+    if (!isRecord(entry)) {
+      throw new CliError('process auto-build source_inputs entries must be objects.', {
+        code: 'PROCESS_AUTO_BUILD_SOURCE_INVALID',
+        exitCode: 2,
+        details: { index },
+      });
+    }
+
+    const sourceId = requiredRequestString(entry, 'source_id');
+    if (seenIds.has(sourceId)) {
+      throw new CliError(`Duplicate process auto-build source_id: ${sourceId}`, {
+        code: 'PROCESS_AUTO_BUILD_SOURCE_DUPLICATE',
+        exitCode: 2,
+      });
+    }
+    seenIds.add(sourceId);
+
+    const sourcePath = path.resolve(requestDir, requiredRequestString(entry, 'path'));
+    if (!existsSync(sourcePath)) {
+      throw new CliError(`process auto-build source input not found: ${sourcePath}`, {
+        code: 'PROCESS_AUTO_BUILD_SOURCE_NOT_FOUND',
+        exitCode: 2,
+      });
+    }
+
+    const extension = path.extname(sourcePath);
+    const artifactFileName = `${String(index + 1).padStart(2, '0')}_${runIdToken(sourceId, 'source')}${extension}`;
+
+    return {
+      source_id: sourceId,
+      type: normalizeSourceInputType(entry.type),
+      source_path: sourcePath,
+      artifact_file_name: artifactFileName,
+      artifact_path: path.join(evidenceIncomingDir, artifactFileName),
+      intended_roles: normalizeIntendedRoles(entry.intended_roles),
+    };
+  });
+}
+
+function buildLayout(runRoot: string, runId: string): ProcessAutoBuildLayout {
+  const collectionDir = path.dirname(runRoot);
+  const layout: RunLayout = {
+    namespace: 'process_from_flow',
+    runId,
+    artifactsRoot: path.dirname(collectionDir),
+    collectionDir,
+    runRoot,
+    cacheDir: path.join(runRoot, 'cache'),
+    inputsDir: path.join(runRoot, 'input'),
+    outputsDir: path.join(runRoot, 'exports'),
+    reportsDir: path.join(runRoot, 'reports'),
+    logsDir: path.join(runRoot, 'logs'),
+    manifestsDir: path.join(runRoot, 'manifests'),
+    latestRunIdPath: path.join(collectionDir, '.latest_run_id'),
+  };
+
+  return {
+    ...layout,
+    requestDir: path.join(runRoot, 'request'),
+    evidenceDir: path.join(runRoot, 'evidence'),
+    evidenceIncomingDir: path.join(runRoot, 'evidence', 'incoming'),
+    evidenceNormalizedDir: path.join(runRoot, 'evidence', 'normalized'),
+    evidenceTextDir: path.join(runRoot, 'evidence', 'text'),
+    evidenceStructuredDir: path.join(runRoot, 'evidence', 'structured'),
+    stageOutputsDir: path.join(runRoot, 'stage_outputs'),
+    reviewsDir: path.join(runRoot, 'reviews'),
+    requestSnapshotPath: path.join(runRoot, 'request', 'pff-request.json'),
+    normalizedRequestPath: path.join(runRoot, 'request', 'request.normalized.json'),
+    sourcePolicyPath: path.join(runRoot, 'request', 'source-policy.json'),
+    flowSummaryPath: path.join(runRoot, 'manifests', 'flow-summary.json'),
+    inputManifestPath: path.join(runRoot, 'input', 'input_manifest.json'),
+    assemblyPlanPath: path.join(runRoot, 'manifests', 'assembly-plan.json'),
+    lineageManifestPath: path.join(runRoot, 'manifests', 'lineage-manifest.json'),
+    invocationIndexPath: path.join(runRoot, 'manifests', 'invocation-index.json'),
+    runManifestPath: path.join(runRoot, 'manifests', 'run-manifest.json'),
+    reportPath: path.join(runRoot, 'reports', 'process-auto-build-report.json'),
+    statePath: path.join(runRoot, 'cache', 'process_from_flow_state.json'),
+    handoffSummaryPath: path.join(runRoot, 'cache', 'agent_handoff_summary.json'),
+    processExportsDir: path.join(runRoot, 'exports', 'processes'),
+    sourceExportsDir: path.join(runRoot, 'exports', 'sources'),
+  };
+}
+
+function ensureEmptyRunRoot(runRoot: string): void {
+  if (!existsSync(runRoot)) {
+    return;
+  }
+
+  const entries = readdirSync(runRoot);
+  if (entries.length > 0) {
+    throw new CliError(`process auto-build run root already exists and is not empty: ${runRoot}`, {
+      code: 'PROCESS_AUTO_BUILD_RUN_EXISTS',
+      exitCode: 2,
+    });
+  }
+}
+
+function ensureProcessAutoBuildLayout(layout: ProcessAutoBuildLayout): void {
+  ensureRunLayout(layout);
+  [
+    layout.requestDir,
+    layout.evidenceDir,
+    layout.evidenceIncomingDir,
+    layout.evidenceNormalizedDir,
+    layout.evidenceTextDir,
+    layout.evidenceStructuredDir,
+    layout.stageOutputsDir,
+    layout.reviewsDir,
+    layout.processExportsDir,
+    layout.sourceExportsDir,
+  ].forEach((dirPath) => {
+    mkdirSync(dirPath, { recursive: true });
+  });
+
+  for (const stage of PROCESS_AUTO_BUILD_STAGES) {
+    const stageDir = path.join(layout.stageOutputsDir, stage.id);
+    mkdirSync(stageDir, { recursive: true });
+    if (stage.createsCandidatesDir) {
+      mkdirSync(path.join(stageDir, 'candidates'), { recursive: true });
+    }
+  }
+}
+
+function copyArtifactFile(sourcePath: string, targetPath: string, code: string): void {
+  mkdirSync(path.dirname(targetPath), { recursive: true });
+  try {
+    copyFileSync(sourcePath, targetPath);
+  } catch (error) {
+    throw new CliError(`Failed to copy artifact file: ${sourcePath}`, {
+      code,
+      exitCode: 1,
+      details: String(error),
+    });
+  }
+}
+
+function buildAssemblyPlan(runRoot: string): JsonRecord {
+  return {
+    schema_version: 1,
+    stages: PROCESS_AUTO_BUILD_STAGES.map((stage) => ({
+      id: stage.id,
+      title: stage.title,
+      status: 'pending',
+      modules: stage.modules,
+      output: stage.output,
+      candidates_dir: stage.createsCandidatesDir
+        ? path.posix.join(path.posix.dirname(stage.output), 'candidates')
+        : null,
+      output_abs: path.join(runRoot, stage.output),
+    })),
+  };
+}
+
+function buildLineageManifest(normalized: NormalizedProcessAutoBuildRequest): JsonRecord {
+  return {
+    schema_version: 1,
+    request_id: normalized.request_id,
+    run_id: normalized.run_id,
+    flow: {
+      source_path: normalized.flow_file,
+      uuid: normalized.flow_summary.uuid,
+      version: normalized.flow_summary.version,
+      base_name: normalized.flow_summary.base_name,
+    },
+    source_inputs: normalized.source_inputs.map((source) => ({
+      source_id: source.source_id,
+      type: source.type,
+      source_path: source.source_path,
+      artifact_path: source.artifact_path,
+      intended_roles: source.intended_roles,
+    })),
+  };
+}
+
+function buildInvocationIndex(
+  normalized: NormalizedProcessAutoBuildRequest,
+  options: RunProcessAutoBuildOptions,
+  reportPath: string,
+  now: Date,
+): JsonRecord {
+  const command = ['process', 'auto-build', '--input', options.inputPath];
+  if (options.outDir) {
+    command.push('--out-dir', options.outDir);
+  }
+
+  return {
+    schema_version: 1,
+    invocations: [
+      {
+        command,
+        cwd: options.cwd ?? process.cwd(),
+        created_at: now.toISOString(),
+        request_path: normalized.request_path,
+        report_path: reportPath,
+      },
+    ],
+  };
+}
+
+function buildStepMarkers(now: Date): JsonRecord {
+  const completedAt = now.toISOString();
+  const markers: JsonRecord = {
+    intake_prepared: {
+      status: 'completed',
+      completed_at: completedAt,
+    },
+  };
+
+  PROCESS_AUTO_BUILD_STAGES.forEach((stage) => {
+    markers[stage.id] = {
+      status: 'pending',
+    };
+  });
+
+  return markers;
+}
+
+function buildInitialState(
+  normalized: NormalizedProcessAutoBuildRequest,
+  flowArtifactPath: string,
+  now: Date,
+): JsonRecord {
+  return {
+    schema_version: 1,
+    build_status: 'intake_prepared',
+    next_stage: PROCESS_AUTO_BUILD_STAGES[0]?.id ?? null,
+    run_id: normalized.run_id,
+    request_id: normalized.request_id,
+    flow_path: normalized.flow_file,
+    flow_artifact_path: flowArtifactPath,
+    flow_dataset: normalized.flow_dataset,
+    flow_summary: normalized.flow_summary,
+    operation: normalized.operation,
+    source_inputs: normalized.source_inputs,
+    source_policy: normalized.source_policy,
+    scientific_references: {
+      source_inputs: normalized.source_inputs.map((source) => ({
+        source_id: source.source_id,
+        type: source.type,
+        intended_roles: source.intended_roles,
+        source_path: source.source_path,
+      })),
+    },
+    processes: [],
+    process_exchanges: [],
+    matched_process_exchanges: [],
+    process_datasets: [],
+    source_datasets: [],
+    coverage_metrics: {},
+    coverage_history: [],
+    step_markers: buildStepMarkers(now),
+  };
+}
+
+function buildNextActions(
+  layout: ProcessAutoBuildLayout,
+  normalized: NormalizedProcessAutoBuildRequest,
+): string[] {
+  return [
+    `inspect: ${layout.normalizedRequestPath}`,
+    `inspect: ${layout.statePath}`,
+    `inspect: ${layout.assemblyPlanPath}`,
+    `future: tiangong process resume-build --run-id ${normalized.run_id}`,
+    `future: tiangong process publish-build --run-id ${normalized.run_id}`,
+  ];
+}
+
+function buildAgentHandoffSummary(
+  normalized: NormalizedProcessAutoBuildRequest,
+  layout: ProcessAutoBuildLayout,
+  flowArtifactPath: string,
+  now: Date,
+): JsonRecord {
+  return {
+    schema_version: 1,
+    generated_at_utc: now.toISOString(),
+    run_id: normalized.run_id,
+    command: 'process auto-build',
+    flow_path: normalized.flow_file,
+    operation: normalized.operation,
+    stop_after: null,
+    process_count: 0,
+    matched_exchange_count: 0,
+    process_dataset_count: 0,
+    source_dataset_count: 0,
+    remaining_placeholder_refs: 0,
+    placeholder_examples: [],
+    publish_summary: {},
+    artifacts: {
+      state_path: layout.statePath,
+      timing_report: null,
+      publish_summary: null,
+      llm_cost_report: null,
+      process_update_report: null,
+      flow_auto_build_manifest: null,
+      request_snapshot: layout.requestSnapshotPath,
+      normalized_request: layout.normalizedRequestPath,
+      assembly_plan: layout.assemblyPlanPath,
+      flow_copy: flowArtifactPath,
+    },
+    next_actions: buildNextActions(layout, normalized),
+    extra: {
+      status: 'prepared_local_process_auto_build_run',
+      request_id: normalized.request_id,
+      source_input_count: normalized.source_inputs.length,
+    },
+  };
+}
+
+function buildReport(
+  normalized: NormalizedProcessAutoBuildRequest,
+  layout: ProcessAutoBuildLayout,
+  flowArtifactPath: string,
+  now: Date,
+): ProcessAutoBuildReport {
+  return {
+    schema_version: 1,
+    generated_at_utc: now.toISOString(),
+    status: 'prepared_local_process_auto_build_run',
+    request_path: normalized.request_path,
+    request_id: normalized.request_id,
+    run_id: normalized.run_id,
+    run_root: normalized.run_root,
+    operation: normalized.operation,
+    flow: {
+      source_path: normalized.flow_file,
+      artifact_path: flowArtifactPath,
+      wrapper: normalized.flow_summary.wrapper,
+      uuid: normalized.flow_summary.uuid,
+      version: normalized.flow_summary.version,
+      base_name: normalized.flow_summary.base_name,
+    },
+    source_input_count: normalized.source_inputs.length,
+    stage_count: PROCESS_AUTO_BUILD_STAGES.length,
+    files: {
+      request_snapshot: layout.requestSnapshotPath,
+      normalized_request: layout.normalizedRequestPath,
+      source_policy: layout.sourcePolicyPath,
+      flow_summary: layout.flowSummaryPath,
+      input_manifest: layout.inputManifestPath,
+      assembly_plan: layout.assemblyPlanPath,
+      lineage_manifest: layout.lineageManifestPath,
+      invocation_index: layout.invocationIndexPath,
+      run_manifest: layout.runManifestPath,
+      state: layout.statePath,
+      handoff_summary: layout.handoffSummaryPath,
+      report: layout.reportPath,
+    },
+    next_actions: buildNextActions(layout, normalized),
+  };
+}
+
+export function normalizeProcessAutoBuildRequest(
+  input: unknown,
+  options: { inputPath: string; outDir?: string | null; now?: Date },
+): NormalizedProcessAutoBuildRequest {
+  const request = requiredRequestObject(input);
+  const requestDir = path.dirname(path.resolve(options.inputPath));
+  const operation = normalizeOperation(request.operation);
+  const flowFile = path.resolve(requestDir, requiredRequestString(request, 'flow_file'));
+  const flowPayload = readJsonInput(flowFile);
+  const { flowDataset, wrapper } = extractFlowDatasetRoot(flowPayload);
+  const flowSummary = extractFlowSummary(flowDataset, wrapper);
+  const runId =
+    nonEmptyString(request.run_id) ??
+    buildProcessAutoBuildRunId(flowFile, operation, flowSummary, options.now);
+  const runRoot = resolveRunRoot(requestDir, runId, options.outDir, request.workspace_run_root);
+  const layout = buildLayout(runRoot, runId);
+
+  return {
+    schema_version: 1,
+    request_path: path.resolve(options.inputPath),
+    request_id: nonEmptyString(request.request_id) ?? `pff-${runId}`,
+    flow_file: flowFile,
+    flow_summary: flowSummary,
+    flow_dataset: flowDataset,
+    operation,
+    run_id: runId,
+    run_root: runRoot,
+    source_inputs: normalizeSourceInputs(
+      request.source_inputs,
+      requestDir,
+      layout.evidenceIncomingDir,
+    ),
+    source_policy: normalizeSourcePolicy(request.source_policy),
+  };
+}
+
+export async function runProcessAutoBuild(
+  options: RunProcessAutoBuildOptions,
+): Promise<ProcessAutoBuildReport> {
+  const input = readJsonInput(options.inputPath);
+  const now = options.now ?? new Date();
+  const normalized = normalizeProcessAutoBuildRequest(input, {
+    inputPath: options.inputPath,
+    outDir: options.outDir,
+    now,
+  });
+  const layout = buildLayout(normalized.run_root, normalized.run_id);
+  const flowArtifactPath = path.join(layout.inputsDir, path.basename(normalized.flow_file));
+
+  ensureEmptyRunRoot(layout.runRoot);
+  ensureProcessAutoBuildLayout(layout);
+
+  copyArtifactFile(normalized.flow_file, flowArtifactPath, 'PROCESS_AUTO_BUILD_FLOW_COPY_FAILED');
+  normalized.source_inputs.forEach((source) => {
+    copyArtifactFile(
+      source.source_path,
+      source.artifact_path,
+      'PROCESS_AUTO_BUILD_SOURCE_COPY_FAILED',
+    );
+  });
+
+  const request = requiredRequestObject(input);
+  writeJsonArtifact(layout.requestSnapshotPath, request);
+  writeJsonArtifact(layout.normalizedRequestPath, normalized);
+  writeJsonArtifact(layout.sourcePolicyPath, normalized.source_policy);
+  writeJsonArtifact(layout.flowSummaryPath, normalized.flow_summary);
+  writeJsonArtifact(layout.inputManifestPath, {
+    run_id: normalized.run_id,
+    flow_path: normalized.flow_file,
+    flow_artifact_path: flowArtifactPath,
+    operation: normalized.operation,
+  });
+  writeJsonArtifact(layout.assemblyPlanPath, buildAssemblyPlan(layout.runRoot));
+  writeJsonArtifact(layout.lineageManifestPath, buildLineageManifest(normalized));
+  writeJsonArtifact(
+    layout.invocationIndexPath,
+    buildInvocationIndex(normalized, options, layout.reportPath, now),
+  );
+  writeJsonArtifact(
+    layout.runManifestPath,
+    buildRunManifest({
+      layout,
+      command: options.outDir
+        ? ['process', 'auto-build', '--input', options.inputPath, '--out-dir', options.outDir]
+        : ['process', 'auto-build', '--input', options.inputPath],
+      cwd: options.cwd,
+      createdAt: now,
+    }),
+  );
+
+  const state = buildInitialState(normalized, flowArtifactPath, now);
+  await withStateFileLock(
+    layout.statePath,
+    { reason: 'process-auto-build.initial_state', now },
+    () => writeJsonArtifact(layout.statePath, state),
+  );
+
+  const handoff = buildAgentHandoffSummary(normalized, layout, flowArtifactPath, now);
+  writeJsonArtifact(layout.handoffSummaryPath, handoff);
+  writeLatestRunId(layout, normalized.run_id);
+
+  const report = buildReport(normalized, layout, flowArtifactPath, now);
+  writeJsonArtifact(layout.reportPath, report);
+  return report;
+}
+
+// Exposed for deterministic unit coverage of process auto-build normalization and scaffold helpers.
+export const __testInternals = {
+  PROCESS_AUTO_BUILD_STAGES,
+  extractText,
+  normalizeOperation,
+  normalizeSourcePolicy,
+  extractFlowDatasetRoot,
+  extractFlowSummary,
+  buildProcessAutoBuildRunId,
+  buildLayout,
+  buildAssemblyPlan,
+  buildLineageManifest,
+  buildInvocationIndex,
+  buildInitialState,
+  buildAgentHandoffSummary,
+  buildReport,
+};

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -37,6 +37,7 @@ test('executeCli prints main help when no command is given', async () => {
   assert.match(result.stdout, /Unified TianGong command entrypoint/u);
   assert.match(result.stdout, /Implemented Commands:/u);
   assert.match(result.stdout, /Planned Surface \(not implemented yet\):/u);
+  assert.match(result.stdout, /process\s+auto-build/u);
   assert.match(result.stdout, /lifecyclemodel build-resulting-process/u);
   assert.match(result.stdout, /publish-resulting-process/u);
   assert.match(result.stdout, /exit with code 2/u);
@@ -178,6 +179,20 @@ test('executeCli returns help for the lifecyclemodel namespace and implemented s
   assert.doesNotMatch(publishHelp.stdout, /Planned command/u);
 });
 
+test('executeCli returns help for the process namespace and implemented subcommands', async () => {
+  const processHelp = await executeCli(['process'], makeDeps());
+  assert.equal(processHelp.exitCode, 0);
+  assert.match(processHelp.stdout, /tiangong process <subcommand>/u);
+  assert.match(processHelp.stdout, /auto-build/u);
+  assert.match(processHelp.stdout, /resume-build/u);
+
+  const autoBuildHelp = await executeCli(['process', 'auto-build', '--help'], makeDeps());
+  assert.equal(autoBuildHelp.exitCode, 0);
+  assert.match(autoBuildHelp.stdout, /tiangong process auto-build --input <file>/u);
+  assert.match(autoBuildHelp.stdout, /--out-dir/u);
+  assert.doesNotMatch(autoBuildHelp.stdout, /Planned command/u);
+});
+
 test('executeCli executes lifecyclemodel build-resulting-process with injected implementation', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-cli-'));
   const inputPath = path.join(dir, 'request.json');
@@ -281,6 +296,66 @@ test('executeCli executes lifecyclemodel publish-resulting-process with injected
     assert.equal(result.exitCode, 0);
     assert.match(result.stdout, /"status":"prepared_local_publish_bundle"/u);
     assert.match(result.stdout, /"publish_bundle"/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli executes process auto-build with injected implementation', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-auto-build-cli-'));
+  const inputPath = path.join(dir, 'request.json');
+  writeFileSync(inputPath, '{"flow_file":"./flow.json"}', 'utf8');
+
+  try {
+    const result = await executeCli(
+      ['process', 'auto-build', '--json', '--input', inputPath, '--out-dir', './run-root'],
+      {
+        ...makeDeps(),
+        runProcessAutoBuildImpl: async (options) => {
+          assert.equal(options.inputPath, inputPath);
+          assert.equal(options.outDir, './run-root');
+          return {
+            schema_version: 1,
+            generated_at_utc: '2026-03-29T00:00:00.000Z',
+            status: 'prepared_local_process_auto_build_run',
+            request_path: inputPath,
+            request_id: 'pff-demo',
+            run_id: 'pfw_demo_unknown_produce_20260329T000000Z',
+            run_root: path.join(dir, 'run-root'),
+            operation: 'produce',
+            flow: {
+              source_path: path.join(dir, 'flow.json'),
+              artifact_path: path.join(dir, 'run-root', 'input', 'flow.json'),
+              wrapper: 'flowDataSet',
+              uuid: 'flow-uuid',
+              version: '00.00.001',
+              base_name: 'Demo flow',
+            },
+            source_input_count: 0,
+            stage_count: 10,
+            files: {
+              request_snapshot: path.join(dir, 'run-root', 'request', 'pff-request.json'),
+              normalized_request: path.join(dir, 'run-root', 'request', 'request.normalized.json'),
+              source_policy: path.join(dir, 'run-root', 'request', 'source-policy.json'),
+              flow_summary: path.join(dir, 'run-root', 'manifests', 'flow-summary.json'),
+              input_manifest: path.join(dir, 'run-root', 'input', 'input_manifest.json'),
+              assembly_plan: path.join(dir, 'run-root', 'manifests', 'assembly-plan.json'),
+              lineage_manifest: path.join(dir, 'run-root', 'manifests', 'lineage-manifest.json'),
+              invocation_index: path.join(dir, 'run-root', 'manifests', 'invocation-index.json'),
+              run_manifest: path.join(dir, 'run-root', 'manifests', 'run-manifest.json'),
+              state: path.join(dir, 'run-root', 'cache', 'process_from_flow_state.json'),
+              handoff_summary: path.join(dir, 'run-root', 'cache', 'agent_handoff_summary.json'),
+              report: path.join(dir, 'run-root', 'reports', 'process-auto-build-report.json'),
+            },
+            next_actions: ['inspect: state'],
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /"status":"prepared_local_process_auto_build_run"/u);
+    assert.match(result.stdout, /"request_snapshot"/u);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -599,7 +674,7 @@ test('executeCli returns parsing errors for invalid publish and validation flags
   assert.match(validationResult.stderr, /INVALID_ARGS/u);
 });
 
-test('executeCli returns parsing errors for invalid lifecyclemodel build and publish flags', async () => {
+test('executeCli returns parsing errors for invalid lifecyclemodel build, process build, and publish flags', async () => {
   const result = await executeCli(
     ['lifecyclemodel', 'build-resulting-process', '--bad-flag'],
     makeDeps(),
@@ -615,6 +690,11 @@ test('executeCli returns parsing errors for invalid lifecyclemodel build and pub
   assert.equal(publishResult.exitCode, 2);
   assert.equal(publishResult.stdout, '');
   assert.match(publishResult.stderr, /INVALID_ARGS/u);
+
+  const processResult = await executeCli(['process', 'auto-build', '--bad-flag'], makeDeps());
+  assert.equal(processResult.exitCode, 2);
+  assert.equal(processResult.stdout, '');
+  assert.match(processResult.stderr, /INVALID_ARGS/u);
 });
 
 test('executeCli executes validation run with injected implementation and report file', async () => {
@@ -725,7 +805,7 @@ test('executeCli prints main help for the explicit help command', async () => {
 });
 
 test('executeCli returns planned command message for unimplemented command', async () => {
-  const result = await executeCli(['process', 'auto-build'], makeDeps());
+  const result = await executeCli(['flow', 'get'], makeDeps());
   assert.equal(result.exitCode, 2);
   assert.equal(result.stdout, '');
   assert.match(result.stderr, /not implemented yet/u);
@@ -738,11 +818,26 @@ test('executeCli returns planned command message for lifecyclemodel subcommands 
   assert.match(result.stderr, /Command 'lifecyclemodel auto-build'/u);
 });
 
+test('executeCli returns planned command message for process subcommands after help is introduced', async () => {
+  const result = await executeCli(['process', 'resume-build'], makeDeps());
+  assert.equal(result.exitCode, 2);
+  assert.equal(result.stdout, '');
+  assert.match(result.stderr, /Command 'process resume-build'/u);
+});
+
 test('executeCli returns dedicated help for planned lifecyclemodel subcommands', async () => {
   const result = await executeCli(['lifecyclemodel', 'auto-build', '--help'], makeDeps());
   assert.equal(result.exitCode, 0);
   assert.match(result.stdout, /Planned contract:/u);
   assert.match(result.stdout, /discover candidate processes/u);
+  assert.equal(result.stderr, '');
+});
+
+test('executeCli returns dedicated help for planned process subcommands', async () => {
+  const result = await executeCli(['process', 'resume-build', '--help'], makeDeps());
+  assert.equal(result.exitCode, 0);
+  assert.match(result.stdout, /tiangong process resume-build --run-id <id>/u);
+  assert.match(result.stdout, /Execution is not implemented yet/u);
   assert.equal(result.stderr, '');
 });
 

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -31,7 +31,8 @@ test('main writes stdout and stderr from CLI results', async () => {
 
     assert.equal(exitCode, 2);
     assert.equal(stdout, '');
-    assert.match(stderr, /not implemented yet/u);
+    assert.match(stderr, /"code":"INPUT_REQUIRED"/u);
+    assert.match(stderr, /Missing required --input value\./u);
   } finally {
     process.stdout.write = originalStdoutWrite;
     process.stderr.write = originalStderrWrite;

--- a/test/process-auto-build.test.ts
+++ b/test/process-auto-build.test.ts
@@ -1,0 +1,637 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  __testInternals,
+  normalizeProcessAutoBuildRequest,
+  runProcessAutoBuild,
+} from '../src/lib/process-auto-build.js';
+
+function writeJson(filePath: string, value: unknown): void {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function readJson(filePath: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(filePath, 'utf8')) as Record<string, unknown>;
+}
+
+function bundledFlowPayload(): Record<string, unknown> {
+  return readJson(
+    path.resolve(process.cwd(), '../tidas-sdk/test-data/tidas-example-flow.json'),
+  ) as Record<string, unknown>;
+}
+
+function writeFlowFixture(
+  dir: string,
+  options?: {
+    fileName?: string;
+    direct?: boolean;
+    payload?: unknown;
+  },
+): string {
+  const fileName = options?.fileName ?? '01211_3a8d74d8_reference-flow.json';
+  const payload = options?.payload ?? bundledFlowPayload();
+  const value =
+    options?.direct && payload && typeof payload === 'object' && 'flowDataSet' in payload
+      ? (payload as { flowDataSet: unknown }).flowDataSet
+      : payload;
+  const filePath = path.join(dir, fileName);
+  writeJson(filePath, value);
+  return filePath;
+}
+
+test('normalizeProcessAutoBuildRequest resolves defaults, flow summaries, and source inputs', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-auto-build-normalize-'));
+  const flowPath = writeFlowFixture(dir);
+  const sourcePath = path.join(dir, 'paper.pdf');
+  const requestPath = path.join(dir, 'request.json');
+  writeFileSync(sourcePath, 'paper-data', 'utf8');
+  writeJson(requestPath, {
+    flow_file: `./${path.basename(flowPath)}`,
+    source_inputs: [
+      {
+        source_id: 'paper-1',
+        type: 'local_file',
+        path: './paper.pdf',
+        intended_roles: ['tech_route', 'exchange_values'],
+      },
+    ],
+  });
+
+  try {
+    const normalized = normalizeProcessAutoBuildRequest(readJson(requestPath), {
+      inputPath: requestPath,
+      now: new Date('2026-03-29T00:00:00Z'),
+    });
+
+    assert.equal(normalized.request_id, 'pff-pfw_01211_3a8d74d8_produce_20260329T000000Z');
+    assert.equal(normalized.run_id, 'pfw_01211_3a8d74d8_produce_20260329T000000Z');
+    assert.equal(
+      normalized.run_root,
+      path.join(dir, 'artifacts', 'process_from_flow', normalized.run_id),
+    );
+    assert.equal(normalized.flow_file, flowPath);
+    assert.equal(normalized.flow_summary.wrapper, 'flowDataSet');
+    assert.equal(normalized.flow_summary.uuid, '4d8a3345-51fd-44ac-87e0-59bc8d3b0fdc');
+    assert.equal(normalized.flow_summary.version, '00.00.002');
+    assert.match(normalized.flow_summary.base_name ?? '', /2-chloro-3-methyl/u);
+    assert.equal(normalized.source_inputs.length, 1);
+    assert.deepEqual(normalized.source_inputs[0]?.intended_roles, [
+      'tech_route',
+      'exchange_values',
+    ]);
+    assert.equal(
+      normalized.source_inputs[0]?.artifact_path,
+      path.join(
+        dir,
+        'artifacts',
+        'process_from_flow',
+        normalized.run_id,
+        'evidence',
+        'incoming',
+        '01_paper_1.pdf',
+      ),
+    );
+    assert.deepEqual(normalized.source_policy.step1_route.preferred, ['user_bundle', 'kb_bundle']);
+    assert.equal(normalized.source_policy.step3b_exchange_values.allow_estimation, true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('normalizeProcessAutoBuildRequest applies overrides, direct flow roots, and merged source policy', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-auto-build-overrides-'));
+  const flowPath = writeFlowFixture(dir, {
+    fileName: 'direct-flow.json',
+    direct: true,
+  });
+  const requestPath = path.join(dir, 'request.json');
+  writeJson(requestPath, {
+    request_id: 'req-1',
+    run_id: 'custom-run',
+    flow_file: './direct-flow.json',
+    workspace_run_root: './workspace-run-root',
+    operation: 'treat',
+    source_policy: {
+      step1_route: {
+        preferred: ['kb_bundle'],
+        fallback: 'manual',
+      },
+      step3b_exchange_values: {
+        allow_estimation: false,
+      },
+    },
+  });
+
+  try {
+    const normalized = normalizeProcessAutoBuildRequest(readJson(requestPath), {
+      inputPath: requestPath,
+      outDir: './override-run-root',
+    });
+
+    assert.equal(normalized.request_id, 'req-1');
+    assert.equal(normalized.run_id, 'custom-run');
+    assert.equal(normalized.run_root, path.join(dir, 'override-run-root'));
+    assert.equal(normalized.operation, 'treat');
+    assert.equal(normalized.flow_file, flowPath);
+    assert.equal(normalized.flow_summary.wrapper, 'direct');
+    assert.deepEqual(normalized.source_policy.step1_route.preferred, ['kb_bundle']);
+    assert.equal(normalized.source_policy.step1_route.fallback, 'manual');
+    assert.deepEqual(normalized.source_policy.step2_process_split.preferred, [
+      'user_bundle.process_split',
+      'si_bundle',
+      'kb_bundle.process_split',
+    ]);
+    assert.equal(normalized.source_policy.step3b_exchange_values.require_numeric_evidence, true);
+    assert.equal(normalized.source_policy.step3b_exchange_values.allow_estimation, false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('normalizeProcessAutoBuildRequest rejects invalid request and source input shapes', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-auto-build-invalid-'));
+  const flowPath = writeFlowFixture(dir);
+  const requestPath = path.join(dir, 'request.json');
+  const sourcePath = path.join(dir, 'notes.md');
+  writeFileSync(sourcePath, 'hello', 'utf8');
+  writeJson(requestPath, {
+    flow_file: `./${path.basename(flowPath)}`,
+  });
+
+  try {
+    assert.throws(
+      () =>
+        normalizeProcessAutoBuildRequest('not-an-object', {
+          inputPath: requestPath,
+        }),
+      /must be a JSON object/u,
+    );
+
+    assert.throws(
+      () =>
+        normalizeProcessAutoBuildRequest(
+          {
+            operation: 'produce',
+          },
+          {
+            inputPath: requestPath,
+          },
+        ),
+      /missing 'flow_file'/u,
+    );
+
+    assert.throws(
+      () =>
+        normalizeProcessAutoBuildRequest(
+          {
+            flow_file: './01211_3a8d74d8_reference-flow.json',
+            operation: 'ship',
+          },
+          {
+            inputPath: requestPath,
+          },
+        ),
+      /must be 'produce' or 'treat'/u,
+    );
+
+    assert.throws(
+      () =>
+        normalizeProcessAutoBuildRequest(
+          {
+            flow_file: './01211_3a8d74d8_reference-flow.json',
+            source_inputs: {},
+          },
+          {
+            inputPath: requestPath,
+          },
+        ),
+      /source_inputs must be an array/u,
+    );
+
+    assert.throws(
+      () =>
+        normalizeProcessAutoBuildRequest(
+          {
+            flow_file: './01211_3a8d74d8_reference-flow.json',
+            source_inputs: ['bad'],
+          },
+          {
+            inputPath: requestPath,
+          },
+        ),
+      /entries must be objects/u,
+    );
+
+    assert.throws(
+      () =>
+        normalizeProcessAutoBuildRequest(
+          {
+            flow_file: './01211_3a8d74d8_reference-flow.json',
+            source_inputs: [
+              {
+                source_id: 'src-1',
+                type: 'remote_url',
+                path: './notes.md',
+              },
+            ],
+          },
+          {
+            inputPath: requestPath,
+          },
+        ),
+      /type must be 'local_file' or 'local_text'/u,
+    );
+
+    assert.throws(
+      () =>
+        normalizeProcessAutoBuildRequest(
+          {
+            flow_file: './01211_3a8d74d8_reference-flow.json',
+            source_inputs: [
+              {
+                source_id: 'src-1',
+                type: 'local_text',
+                path: './missing.md',
+              },
+            ],
+          },
+          {
+            inputPath: requestPath,
+          },
+        ),
+      /source input not found/u,
+    );
+
+    assert.throws(
+      () =>
+        normalizeProcessAutoBuildRequest(
+          {
+            flow_file: './01211_3a8d74d8_reference-flow.json',
+            source_inputs: [
+              {
+                source_id: 'dup',
+                type: 'local_text',
+                path: './notes.md',
+              },
+              {
+                source_id: 'dup',
+                type: 'local_text',
+                path: './notes.md',
+              },
+            ],
+          },
+          {
+            inputPath: requestPath,
+          },
+        ),
+      /Duplicate process auto-build source_id/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('process auto-build internals cover text extraction and fallback summaries', () => {
+  assert.equal(__testInternals.extractText('direct value'), 'direct value');
+  assert.equal(__testInternals.extractText('   '), null);
+  assert.equal(
+    __testInternals.extractText([{ '#text': 'from object' }, { '#text': 'ignored' }]),
+    'from object',
+  );
+  assert.equal(__testInternals.extractText([]), null);
+  assert.equal(__testInternals.extractText({ '#text': 'wrapped' }), 'wrapped');
+  assert.equal(__testInternals.extractText({ value: 'missing' }), null);
+
+  const directRoot = __testInternals.extractFlowDatasetRoot({
+    '@id': 'flow-direct',
+    '@version': '01.00.000',
+  });
+  assert.equal(directRoot.wrapper, 'direct');
+
+  const summary = __testInternals.extractFlowSummary(
+    {
+      '@id': 'flow-direct',
+      '@version': '01.00.000',
+    },
+    'direct',
+  );
+  assert.equal(summary.uuid, 'flow-direct');
+  assert.equal(summary.version, '01.00.000');
+  assert.equal(summary.base_name, null);
+
+  const emptySummary = __testInternals.extractFlowSummary({}, 'direct');
+  assert.equal(emptySummary.uuid, null);
+  assert.equal(emptySummary.version, null);
+  assert.equal(emptySummary.base_name, null);
+  assert.equal(emptySummary.permanent_uri, null);
+
+  const runId = __testInternals.buildProcessAutoBuildRunId(
+    '/tmp/flow.json',
+    'treat',
+    {
+      wrapper: 'direct',
+      uuid: 'abc-1234',
+      version: '01.00.000',
+      base_name: null,
+      permanent_uri: null,
+    },
+    new Date('2026-03-29T01:02:03Z'),
+  );
+  assert.equal(runId, 'pfw_flow_abc_1234_treat_20260329T010203Z');
+
+  const fallbackRunId = __testInternals.buildProcessAutoBuildRunId(
+    '/tmp/_.json',
+    'produce',
+    {
+      wrapper: 'direct',
+      uuid: null,
+      version: null,
+      base_name: 'Fallback Flow',
+      permanent_uri: null,
+    },
+    new Date('2026-03-29T04:05:06Z'),
+  );
+  assert.equal(fallbackRunId, 'pfw_fallback_flow_unknown_produce_20260329T040506Z');
+
+  const uuidFallbackRunId = __testInternals.buildProcessAutoBuildRunId(
+    '/tmp/_.json',
+    'treat',
+    {
+      wrapper: 'direct',
+      uuid: 'abc-1234',
+      version: null,
+      base_name: null,
+      permanent_uri: null,
+    },
+    new Date('2026-03-29T04:06:07Z'),
+  );
+  assert.equal(uuidFallbackRunId, 'pfw_abc_1234_abc_1234_treat_20260329T040607Z');
+
+  const layout = __testInternals.buildLayout('/tmp/custom-run-root', 'run-1');
+  assert.equal(layout.inputsDir, '/tmp/custom-run-root/input');
+  assert.equal(layout.outputsDir, '/tmp/custom-run-root/exports');
+
+  const assemblyPlan = __testInternals.buildAssemblyPlan('/tmp/custom-run-root') as {
+    stages: Array<Record<string, unknown>>;
+  };
+  assert.equal(assemblyPlan.stages.length, 10);
+  assert.equal(assemblyPlan.stages[0]?.candidates_dir, 'stage_outputs/01_route/candidates');
+  assert.equal(assemblyPlan.stages[2]?.candidates_dir, null);
+});
+
+test('process auto-build internals cover source-policy and empty-stage fallbacks', () => {
+  const invalidSections = __testInternals.normalizeSourcePolicy({
+    step1_route: 'bad',
+    step2_process_split: 'bad',
+    step3b_exchange_values: 'bad',
+  });
+  assert.deepEqual(invalidSections.step1_route.preferred, ['user_bundle', 'kb_bundle']);
+  assert.equal(invalidSections.step1_route.fallback, 'expert_judgement');
+  assert.deepEqual(invalidSections.step2_process_split.preferred, [
+    'user_bundle.process_split',
+    'si_bundle',
+    'kb_bundle.process_split',
+  ]);
+  assert.deepEqual(invalidSections.step3b_exchange_values.preferred, [
+    'user_bundle.exchange_values',
+    'si_bundle',
+    'kb_bundle.exchange_values',
+  ]);
+
+  const emptyPreferred = __testInternals.normalizeSourcePolicy({
+    step1_route: {
+      preferred: [' ', null],
+    },
+  });
+  assert.deepEqual(emptyPreferred.step1_route.preferred, ['user_bundle', 'kb_bundle']);
+  assert.equal(emptyPreferred.step1_route.fallback, 'expert_judgement');
+
+  const explicitStep2 = __testInternals.normalizeSourcePolicy({
+    step2_process_split: {
+      preferred: ['custom.process_split'],
+      fallback: 'manual',
+    },
+  });
+  assert.deepEqual(explicitStep2.step2_process_split.preferred, ['custom.process_split']);
+  assert.equal(explicitStep2.step2_process_split.fallback, 'manual');
+
+  const stages = __testInternals.PROCESS_AUTO_BUILD_STAGES;
+  const originalStages = stages.splice(0, stages.length);
+
+  try {
+    const initialState = __testInternals.buildInitialState(
+      {
+        schema_version: 1,
+        request_path: '/tmp/request.json',
+        request_id: 'req-1',
+        flow_file: '/tmp/flow.json',
+        flow_summary: {
+          wrapper: 'direct',
+          uuid: null,
+          version: null,
+          base_name: null,
+          permanent_uri: null,
+        },
+        flow_dataset: {},
+        operation: 'produce',
+        run_id: 'run-1',
+        run_root: '/tmp/run-1',
+        source_inputs: [],
+        source_policy: __testInternals.normalizeSourcePolicy(undefined),
+      },
+      '/tmp/run-1/input/flow.json',
+      new Date('2026-03-29T05:06:07Z'),
+    ) as Record<string, unknown>;
+
+    assert.equal(initialState.next_stage, null);
+  } finally {
+    stages.push(...originalStages);
+  }
+});
+
+test('runProcessAutoBuild writes the local artifact scaffold, state, and handoff summary', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-auto-build-run-'));
+  const flowPath = writeFlowFixture(dir);
+  const requestPath = path.join(dir, 'request.json');
+  writeJson(requestPath, {
+    flow_file: `./${path.basename(flowPath)}`,
+  });
+
+  try {
+    const report = await runProcessAutoBuild({
+      inputPath: requestPath,
+      now: new Date('2026-03-29T02:00:00Z'),
+      cwd: '/tmp/workspace',
+    });
+
+    assert.equal(report.status, 'prepared_local_process_auto_build_run');
+    assert.equal(report.run_root, path.join(dir, 'artifacts', 'process_from_flow', report.run_id));
+    assert.equal(existsSync(report.files.state), true);
+    assert.equal(existsSync(report.files.handoff_summary), true);
+    assert.equal(existsSync(report.files.run_manifest), true);
+    assert.equal(existsSync(report.files.request_snapshot), true);
+    assert.equal(
+      readFileSync(path.join(path.dirname(report.run_root), '.latest_run_id'), 'utf8'),
+      `${report.run_id}\n`,
+    );
+
+    const inputManifest = readJson(report.files.input_manifest);
+    assert.equal(inputManifest.run_id, report.run_id);
+    assert.equal(inputManifest.flow_path, flowPath);
+
+    const runManifest = readJson(report.files.run_manifest);
+    assert.deepEqual(runManifest.command, ['process', 'auto-build', '--input', requestPath]);
+    assert.equal(runManifest.cwd, '/tmp/workspace');
+
+    const state = readJson(report.files.state);
+    assert.equal(state.build_status, 'intake_prepared');
+    assert.equal(state.next_stage, '01_route');
+    const stepMarkers = state.step_markers as Record<string, { status?: unknown }>;
+    assert.equal(stepMarkers.intake_prepared?.status, 'completed');
+    assert.equal(Array.isArray(state.process_datasets), true);
+
+    const handoff = readJson(report.files.handoff_summary);
+    assert.equal(handoff.command, 'process auto-build');
+    assert.equal((handoff.extra as Record<string, unknown>).status, report.status);
+    assert.equal(Array.isArray(handoff.next_actions), true);
+
+    const reportArtifact = readJson(report.files.report);
+    assert.equal(reportArtifact.run_id, report.run_id);
+    const reportArtifactFiles = reportArtifact.files as Record<string, unknown>;
+    assert.equal(reportArtifactFiles.state, report.files.state);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessAutoBuild respects outDir overrides, copies source inputs, and tracks invocation metadata', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-auto-build-outdir-'));
+  const flowPath = writeFlowFixture(dir);
+  const sourcePath = path.join(dir, 'notes.md');
+  const requestPath = path.join(dir, 'request.json');
+  const overrideRoot = path.join(dir, 'existing-empty-run-root');
+  mkdirSync(overrideRoot, { recursive: true });
+  writeFileSync(sourcePath, '# notes\n', 'utf8');
+  writeJson(requestPath, {
+    request_id: 'req-override',
+    run_id: 'run-override',
+    flow_file: `./${path.basename(flowPath)}`,
+    source_inputs: [
+      {
+        source_id: 'notes',
+        type: 'local_text',
+        path: './notes.md',
+        intended_roles: ['assumptions'],
+      },
+    ],
+  });
+
+  try {
+    const report = await runProcessAutoBuild({
+      inputPath: requestPath,
+      outDir: './existing-empty-run-root',
+      now: new Date('2026-03-29T03:00:00Z'),
+    });
+
+    assert.equal(report.run_root, overrideRoot);
+    assert.equal(
+      readFileSync(path.join(report.run_root, 'input', path.basename(flowPath)), 'utf8'),
+      readFileSync(flowPath, 'utf8'),
+    );
+    assert.equal(
+      readFileSync(path.join(report.run_root, 'evidence', 'incoming', '01_notes.md'), 'utf8'),
+      '# notes\n',
+    );
+
+    const lineage = readJson(report.files.lineage_manifest);
+    const lineageSources = lineage.source_inputs as Array<Record<string, unknown>>;
+    assert.equal(lineageSources.length, 1);
+    assert.equal(
+      lineageSources[0]?.artifact_path,
+      path.join(report.run_root, 'evidence', 'incoming', '01_notes.md'),
+    );
+
+    const invocationIndex = readJson(report.files.invocation_index);
+    const command = (invocationIndex.invocations as Array<Record<string, unknown>>)[0]
+      ?.command as string[];
+    assert.deepEqual(command, [
+      'process',
+      'auto-build',
+      '--input',
+      requestPath,
+      '--out-dir',
+      './existing-empty-run-root',
+    ]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessAutoBuild rejects invalid flow payloads, non-empty run roots, and source copy failures', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-auto-build-errors-'));
+  const invalidFlowPath = writeFlowFixture(dir, {
+    fileName: 'invalid-flow.json',
+    payload: [],
+  });
+  const invalidRequestPath = path.join(dir, 'invalid-request.json');
+  writeJson(invalidRequestPath, {
+    flow_file: `./${path.basename(invalidFlowPath)}`,
+  });
+
+  writeFlowFixture(dir, {
+    fileName: 'valid-flow.json',
+  });
+  const existingRoot = path.join(dir, 'non-empty-run-root');
+  mkdirSync(existingRoot, { recursive: true });
+  writeFileSync(path.join(existingRoot, 'keep.txt'), 'busy', 'utf8');
+  const existingRootRequestPath = path.join(dir, 'existing-root-request.json');
+  writeJson(existingRootRequestPath, {
+    flow_file: './valid-flow.json',
+    workspace_run_root: './non-empty-run-root',
+  });
+
+  const sourceDir = path.join(dir, 'source-dir');
+  mkdirSync(sourceDir, { recursive: true });
+  const sourceDirRequestPath = path.join(dir, 'source-dir-request.json');
+  writeJson(sourceDirRequestPath, {
+    flow_file: './valid-flow.json',
+    source_inputs: [
+      {
+        source_id: 'source-dir',
+        type: 'local_text',
+        path: './source-dir',
+      },
+    ],
+  });
+
+  try {
+    await assert.rejects(
+      () =>
+        runProcessAutoBuild({
+          inputPath: invalidRequestPath,
+        }),
+      /flow file must contain a JSON object/u,
+    );
+
+    await assert.rejects(
+      () =>
+        runProcessAutoBuild({
+          inputPath: existingRootRequestPath,
+        }),
+      /run root already exists and is not empty/u,
+    );
+
+    await assert.rejects(
+      () =>
+        runProcessAutoBuild({
+          inputPath: sourceDirRequestPath,
+        }),
+      /Failed to copy artifact file/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #13

## Summary
- Add the local-first `tiangong process auto-build` command and its artifact-first run contract.
- Prepare deterministic local scaffolding for process-from-flow runs without reintroducing Python executors or MCP into the CLI runtime.

## Key Decisions
- Base this PR on `feature/issue-11` because the process command stack depends on the lifecyclemodel publish slice that still needs to land on `main`.
- Keep the scope to local artifact preparation only; remote execution and skill-wrapper switching stay out of this slice.

## Validation
- npm run prepush:gate

## Risks / Rollback
- This is part of a stacked CLI review chain; if the base branch changes, the remaining process-command PRs should be rebased in order.

## Follow-ups
- Use this PR as the base for process resume-build, publish-build, and batch-build.

## Workspace Integration
- Requires a later `lca-workspace` submodule bump after the CLI stack merges to the default branch.