### PR TITLE
feat: implement process resume-build local state handoff

### DIFF
--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -16,6 +16,7 @@
 - `tiangong search process`
 - `tiangong search lifecyclemodel`
 - `tiangong process auto-build`
+- `tiangong process resume-build`
 - `tiangong lifecyclemodel build-resulting-process`
 - `tiangong lifecyclemodel publish-resulting-process`
 - `tiangong publish run`
@@ -73,6 +74,7 @@ npm start -- doctor
 npm start -- doctor --json
 npm start -- search flow --input ./request.json --dry-run
 npm start -- process auto-build --input ./pff-request.json --json
+npm start -- process resume-build --run-id <run-id> --json
 npm start -- lifecyclemodel build-resulting-process --input ./request.json --json
 npm start -- lifecyclemodel publish-resulting-process --run-dir ./runs/example --publish-processes --publish-relations --json
 npm start -- publish run --input ./publish-request.json --dry-run
@@ -94,9 +96,20 @@ npm start -- admin embedding-run --input ./jobs.json --dry-run
 
 这个命令当前只负责本地 intake 与 scaffold，不负责继续执行后续工作流阶段。
 
+`tiangong process resume-build` 现在也已经进入可执行状态，负责：
+
+- 从 `--run-id` 或 `--run-dir` 重开一个现有 process build run
+- 校验 `process_from_flow_state.json`、`agent_handoff_summary.json`、`run-manifest.json` 等关键产物
+- 复用本地 state lock，避免并发写入同一个 run
+- 清理持久化的 `stop_after` checkpoint，并把状态推进到 `resume_prepared`
+- 输出 `resume-metadata.json`、`resume-history.jsonl`、更新 `invocation-index.json`
+- 重写 `agent_handoff_summary.json`
+- 输出 `process-resume-build-report.json`
+
+这个命令当前也只负责本地 resume handoff，不负责继续执行后续工作流阶段。
+
 也就是说，下面这些还没有迁完：
 
-- `tiangong process resume-build`
 - `tiangong process publish-build`
 - `tiangong process batch-build`
 
@@ -181,6 +194,7 @@ npm run build
 
 - 轻量远程 skill 直接调用 `tiangong search ...` 或 `tiangong admin ...`
 - `process-automated-builder` 已先迁入 `tiangong process auto-build` 本地 scaffold；剩余阶段继续按子命令切片迁移
+- `process-automated-builder` 的本地 resume handoff 也已迁入 `tiangong process resume-build`；后续阶段继续按子命令切片迁移
 - 其余重型 workflow 先保留原执行器，但由 `tiangong` 统一调度
 - 所有新脚本优先使用统一环境变量名，不再扩散旧变量名
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Current implementation choices:
 - `tiangong search process`
 - `tiangong search lifecyclemodel`
 - `tiangong process auto-build`
+- `tiangong process resume-build`
 - `tiangong lifecyclemodel build-resulting-process`
 - `tiangong lifecyclemodel publish-resulting-process`
 - `tiangong publish run`
@@ -32,7 +33,6 @@ The `lifecyclemodel` and `process` namespaces are now partially implemented. The
 - `tiangong lifecyclemodel validate-build`
 - `tiangong lifecyclemodel publish-build`
 - `tiangong process get`
-- `tiangong process resume-build`
 - `tiangong process publish-build`
 - `tiangong process batch-build`
 
@@ -91,6 +91,7 @@ npm start -- doctor
 npm start -- doctor --json
 npm start -- search flow --input ./request.json --dry-run
 npm start -- process auto-build --input ./pff-request.json --json
+npm start -- process resume-build --run-id <run-id> --json
 npm start -- lifecyclemodel build-resulting-process --input ./request.json --json
 npm start -- lifecyclemodel publish-resulting-process --run-dir ./runs/example --publish-processes --publish-relations --json
 npm start -- publish run --input ./publish-request.json --dry-run
@@ -104,7 +105,9 @@ npm start -- admin embedding-run --input ./jobs.json --dry-run
 
 The command keeps the legacy per-run layout that later stages still expect, including `input/`, `exports/processes/`, `exports/sources/`, `cache/process_from_flow_state.json`, and `cache/agent_handoff_summary.json`. It also adds CLI-owned manifests such as the normalized request snapshot, flow summary, assembly plan, lineage manifest, invocation index, run manifest, and a compact report artifact.
 
-This command does not yet execute the downstream workflow stages. `resume-build`, `publish-build`, and `batch-build` remain separate planned slices.
+`tiangong process resume-build` is the second migrated `process_from_flow` slice. It reopens one existing local run by `--run-id` or `--run-dir`, validates the required run artifacts, takes the local state lock, clears any persisted `stop_after` checkpoint, records `resume-metadata.json` and `resume-history.jsonl`, updates `invocation-index.json`, rewrites `agent_handoff_summary.json`, and emits `process-resume-build-report.json`.
+
+`resume-build` still stops at the handoff boundary. It does not yet execute the downstream workflow stages; `publish-build` and `batch-build` remain planned slices.
 
 ## Publish and validation
 
@@ -119,6 +122,7 @@ Run the built artifact directly:
 ```bash
 node ./bin/tiangong.js doctor
 node ./bin/tiangong.js process auto-build --input ./pff-request.json --json
+node ./bin/tiangong.js process resume-build --run-id <run-id> --json
 node ./dist/src/main.js doctor --json
 ```
 

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -32,6 +32,7 @@ tiangong
     lifecyclemodel
   process
     auto-build
+    resume-build
   lifecyclemodel
     build-resulting-process
     publish-resulting-process
@@ -52,6 +53,7 @@ tiangong
 | `tiangong search process` | `process_hybrid_search` |
 | `tiangong search lifecyclemodel` | `lifecyclemodel_hybrid_search` |
 | `tiangong process auto-build` | 本地 `process_from_flow` intake、run-id 生成、artifact scaffold 预写 |
+| `tiangong process resume-build` | 本地 `process_from_flow` resume handoff、state-lock/manifest 收口、resume 元数据与报告输出 |
 | `tiangong lifecyclemodel build-resulting-process` | 本地 lifecycle model resulting process 聚合、内部 flow 抵消、artifact 输出 |
 | `tiangong lifecyclemodel publish-resulting-process` | 读取 resulting-process run，生成 `publish-bundle.json` / `publish-intent.json` 本地交付物 |
 | `tiangong publish run` | 本地 publish 契约归一化、dry-run/commit、report 输出 |
@@ -67,12 +69,15 @@ tiangong
 `tiangong process ...` 也已经开始承接 `process_from_flow` 主链迁移，其中：
 
 - `tiangong process auto-build` 已可执行
-- `get`、`resume-build`、`publish-build`、`batch-build` 仍处于 planned 状态
+- `tiangong process resume-build` 已可执行
+- `get`、`publish-build`、`batch-build` 仍处于 planned 状态
 
 注意：
 
 - 已实现的 `process auto-build` 保留了旧 `artifacts/process_from_flow/<run_id>/`、`cache/process_from_flow_state.json`、`cache/agent_handoff_summary.json` 等运行布局
 - `process auto-build` 当前只负责本地 request intake、flow 归一化、run scaffold 和 manifest/report 预写，不继续执行后续阶段
+- 已实现的 `process resume-build` 保留同一套 run 布局，并把本地 state-lock、run-manifest 校验、resume metadata/history、invocation index 更新统一收口到 CLI
+- `process resume-build` 当前只负责本地 resume handoff，不继续执行 route / split / exchange / QA / publish 阶段
 - 已实现的 `build-resulting-process` 和 `publish-resulting-process` 都走本地优先、artifact-first 路径，不依赖 Python 或 MCP
 - `publish-resulting-process` 当前负责生成本地 publish handoff 产物，还没有把提交语义直接并入 `publish run`
 - 其余未实现的 `lifecyclemodel` / `process` 子命令仍只提供 help 和固定命名
@@ -190,6 +195,25 @@ tiangong admin embedding-run --input ./jobs.json --dry-run
 - 远程检索、LLM、OCR、publish commit
 - `resume-build`、`publish-build`、`batch-build`
 
+`process resume-build` 现在固定的是“本地 process-from-flow resume handoff 契约层”。
+
+它负责：
+
+- 从 `--run-id` 或 `--run-dir` 重开已有 run
+- 校验 `run-manifest.json`、`process_from_flow_state.json`、`agent_handoff_summary.json`
+- 使用 CLI 的 state lock 保护本地状态更新
+- 清除历史 `stop_after` checkpoint，并将状态推进到 `resume_prepared`
+- 写出 `resume-metadata.json`、追加 `resume-history.jsonl`
+- 更新 `invocation-index.json`
+- 重写 `agent_handoff_summary.json`
+- 产出 `process-resume-build-report.json`
+
+它现在还不负责：
+
+- 执行 route / split / exchange / QA / publish 等后续阶段
+- 远程检索、LLM、OCR、publish commit
+- `publish-build`、`batch-build`
+
 `publish run` 现在固定的是“稳定 publish 契约层”，不是历史 MCP 写库脚本的 TypeScript 复刻。
 
 它负责：
@@ -290,7 +314,8 @@ npm run prepush:gate
 
 - `process-automated-builder`
   - 已落地 `tiangong process auto-build`
-  - 仍待迁移 `resume-build`、`publish-build`、`batch-build`
+  - 已落地 `tiangong process resume-build`
+  - 仍待迁移 `publish-build`、`batch-build`
 - `lifecycleinventory-review`
 - 其他重型 Python workflow
 
@@ -327,7 +352,7 @@ npm run prepush:gate
 
 ### Phase 2
 
-- 继续补齐 `process resume-build` / `publish-build` / `batch-build`
+- 继续补齐 `process publish-build` / `batch-build`
 - 引入 `review` / `job` / `flow` / `process` 的更多业务子命令
 - 用 CLI 接管现有 workflow 的稳定 contract 层
 - 统一 run-dir / artifact / manifest 输入输出格式

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -69,7 +69,7 @@
 | `process-hybrid-search` | 已有等价 CLI | shell wrapper，历史 token/env 兼容 | 只保留 skill 文档，调用 `tiangong search process` | P0 |
 | `lifecyclemodel-hybrid-search` | 已有等价 CLI | shell wrapper，历史 token/env 兼容 | 只保留 skill 文档，调用 `tiangong search lifecyclemodel` | P0 |
 | `embedding-ft` | 已有等价 CLI | shell wrapper | 只保留 skill 文档，调用 `tiangong admin embedding-run` | P0 |
-| `process-automated-builder` | 已进入 CLI 化，6.1 已落地 | `tiangong process auto-build` + shell/Python/LangGraph/MCP/OpenAI/AI edge search/TianGong unstructured 遗留阶段 | 迁成 `tiangong process ...` 主链 | P1 |
+| `process-automated-builder` | 已进入 CLI 化，6.1/6.2 已落地 | `tiangong process auto-build` / `resume-build` + shell/Python/LangGraph/MCP/OpenAI/AI edge search/TianGong unstructured 遗留阶段 | 迁成 `tiangong process ...` 主链 | P1 |
 | `lifecyclemodel-automated-builder` | 仍是重 workflow | shell + Python + MCP + OpenAI | 迁成 `tiangong lifecyclemodel ...` 主链 | P1 |
 | `lifecyclemodel-resulting-process-builder` | CLI 本地 build/publish handoff 已落地，skill wrapper 已切换 | `skill -> tiangong lifecyclemodel build/publish-resulting-process` | 保持薄 wrapper，继续去掉遗留 lookup 分支 | P1 |
 | `lifecycleinventory-review` | 仍是 review workflow | Python review script | 迁成 `tiangong review process` | P2 |
@@ -260,27 +260,27 @@ ToDo：
 目标命令：
 
 - [x] `tiangong process auto-build`
-- [ ] `tiangong process resume-build`
+- [x] `tiangong process resume-build`
 - [ ] `tiangong process publish-build`
 - [ ] `tiangong process batch-build`
 
 建议拆成 4 个连续小步骤，而不是一次性大迁移：
 
 - [x] 6.1 先实现 `auto-build` 的本地产物路径，不做 publish
-- [ ] 6.2 再实现 `resume-build`，把 state-lock / run manifest 彻底收口到 CLI
+- [x] 6.2 再实现 `resume-build`，把 state-lock / run manifest 彻底收口到 CLI
 - [ ] 6.3 再实现 `publish-build`，接到统一 publish 模块
 - [ ] 6.4 最后实现 `batch-build`
 
 迁移内容：
 
 - [x] intake request normalization / flow 归一化 / run-id / local artifact scaffold 迁到 TS CLI
+- [x] 本地状态锁、cache、resume handoff 逻辑迁到 CLI
 - [ ] 流程编排迁到 TS
 - [ ] flow search 改为直接 REST，而不是 MCP
 - [ ] publish 改为直接 REST / CLI publish，而不是 MCP CRUD
 - [ ] LLM 调用改为 CLI 的 provider abstraction
 - [ ] KB 检索改为 CLI 的 AI edge search client
 - [ ] unstructured 调用改为 CLI 的 client
-- [ ] 本地状态锁、cache、resume 逻辑迁到 CLI
 - [ ] 保留 artifact 契约，不保留 Python 实现
 
 迁移完成后应删除：
@@ -433,7 +433,7 @@ ToDo：
 
 如果只按最短路径推进，下一轮建议严格做这 8 件事：
 
-当前重点已经推进到第 8 项，且 `tiangong process auto-build` / Phase 6.1 已完成。
+当前重点已经推进到第 8 项，且 `tiangong process auto-build` / `resume-build`（Phase 6.1 / 6.2）已完成。
 
 1. 修 CLI help，让命令面和真实实现一致。
 2. 修 skills 文档中的 `TIANGONG_CLI_DIR` 残留。
@@ -442,7 +442,7 @@ ToDo：
 5. 完成 `tiangong lifecyclemodel publish-resulting-process`。
 6. 把 `lifecyclemodel-resulting-process-builder` 改成薄 wrapper。
 7. 把 `lca-publish-executor` 收口到 `tiangong publish run`。
-8. 继续推进 `tiangong process resume-build`，把后续阶段执行面从遗留 workflow 收口到 CLI。
+8. 继续推进 `tiangong process publish-build`，把本地 run 交付面从遗留 workflow 收口到 CLI。
 
 ## 10. 不应该做的事
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,11 @@ import {
   type ProcessAutoBuildReport,
   type RunProcessAutoBuildOptions,
 } from './lib/process-auto-build.js';
+import {
+  runProcessResumeBuild,
+  type ProcessResumeBuildReport,
+  type RunProcessResumeBuildOptions,
+} from './lib/process-resume-build.js';
 import { runPublish, type PublishReport, type RunPublishOptions } from './lib/publish.js';
 import { executeRemoteCommand, getRemoteCommandHelp } from './lib/remote.js';
 import {
@@ -42,6 +47,9 @@ export type CliDeps = {
   runProcessAutoBuildImpl?: (
     options: RunProcessAutoBuildOptions,
   ) => Promise<ProcessAutoBuildReport>;
+  runProcessResumeBuildImpl?: (
+    options: RunProcessResumeBuildOptions,
+  ) => Promise<ProcessResumeBuildReport>;
 };
 
 export type CliResult = {
@@ -73,7 +81,7 @@ Commands:
 Implemented Commands:
   doctor     show environment diagnostics
   search     flow | process | lifecyclemodel
-  process    auto-build
+  process    auto-build | resume-build
   lifecyclemodel build-resulting-process | publish-resulting-process
   publish    run
   validation run
@@ -94,6 +102,7 @@ Examples:
   tiangong search flow --input ./request.json
   tiangong search process --input ./request.json --dry-run
   tiangong process auto-build --input ./pff-request.json
+  tiangong process resume-build --run-id <id>
   tiangong publish run --input ./publish-request.json --dry-run
   tiangong validation run --input-dir ./package --engine auto
   tiangong admin embedding-run --input ./jobs.json
@@ -228,23 +237,35 @@ Options:
 `.trim();
 }
 
+function renderProcessResumeBuildHelp(): string {
+  return `Usage:
+  tiangong process resume-build [--run-id <id>] [--run-dir <dir>] [options]
+
+Options:
+  --run-id <id>      Existing process build run id
+  --run-dir <dir>    Existing process build run directory
+  --json             Print compact JSON
+  -h, --help
+`.trim();
+}
+
 function renderProcessHelp(): string {
   return `Usage:
   tiangong process <subcommand> [options]
 
 Implemented Subcommands:
   auto-build   Prepare a local process-from-flow run scaffold and artifact workspace
+  resume-build Prepare a local resume handoff from one existing process build run
 
 Planned Subcommands:
   get          Load one process dataset or process build run summary
-  resume-build Resume a prepared process build run and continue execution stages
   publish-build Publish a process build run through the unified publish layer
   batch-build  Run multiple process build requests through one batch-oriented CLI surface
 
 Examples:
   tiangong process --help
   tiangong process auto-build --help
-  tiangong process resume-build --help
+  tiangong process resume-build --run-id <id> --help
 `.trim();
 }
 
@@ -291,16 +312,6 @@ const processPlannedHelp = {
 Planned contract:
   - load one process dataset or process build run summary by identifier
   - keep read-only access distinct from build/publish workflows
-
-Status:
-  Planned command. Execution is not implemented yet.
-`.trim(),
-  'resume-build': `Usage:
-  tiangong process resume-build --run-id <id> [options]
-
-Planned contract:
-  - load one prepared process auto-build run
-  - continue stage execution from the persisted local state under artifacts/process_from_flow/<run_id>
 
 Status:
   Planned command. Execution is not implemented yet.
@@ -695,6 +706,40 @@ function parseProcessAutoBuildFlags(args: string[]): {
   };
 }
 
+function parseProcessResumeBuildFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  runId: string;
+  runDir: string | null;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        'run-id': { type: 'string' },
+        'run-dir': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    runId: typeof values['run-id'] === 'string' ? values['run-id'] : '',
+    runDir: typeof values['run-dir'] === 'string' ? values['run-dir'] : null,
+  };
+}
+
 function plannedCommand(command: string, subcommand?: string): CliResult {
   const suffix = subcommand ? ` ${subcommand}` : '';
   return {
@@ -727,6 +772,7 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
     const lifecyclemodelPublishImpl =
       deps.runLifecyclemodelPublishResultingProcessImpl ?? runLifecyclemodelPublishResultingProcess;
     const processAutoBuildImpl = deps.runProcessAutoBuildImpl ?? runProcessAutoBuild;
+    const processResumeBuildImpl = deps.runProcessResumeBuildImpl ?? runProcessResumeBuild;
 
     if (flags.version) {
       return { exitCode: 0, stdout: '0.0.1\n', stderr: '' };
@@ -855,6 +901,28 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
       const report = await processAutoBuildImpl({
         inputPath: processFlags.inputPath,
         outDir: processFlags.outDir,
+      });
+
+      return {
+        exitCode: 0,
+        stdout: stringifyJson(report, processFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'process' && subcommand === 'resume-build') {
+      const processFlags = parseProcessResumeBuildFlags(commandArgs);
+      if (processFlags.help) {
+        return {
+          exitCode: 0,
+          stdout: `${renderProcessResumeBuildHelp()}\n`,
+          stderr: '',
+        };
+      }
+
+      const report = await processResumeBuildImpl({
+        runId: processFlags.runId || undefined,
+        runDir: processFlags.runDir,
       });
 
       return {

--- a/src/lib/process-resume-build.ts
+++ b/src/lib/process-resume-build.ts
@@ -1,0 +1,542 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import {
+  readJsonArtifact,
+  readJsonLinesArtifact,
+  writeJsonArtifact,
+  writeJsonLinesArtifact,
+} from './artifacts.js';
+import { CliError } from './errors.js';
+import { buildResumeMetadata, writeLatestRunId, type RunLayout } from './run.js';
+import { withStateFileLock } from './state-lock.js';
+
+type JsonRecord = Record<string, unknown>;
+
+export type ProcessResumeBuildLayout = {
+  runId: string;
+  runRoot: string;
+  collectionDir: string;
+  cacheDir: string;
+  manifestsDir: string;
+  reportsDir: string;
+  latestRunIdPath: string;
+  statePath: string;
+  handoffSummaryPath: string;
+  runManifestPath: string;
+  invocationIndexPath: string;
+  resumeMetadataPath: string;
+  resumeHistoryPath: string;
+  reportPath: string;
+};
+
+export type ProcessResumeBuildReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: 'prepared_local_process_resume_run';
+  run_id: string;
+  run_root: string;
+  request_id: string | null;
+  resumed_from: string;
+  checkpoint: string | null;
+  attempt: number;
+  state_summary: {
+    build_status: string | null;
+    next_stage: string | null;
+    stop_after: string | null;
+    process_count: number;
+    matched_exchange_count: number;
+    process_dataset_count: number;
+    source_dataset_count: number;
+  };
+  files: {
+    state: string;
+    handoff_summary: string;
+    run_manifest: string;
+    invocation_index: string;
+    resume_metadata: string;
+    resume_history: string;
+    report: string;
+  };
+  next_actions: string[];
+};
+
+export type RunProcessResumeBuildOptions = {
+  runId?: string;
+  runDir?: string | null;
+  now?: Date;
+  cwd?: string;
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized || null;
+}
+
+function readRequiredJsonObject(
+  filePath: string,
+  missingCode: string,
+  invalidCode: string,
+  label: string,
+): JsonRecord {
+  if (!existsSync(filePath)) {
+    throw new CliError(`Required process resume artifact not found: ${filePath}`, {
+      code: missingCode,
+      exitCode: 2,
+      details: { label, filePath },
+    });
+  }
+
+  const value = readJsonArtifact(filePath);
+  if (!isRecord(value)) {
+    throw new CliError(`Expected process resume artifact JSON object: ${filePath}`, {
+      code: invalidCode,
+      exitCode: 2,
+      details: { label, filePath },
+    });
+  }
+
+  return value;
+}
+
+function buildLayout(runRoot: string, runId: string): ProcessResumeBuildLayout {
+  const collectionDir = path.dirname(runRoot);
+
+  return {
+    runId,
+    runRoot,
+    collectionDir,
+    cacheDir: path.join(runRoot, 'cache'),
+    manifestsDir: path.join(runRoot, 'manifests'),
+    reportsDir: path.join(runRoot, 'reports'),
+    latestRunIdPath: path.join(collectionDir, '.latest_run_id'),
+    statePath: path.join(runRoot, 'cache', 'process_from_flow_state.json'),
+    handoffSummaryPath: path.join(runRoot, 'cache', 'agent_handoff_summary.json'),
+    runManifestPath: path.join(runRoot, 'manifests', 'run-manifest.json'),
+    invocationIndexPath: path.join(runRoot, 'manifests', 'invocation-index.json'),
+    resumeMetadataPath: path.join(runRoot, 'manifests', 'resume-metadata.json'),
+    resumeHistoryPath: path.join(runRoot, 'manifests', 'resume-history.jsonl'),
+    reportPath: path.join(runRoot, 'reports', 'process-resume-build-report.json'),
+  };
+}
+
+function resolveLayout(options: RunProcessResumeBuildOptions): ProcessResumeBuildLayout {
+  const runId = nonEmptyString(options.runId);
+  const runDir = nonEmptyString(options.runDir);
+
+  if (!runId && !runDir) {
+    throw new CliError('Missing required --run-id or --run-dir for process resume-build.', {
+      code: 'PROCESS_RESUME_RUN_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  const runRoot = runDir
+    ? path.resolve(runDir)
+    : path.resolve('artifacts', 'process_from_flow', runId as string);
+  const derivedRunId = path.basename(runRoot);
+
+  if (runDir && runId && derivedRunId !== runId) {
+    throw new CliError(
+      `process resume-build run-id does not match run-dir basename: ${runId} !== ${derivedRunId}`,
+      {
+        code: 'PROCESS_RESUME_RUN_ID_MISMATCH',
+        exitCode: 2,
+      },
+    );
+  }
+
+  return buildLayout(runRoot, runId ?? derivedRunId);
+}
+
+function ensureRunRootExists(layout: ProcessResumeBuildLayout): void {
+  if (!existsSync(layout.runRoot)) {
+    throw new CliError(`process resume-build run root not found: ${layout.runRoot}`, {
+      code: 'PROCESS_RESUME_RUN_NOT_FOUND',
+      exitCode: 2,
+    });
+  }
+}
+
+function readRequiredRunManifest(layout: ProcessResumeBuildLayout): JsonRecord {
+  const manifest = readRequiredJsonObject(
+    layout.runManifestPath,
+    'PROCESS_RESUME_RUN_MANIFEST_MISSING',
+    'PROCESS_RESUME_RUN_MANIFEST_INVALID',
+    'run-manifest',
+  );
+
+  const manifestRunId = nonEmptyString(manifest.runId);
+  if (manifestRunId && manifestRunId !== layout.runId) {
+    throw new CliError(
+      `process resume-build run manifest runId mismatch: ${layout.runManifestPath}`,
+      {
+        code: 'PROCESS_RESUME_RUN_MANIFEST_MISMATCH',
+        exitCode: 2,
+        details: {
+          expected: layout.runId,
+          actual: manifestRunId,
+        },
+      },
+    );
+  }
+
+  return manifest;
+}
+
+function readRequiredState(layout: ProcessResumeBuildLayout): JsonRecord {
+  const state = readRequiredJsonObject(
+    layout.statePath,
+    'PROCESS_RESUME_STATE_MISSING',
+    'PROCESS_RESUME_STATE_INVALID',
+    'state',
+  );
+
+  const stateRunId = nonEmptyString(state.run_id);
+  if (stateRunId && stateRunId !== layout.runId) {
+    throw new CliError(`process resume-build state run_id mismatch: ${layout.statePath}`, {
+      code: 'PROCESS_RESUME_STATE_RUN_ID_MISMATCH',
+      exitCode: 2,
+      details: {
+        expected: layout.runId,
+        actual: stateRunId,
+      },
+    });
+  }
+
+  return state;
+}
+
+function readRequiredHandoffSummary(layout: ProcessResumeBuildLayout): JsonRecord {
+  return readRequiredJsonObject(
+    layout.handoffSummaryPath,
+    'PROCESS_RESUME_HANDOFF_MISSING',
+    'PROCESS_RESUME_HANDOFF_INVALID',
+    'handoff-summary',
+  );
+}
+
+function readInvocationIndex(layout: ProcessResumeBuildLayout): JsonRecord {
+  if (!existsSync(layout.invocationIndexPath)) {
+    return {
+      schema_version: 1,
+      invocations: [],
+    };
+  }
+
+  const value = readJsonArtifact(layout.invocationIndexPath);
+  if (!isRecord(value)) {
+    throw new CliError(
+      `Expected process resume invocation index JSON object: ${layout.invocationIndexPath}`,
+      {
+        code: 'PROCESS_RESUME_INVOCATION_INDEX_INVALID',
+        exitCode: 2,
+      },
+    );
+  }
+
+  if (value.invocations === undefined) {
+    return {
+      schema_version: 1,
+      invocations: [],
+    };
+  }
+
+  if (!Array.isArray(value.invocations)) {
+    throw new CliError(
+      `Expected process resume invocation index to contain an invocations array: ${layout.invocationIndexPath}`,
+      {
+        code: 'PROCESS_RESUME_INVOCATION_INDEX_INVALID',
+        exitCode: 2,
+      },
+    );
+  }
+
+  return value;
+}
+
+function readResumeHistory(layout: ProcessResumeBuildLayout): JsonRecord[] {
+  if (!existsSync(layout.resumeHistoryPath)) {
+    return [];
+  }
+
+  const rows = readJsonLinesArtifact(layout.resumeHistoryPath);
+  return rows.map((row, index) => {
+    if (!isRecord(row)) {
+      throw new CliError(
+        `Expected process resume history JSONL rows to be objects: ${layout.resumeHistoryPath}`,
+        {
+          code: 'PROCESS_RESUME_HISTORY_INVALID',
+          exitCode: 2,
+          details: { index },
+        },
+      );
+    }
+
+    return row;
+  });
+}
+
+function stateArrayLength(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+function buildStateSummary(state: JsonRecord): ProcessResumeBuildReport['state_summary'] {
+  return {
+    build_status: nonEmptyString(state.build_status),
+    next_stage: nonEmptyString(state.next_stage),
+    stop_after: nonEmptyString(state.stop_after),
+    process_count: stateArrayLength(state.processes),
+    matched_exchange_count: stateArrayLength(state.matched_process_exchanges),
+    process_dataset_count: stateArrayLength(state.process_datasets),
+    source_dataset_count: stateArrayLength(state.source_datasets),
+  };
+}
+
+function resolveResumedFrom(state: JsonRecord): string {
+  return nonEmptyString(state.next_stage) ?? nonEmptyString(state.build_status) ?? 'unknown';
+}
+
+function nextAttempt(history: JsonRecord[]): number {
+  return (
+    history.reduce((maxAttempt, entry) => {
+      const attempt = entry.attempt;
+      return typeof attempt === 'number' && Number.isFinite(attempt) && attempt > maxAttempt
+        ? attempt
+        : maxAttempt;
+    }, 0) + 1
+  );
+}
+
+function updateStepMarkers(stepMarkers: unknown, completedAt: string): JsonRecord {
+  const markers = isRecord(stepMarkers) ? { ...stepMarkers } : {};
+  markers.resume_prepared = {
+    status: 'completed',
+    completed_at: completedAt,
+  };
+  return markers;
+}
+
+function buildUpdatedState(state: JsonRecord, resumeMetadata: JsonRecord, now: Date): JsonRecord {
+  return {
+    ...state,
+    build_status: 'resume_prepared',
+    stop_after: null,
+    resume_attempt: resumeMetadata.attempt,
+    resume_requested_at: now.toISOString(),
+    last_resume_metadata: resumeMetadata,
+    step_markers: updateStepMarkers(state.step_markers, now.toISOString()),
+  };
+}
+
+function buildInvocationIndex(
+  layout: ProcessResumeBuildLayout,
+  invocationIndex: JsonRecord,
+  options: RunProcessResumeBuildOptions,
+  now: Date,
+): JsonRecord {
+  const priorInvocations = Array.isArray(invocationIndex.invocations)
+    ? [...invocationIndex.invocations]
+    : [];
+  const command = ['process', 'resume-build'];
+
+  if (options.runId) {
+    command.push('--run-id', options.runId);
+  }
+  if (options.runDir) {
+    command.push('--run-dir', options.runDir);
+  }
+
+  return {
+    ...invocationIndex,
+    schema_version:
+      typeof invocationIndex.schema_version === 'number' ? invocationIndex.schema_version : 1,
+    invocations: [
+      ...priorInvocations,
+      {
+        command,
+        cwd: options.cwd ?? process.cwd(),
+        created_at: now.toISOString(),
+        run_id: layout.runId,
+        run_root: layout.runRoot,
+        report_path: layout.reportPath,
+      },
+    ],
+  };
+}
+
+function asRunLayout(layout: ProcessResumeBuildLayout): RunLayout {
+  return {
+    namespace: 'process_from_flow',
+    runId: layout.runId,
+    artifactsRoot: path.dirname(layout.collectionDir),
+    collectionDir: layout.collectionDir,
+    runRoot: layout.runRoot,
+    cacheDir: layout.cacheDir,
+    inputsDir: path.join(layout.runRoot, 'input'),
+    outputsDir: path.join(layout.runRoot, 'exports'),
+    reportsDir: layout.reportsDir,
+    logsDir: path.join(layout.runRoot, 'logs'),
+    manifestsDir: layout.manifestsDir,
+    latestRunIdPath: layout.latestRunIdPath,
+  };
+}
+
+function buildNextActions(
+  layout: ProcessResumeBuildLayout,
+  summary: ProcessResumeBuildReport['state_summary'],
+): string[] {
+  return [
+    `inspect: ${layout.statePath}`,
+    `inspect: ${layout.resumeMetadataPath}`,
+    `inspect: ${layout.invocationIndexPath}`,
+    summary.next_stage
+      ? `future: migrate CLI stage executor for ${summary.next_stage}`
+      : `future: inspect completed run state for ${layout.runId}`,
+    `future: tiangong process publish-build --run-id ${layout.runId}`,
+  ];
+}
+
+function buildAgentHandoffSummary(
+  layout: ProcessResumeBuildLayout,
+  state: JsonRecord,
+  resumeMetadata: JsonRecord,
+  summary: ProcessResumeBuildReport['state_summary'],
+  now: Date,
+): JsonRecord {
+  return {
+    schema_version: 1,
+    generated_at_utc: now.toISOString(),
+    run_id: layout.runId,
+    command: 'process resume-build',
+    flow_path: nonEmptyString(state.flow_path),
+    operation: nonEmptyString(state.operation),
+    stop_after: null,
+    process_count: summary.process_count,
+    matched_exchange_count: summary.matched_exchange_count,
+    process_dataset_count: summary.process_dataset_count,
+    source_dataset_count: summary.source_dataset_count,
+    remaining_placeholder_refs: stateArrayLength(state.placeholder_resolutions),
+    placeholder_examples: [],
+    publish_summary: {},
+    artifacts: {
+      state_path: layout.statePath,
+      timing_report: null,
+      publish_summary: null,
+      llm_cost_report: null,
+      process_update_report: null,
+      flow_auto_build_manifest: null,
+      resume_metadata: layout.resumeMetadataPath,
+      resume_history: layout.resumeHistoryPath,
+      invocation_index: layout.invocationIndexPath,
+    },
+    next_actions: buildNextActions(layout, summary),
+    extra: {
+      status: 'prepared_local_process_resume_run',
+      request_id: nonEmptyString(state.request_id),
+      resumed_from: resumeMetadata.resumedFrom,
+      checkpoint: resumeMetadata.checkpoint,
+      attempt: resumeMetadata.attempt,
+    },
+  };
+}
+
+function buildReport(
+  layout: ProcessResumeBuildLayout,
+  state: JsonRecord,
+  resumeMetadata: JsonRecord,
+  summary: ProcessResumeBuildReport['state_summary'],
+  now: Date,
+): ProcessResumeBuildReport {
+  return {
+    schema_version: 1,
+    generated_at_utc: now.toISOString(),
+    status: 'prepared_local_process_resume_run',
+    run_id: layout.runId,
+    run_root: layout.runRoot,
+    request_id: nonEmptyString(state.request_id),
+    resumed_from: String(resumeMetadata.resumedFrom),
+    checkpoint: resumeMetadata.checkpoint === null ? null : String(resumeMetadata.checkpoint ?? ''),
+    attempt: Number(resumeMetadata.attempt ?? 1),
+    state_summary: summary,
+    files: {
+      state: layout.statePath,
+      handoff_summary: layout.handoffSummaryPath,
+      run_manifest: layout.runManifestPath,
+      invocation_index: layout.invocationIndexPath,
+      resume_metadata: layout.resumeMetadataPath,
+      resume_history: layout.resumeHistoryPath,
+      report: layout.reportPath,
+    },
+    next_actions: buildNextActions(layout, summary),
+  };
+}
+
+export async function runProcessResumeBuild(
+  options: RunProcessResumeBuildOptions,
+): Promise<ProcessResumeBuildReport> {
+  const now = options.now ?? new Date();
+  const layout = resolveLayout(options);
+  ensureRunRootExists(layout);
+  readRequiredRunManifest(layout);
+  readRequiredHandoffSummary(layout);
+  const history = readResumeHistory(layout);
+  const invocationIndex = readInvocationIndex(layout);
+
+  return await withStateFileLock(
+    layout.statePath,
+    { reason: 'process-resume-build.prepare_resume', now },
+    () => {
+      const state = readRequiredState(layout);
+      const resumeMetadata = buildResumeMetadata({
+        runId: layout.runId,
+        resumedFrom: resolveResumedFrom(state),
+        checkpoint: nonEmptyString(state.stop_after),
+        attempt: nextAttempt(history),
+        resumedAt: now,
+      });
+      const updatedState = buildUpdatedState(state, resumeMetadata, now);
+      const summary = buildStateSummary(updatedState);
+      const updatedInvocationIndex = buildInvocationIndex(layout, invocationIndex, options, now);
+      const handoffSummary = buildAgentHandoffSummary(
+        layout,
+        updatedState,
+        resumeMetadata,
+        summary,
+        now,
+      );
+      const report = buildReport(layout, updatedState, resumeMetadata, summary, now);
+
+      writeJsonArtifact(layout.statePath, updatedState);
+      writeJsonArtifact(layout.invocationIndexPath, updatedInvocationIndex);
+      writeJsonArtifact(layout.resumeMetadataPath, resumeMetadata);
+      writeJsonLinesArtifact(layout.resumeHistoryPath, resumeMetadata, { append: true });
+      writeJsonArtifact(layout.handoffSummaryPath, handoffSummary);
+      writeLatestRunId(asRunLayout(layout), layout.runId);
+      writeJsonArtifact(layout.reportPath, report);
+
+      return report;
+    },
+  );
+}
+
+// Exposed for deterministic unit coverage of process resume-build helpers.
+export const __testInternals = {
+  buildLayout,
+  resolveLayout,
+  buildStateSummary,
+  resolveResumedFrom,
+  nextAttempt,
+  updateStepMarkers,
+  buildUpdatedState,
+  buildInvocationIndex,
+  buildNextActions,
+  buildReport,
+};

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -191,6 +191,15 @@ test('executeCli returns help for the process namespace and implemented subcomma
   assert.match(autoBuildHelp.stdout, /tiangong process auto-build --input <file>/u);
   assert.match(autoBuildHelp.stdout, /--out-dir/u);
   assert.doesNotMatch(autoBuildHelp.stdout, /Planned command/u);
+
+  const resumeBuildHelp = await executeCli(['process', 'resume-build', '--help'], makeDeps());
+  assert.equal(resumeBuildHelp.exitCode, 0);
+  assert.match(
+    resumeBuildHelp.stdout,
+    /tiangong process resume-build \[--run-id <id>\] \[--run-dir <dir>\]/u,
+  );
+  assert.match(resumeBuildHelp.stdout, /--run-dir/u);
+  assert.doesNotMatch(resumeBuildHelp.stdout, /Planned command/u);
 });
 
 test('executeCli executes lifecyclemodel build-resulting-process with injected implementation', async () => {
@@ -356,6 +365,110 @@ test('executeCli executes process auto-build with injected implementation', asyn
     assert.equal(result.exitCode, 0);
     assert.match(result.stdout, /"status":"prepared_local_process_auto_build_run"/u);
     assert.match(result.stdout, /"request_snapshot"/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli executes process resume-build with injected implementation', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-resume-build-cli-'));
+  const runDir = path.join(dir, 'artifacts', 'process_from_flow', 'run-1');
+
+  try {
+    const result = await executeCli(
+      ['process', 'resume-build', '--json', '--run-id', 'run-1', '--run-dir', runDir],
+      {
+        ...makeDeps(),
+        runProcessResumeBuildImpl: async (options) => {
+          assert.equal(options.runId, 'run-1');
+          assert.equal(options.runDir, runDir);
+          return {
+            schema_version: 1,
+            generated_at_utc: '2026-03-29T00:00:00.000Z',
+            status: 'prepared_local_process_resume_run',
+            run_id: 'run-1',
+            run_root: runDir,
+            request_id: 'req-1',
+            resumed_from: '04_exchange_values',
+            checkpoint: 'matches',
+            attempt: 2,
+            state_summary: {
+              build_status: 'resume_prepared',
+              next_stage: '04_exchange_values',
+              stop_after: null,
+              process_count: 1,
+              matched_exchange_count: 1,
+              process_dataset_count: 1,
+              source_dataset_count: 1,
+            },
+            files: {
+              state: path.join(runDir, 'cache', 'process_from_flow_state.json'),
+              handoff_summary: path.join(runDir, 'cache', 'agent_handoff_summary.json'),
+              run_manifest: path.join(runDir, 'manifests', 'run-manifest.json'),
+              invocation_index: path.join(runDir, 'manifests', 'invocation-index.json'),
+              resume_metadata: path.join(runDir, 'manifests', 'resume-metadata.json'),
+              resume_history: path.join(runDir, 'manifests', 'resume-history.jsonl'),
+              report: path.join(runDir, 'reports', 'process-resume-build-report.json'),
+            },
+            next_actions: ['inspect: state'],
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /"status":"prepared_local_process_resume_run"/u);
+    assert.match(result.stdout, /"resume_metadata"/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli executes process resume-build with run-dir only', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-resume-build-cli-rundir-'));
+  const runDir = path.join(dir, 'artifacts', 'process_from_flow', 'run-2');
+
+  try {
+    const result = await executeCli(['process', 'resume-build', '--run-dir', runDir], {
+      ...makeDeps(),
+      runProcessResumeBuildImpl: async (options) => {
+        assert.equal(options.runId, undefined);
+        assert.equal(options.runDir, runDir);
+        return {
+          schema_version: 1,
+          generated_at_utc: '2026-03-29T00:10:00.000Z',
+          status: 'prepared_local_process_resume_run',
+          run_id: 'run-2',
+          run_root: runDir,
+          request_id: null,
+          resumed_from: 'resume_prepared',
+          checkpoint: null,
+          attempt: 1,
+          state_summary: {
+            build_status: 'resume_prepared',
+            next_stage: null,
+            stop_after: null,
+            process_count: 0,
+            matched_exchange_count: 0,
+            process_dataset_count: 0,
+            source_dataset_count: 0,
+          },
+          files: {
+            state: path.join(runDir, 'cache', 'process_from_flow_state.json'),
+            handoff_summary: path.join(runDir, 'cache', 'agent_handoff_summary.json'),
+            run_manifest: path.join(runDir, 'manifests', 'run-manifest.json'),
+            invocation_index: path.join(runDir, 'manifests', 'invocation-index.json'),
+            resume_metadata: path.join(runDir, 'manifests', 'resume-metadata.json'),
+            resume_history: path.join(runDir, 'manifests', 'resume-history.jsonl'),
+            report: path.join(runDir, 'reports', 'process-resume-build-report.json'),
+          },
+          next_actions: ['inspect: state'],
+        };
+      },
+    });
+
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /prepared_local_process_resume_run/u);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -674,7 +787,7 @@ test('executeCli returns parsing errors for invalid publish and validation flags
   assert.match(validationResult.stderr, /INVALID_ARGS/u);
 });
 
-test('executeCli returns parsing errors for invalid lifecyclemodel build, process build, and publish flags', async () => {
+test('executeCli returns parsing errors for invalid lifecyclemodel build, process build, resume, and publish flags', async () => {
   const result = await executeCli(
     ['lifecyclemodel', 'build-resulting-process', '--bad-flag'],
     makeDeps(),
@@ -695,6 +808,14 @@ test('executeCli returns parsing errors for invalid lifecyclemodel build, proces
   assert.equal(processResult.exitCode, 2);
   assert.equal(processResult.stdout, '');
   assert.match(processResult.stderr, /INVALID_ARGS/u);
+
+  const processResumeResult = await executeCli(
+    ['process', 'resume-build', '--bad-flag'],
+    makeDeps(),
+  );
+  assert.equal(processResumeResult.exitCode, 2);
+  assert.equal(processResumeResult.stdout, '');
+  assert.match(processResumeResult.stderr, /INVALID_ARGS/u);
 });
 
 test('executeCli executes validation run with injected implementation and report file', async () => {
@@ -819,10 +940,10 @@ test('executeCli returns planned command message for lifecyclemodel subcommands 
 });
 
 test('executeCli returns planned command message for process subcommands after help is introduced', async () => {
-  const result = await executeCli(['process', 'resume-build'], makeDeps());
+  const result = await executeCli(['process', 'publish-build'], makeDeps());
   assert.equal(result.exitCode, 2);
   assert.equal(result.stdout, '');
-  assert.match(result.stderr, /Command 'process resume-build'/u);
+  assert.match(result.stderr, /Command 'process publish-build'/u);
 });
 
 test('executeCli returns dedicated help for planned lifecyclemodel subcommands', async () => {
@@ -834,9 +955,9 @@ test('executeCli returns dedicated help for planned lifecyclemodel subcommands',
 });
 
 test('executeCli returns dedicated help for planned process subcommands', async () => {
-  const result = await executeCli(['process', 'resume-build', '--help'], makeDeps());
+  const result = await executeCli(['process', 'publish-build', '--help'], makeDeps());
   assert.equal(result.exitCode, 0);
-  assert.match(result.stdout, /tiangong process resume-build --run-id <id>/u);
+  assert.match(result.stdout, /tiangong process publish-build --run-id <id>/u);
   assert.match(result.stdout, /Execution is not implemented yet/u);
   assert.equal(result.stderr, '');
 });

--- a/test/process-resume-build.test.ts
+++ b/test/process-resume-build.test.ts
@@ -1,0 +1,516 @@
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdtempSync,
+  realpathSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { runProcessAutoBuild } from '../src/lib/process-auto-build.js';
+import { __testInternals, runProcessResumeBuild } from '../src/lib/process-resume-build.js';
+
+function writeJson(filePath: string, value: unknown): void {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function readJson(filePath: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(filePath, 'utf8')) as Record<string, unknown>;
+}
+
+function bundledFlowPayload(): Record<string, unknown> {
+  return readJson(
+    path.resolve(process.cwd(), '../tidas-sdk/test-data/tidas-example-flow.json'),
+  ) as Record<string, unknown>;
+}
+
+function writeFlowFixture(dir: string): string {
+  const filePath = path.join(dir, '01211_3a8d74d8_reference-flow.json');
+  writeJson(filePath, bundledFlowPayload());
+  return filePath;
+}
+
+async function createPreparedRun(dir: string): Promise<{
+  requestPath: string;
+  report: Awaited<ReturnType<typeof runProcessAutoBuild>>;
+}> {
+  const flowPath = writeFlowFixture(dir);
+  const requestPath = path.join(dir, 'request.json');
+  writeJson(requestPath, {
+    flow_file: `./${path.basename(flowPath)}`,
+  });
+
+  const report = await runProcessAutoBuild({
+    inputPath: requestPath,
+    now: new Date('2026-03-29T02:00:00Z'),
+    cwd: '/tmp/process-resume-build-auto',
+  });
+
+  return {
+    requestPath,
+    report,
+  };
+}
+
+test('runProcessResumeBuild clears stop_after and writes resume artifacts from run-id', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-resume-build-runid-'));
+  const originalCwd = process.cwd();
+
+  try {
+    const { report: autoReport } = await createPreparedRun(dir);
+    const state = readJson(autoReport.files.state);
+    state.build_status = 'stopped_after_matches';
+    state.next_stage = '04_exchange_values';
+    state.stop_after = 'matches';
+    state.processes = [{ id: 'p-1' }];
+    state.matched_process_exchanges = [{ id: 'ex-1' }];
+    state.process_datasets = [{ id: 'proc-ds-1' }];
+    state.source_datasets = [{ id: 'src-ds-1' }];
+    writeJson(autoReport.files.state, state);
+
+    process.chdir(dir);
+    const resumeReport = await runProcessResumeBuild({
+      runId: autoReport.run_id,
+      now: new Date('2026-03-29T03:00:00Z'),
+      cwd: '/tmp/process-resume-build-resume',
+    });
+
+    assert.equal(resumeReport.status, 'prepared_local_process_resume_run');
+    assert.equal(realpathSync(resumeReport.run_root), realpathSync(autoReport.run_root));
+    assert.equal(resumeReport.request_id, autoReport.request_id);
+    assert.equal(resumeReport.resumed_from, '04_exchange_values');
+    assert.equal(resumeReport.checkpoint, 'matches');
+    assert.equal(resumeReport.attempt, 1);
+    assert.equal(resumeReport.state_summary.build_status, 'resume_prepared');
+    assert.equal(resumeReport.state_summary.next_stage, '04_exchange_values');
+    assert.equal(resumeReport.state_summary.stop_after, null);
+    assert.equal(resumeReport.state_summary.process_count, 1);
+    assert.equal(resumeReport.state_summary.matched_exchange_count, 1);
+    assert.equal(resumeReport.state_summary.process_dataset_count, 1);
+    assert.equal(resumeReport.state_summary.source_dataset_count, 1);
+    assert.equal(existsSync(resumeReport.files.resume_metadata), true);
+    assert.equal(existsSync(resumeReport.files.resume_history), true);
+    assert.equal(existsSync(resumeReport.files.invocation_index), true);
+    assert.equal(existsSync(resumeReport.files.report), true);
+
+    const updatedState = readJson(resumeReport.files.state);
+    assert.equal(updatedState.build_status, 'resume_prepared');
+    assert.equal(updatedState.stop_after, null);
+    assert.equal(updatedState.resume_attempt, 1);
+    assert.equal(updatedState.resume_requested_at, '2026-03-29T03:00:00.000Z');
+    const stepMarkers = updatedState.step_markers as Record<string, { status?: unknown }>;
+    assert.equal(stepMarkers.resume_prepared?.status, 'completed');
+
+    const resumeMetadata = readJson(resumeReport.files.resume_metadata);
+    assert.equal(resumeMetadata.runId, autoReport.run_id);
+    assert.equal(resumeMetadata.resumedFrom, '04_exchange_values');
+    assert.equal(resumeMetadata.checkpoint, 'matches');
+    assert.equal(resumeMetadata.attempt, 1);
+    assert.equal(resumeMetadata.resumedAt, '2026-03-29T03:00:00.000Z');
+
+    const invocationIndex = readJson(resumeReport.files.invocation_index) as {
+      invocations: Array<Record<string, unknown>>;
+    };
+    assert.equal(invocationIndex.invocations.length, 2);
+    assert.deepEqual(invocationIndex.invocations[1]?.command, [
+      'process',
+      'resume-build',
+      '--run-id',
+      autoReport.run_id,
+    ]);
+    assert.equal(invocationIndex.invocations[1]?.cwd, '/tmp/process-resume-build-resume');
+
+    const handoff = readJson(resumeReport.files.handoff_summary);
+    assert.equal(handoff.command, 'process resume-build');
+    assert.equal(handoff.stop_after, null);
+    assert.equal((handoff.extra as Record<string, unknown>).status, resumeReport.status);
+
+    const historyLines = readFileSync(resumeReport.files.resume_history, 'utf8')
+      .trim()
+      .split(/\r?\n/u);
+    assert.equal(historyLines.length, 1);
+
+    assert.equal(
+      readFileSync(path.join(path.dirname(autoReport.run_root), '.latest_run_id'), 'utf8'),
+      `${autoReport.run_id}\n`,
+    );
+  } finally {
+    process.chdir(originalCwd);
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessResumeBuild supports run-dir resume, recreates invocation history, and increments attempts', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-resume-build-rundir-'));
+
+  try {
+    const { report: autoReport } = await createPreparedRun(dir);
+    const state = readJson(autoReport.files.state);
+    delete state.next_stage;
+    state.build_status = 'waiting_manual_review';
+    writeJson(autoReport.files.state, state);
+    unlinkSync(autoReport.files.invocation_index);
+
+    const firstResume = await runProcessResumeBuild({
+      runDir: autoReport.run_root,
+      now: new Date('2026-03-29T04:00:00Z'),
+      cwd: '/tmp/process-resume-build-rundir-1',
+    });
+
+    assert.equal(firstResume.run_id, autoReport.run_id);
+    assert.equal(firstResume.resumed_from, 'waiting_manual_review');
+    assert.equal(firstResume.checkpoint, null);
+    assert.equal(firstResume.attempt, 1);
+    const firstInvocationIndex = readJson(firstResume.files.invocation_index) as {
+      invocations: Array<Record<string, unknown>>;
+    };
+    assert.equal(firstInvocationIndex.invocations.length, 1);
+    assert.deepEqual(firstInvocationIndex.invocations[0]?.command, [
+      'process',
+      'resume-build',
+      '--run-dir',
+      autoReport.run_root,
+    ]);
+    assert.match(firstResume.next_actions[3] ?? '', /future: inspect completed run state/u);
+
+    const secondResume = await runProcessResumeBuild({
+      runDir: autoReport.run_root,
+      now: new Date('2026-03-29T05:00:00Z'),
+      cwd: '/tmp/process-resume-build-rundir-2',
+    });
+
+    assert.equal(secondResume.attempt, 2);
+    const secondInvocationIndex = readJson(secondResume.files.invocation_index) as {
+      invocations: Array<Record<string, unknown>>;
+    };
+    assert.equal(secondInvocationIndex.invocations.length, 2);
+    const historyLines = readFileSync(secondResume.files.resume_history, 'utf8')
+      .trim()
+      .split(/\r?\n/u);
+    assert.equal(historyLines.length, 2);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessResumeBuild rebuilds invocation history when invocation index omits invocations', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-resume-build-no-invocations-'));
+
+  try {
+    const { report: autoReport } = await createPreparedRun(dir);
+    writeJson(autoReport.files.invocation_index, {
+      schema_version: 9,
+    });
+
+    const resumeReport = await runProcessResumeBuild({
+      runDir: autoReport.run_root,
+      now: new Date('2026-03-29T04:30:00Z'),
+      cwd: '/tmp/process-resume-build-no-invocations',
+    });
+
+    const invocationIndex = readJson(resumeReport.files.invocation_index) as {
+      schema_version: unknown;
+      invocations: Array<Record<string, unknown>>;
+    };
+    assert.equal(invocationIndex.schema_version, 1);
+    assert.equal(invocationIndex.invocations.length, 1);
+    assert.deepEqual(invocationIndex.invocations[0]?.command, [
+      'process',
+      'resume-build',
+      '--run-dir',
+      autoReport.run_root,
+    ]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessResumeBuild rejects invalid inputs and corrupted process run artifacts', async () => {
+  await assert.rejects(() => runProcessResumeBuild({}), /Missing required --run-id or --run-dir/u);
+
+  const mismatchDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-resume-build-mismatch-'));
+  try {
+    await assert.rejects(
+      () =>
+        runProcessResumeBuild({
+          runId: 'run-a',
+          runDir: path.join(mismatchDir, 'run-b'),
+        }),
+      /run-id does not match run-dir basename/u,
+    );
+  } finally {
+    rmSync(mismatchDir, { recursive: true, force: true });
+  }
+
+  const missingDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-resume-build-missing-'));
+  try {
+    await assert.rejects(
+      () => runProcessResumeBuild({ runDir: path.join(missingDir, 'run-missing') }),
+      /run root not found/u,
+    );
+  } finally {
+    rmSync(missingDir, { recursive: true, force: true });
+  }
+
+  const invalidManifestDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-resume-build-bad-manifest-'),
+  );
+  try {
+    const { report: autoReport } = await createPreparedRun(invalidManifestDir);
+    writeJson(autoReport.files.run_manifest, { runId: 'other-run' });
+    await assert.rejects(
+      () => runProcessResumeBuild({ runDir: autoReport.run_root }),
+      /run manifest runId mismatch/u,
+    );
+  } finally {
+    rmSync(invalidManifestDir, { recursive: true, force: true });
+  }
+
+  const invalidStateDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-resume-build-bad-state-'),
+  );
+  try {
+    const { report: autoReport } = await createPreparedRun(invalidStateDir);
+    writeJson(autoReport.files.state, []);
+    await assert.rejects(
+      () => runProcessResumeBuild({ runDir: autoReport.run_root }),
+      /Expected process resume artifact JSON object/u,
+    );
+  } finally {
+    rmSync(invalidStateDir, { recursive: true, force: true });
+  }
+
+  const mismatchedStateDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-resume-build-state-mismatch-'),
+  );
+  try {
+    const { report: autoReport } = await createPreparedRun(mismatchedStateDir);
+    const state = readJson(autoReport.files.state);
+    state.run_id = 'other-run';
+    writeJson(autoReport.files.state, state);
+    await assert.rejects(
+      () => runProcessResumeBuild({ runDir: autoReport.run_root }),
+      /state run_id mismatch/u,
+    );
+  } finally {
+    rmSync(mismatchedStateDir, { recursive: true, force: true });
+  }
+
+  const invalidHandoffDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-resume-build-bad-handoff-'),
+  );
+  try {
+    const { report: autoReport } = await createPreparedRun(invalidHandoffDir);
+    writeJson(autoReport.files.handoff_summary, []);
+    await assert.rejects(
+      () => runProcessResumeBuild({ runDir: autoReport.run_root }),
+      /Expected process resume artifact JSON object/u,
+    );
+  } finally {
+    rmSync(invalidHandoffDir, { recursive: true, force: true });
+  }
+
+  const missingHandoffDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-resume-build-missing-handoff-'),
+  );
+  try {
+    const { report: autoReport } = await createPreparedRun(missingHandoffDir);
+    unlinkSync(autoReport.files.handoff_summary);
+    await assert.rejects(
+      () => runProcessResumeBuild({ runDir: autoReport.run_root }),
+      /Required process resume artifact not found/u,
+    );
+  } finally {
+    rmSync(missingHandoffDir, { recursive: true, force: true });
+  }
+
+  const invalidInvocationDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-resume-build-bad-invocation-'),
+  );
+  try {
+    const { report: autoReport } = await createPreparedRun(invalidInvocationDir);
+    writeJson(autoReport.files.invocation_index, { invocations: {} });
+    await assert.rejects(
+      () => runProcessResumeBuild({ runDir: autoReport.run_root }),
+      /invocations array/u,
+    );
+  } finally {
+    rmSync(invalidInvocationDir, { recursive: true, force: true });
+  }
+
+  const invalidInvocationShapeDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-resume-build-bad-invocation-shape-'),
+  );
+  try {
+    const { report: autoReport } = await createPreparedRun(invalidInvocationShapeDir);
+    writeJson(autoReport.files.invocation_index, []);
+    await assert.rejects(
+      () => runProcessResumeBuild({ runDir: autoReport.run_root }),
+      /invocation index JSON object/u,
+    );
+  } finally {
+    rmSync(invalidInvocationShapeDir, { recursive: true, force: true });
+  }
+
+  const invalidHistoryDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-resume-build-bad-history-'),
+  );
+  try {
+    const { report: autoReport } = await createPreparedRun(invalidHistoryDir);
+    writeFileSync(
+      path.join(autoReport.run_root, 'manifests', 'resume-history.jsonl'),
+      '123\n',
+      'utf8',
+    );
+    await assert.rejects(
+      () => runProcessResumeBuild({ runDir: autoReport.run_root }),
+      /JSONL rows to be objects/u,
+    );
+  } finally {
+    rmSync(invalidHistoryDir, { recursive: true, force: true });
+  }
+});
+
+test('process resume-build internals cover fallback layout and metadata helpers', () => {
+  const resolvedLayout = __testInternals.resolveLayout({
+    runDir: '/tmp/process-run/run-123',
+  });
+  assert.equal(resolvedLayout.runId, 'run-123');
+  assert.equal(
+    resolvedLayout.statePath,
+    '/tmp/process-run/run-123/cache/process_from_flow_state.json',
+  );
+  assert.equal(
+    __testInternals.resolveLayout({
+      runId: '   ',
+      runDir: '/tmp/process-run/run-123',
+    }).runId,
+    'run-123',
+  );
+
+  const stateSummary = __testInternals.buildStateSummary({
+    build_status: 'resume_prepared',
+    next_stage: '04_exchange_values',
+    stop_after: null,
+    processes: ['a', 'b'],
+  });
+  assert.deepEqual(stateSummary, {
+    build_status: 'resume_prepared',
+    next_stage: '04_exchange_values',
+    stop_after: null,
+    process_count: 2,
+    matched_exchange_count: 0,
+    process_dataset_count: 0,
+    source_dataset_count: 0,
+  });
+
+  assert.equal(
+    __testInternals.resolveResumedFrom({
+      build_status: 'fallback-status',
+    }),
+    'fallback-status',
+  );
+  assert.equal(__testInternals.resolveResumedFrom({}), 'unknown');
+
+  assert.equal(__testInternals.nextAttempt([{ attempt: 2 }, { attempt: 4 }]), 5);
+  assert.equal(__testInternals.nextAttempt([{ attempt: 'bad' }, { attempt: 0 }]), 1);
+
+  const updatedMarkers = __testInternals.updateStepMarkers('bad', '2026-03-29T06:00:00.000Z') as {
+    resume_prepared: { status?: unknown };
+  };
+  assert.equal(updatedMarkers.resume_prepared.status, 'completed');
+
+  const updatedState = __testInternals.buildUpdatedState(
+    {
+      build_status: 'stopped',
+      stop_after: 'sources',
+    },
+    {
+      attempt: 3,
+    },
+    new Date('2026-03-29T06:00:00Z'),
+  ) as Record<string, unknown>;
+  assert.equal(updatedState.build_status, 'resume_prepared');
+  assert.equal(updatedState.stop_after, null);
+  assert.equal(updatedState.resume_attempt, 3);
+
+  const invocationIndex = __testInternals.buildInvocationIndex(
+    __testInternals.buildLayout('/tmp/process-run/run-123', 'run-123'),
+    {
+      schema_version: 2,
+      invocations: [{ command: ['existing'] }],
+    },
+    {
+      runId: 'run-123',
+      runDir: '/tmp/process-run/run-123',
+      cwd: '/tmp/workspace',
+    },
+    new Date('2026-03-29T06:30:00Z'),
+  ) as {
+    invocations: Array<Record<string, unknown>>;
+  };
+  assert.equal(invocationIndex.invocations.length, 2);
+
+  const fallbackInvocationIndex = __testInternals.buildInvocationIndex(
+    __testInternals.buildLayout('/tmp/process-run/run-123', 'run-123'),
+    {},
+    {
+      runId: 'run-123',
+      cwd: '/tmp/workspace',
+    },
+    new Date('2026-03-29T06:45:00Z'),
+  ) as {
+    schema_version: unknown;
+    invocations: Array<Record<string, unknown>>;
+  };
+  assert.equal(fallbackInvocationIndex.schema_version, 1);
+  assert.equal(fallbackInvocationIndex.invocations.length, 1);
+  assert.deepEqual(fallbackInvocationIndex.invocations[0]?.command, [
+    'process',
+    'resume-build',
+    '--run-id',
+    'run-123',
+  ]);
+
+  const cwdFallbackInvocationIndex = __testInternals.buildInvocationIndex(
+    __testInternals.buildLayout('/tmp/process-run/run-123', 'run-123'),
+    {},
+    {
+      runId: 'run-123',
+    },
+    new Date('2026-03-29T06:46:00Z'),
+  ) as {
+    invocations: Array<Record<string, unknown>>;
+  };
+  assert.equal(cwdFallbackInvocationIndex.invocations[0]?.cwd, process.cwd());
+
+  const fallbackReport = __testInternals.buildReport(
+    __testInternals.buildLayout('/tmp/process-run/run-123', 'run-123'),
+    {},
+    {
+      resumedFrom: 'resume_prepared',
+    },
+    {
+      build_status: 'resume_prepared',
+      next_stage: null,
+      stop_after: null,
+      process_count: 0,
+      matched_exchange_count: 0,
+      process_dataset_count: 0,
+      source_dataset_count: 0,
+    },
+    new Date('2026-03-29T06:47:00Z'),
+  );
+  assert.equal(fallbackReport.checkpoint, '');
+  assert.equal(fallbackReport.attempt, 1);
+
+  const nextActions = __testInternals.buildNextActions(
+    __testInternals.buildLayout('/tmp/process-run/run-123', 'run-123'),
+    stateSummary,
+  );
+  assert.match(nextActions[3] ?? '', /future: migrate CLI stage executor/u);
+});


### PR DESCRIPTION
Closes #14

## Summary
- Add `tiangong process resume-build` as the local state-handoff command for existing process auto-build runs.
- Rebuild invocation metadata and resume state from the CLI-owned run contract instead of shell or Python orchestration.

## Key Decisions
- Base this PR on `feature/issue-13` so the resume slice reviews only its incremental contract on top of process auto-build.
- Keep the slice file-first and local-first; later execution agents remain separate follow-up work.

## Validation
- npm run prepush:gate

## Risks / Rollback
- This PR is stacked on the process auto-build slice and must follow its merge order or be rebased later.

## Follow-ups
- Use this PR as the base for process publish-build and process batch-build.

## Workspace Integration
- Requires a later `lca-workspace` submodule bump after the CLI stack merges to the default branch.