### PR TITLE
feat: implement process resume-build local state handoff in CLI

### DIFF
--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -17,6 +17,8 @@
 - `tiangong search lifecyclemodel`
 - `tiangong process auto-build`
 - `tiangong process resume-build`
+- `tiangong process publish-build`
+- `tiangong process batch-build`
 - `tiangong lifecyclemodel build-resulting-process`
 - `tiangong lifecyclemodel publish-resulting-process`
 - `tiangong publish run`
@@ -75,6 +77,8 @@ npm start -- doctor --json
 npm start -- search flow --input ./request.json --dry-run
 npm start -- process auto-build --input ./pff-request.json --json
 npm start -- process resume-build --run-id <run-id> --json
+npm start -- process publish-build --run-id <run-id> --json
+npm start -- process batch-build --input ./batch-request.json --json
 npm start -- lifecyclemodel build-resulting-process --input ./request.json --json
 npm start -- lifecyclemodel publish-resulting-process --run-dir ./runs/example --publish-processes --publish-relations --json
 npm start -- publish run --input ./publish-request.json --dry-run
@@ -108,10 +112,29 @@ npm start -- admin embedding-run --input ./jobs.json --dry-run
 
 这个命令当前也只负责本地 resume handoff，不负责继续执行后续工作流阶段。
 
-也就是说，下面这些还没有迁完：
+`tiangong process publish-build` 现在也已经进入可执行状态，负责：
 
-- `tiangong process publish-build`
-- `tiangong process batch-build`
+- 从 `--run-id` 或 `--run-dir` 读取一个现有 process build run
+- 校验 `process_from_flow_state.json`、`agent_handoff_summary.json`、`run-manifest.json`、`invocation-index.json`
+- 优先从 `exports/processes`、`exports/sources` 收集 canonical 数据，缺失时回退到 state 中的 `process_datasets`、`source_datasets`
+- 生成 `stage_outputs/10_publish/publish-bundle.json`
+- 生成 `stage_outputs/10_publish/publish-request.json`
+- 生成 `stage_outputs/10_publish/publish-intent.json`
+- 更新 `process_from_flow_state.json`、`invocation-index.json`、`agent_handoff_summary.json`
+- 输出 `process-publish-build-report.json`
+
+这个命令当前只负责本地 publish handoff，不负责真正的远端 publish commit；真正的 dry-run / commit 边界仍由 `tiangong publish run` 负责。
+
+`tiangong process batch-build` 现在也已经进入可执行状态，负责：
+
+- 读取单个 batch manifest
+- 创建自包含的 batch root 和聚合 report 路径
+- 顺序复用 CLI 的 `process auto-build` 契约执行多个 item
+- 为每个 item 生成稳定的本地 run 目录
+- 在 batch report 中记录 per-item prepared / failed / skipped 结果
+- 为后续 `resume-build` / `publish-build` 保留明确的 `run_root`
+
+这个命令当前只负责本地 batch orchestration，不负责继续串接 resume / publish，也不负责远端 publish commit。
 
 `tiangong publish run` 现在已经成为统一 publish 契约入口，负责：
 
@@ -195,6 +218,8 @@ npm run build
 - 轻量远程 skill 直接调用 `tiangong search ...` 或 `tiangong admin ...`
 - `process-automated-builder` 已先迁入 `tiangong process auto-build` 本地 scaffold；剩余阶段继续按子命令切片迁移
 - `process-automated-builder` 的本地 resume handoff 也已迁入 `tiangong process resume-build`；后续阶段继续按子命令切片迁移
+- `process-automated-builder` 的本地 publish handoff 也已迁入 `tiangong process publish-build`
+- `process-automated-builder` 的本地 batch orchestration 也已迁入 `tiangong process batch-build`
 - 其余重型 workflow 先保留原执行器，但由 `tiangong` 统一调度
 - 所有新脚本优先使用统一环境变量名，不再扩散旧变量名
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Current implementation choices:
 - `tiangong search lifecyclemodel`
 - `tiangong process auto-build`
 - `tiangong process resume-build`
+- `tiangong process publish-build`
+- `tiangong process batch-build`
 - `tiangong lifecyclemodel build-resulting-process`
 - `tiangong lifecyclemodel publish-resulting-process`
 - `tiangong publish run`
@@ -33,8 +35,6 @@ The `lifecyclemodel` and `process` namespaces are now partially implemented. The
 - `tiangong lifecyclemodel validate-build`
 - `tiangong lifecyclemodel publish-build`
 - `tiangong process get`
-- `tiangong process publish-build`
-- `tiangong process batch-build`
 
 These remaining commands are intentionally not executable yet. They print an explicit `not implemented yet` message and exit with code `2` until the corresponding workflows are migrated into TypeScript.
 
@@ -92,6 +92,8 @@ npm start -- doctor --json
 npm start -- search flow --input ./request.json --dry-run
 npm start -- process auto-build --input ./pff-request.json --json
 npm start -- process resume-build --run-id <run-id> --json
+npm start -- process publish-build --run-id <run-id> --json
+npm start -- process batch-build --input ./batch-request.json --json
 npm start -- lifecyclemodel build-resulting-process --input ./request.json --json
 npm start -- lifecyclemodel publish-resulting-process --run-dir ./runs/example --publish-processes --publish-relations --json
 npm start -- publish run --input ./publish-request.json --dry-run
@@ -107,9 +109,17 @@ The command keeps the legacy per-run layout that later stages still expect, incl
 
 `tiangong process resume-build` is the second migrated `process_from_flow` slice. It reopens one existing local run by `--run-id` or `--run-dir`, validates the required run artifacts, takes the local state lock, clears any persisted `stop_after` checkpoint, records `resume-metadata.json` and `resume-history.jsonl`, updates `invocation-index.json`, rewrites `agent_handoff_summary.json`, and emits `process-resume-build-report.json`.
 
-`resume-build` still stops at the handoff boundary. It does not yet execute the downstream workflow stages; `publish-build` and `batch-build` remain planned slices.
+`tiangong process publish-build` is the third migrated `process_from_flow` slice. It reopens one existing local run by `--run-id` or `--run-dir`, validates `process_from_flow_state.json`, `agent_handoff_summary.json`, `run-manifest.json`, and `invocation-index.json`, collects canonical process/source datasets from `exports/` or state fallbacks, writes `stage_outputs/10_publish/publish-bundle.json`, `publish-request.json`, `publish-intent.json`, rewrites `agent_handoff_summary.json`, updates the run state and invocation index, and emits `process-publish-build-report.json`.
+
+`tiangong process batch-build` is the fourth migrated `process_from_flow` slice. It reads one batch manifest, prepares a self-contained batch root, fans out multiple local `process auto-build` runs through the CLI-owned contract, writes a structured per-item aggregate report, and preserves deterministic item-level artifact paths for downstream `resume-build` or `publish-build` steps.
+
+`resume-build`, `publish-build`, and `batch-build` all still stop at local handoff boundaries. They do not execute remote publish CRUD or commit mode themselves; that boundary remains in `tiangong publish run`.
 
 ## Publish and validation
+
+`tiangong process publish-build` is the process-side local publish handoff command. It prepares the local bundle/request/intent artifacts expected by `tiangong publish run` without reintroducing Python, MCP, or legacy remote writers into the CLI.
+
+`tiangong process batch-build` is the process-side local batch orchestration command. It keeps batch execution file-first and JSON-first, reuses the single-run `process auto-build` contract for each item, and emits one batch report instead of pushing shell loops or Python coordinators back onto the caller.
 
 `tiangong lifecyclemodel publish-resulting-process` is the lifecyclemodel-side local publish handoff command. It reads a prior resulting-process run, writes `publish-bundle.json` and `publish-intent.json`, and preserves the old builder's artifact contract without reintroducing Python or MCP into the CLI.
 
@@ -123,6 +133,8 @@ Run the built artifact directly:
 node ./bin/tiangong.js doctor
 node ./bin/tiangong.js process auto-build --input ./pff-request.json --json
 node ./bin/tiangong.js process resume-build --run-id <run-id> --json
+node ./bin/tiangong.js process publish-build --run-id <run-id> --json
+node ./bin/tiangong.js process batch-build --input ./batch-request.json --json
 node ./dist/src/main.js doctor --json
 ```
 

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -33,6 +33,8 @@ tiangong
   process
     auto-build
     resume-build
+    publish-build
+    batch-build
   lifecyclemodel
     build-resulting-process
     publish-resulting-process
@@ -54,6 +56,8 @@ tiangong
 | `tiangong search lifecyclemodel` | `lifecyclemodel_hybrid_search` |
 | `tiangong process auto-build` | 本地 `process_from_flow` intake、run-id 生成、artifact scaffold 预写 |
 | `tiangong process resume-build` | 本地 `process_from_flow` resume handoff、state-lock/manifest 收口、resume 元数据与报告输出 |
+| `tiangong process publish-build` | 本地 `process_from_flow` publish handoff、publish bundle/request/intent 产出、state/invocation/handoff 更新 |
+| `tiangong process batch-build` | 本地 `process_from_flow` batch manifest 编排、批量调用 auto-build、batch report 输出 |
 | `tiangong lifecyclemodel build-resulting-process` | 本地 lifecycle model resulting process 聚合、内部 flow 抵消、artifact 输出 |
 | `tiangong lifecyclemodel publish-resulting-process` | 读取 resulting-process run，生成 `publish-bundle.json` / `publish-intent.json` 本地交付物 |
 | `tiangong publish run` | 本地 publish 契约归一化、dry-run/commit、report 输出 |
@@ -70,14 +74,20 @@ tiangong
 
 - `tiangong process auto-build` 已可执行
 - `tiangong process resume-build` 已可执行
-- `get`、`publish-build`、`batch-build` 仍处于 planned 状态
+- `tiangong process publish-build` 已可执行
+- `tiangong process batch-build` 已可执行
+- `get` 仍处于 planned 状态
 
 注意：
 
 - 已实现的 `process auto-build` 保留了旧 `artifacts/process_from_flow/<run_id>/`、`cache/process_from_flow_state.json`、`cache/agent_handoff_summary.json` 等运行布局
 - `process auto-build` 当前只负责本地 request intake、flow 归一化、run scaffold 和 manifest/report 预写，不继续执行后续阶段
 - 已实现的 `process resume-build` 保留同一套 run 布局，并把本地 state-lock、run-manifest 校验、resume metadata/history、invocation index 更新统一收口到 CLI
-- `process resume-build` 当前只负责本地 resume handoff，不继续执行 route / split / exchange / QA / publish 阶段
+- `process resume-build` 当前只负责本地 resume handoff，不直接执行 route / split / exchange / QA / publish 阶段
+- 已实现的 `process publish-build` 继续保留同一套 run 布局，并把本地 publish-bundle/request/intent、state/invocation/handoff 更新统一收口到 CLI
+- `process publish-build` 当前只负责本地 publish handoff，不直接执行远端 publish commit 或数据库写入
+- 已实现的 `process batch-build` 继续走本地优先、artifact-first 路径，并把批量 item 编排、聚合 report、默认 run_dir 分配统一收口到 CLI
+- `process batch-build` 当前只负责本地 batch orchestration，不直接串接 resume / publish 或远端执行器
 - 已实现的 `build-resulting-process` 和 `publish-resulting-process` 都走本地优先、artifact-first 路径，不依赖 Python 或 MCP
 - `publish-resulting-process` 当前负责生成本地 publish handoff 产物，还没有把提交语义直接并入 `publish run`
 - 其余未实现的 `lifecyclemodel` / `process` 子命令仍只提供 help 和固定命名
@@ -212,7 +222,45 @@ tiangong admin embedding-run --input ./jobs.json --dry-run
 
 - 执行 route / split / exchange / QA / publish 等后续阶段
 - 远程检索、LLM、OCR、publish commit
-- `publish-build`、`batch-build`
+- 直接触发后续 `batch-build` 或远端 publish executor
+
+`process publish-build` 现在固定的是“本地 process-from-flow publish handoff 契约层”。
+
+它负责：
+
+- 从 `--run-id` 或 `--run-dir` 读取已有 run
+- 校验 `run-manifest.json`、`process_from_flow_state.json`、`agent_handoff_summary.json`、`invocation-index.json`
+- 优先读取 `exports/processes/`、`exports/sources/`，缺失时回退到 state 中的 `process_datasets`、`source_datasets`
+- 写出 `stage_outputs/10_publish/publish-bundle.json`
+- 写出 `stage_outputs/10_publish/publish-request.json`
+- 写出 `stage_outputs/10_publish/publish-intent.json`
+- 更新 `process_from_flow_state.json`
+- 更新 `invocation-index.json`
+- 重写 `agent_handoff_summary.json`
+- 产出 `process-publish-build-report.json`
+
+它现在还不负责：
+
+- 直接执行远端 publish commit 或数据库 CRUD
+- 重新实现历史 MCP transport
+- `batch-build`
+
+`process batch-build` 现在固定的是“本地 process-from-flow batch orchestration 契约层”。
+
+它负责：
+
+- 读取单个 batch manifest
+- 生成 batch root、normalized request、invocation index、run manifest、aggregate report
+- 顺序复用 `process auto-build` 为多个 item 准备本地 run
+- 给每个 item 分配稳定的默认 `run_root`
+- 输出 per-item `prepared` / `failed` / `skipped` 状态
+- 为后续 `resume-build` / `publish-build` 保留明确的 `run_root`
+
+它现在还不负责：
+
+- 直接串接 `resume-build` / `publish-build`
+- 并发调度、daemon、远端 CRUD、历史 Python orchestrator 复刻
+- `process get`
 
 `publish run` 现在固定的是“稳定 publish 契约层”，不是历史 MCP 写库脚本的 TypeScript 复刻。
 
@@ -315,7 +363,8 @@ npm run prepush:gate
 - `process-automated-builder`
   - 已落地 `tiangong process auto-build`
   - 已落地 `tiangong process resume-build`
-  - 仍待迁移 `publish-build`、`batch-build`
+  - 已落地 `tiangong process publish-build`
+  - 已落地 `tiangong process batch-build`
 - `lifecycleinventory-review`
 - 其他重型 Python workflow
 
@@ -352,7 +401,7 @@ npm run prepush:gate
 
 ### Phase 2
 
-- 继续补齐 `process publish-build` / `batch-build`
+- 切 `process-automated-builder` 到 CLI-only wrapper
 - 引入 `review` / `job` / `flow` / `process` 的更多业务子命令
 - 用 CLI 接管现有 workflow 的稳定 contract 层
 - 统一 run-dir / artifact / manifest 输入输出格式

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -69,7 +69,7 @@
 | `process-hybrid-search` | 已有等价 CLI | shell wrapper，历史 token/env 兼容 | 只保留 skill 文档，调用 `tiangong search process` | P0 |
 | `lifecyclemodel-hybrid-search` | 已有等价 CLI | shell wrapper，历史 token/env 兼容 | 只保留 skill 文档，调用 `tiangong search lifecyclemodel` | P0 |
 | `embedding-ft` | 已有等价 CLI | shell wrapper | 只保留 skill 文档，调用 `tiangong admin embedding-run` | P0 |
-| `process-automated-builder` | 已进入 CLI 化，6.1/6.2 已落地 | `tiangong process auto-build` / `resume-build` + shell/Python/LangGraph/MCP/OpenAI/AI edge search/TianGong unstructured 遗留阶段 | 迁成 `tiangong process ...` 主链 | P1 |
+| `process-automated-builder` | 已进入 CLI 化，6.1/6.2/6.3/6.4 已落地 | `tiangong process auto-build` / `resume-build` / `publish-build` / `batch-build` + shell/Python/LangGraph/MCP/OpenAI/AI edge search/TianGong unstructured 遗留阶段 | 迁成 `tiangong process ...` 主链 | P1 |
 | `lifecyclemodel-automated-builder` | 仍是重 workflow | shell + Python + MCP + OpenAI | 迁成 `tiangong lifecyclemodel ...` 主链 | P1 |
 | `lifecyclemodel-resulting-process-builder` | CLI 本地 build/publish handoff 已落地，skill wrapper 已切换 | `skill -> tiangong lifecyclemodel build/publish-resulting-process` | 保持薄 wrapper，继续去掉遗留 lookup 分支 | P1 |
 | `lifecycleinventory-review` | 仍是 review workflow | Python review script | 迁成 `tiangong review process` | P2 |
@@ -261,20 +261,22 @@ ToDo：
 
 - [x] `tiangong process auto-build`
 - [x] `tiangong process resume-build`
-- [ ] `tiangong process publish-build`
-- [ ] `tiangong process batch-build`
+- [x] `tiangong process publish-build`
+- [x] `tiangong process batch-build`
 
 建议拆成 4 个连续小步骤，而不是一次性大迁移：
 
 - [x] 6.1 先实现 `auto-build` 的本地产物路径，不做 publish
 - [x] 6.2 再实现 `resume-build`，把 state-lock / run manifest 彻底收口到 CLI
-- [ ] 6.3 再实现 `publish-build`，接到统一 publish 模块
-- [ ] 6.4 最后实现 `batch-build`
+- [x] 6.3 再实现 `publish-build`，接到统一 publish 模块的本地 handoff 契约
+- [x] 6.4 最后实现 `batch-build`
 
 迁移内容：
 
 - [x] intake request normalization / flow 归一化 / run-id / local artifact scaffold 迁到 TS CLI
 - [x] 本地状态锁、cache、resume handoff 逻辑迁到 CLI
+- [x] 本地 publish handoff、publish-bundle/request/intent 契约迁到 CLI
+- [x] 本地 batch manifest orchestration、aggregate report、default run_dir 分配迁到 CLI
 - [ ] 流程编排迁到 TS
 - [ ] flow search 改为直接 REST，而不是 MCP
 - [ ] publish 改为直接 REST / CLI publish，而不是 MCP CRUD
@@ -433,7 +435,7 @@ ToDo：
 
 如果只按最短路径推进，下一轮建议严格做这 8 件事：
 
-当前重点已经推进到第 8 项，且 `tiangong process auto-build` / `resume-build`（Phase 6.1 / 6.2）已完成。
+当前重点已经推进到第 8 项，且 `tiangong process auto-build` / `resume-build` / `publish-build` / `batch-build`（Phase 6.1 / 6.2 / 6.3 / 6.4）已完成。
 
 1. 修 CLI help，让命令面和真实实现一致。
 2. 修 skills 文档中的 `TIANGONG_CLI_DIR` 残留。
@@ -442,7 +444,7 @@ ToDo：
 5. 完成 `tiangong lifecyclemodel publish-resulting-process`。
 6. 把 `lifecyclemodel-resulting-process-builder` 改成薄 wrapper。
 7. 把 `lca-publish-executor` 收口到 `tiangong publish run`。
-8. 继续推进 `tiangong process publish-build`，把本地 run 交付面从遗留 workflow 收口到 CLI。
+8. 创建 follow-up skills child issue，把 `process-automated-builder` 切到 CLI-only 执行链。
 
 ## 10. 不应该做的事
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,10 +20,20 @@ import {
   type RunProcessAutoBuildOptions,
 } from './lib/process-auto-build.js';
 import {
+  runProcessBatchBuild,
+  type ProcessBatchBuildReport,
+  type RunProcessBatchBuildOptions,
+} from './lib/process-batch-build.js';
+import {
   runProcessResumeBuild,
   type ProcessResumeBuildReport,
   type RunProcessResumeBuildOptions,
 } from './lib/process-resume-build.js';
+import {
+  runProcessPublishBuild,
+  type ProcessPublishBuildReport,
+  type RunProcessPublishBuildOptions,
+} from './lib/process-publish-build.js';
 import { runPublish, type PublishReport, type RunPublishOptions } from './lib/publish.js';
 import { executeRemoteCommand, getRemoteCommandHelp } from './lib/remote.js';
 import {
@@ -47,9 +57,15 @@ export type CliDeps = {
   runProcessAutoBuildImpl?: (
     options: RunProcessAutoBuildOptions,
   ) => Promise<ProcessAutoBuildReport>;
+  runProcessBatchBuildImpl?: (
+    options: RunProcessBatchBuildOptions,
+  ) => Promise<ProcessBatchBuildReport>;
   runProcessResumeBuildImpl?: (
     options: RunProcessResumeBuildOptions,
   ) => Promise<ProcessResumeBuildReport>;
+  runProcessPublishBuildImpl?: (
+    options: RunProcessPublishBuildOptions,
+  ) => Promise<ProcessPublishBuildReport>;
 };
 
 export type CliResult = {
@@ -81,7 +97,7 @@ Commands:
 Implemented Commands:
   doctor     show environment diagnostics
   search     flow | process | lifecyclemodel
-  process    auto-build | resume-build
+  process    auto-build | resume-build | publish-build | batch-build
   lifecyclemodel build-resulting-process | publish-resulting-process
   publish    run
   validation run
@@ -92,7 +108,7 @@ Planned Surface (not implemented yet):
   lifecyclemodel auto-build | validate-build | publish-build
   review     flow | process
   flow       get | list | remediate | publish-version | regen-product
-  process    get | auto-build | resume-build | publish-build | batch-build
+  process    get
   job        get | wait | logs
 
 Planned commands currently print an explicit "not implemented yet" message and exit with code 2.
@@ -103,6 +119,8 @@ Examples:
   tiangong search process --input ./request.json --dry-run
   tiangong process auto-build --input ./pff-request.json
   tiangong process resume-build --run-id <id>
+  tiangong process publish-build --run-id <id>
+  tiangong process batch-build --input ./batch-request.json
   tiangong publish run --input ./publish-request.json --dry-run
   tiangong validation run --input-dir ./package --engine auto
   tiangong admin embedding-run --input ./jobs.json
@@ -249,6 +267,30 @@ Options:
 `.trim();
 }
 
+function renderProcessPublishBuildHelp(): string {
+  return `Usage:
+  tiangong process publish-build [--run-id <id>] [--run-dir <dir>] [options]
+
+Options:
+  --run-id <id>      Existing process build run id
+  --run-dir <dir>    Existing process build run directory
+  --json             Print compact JSON
+  -h, --help
+`.trim();
+}
+
+function renderProcessBatchBuildHelp(): string {
+  return `Usage:
+  tiangong process batch-build --input <file> [options]
+
+Options:
+  --input <file>     JSON batch manifest file
+  --out-dir <dir>    Override the batch artifact output directory
+  --json             Print compact JSON
+  -h, --help
+`.trim();
+}
+
 function renderProcessHelp(): string {
   return `Usage:
   tiangong process <subcommand> [options]
@@ -256,16 +298,18 @@ function renderProcessHelp(): string {
 Implemented Subcommands:
   auto-build   Prepare a local process-from-flow run scaffold and artifact workspace
   resume-build Prepare a local resume handoff from one existing process build run
+  publish-build Prepare publish handoff artifacts from one existing process build run
+  batch-build  Run multiple process auto-build requests through one batch-oriented CLI surface
 
 Planned Subcommands:
   get          Load one process dataset or process build run summary
-  publish-build Publish a process build run through the unified publish layer
-  batch-build  Run multiple process build requests through one batch-oriented CLI surface
 
 Examples:
   tiangong process --help
   tiangong process auto-build --help
   tiangong process resume-build --run-id <id> --help
+  tiangong process publish-build --run-id <id> --help
+  tiangong process batch-build --input ./batch-request.json --help
 `.trim();
 }
 
@@ -312,16 +356,6 @@ const processPlannedHelp = {
 Planned contract:
   - load one process dataset or process build run summary by identifier
   - keep read-only access distinct from build/publish workflows
-
-Status:
-  Planned command. Execution is not implemented yet.
-`.trim(),
-  'publish-build': `Usage:
-  tiangong process publish-build --run-id <id> [options]
-
-Planned contract:
-  - load one completed process build run
-  - generate publish handoff artifacts and later commit through the unified publish layer
 
 Status:
   Planned command. Execution is not implemented yet.
@@ -740,6 +774,74 @@ function parseProcessResumeBuildFlags(args: string[]): {
   };
 }
 
+function parseProcessPublishBuildFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  runId: string;
+  runDir: string | null;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        'run-id': { type: 'string' },
+        'run-dir': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    runId: typeof values['run-id'] === 'string' ? values['run-id'] : '',
+    runDir: typeof values['run-dir'] === 'string' ? values['run-dir'] : null,
+  };
+}
+
+function parseProcessBatchBuildFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  inputPath: string;
+  outDir: string | null;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        input: { type: 'string' },
+        'out-dir': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    inputPath: typeof values.input === 'string' ? values.input : '',
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : null,
+  };
+}
+
 function plannedCommand(command: string, subcommand?: string): CliResult {
   const suffix = subcommand ? ` ${subcommand}` : '';
   return {
@@ -772,7 +874,9 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
     const lifecyclemodelPublishImpl =
       deps.runLifecyclemodelPublishResultingProcessImpl ?? runLifecyclemodelPublishResultingProcess;
     const processAutoBuildImpl = deps.runProcessAutoBuildImpl ?? runProcessAutoBuild;
+    const processBatchBuildImpl = deps.runProcessBatchBuildImpl ?? runProcessBatchBuild;
     const processResumeBuildImpl = deps.runProcessResumeBuildImpl ?? runProcessResumeBuild;
+    const processPublishBuildImpl = deps.runProcessPublishBuildImpl ?? runProcessPublishBuild;
 
     if (flags.version) {
       return { exitCode: 0, stdout: '0.0.1\n', stderr: '' };
@@ -927,6 +1031,50 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
 
       return {
         exitCode: 0,
+        stdout: stringifyJson(report, processFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'process' && subcommand === 'publish-build') {
+      const processFlags = parseProcessPublishBuildFlags(commandArgs);
+      if (processFlags.help) {
+        return {
+          exitCode: 0,
+          stdout: `${renderProcessPublishBuildHelp()}\n`,
+          stderr: '',
+        };
+      }
+
+      const report = await processPublishBuildImpl({
+        runId: processFlags.runId || undefined,
+        runDir: processFlags.runDir,
+      });
+
+      return {
+        exitCode: 0,
+        stdout: stringifyJson(report, processFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'process' && subcommand === 'batch-build') {
+      const processFlags = parseProcessBatchBuildFlags(commandArgs);
+      if (processFlags.help) {
+        return {
+          exitCode: 0,
+          stdout: `${renderProcessBatchBuildHelp()}\n`,
+          stderr: '',
+        };
+      }
+
+      const report = await processBatchBuildImpl({
+        inputPath: processFlags.inputPath,
+        outDir: processFlags.outDir,
+      });
+
+      return {
+        exitCode: report.status === 'completed_with_failures' ? 1 : 0,
         stdout: stringifyJson(report, processFlags.json),
         stderr: '',
       };

--- a/src/lib/process-auto-build.ts
+++ b/src/lib/process-auto-build.ts
@@ -131,6 +131,9 @@ export type RunProcessAutoBuildOptions = {
   outDir?: string | null;
   now?: Date;
   cwd?: string;
+  inputValue?: unknown;
+  requestIdOverride?: string;
+  runIdOverride?: string;
 };
 
 type ProcessAutoBuildStage = {
@@ -883,7 +886,13 @@ function buildReport(
 
 export function normalizeProcessAutoBuildRequest(
   input: unknown,
-  options: { inputPath: string; outDir?: string | null; now?: Date },
+  options: {
+    inputPath: string;
+    outDir?: string | null;
+    now?: Date;
+    requestIdOverride?: string;
+    runIdOverride?: string;
+  },
 ): NormalizedProcessAutoBuildRequest {
   const request = requiredRequestObject(input);
   const requestDir = path.dirname(path.resolve(options.inputPath));
@@ -893,6 +902,7 @@ export function normalizeProcessAutoBuildRequest(
   const { flowDataset, wrapper } = extractFlowDatasetRoot(flowPayload);
   const flowSummary = extractFlowSummary(flowDataset, wrapper);
   const runId =
+    nonEmptyString(options.runIdOverride) ??
     nonEmptyString(request.run_id) ??
     buildProcessAutoBuildRunId(flowFile, operation, flowSummary, options.now);
   const runRoot = resolveRunRoot(requestDir, runId, options.outDir, request.workspace_run_root);
@@ -901,7 +911,10 @@ export function normalizeProcessAutoBuildRequest(
   return {
     schema_version: 1,
     request_path: path.resolve(options.inputPath),
-    request_id: nonEmptyString(request.request_id) ?? `pff-${runId}`,
+    request_id:
+      nonEmptyString(options.requestIdOverride) ??
+      nonEmptyString(request.request_id) ??
+      `pff-${runId}`,
     flow_file: flowFile,
     flow_summary: flowSummary,
     flow_dataset: flowDataset,
@@ -920,12 +933,14 @@ export function normalizeProcessAutoBuildRequest(
 export async function runProcessAutoBuild(
   options: RunProcessAutoBuildOptions,
 ): Promise<ProcessAutoBuildReport> {
-  const input = readJsonInput(options.inputPath);
+  const input = options.inputValue ?? readJsonInput(options.inputPath);
   const now = options.now ?? new Date();
   const normalized = normalizeProcessAutoBuildRequest(input, {
     inputPath: options.inputPath,
     outDir: options.outDir,
     now,
+    requestIdOverride: options.requestIdOverride,
+    runIdOverride: options.runIdOverride,
   });
   const layout = buildLayout(normalized.run_root, normalized.run_id);
   const flowArtifactPath = path.join(layout.inputsDir, path.basename(normalized.flow_file));

--- a/src/lib/process-batch-build.ts
+++ b/src/lib/process-batch-build.ts
@@ -1,0 +1,617 @@
+import { existsSync, mkdirSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { readJsonInput } from './io.js';
+import { writeJsonArtifact } from './artifacts.js';
+import { CliError, toErrorPayload, type ErrorPayload } from './errors.js';
+import {
+  normalizeProcessAutoBuildRequest,
+  runProcessAutoBuild,
+  type ProcessAutoBuildReport,
+} from './process-auto-build.js';
+import {
+  buildRunId,
+  buildRunManifest,
+  ensureRunLayout,
+  sanitizeRunToken,
+  writeLatestRunId,
+  type RunLayout,
+} from './run.js';
+
+type JsonRecord = Record<string, unknown>;
+
+type ProcessBatchBuildStatus = 'completed' | 'completed_with_failures';
+type ProcessBatchBuildItemStatus = 'prepared' | 'failed' | 'skipped';
+
+type ProcessBatchBuildManifestItem = {
+  item_id: string;
+  input_path: string;
+  out_dir: string;
+};
+
+export type ProcessBatchBuildLayout = RunLayout & {
+  requestDir: string;
+  runsDir: string;
+  requestSnapshotPath: string;
+  normalizedRequestPath: string;
+  invocationIndexPath: string;
+  runManifestPath: string;
+  reportPath: string;
+};
+
+export type NormalizedProcessBatchBuildRequest = {
+  schema_version: 1;
+  manifest_path: string;
+  batch_id: string;
+  batch_root: string;
+  continue_on_error: boolean;
+  items: ProcessBatchBuildManifestItem[];
+};
+
+export type ProcessBatchBuildItemReport = {
+  item_id: string;
+  index: number;
+  input_path: string;
+  out_dir: string;
+  status: ProcessBatchBuildItemStatus;
+  run_id: string | null;
+  run_root: string | null;
+  request_id: string | null;
+  files: {
+    request_snapshot: string | null;
+    report: string | null;
+    state: string | null;
+    handoff_summary: string | null;
+    run_manifest: string | null;
+  };
+  error: ErrorPayload['error'] | null;
+};
+
+export type ProcessBatchBuildReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: ProcessBatchBuildStatus;
+  manifest_path: string;
+  batch_id: string;
+  batch_root: string;
+  continue_on_error: boolean;
+  counts: {
+    total: number;
+    prepared: number;
+    failed: number;
+    skipped: number;
+  };
+  files: {
+    request_snapshot: string;
+    normalized_request: string;
+    invocation_index: string;
+    run_manifest: string;
+    report: string;
+  };
+  items: ProcessBatchBuildItemReport[];
+  next_actions: string[];
+};
+
+export type RunProcessBatchBuildOptions = {
+  inputPath: string;
+  outDir?: string | null;
+  now?: Date;
+  cwd?: string;
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized || null;
+}
+
+function normalizeBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function requiredRequestObject(input: unknown): JsonRecord {
+  if (!isRecord(input)) {
+    throw new CliError('process batch-build request must be a JSON object.', {
+      code: 'PROCESS_BATCH_BUILD_REQUEST_INVALID',
+      exitCode: 2,
+    });
+  }
+
+  return input;
+}
+
+function resolveBatchRoot(
+  manifestDir: string,
+  batchId: string,
+  outDirOverride: string | null | undefined,
+  requestOutDir: unknown,
+): string {
+  const override = nonEmptyString(outDirOverride);
+  if (override) {
+    return path.resolve(manifestDir, override);
+  }
+
+  const requestValue = nonEmptyString(requestOutDir);
+  if (requestValue) {
+    return path.resolve(manifestDir, requestValue);
+  }
+
+  return path.join(manifestDir, 'artifacts', 'process_batch', batchId);
+}
+
+function buildLayout(batchRoot: string, batchId: string): ProcessBatchBuildLayout {
+  const collectionDir = path.dirname(batchRoot);
+  const layout: RunLayout = {
+    namespace: 'process_batch',
+    runId: batchId,
+    artifactsRoot: path.dirname(collectionDir),
+    collectionDir,
+    runRoot: batchRoot,
+    cacheDir: path.join(batchRoot, 'cache'),
+    inputsDir: path.join(batchRoot, 'request'),
+    outputsDir: path.join(batchRoot, 'runs'),
+    reportsDir: path.join(batchRoot, 'reports'),
+    logsDir: path.join(batchRoot, 'logs'),
+    manifestsDir: path.join(batchRoot, 'manifests'),
+    latestRunIdPath: path.join(collectionDir, '.latest_run_id'),
+  };
+
+  return {
+    ...layout,
+    requestDir: path.join(batchRoot, 'request'),
+    runsDir: path.join(batchRoot, 'runs'),
+    requestSnapshotPath: path.join(batchRoot, 'request', 'batch-request.json'),
+    normalizedRequestPath: path.join(batchRoot, 'request', 'request.normalized.json'),
+    invocationIndexPath: path.join(batchRoot, 'manifests', 'invocation-index.json'),
+    runManifestPath: path.join(batchRoot, 'manifests', 'run-manifest.json'),
+    reportPath: path.join(batchRoot, 'reports', 'process-batch-build-report.json'),
+  };
+}
+
+function ensureEmptyRunRoot(runRoot: string): void {
+  if (!existsSync(runRoot)) {
+    return;
+  }
+
+  const entries = readdirSync(runRoot);
+  if (entries.length > 0) {
+    throw new CliError(`process batch-build run root already exists and is not empty: ${runRoot}`, {
+      code: 'PROCESS_BATCH_BUILD_RUN_EXISTS',
+      exitCode: 2,
+    });
+  }
+}
+
+function ensureProcessBatchBuildLayout(layout: ProcessBatchBuildLayout): void {
+  ensureRunLayout(layout);
+  [layout.requestDir, layout.runsDir].forEach((dirPath) => {
+    mkdirSync(dirPath, { recursive: true });
+  });
+}
+
+function normalizeBatchId(inputPath: string, request: JsonRecord, now: Date): string {
+  const explicit = nonEmptyString(request.batch_id);
+  if (explicit) {
+    return explicit;
+  }
+
+  return buildRunId({
+    namespace: 'process_batch',
+    subject: path.basename(inputPath, path.extname(inputPath)),
+    operation: 'build',
+    now,
+  });
+}
+
+function normalizeItemId(
+  request: JsonRecord,
+  inputPath: string,
+  index: number,
+  seenIds: Set<string>,
+): string {
+  const explicit = nonEmptyString(request.item_id);
+  const baseId = sanitizeRunToken(
+    explicit ?? path.basename(inputPath, path.extname(inputPath)),
+    `item_${index + 1}`,
+  );
+
+  if (explicit) {
+    if (seenIds.has(baseId)) {
+      throw new CliError(`Duplicate process batch-build item_id: ${baseId}`, {
+        code: 'PROCESS_BATCH_BUILD_ITEM_DUPLICATE',
+        exitCode: 2,
+      });
+    }
+
+    seenIds.add(baseId);
+    return baseId;
+  }
+
+  if (!seenIds.has(baseId)) {
+    seenIds.add(baseId);
+    return baseId;
+  }
+
+  let suffix = 2;
+  while (seenIds.has(`${baseId}_${suffix}`)) {
+    suffix += 1;
+  }
+
+  const deduped = `${baseId}_${suffix}`;
+  seenIds.add(deduped);
+  return deduped;
+}
+
+function normalizeItems(
+  value: unknown,
+  manifestDir: string,
+  batchRoot: string,
+): ProcessBatchBuildManifestItem[] {
+  if (!Array.isArray(value)) {
+    throw new CliError('process batch-build items must be an array.', {
+      code: 'PROCESS_BATCH_BUILD_REQUEST_INVALID',
+      exitCode: 2,
+    });
+  }
+
+  if (value.length === 0) {
+    throw new CliError('process batch-build items must not be empty.', {
+      code: 'PROCESS_BATCH_BUILD_REQUEST_INVALID',
+      exitCode: 2,
+    });
+  }
+
+  const seenIds = new Set<string>();
+
+  return value.map((entry, index) => {
+    const request = typeof entry === 'string' ? { input_path: entry } : entry;
+    if (!isRecord(request)) {
+      throw new CliError('process batch-build items entries must be strings or objects.', {
+        code: 'PROCESS_BATCH_BUILD_REQUEST_INVALID',
+        exitCode: 2,
+        details: { index },
+      });
+    }
+
+    const inputValue = nonEmptyString(request.input_path);
+    if (!inputValue) {
+      throw new CliError("process batch-build items[] is missing 'input_path'.", {
+        code: 'PROCESS_BATCH_BUILD_REQUEST_INVALID',
+        exitCode: 2,
+        details: { index },
+      });
+    }
+
+    const inputPath = path.resolve(manifestDir, inputValue);
+    const itemId = normalizeItemId(request, inputPath, index, seenIds);
+    const explicitOutDir = nonEmptyString(request.out_dir);
+    const outDir = explicitOutDir
+      ? path.resolve(manifestDir, explicitOutDir)
+      : path.join(batchRoot, 'runs', `${String(index + 1).padStart(3, '0')}_${itemId}`);
+
+    return {
+      item_id: itemId,
+      input_path: inputPath,
+      out_dir: outDir,
+    };
+  });
+}
+
+export function normalizeProcessBatchBuildRequest(
+  input: unknown,
+  options: {
+    inputPath: string;
+    outDir?: string | null;
+    now?: Date;
+  },
+): NormalizedProcessBatchBuildRequest {
+  const request = requiredRequestObject(input);
+  const manifestPath = path.resolve(options.inputPath);
+  const manifestDir = path.dirname(manifestPath);
+  const now = options.now ?? new Date();
+  const batchId = normalizeBatchId(manifestPath, request, now);
+  const batchRoot = resolveBatchRoot(manifestDir, batchId, options.outDir, request.out_dir);
+
+  return {
+    schema_version: 1,
+    manifest_path: manifestPath,
+    batch_id: batchId,
+    batch_root: batchRoot,
+    continue_on_error: normalizeBoolean(request.continue_on_error, true),
+    items: normalizeItems(request.items, manifestDir, batchRoot),
+  };
+}
+
+function buildInvocationIndex(
+  normalized: NormalizedProcessBatchBuildRequest,
+  options: RunProcessBatchBuildOptions,
+  layout: ProcessBatchBuildLayout,
+  now: Date,
+): JsonRecord {
+  const command = ['process', 'batch-build', '--input', options.inputPath];
+  if (options.outDir) {
+    command.push('--out-dir', options.outDir);
+  }
+
+  return {
+    schema_version: 1,
+    invocations: [
+      {
+        command,
+        cwd: options.cwd ?? process.cwd(),
+        created_at: now.toISOString(),
+        manifest_path: normalized.manifest_path,
+        batch_id: normalized.batch_id,
+        report_path: layout.reportPath,
+      },
+    ],
+  };
+}
+
+function buildNextActions(layout: ProcessBatchBuildLayout): string[] {
+  return [
+    `inspect: ${layout.normalizedRequestPath}`,
+    `inspect: ${layout.reportPath}`,
+    `future: consume items[].run_root for downstream resume-build or publish-build steps`,
+  ];
+}
+
+function buildPreparedItemResult(
+  item: ProcessBatchBuildManifestItem,
+  index: number,
+  report: ProcessAutoBuildReport,
+): ProcessBatchBuildItemReport {
+  return {
+    item_id: item.item_id,
+    index,
+    input_path: item.input_path,
+    out_dir: item.out_dir,
+    status: 'prepared',
+    run_id: report.run_id,
+    run_root: report.run_root,
+    request_id: report.request_id,
+    files: {
+      request_snapshot: report.files.request_snapshot,
+      report: report.files.report,
+      state: report.files.state,
+      handoff_summary: report.files.handoff_summary,
+      run_manifest: report.files.run_manifest,
+    },
+    error: null,
+  };
+}
+
+function buildFailedItemResult(
+  item: ProcessBatchBuildManifestItem,
+  index: number,
+  error: unknown,
+): ProcessBatchBuildItemReport {
+  return {
+    item_id: item.item_id,
+    index,
+    input_path: item.input_path,
+    out_dir: item.out_dir,
+    status: 'failed',
+    run_id: null,
+    run_root: null,
+    request_id: null,
+    files: {
+      request_snapshot: null,
+      report: null,
+      state: null,
+      handoff_summary: null,
+      run_manifest: null,
+    },
+    error: toErrorPayload(error).error,
+  };
+}
+
+function buildSkippedItemResult(
+  item: ProcessBatchBuildManifestItem,
+  index: number,
+): ProcessBatchBuildItemReport {
+  return {
+    item_id: item.item_id,
+    index,
+    input_path: item.input_path,
+    out_dir: item.out_dir,
+    status: 'skipped',
+    run_id: null,
+    run_root: null,
+    request_id: null,
+    files: {
+      request_snapshot: null,
+      report: null,
+      state: null,
+      handoff_summary: null,
+      run_manifest: null,
+    },
+    error: null,
+  };
+}
+
+function buildReport(
+  normalized: NormalizedProcessBatchBuildRequest,
+  layout: ProcessBatchBuildLayout,
+  items: ProcessBatchBuildItemReport[],
+  now: Date,
+): ProcessBatchBuildReport {
+  const counts = items.reduce(
+    (summary, item) => {
+      summary.total += 1;
+      if (item.status === 'prepared') {
+        summary.prepared += 1;
+      } else if (item.status === 'failed') {
+        summary.failed += 1;
+      } else {
+        summary.skipped += 1;
+      }
+
+      return summary;
+    },
+    {
+      total: 0,
+      prepared: 0,
+      failed: 0,
+      skipped: 0,
+    },
+  );
+
+  return {
+    schema_version: 1,
+    generated_at_utc: now.toISOString(),
+    status: counts.failed > 0 ? 'completed_with_failures' : 'completed',
+    manifest_path: normalized.manifest_path,
+    batch_id: normalized.batch_id,
+    batch_root: normalized.batch_root,
+    continue_on_error: normalized.continue_on_error,
+    counts,
+    files: {
+      request_snapshot: layout.requestSnapshotPath,
+      normalized_request: layout.normalizedRequestPath,
+      invocation_index: layout.invocationIndexPath,
+      run_manifest: layout.runManifestPath,
+      report: layout.reportPath,
+    },
+    items,
+    next_actions: buildNextActions(layout),
+  };
+}
+
+function resolveItemOverrides(
+  itemInput: unknown,
+  item: ProcessBatchBuildManifestItem,
+  index: number,
+  now: Date,
+): {
+  runIdOverride?: string;
+  requestIdOverride?: string;
+  finalRunId: string | null;
+} {
+  if (!isRecord(itemInput)) {
+    return {
+      finalRunId: null,
+    };
+  }
+
+  const explicitRunId = nonEmptyString(itemInput.run_id);
+  const explicitRequestId = nonEmptyString(itemInput.request_id);
+  if (explicitRunId) {
+    return {
+      finalRunId: explicitRunId,
+      requestIdOverride: explicitRequestId ? undefined : `pff-${explicitRunId}`,
+    };
+  }
+
+  const preview = normalizeProcessAutoBuildRequest(itemInput, {
+    inputPath: item.input_path,
+    outDir: item.out_dir,
+    now,
+  });
+  const runIdOverride = `${preview.run_id}_b${String(index + 1).padStart(3, '0')}`;
+
+  return {
+    runIdOverride,
+    requestIdOverride: explicitRequestId ?? `pff-${runIdOverride}`,
+    finalRunId: runIdOverride,
+  };
+}
+
+export async function runProcessBatchBuild(
+  options: RunProcessBatchBuildOptions,
+): Promise<ProcessBatchBuildReport> {
+  const input = readJsonInput(options.inputPath);
+  const now = options.now ?? new Date();
+  const normalized = normalizeProcessBatchBuildRequest(input, {
+    inputPath: options.inputPath,
+    outDir: options.outDir,
+    now,
+  });
+  const layout = buildLayout(normalized.batch_root, normalized.batch_id);
+
+  ensureEmptyRunRoot(layout.runRoot);
+  ensureProcessBatchBuildLayout(layout);
+
+  writeJsonArtifact(layout.requestSnapshotPath, input);
+  writeJsonArtifact(layout.normalizedRequestPath, normalized);
+  writeJsonArtifact(
+    layout.invocationIndexPath,
+    buildInvocationIndex(normalized, options, layout, now),
+  );
+  writeJsonArtifact(
+    layout.runManifestPath,
+    buildRunManifest({
+      layout,
+      command: options.outDir
+        ? ['process', 'batch-build', '--input', options.inputPath, '--out-dir', options.outDir]
+        : ['process', 'batch-build', '--input', options.inputPath],
+      cwd: options.cwd,
+      createdAt: now,
+    }),
+  );
+
+  const seenRunIds = new Set<string>();
+  const items: ProcessBatchBuildItemReport[] = [];
+  let stopAfterFailure = false;
+
+  for (const [index, item] of normalized.items.entries()) {
+    if (stopAfterFailure) {
+      items.push(buildSkippedItemResult(item, index));
+      continue;
+    }
+
+    try {
+      const itemInput = readJsonInput(item.input_path);
+      const overrides = resolveItemOverrides(itemInput, item, index, now);
+
+      if (overrides.finalRunId && seenRunIds.has(overrides.finalRunId)) {
+        throw new CliError(`Duplicate process batch-build run_id: ${overrides.finalRunId}`, {
+          code: 'PROCESS_BATCH_BUILD_RUN_ID_DUPLICATE',
+          exitCode: 2,
+          details: { itemId: item.item_id, index },
+        });
+      }
+
+      if (overrides.finalRunId) {
+        seenRunIds.add(overrides.finalRunId);
+      }
+
+      const report = await runProcessAutoBuild({
+        inputPath: item.input_path,
+        inputValue: itemInput,
+        outDir: item.out_dir,
+        now,
+        cwd: options.cwd,
+        requestIdOverride: overrides.requestIdOverride,
+        runIdOverride: overrides.runIdOverride,
+      });
+      items.push(buildPreparedItemResult(item, index, report));
+    } catch (error) {
+      items.push(buildFailedItemResult(item, index, error));
+      if (!normalized.continue_on_error) {
+        stopAfterFailure = true;
+      }
+    }
+  }
+
+  const report = buildReport(normalized, layout, items, now);
+  writeJsonArtifact(layout.reportPath, report);
+  writeLatestRunId(layout, normalized.batch_id);
+  return report;
+}
+
+export const __testInternals = {
+  buildLayout,
+  resolveBatchRoot,
+  normalizeItems,
+  normalizeProcessBatchBuildRequest,
+  buildInvocationIndex,
+  buildNextActions,
+  buildReport,
+};

--- a/src/lib/process-publish-build.ts
+++ b/src/lib/process-publish-build.ts
@@ -1,0 +1,684 @@
+import { existsSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { readJsonArtifact, writeJsonArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+import { normalizePublishRequest } from './publish.js';
+import { withStateFileLock } from './state-lock.js';
+
+type JsonRecord = Record<string, unknown>;
+
+type DatasetOrigin = 'exports' | 'state';
+
+export type ProcessPublishBuildLayout = {
+  runId: string;
+  runRoot: string;
+  collectionDir: string;
+  cacheDir: string;
+  manifestsDir: string;
+  reportsDir: string;
+  processExportsDir: string;
+  sourceExportsDir: string;
+  publishStageDir: string;
+  statePath: string;
+  handoffSummaryPath: string;
+  runManifestPath: string;
+  invocationIndexPath: string;
+  publishBundlePath: string;
+  publishRequestPath: string;
+  publishIntentPath: string;
+  reportPath: string;
+};
+
+export type ProcessPublishBuildReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: 'prepared_local_process_publish_bundle';
+  run_id: string;
+  run_root: string;
+  request_id: string | null;
+  state_summary: {
+    build_status: string | null;
+    next_stage: string | null;
+    stop_after: string | null;
+  };
+  dataset_origins: {
+    processes: DatasetOrigin;
+    sources: DatasetOrigin;
+  };
+  counts: {
+    processes: number;
+    sources: number;
+    relations: number;
+  };
+  publish_defaults: {
+    commit: boolean;
+    publish_lifecyclemodels: boolean;
+    publish_processes: boolean;
+    publish_sources: boolean;
+    publish_relations: boolean;
+    publish_process_build_runs: boolean;
+    relation_mode: 'local_manifest_only';
+  };
+  files: {
+    state: string;
+    handoff_summary: string;
+    run_manifest: string;
+    invocation_index: string;
+    publish_bundle: string;
+    publish_request: string;
+    publish_intent: string;
+    report: string;
+  };
+  next_actions: string[];
+};
+
+export type RunProcessPublishBuildOptions = {
+  runId?: string;
+  runDir?: string | null;
+  now?: Date;
+  cwd?: string;
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized || null;
+}
+
+function copyJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function readRequiredJsonObject(
+  filePath: string,
+  missingCode: string,
+  invalidCode: string,
+  label: string,
+): JsonRecord {
+  if (!existsSync(filePath)) {
+    throw new CliError(`Required process publish artifact not found: ${filePath}`, {
+      code: missingCode,
+      exitCode: 2,
+      details: { label, filePath },
+    });
+  }
+
+  const value = readJsonArtifact(filePath);
+  if (!isRecord(value)) {
+    throw new CliError(`Expected process publish artifact JSON object: ${filePath}`, {
+      code: invalidCode,
+      exitCode: 2,
+      details: { label, filePath },
+    });
+  }
+
+  return value;
+}
+
+function buildLayout(runRoot: string, runId: string): ProcessPublishBuildLayout {
+  return {
+    runId,
+    runRoot,
+    collectionDir: path.dirname(runRoot),
+    cacheDir: path.join(runRoot, 'cache'),
+    manifestsDir: path.join(runRoot, 'manifests'),
+    reportsDir: path.join(runRoot, 'reports'),
+    processExportsDir: path.join(runRoot, 'exports', 'processes'),
+    sourceExportsDir: path.join(runRoot, 'exports', 'sources'),
+    publishStageDir: path.join(runRoot, 'stage_outputs', '10_publish'),
+    statePath: path.join(runRoot, 'cache', 'process_from_flow_state.json'),
+    handoffSummaryPath: path.join(runRoot, 'cache', 'agent_handoff_summary.json'),
+    runManifestPath: path.join(runRoot, 'manifests', 'run-manifest.json'),
+    invocationIndexPath: path.join(runRoot, 'manifests', 'invocation-index.json'),
+    publishBundlePath: path.join(runRoot, 'stage_outputs', '10_publish', 'publish-bundle.json'),
+    publishRequestPath: path.join(runRoot, 'stage_outputs', '10_publish', 'publish-request.json'),
+    publishIntentPath: path.join(runRoot, 'stage_outputs', '10_publish', 'publish-intent.json'),
+    reportPath: path.join(runRoot, 'reports', 'process-publish-build-report.json'),
+  };
+}
+
+function resolveLayout(options: RunProcessPublishBuildOptions): ProcessPublishBuildLayout {
+  const runId = nonEmptyString(options.runId);
+  const runDir = nonEmptyString(options.runDir);
+
+  if (!runId && !runDir) {
+    throw new CliError('Missing required --run-id or --run-dir for process publish-build.', {
+      code: 'PROCESS_PUBLISH_RUN_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  const runRoot = runDir
+    ? path.resolve(runDir)
+    : path.resolve('artifacts', 'process_from_flow', runId as string);
+  const derivedRunId = path.basename(runRoot);
+
+  if (runDir && runId && derivedRunId !== runId) {
+    throw new CliError(
+      `process publish-build run-id does not match run-dir basename: ${runId} !== ${derivedRunId}`,
+      {
+        code: 'PROCESS_PUBLISH_RUN_ID_MISMATCH',
+        exitCode: 2,
+      },
+    );
+  }
+
+  return buildLayout(runRoot, runId ?? derivedRunId);
+}
+
+function ensureRunRootExists(layout: ProcessPublishBuildLayout): void {
+  if (!existsSync(layout.runRoot)) {
+    throw new CliError(`process publish-build run root not found: ${layout.runRoot}`, {
+      code: 'PROCESS_PUBLISH_RUN_NOT_FOUND',
+      exitCode: 2,
+    });
+  }
+}
+
+function readRequiredRunManifest(layout: ProcessPublishBuildLayout): JsonRecord {
+  const manifest = readRequiredJsonObject(
+    layout.runManifestPath,
+    'PROCESS_PUBLISH_RUN_MANIFEST_MISSING',
+    'PROCESS_PUBLISH_RUN_MANIFEST_INVALID',
+    'run-manifest',
+  );
+
+  const manifestRunId = nonEmptyString(manifest.runId);
+  if (manifestRunId && manifestRunId !== layout.runId) {
+    throw new CliError(
+      `process publish-build run manifest runId mismatch: ${layout.runManifestPath}`,
+      {
+        code: 'PROCESS_PUBLISH_RUN_MANIFEST_MISMATCH',
+        exitCode: 2,
+        details: {
+          expected: layout.runId,
+          actual: manifestRunId,
+        },
+      },
+    );
+  }
+
+  return manifest;
+}
+
+function readRequiredState(layout: ProcessPublishBuildLayout): JsonRecord {
+  const state = readRequiredJsonObject(
+    layout.statePath,
+    'PROCESS_PUBLISH_STATE_MISSING',
+    'PROCESS_PUBLISH_STATE_INVALID',
+    'state',
+  );
+
+  const stateRunId = nonEmptyString(state.run_id);
+  if (stateRunId && stateRunId !== layout.runId) {
+    throw new CliError(`process publish-build state run_id mismatch: ${layout.statePath}`, {
+      code: 'PROCESS_PUBLISH_STATE_RUN_ID_MISMATCH',
+      exitCode: 2,
+      details: {
+        expected: layout.runId,
+        actual: stateRunId,
+      },
+    });
+  }
+
+  return state;
+}
+
+function readRequiredHandoffSummary(layout: ProcessPublishBuildLayout): JsonRecord {
+  return readRequiredJsonObject(
+    layout.handoffSummaryPath,
+    'PROCESS_PUBLISH_HANDOFF_MISSING',
+    'PROCESS_PUBLISH_HANDOFF_INVALID',
+    'handoff-summary',
+  );
+}
+
+function readInvocationIndex(layout: ProcessPublishBuildLayout): JsonRecord {
+  if (!existsSync(layout.invocationIndexPath)) {
+    return {
+      schema_version: 1,
+      invocations: [],
+    };
+  }
+
+  const value = readJsonArtifact(layout.invocationIndexPath);
+  if (!isRecord(value)) {
+    throw new CliError(
+      `Expected process publish invocation index JSON object: ${layout.invocationIndexPath}`,
+      {
+        code: 'PROCESS_PUBLISH_INVOCATION_INDEX_INVALID',
+        exitCode: 2,
+      },
+    );
+  }
+
+  if (value.invocations === undefined) {
+    return {
+      schema_version: 1,
+      invocations: [],
+    };
+  }
+
+  if (!Array.isArray(value.invocations)) {
+    throw new CliError(
+      `Expected process publish invocation index to contain an invocations array: ${layout.invocationIndexPath}`,
+      {
+        code: 'PROCESS_PUBLISH_INVOCATION_INDEX_INVALID',
+        exitCode: 2,
+      },
+    );
+  }
+
+  return value;
+}
+
+function buildStateSummary(state: JsonRecord): ProcessPublishBuildReport['state_summary'] {
+  return {
+    build_status: nonEmptyString(state.build_status),
+    next_stage: nonEmptyString(state.next_stage),
+    stop_after: nonEmptyString(state.stop_after),
+  };
+}
+
+function readDatasetArrayFromState(
+  state: JsonRecord,
+  key: 'process_datasets' | 'source_datasets',
+): JsonRecord[] {
+  if (state[key] === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(state[key])) {
+    throw new CliError(`process publish-build expected state.${key} to be an array.`, {
+      code: 'PROCESS_PUBLISH_STATE_DATASETS_INVALID',
+      exitCode: 2,
+      details: { key },
+    });
+  }
+
+  return state[key].map((item, index) => {
+    if (!isRecord(item)) {
+      throw new CliError(`process publish-build expected state.${key}[${index}] to be an object.`, {
+        code: 'PROCESS_PUBLISH_STATE_DATASETS_INVALID',
+        exitCode: 2,
+        details: { key, index },
+      });
+    }
+
+    return item;
+  });
+}
+
+function readDatasetDir(dirPath: string, label: string): JsonRecord[] {
+  if (!existsSync(dirPath)) {
+    return [];
+  }
+
+  return readdirSync(dirPath)
+    .filter((entry) => entry.endsWith('.json'))
+    .sort()
+    .map((entry) => {
+      const filePath = path.join(dirPath, entry);
+      const value = readJsonArtifact(filePath);
+      if (!isRecord(value)) {
+        throw new CliError(`Expected ${label} export JSON object: ${filePath}`, {
+          code: 'PROCESS_PUBLISH_EXPORT_INVALID',
+          exitCode: 2,
+          details: { label, filePath },
+        });
+      }
+
+      return value;
+    });
+}
+
+function collectCanonicalDatasets(
+  layout: ProcessPublishBuildLayout,
+  state: JsonRecord,
+): {
+  processes: JsonRecord[];
+  processOrigin: DatasetOrigin;
+  sources: JsonRecord[];
+  sourceOrigin: DatasetOrigin;
+} {
+  const processExports = readDatasetDir(layout.processExportsDir, 'process');
+  const sourceExports = readDatasetDir(layout.sourceExportsDir, 'source');
+
+  const stateProcesses = readDatasetArrayFromState(state, 'process_datasets');
+  const stateSources = readDatasetArrayFromState(state, 'source_datasets');
+
+  return {
+    processes: processExports.length > 0 ? processExports : stateProcesses,
+    processOrigin: processExports.length > 0 ? 'exports' : 'state',
+    sources: sourceExports.length > 0 ? sourceExports : stateSources,
+    sourceOrigin: sourceExports.length > 0 ? 'exports' : 'state',
+  };
+}
+
+function updateStepMarkers(stepMarkers: unknown, completedAt: string): JsonRecord {
+  const markers = isRecord(stepMarkers) ? { ...stepMarkers } : {};
+  markers.publish_handoff_prepared = {
+    status: 'completed',
+    completed_at: completedAt,
+  };
+  return markers;
+}
+
+function buildUpdatedState(
+  state: JsonRecord,
+  layout: ProcessPublishBuildLayout,
+  counts: ProcessPublishBuildReport['counts'],
+  datasetOrigins: ProcessPublishBuildReport['dataset_origins'],
+  now: Date,
+): JsonRecord {
+  return {
+    ...state,
+    publish_build_requested_at: now.toISOString(),
+    last_publish_build: {
+      status: 'prepared_local_process_publish_bundle',
+      prepared_at: now.toISOString(),
+      publish_bundle_path: layout.publishBundlePath,
+      publish_request_path: layout.publishRequestPath,
+      publish_intent_path: layout.publishIntentPath,
+      process_count: counts.processes,
+      source_count: counts.sources,
+      relation_count: counts.relations,
+      dataset_origins: datasetOrigins,
+    },
+    step_markers: updateStepMarkers(state.step_markers, now.toISOString()),
+  };
+}
+
+function buildInvocationIndex(
+  layout: ProcessPublishBuildLayout,
+  invocationIndex: JsonRecord,
+  options: RunProcessPublishBuildOptions,
+  now: Date,
+): JsonRecord {
+  const priorInvocations = Array.isArray(invocationIndex.invocations)
+    ? [...invocationIndex.invocations]
+    : [];
+  const command = ['process', 'publish-build'];
+
+  if (options.runId) {
+    command.push('--run-id', options.runId);
+  }
+  if (options.runDir) {
+    command.push('--run-dir', options.runDir);
+  }
+
+  return {
+    ...invocationIndex,
+    schema_version:
+      typeof invocationIndex.schema_version === 'number' ? invocationIndex.schema_version : 1,
+    invocations: [
+      ...priorInvocations,
+      {
+        command,
+        cwd: options.cwd ?? process.cwd(),
+        created_at: now.toISOString(),
+        run_id: layout.runId,
+        run_root: layout.runRoot,
+        report_path: layout.reportPath,
+        publish_request_path: layout.publishRequestPath,
+      },
+    ],
+  };
+}
+
+function buildPublishBundle(
+  layout: ProcessPublishBuildLayout,
+  state: JsonRecord,
+  runManifest: JsonRecord,
+  processes: JsonRecord[],
+  sources: JsonRecord[],
+  counts: ProcessPublishBuildReport['counts'],
+  datasetOrigins: ProcessPublishBuildReport['dataset_origins'],
+  now: Date,
+): JsonRecord {
+  return {
+    generated_at_utc: now.toISOString(),
+    run_id: layout.runId,
+    run_root: layout.runRoot,
+    request_id: nonEmptyString(state.request_id),
+    status: 'prepared_local_process_publish_bundle',
+    counts,
+    dataset_origins: datasetOrigins,
+    source_run: {
+      build_status: nonEmptyString(state.build_status),
+      next_stage: nonEmptyString(state.next_stage),
+      stop_after: nonEmptyString(state.stop_after),
+      run_manifest: copyJson(runManifest),
+    },
+    processes: copyJson(processes),
+    sources: copyJson(sources),
+    relations: [],
+  };
+}
+
+function buildPublishRequest(): JsonRecord {
+  return {
+    inputs: {
+      bundle_paths: ['./publish-bundle.json'],
+    },
+    publish: {
+      commit: false,
+      publish_lifecyclemodels: false,
+      publish_processes: true,
+      publish_sources: true,
+      publish_relations: true,
+      publish_process_build_runs: false,
+      relation_mode: 'local_manifest_only',
+    },
+    out_dir: './publish-run',
+  };
+}
+
+function buildPublishIntent(
+  layout: ProcessPublishBuildLayout,
+  counts: ProcessPublishBuildReport['counts'],
+): JsonRecord {
+  return {
+    ok: true,
+    command: 'publish run',
+    input_path: layout.publishRequestPath,
+    run_id: layout.runId,
+    run_root: layout.runRoot,
+    status: 'prepared_local_process_publish_bundle',
+    process_count: counts.processes,
+    source_count: counts.sources,
+    relation_count: counts.relations,
+  };
+}
+
+function buildNextActions(layout: ProcessPublishBuildLayout): string[] {
+  return [
+    `inspect: ${layout.publishBundlePath}`,
+    `inspect: ${layout.publishRequestPath}`,
+    `run: tiangong publish run --input ${layout.publishRequestPath}`,
+    'future: wire publish executors before remote commit mode is expected',
+  ];
+}
+
+function stateArrayLength(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+function buildAgentHandoffSummary(
+  layout: ProcessPublishBuildLayout,
+  state: JsonRecord,
+  counts: ProcessPublishBuildReport['counts'],
+  now: Date,
+): JsonRecord {
+  return {
+    schema_version: 1,
+    generated_at_utc: now.toISOString(),
+    run_id: layout.runId,
+    command: 'process publish-build',
+    flow_path: nonEmptyString(state.flow_path),
+    operation: nonEmptyString(state.operation),
+    stop_after: nonEmptyString(state.stop_after),
+    process_count: counts.processes,
+    matched_exchange_count: stateArrayLength(state.matched_process_exchanges),
+    process_dataset_count: counts.processes,
+    source_dataset_count: counts.sources,
+    remaining_placeholder_refs: stateArrayLength(state.placeholder_resolutions),
+    placeholder_examples: [],
+    publish_summary: {},
+    artifacts: {
+      state_path: layout.statePath,
+      publish_bundle: layout.publishBundlePath,
+      publish_request: layout.publishRequestPath,
+      publish_intent: layout.publishIntentPath,
+      process_update_report: null,
+      flow_auto_build_manifest: null,
+      publish_summary: null,
+      timing_report: null,
+      llm_cost_report: null,
+    },
+    next_actions: buildNextActions(layout),
+    extra: {
+      status: 'prepared_local_process_publish_bundle',
+      request_id: nonEmptyString(state.request_id),
+    },
+  };
+}
+
+function buildReport(
+  layout: ProcessPublishBuildLayout,
+  state: JsonRecord,
+  counts: ProcessPublishBuildReport['counts'],
+  datasetOrigins: ProcessPublishBuildReport['dataset_origins'],
+  publishDefaults: ProcessPublishBuildReport['publish_defaults'],
+  now: Date,
+): ProcessPublishBuildReport {
+  return {
+    schema_version: 1,
+    generated_at_utc: now.toISOString(),
+    status: 'prepared_local_process_publish_bundle',
+    run_id: layout.runId,
+    run_root: layout.runRoot,
+    request_id: nonEmptyString(state.request_id),
+    state_summary: buildStateSummary(state),
+    dataset_origins: datasetOrigins,
+    counts,
+    publish_defaults: publishDefaults,
+    files: {
+      state: layout.statePath,
+      handoff_summary: layout.handoffSummaryPath,
+      run_manifest: layout.runManifestPath,
+      invocation_index: layout.invocationIndexPath,
+      publish_bundle: layout.publishBundlePath,
+      publish_request: layout.publishRequestPath,
+      publish_intent: layout.publishIntentPath,
+      report: layout.reportPath,
+    },
+    next_actions: buildNextActions(layout),
+  };
+}
+
+export async function runProcessPublishBuild(
+  options: RunProcessPublishBuildOptions,
+): Promise<ProcessPublishBuildReport> {
+  const now = options.now ?? new Date();
+  const layout = resolveLayout(options);
+  ensureRunRootExists(layout);
+  const runManifest = readRequiredRunManifest(layout);
+  readRequiredHandoffSummary(layout);
+  const invocationIndex = readInvocationIndex(layout);
+
+  return await withStateFileLock(
+    layout.statePath,
+    { reason: 'process-publish-build.prepare_publish', now },
+    () => {
+      const state = readRequiredState(layout);
+      const datasets = collectCanonicalDatasets(layout, state);
+
+      if (datasets.processes.length === 0) {
+        throw new CliError(
+          'process publish-build run does not contain any process datasets to publish.',
+          {
+            code: 'PROCESS_PUBLISH_PROCESSES_MISSING',
+            exitCode: 2,
+          },
+        );
+      }
+
+      const counts: ProcessPublishBuildReport['counts'] = {
+        processes: datasets.processes.length,
+        sources: datasets.sources.length,
+        relations: 0,
+      };
+      const datasetOrigins: ProcessPublishBuildReport['dataset_origins'] = {
+        processes: datasets.processOrigin,
+        sources: datasets.sourceOrigin,
+      };
+      const publishBundle = buildPublishBundle(
+        layout,
+        state,
+        runManifest,
+        datasets.processes,
+        datasets.sources,
+        counts,
+        datasetOrigins,
+        now,
+      );
+      const publishRequest = buildPublishRequest();
+      const normalizedPublishRequest = normalizePublishRequest(publishRequest, {
+        requestPath: layout.publishRequestPath,
+        now,
+      });
+      const publishIntent = buildPublishIntent(layout, counts);
+      const updatedState = buildUpdatedState(state, layout, counts, datasetOrigins, now);
+      const updatedInvocationIndex = buildInvocationIndex(layout, invocationIndex, options, now);
+      const handoffSummary = buildAgentHandoffSummary(layout, updatedState, counts, now);
+      const report = buildReport(
+        layout,
+        updatedState,
+        counts,
+        datasetOrigins,
+        {
+          commit: normalizedPublishRequest.publish.commit,
+          publish_lifecyclemodels: normalizedPublishRequest.publish.publish_lifecyclemodels,
+          publish_processes: normalizedPublishRequest.publish.publish_processes,
+          publish_sources: normalizedPublishRequest.publish.publish_sources,
+          publish_relations: normalizedPublishRequest.publish.publish_relations,
+          publish_process_build_runs: normalizedPublishRequest.publish.publish_process_build_runs,
+          relation_mode: normalizedPublishRequest.publish.relation_mode,
+        },
+        now,
+      );
+
+      writeJsonArtifact(layout.statePath, updatedState);
+      writeJsonArtifact(layout.invocationIndexPath, updatedInvocationIndex);
+      writeJsonArtifact(layout.publishBundlePath, publishBundle);
+      writeJsonArtifact(layout.publishRequestPath, publishRequest);
+      writeJsonArtifact(layout.publishIntentPath, publishIntent);
+      writeJsonArtifact(layout.handoffSummaryPath, handoffSummary);
+      writeJsonArtifact(layout.reportPath, report);
+
+      return report;
+    },
+  );
+}
+
+export const __testInternals = {
+  buildLayout,
+  resolveLayout,
+  buildStateSummary,
+  readDatasetArrayFromState,
+  collectCanonicalDatasets,
+  buildPublishRequest,
+  buildPublishIntent,
+  buildUpdatedState,
+  buildInvocationIndex,
+  buildNextActions,
+  buildReport,
+};

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -185,6 +185,8 @@ test('executeCli returns help for the process namespace and implemented subcomma
   assert.match(processHelp.stdout, /tiangong process <subcommand>/u);
   assert.match(processHelp.stdout, /auto-build/u);
   assert.match(processHelp.stdout, /resume-build/u);
+  assert.match(processHelp.stdout, /publish-build/u);
+  assert.match(processHelp.stdout, /batch-build/u);
 
   const autoBuildHelp = await executeCli(['process', 'auto-build', '--help'], makeDeps());
   assert.equal(autoBuildHelp.exitCode, 0);
@@ -200,6 +202,21 @@ test('executeCli returns help for the process namespace and implemented subcomma
   );
   assert.match(resumeBuildHelp.stdout, /--run-dir/u);
   assert.doesNotMatch(resumeBuildHelp.stdout, /Planned command/u);
+
+  const publishBuildHelp = await executeCli(['process', 'publish-build', '--help'], makeDeps());
+  assert.equal(publishBuildHelp.exitCode, 0);
+  assert.match(
+    publishBuildHelp.stdout,
+    /tiangong process publish-build \[--run-id <id>\] \[--run-dir <dir>\]/u,
+  );
+  assert.match(publishBuildHelp.stdout, /--run-dir/u);
+  assert.doesNotMatch(publishBuildHelp.stdout, /Planned command/u);
+
+  const batchBuildHelp = await executeCli(['process', 'batch-build', '--help'], makeDeps());
+  assert.equal(batchBuildHelp.exitCode, 0);
+  assert.match(batchBuildHelp.stdout, /tiangong process batch-build --input <file>/u);
+  assert.match(batchBuildHelp.stdout, /--out-dir/u);
+  assert.doesNotMatch(batchBuildHelp.stdout, /Planned command/u);
 });
 
 test('executeCli executes lifecyclemodel build-resulting-process with injected implementation', async () => {
@@ -469,6 +486,268 @@ test('executeCli executes process resume-build with run-dir only', async () => {
 
     assert.equal(result.exitCode, 0);
     assert.match(result.stdout, /prepared_local_process_resume_run/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli executes process publish-build with injected implementation', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-publish-build-cli-'));
+  const runDir = path.join(dir, 'artifacts', 'process_from_flow', 'run-3');
+
+  try {
+    const result = await executeCli(
+      ['process', 'publish-build', '--json', '--run-id', 'run-3', '--run-dir', runDir],
+      {
+        ...makeDeps(),
+        runProcessPublishBuildImpl: async (options) => {
+          assert.equal(options.runId, 'run-3');
+          assert.equal(options.runDir, runDir);
+          return {
+            schema_version: 1,
+            generated_at_utc: '2026-03-29T00:20:00.000Z',
+            status: 'prepared_local_process_publish_bundle',
+            run_id: 'run-3',
+            run_root: runDir,
+            request_id: 'req-3',
+            state_summary: {
+              build_status: 'resume_prepared',
+              next_stage: '10_publish',
+              stop_after: null,
+            },
+            dataset_origins: {
+              processes: 'exports',
+              sources: 'state',
+            },
+            counts: {
+              processes: 2,
+              sources: 1,
+              relations: 0,
+            },
+            publish_defaults: {
+              commit: false,
+              publish_lifecyclemodels: false,
+              publish_processes: true,
+              publish_sources: true,
+              publish_relations: true,
+              publish_process_build_runs: false,
+              relation_mode: 'local_manifest_only',
+            },
+            files: {
+              state: path.join(runDir, 'cache', 'process_from_flow_state.json'),
+              handoff_summary: path.join(runDir, 'cache', 'agent_handoff_summary.json'),
+              run_manifest: path.join(runDir, 'manifests', 'run-manifest.json'),
+              invocation_index: path.join(runDir, 'manifests', 'invocation-index.json'),
+              publish_bundle: path.join(
+                runDir,
+                'stage_outputs',
+                '10_publish',
+                'publish-bundle.json',
+              ),
+              publish_request: path.join(
+                runDir,
+                'stage_outputs',
+                '10_publish',
+                'publish-request.json',
+              ),
+              publish_intent: path.join(
+                runDir,
+                'stage_outputs',
+                '10_publish',
+                'publish-intent.json',
+              ),
+              report: path.join(runDir, 'reports', 'process-publish-build-report.json'),
+            },
+            next_actions: ['inspect: publish request'],
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /"status":"prepared_local_process_publish_bundle"/u);
+    assert.match(result.stdout, /"publish_request"/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli executes process publish-build with run-dir only', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-publish-build-cli-rundir-'));
+  const runDir = path.join(dir, 'artifacts', 'process_from_flow', 'run-4');
+
+  try {
+    const result = await executeCli(['process', 'publish-build', '--run-dir', runDir], {
+      ...makeDeps(),
+      runProcessPublishBuildImpl: async (options) => {
+        assert.equal(options.runId, undefined);
+        assert.equal(options.runDir, runDir);
+        return {
+          schema_version: 1,
+          generated_at_utc: '2026-03-29T00:21:00.000Z',
+          status: 'prepared_local_process_publish_bundle',
+          run_id: 'run-4',
+          run_root: runDir,
+          request_id: null,
+          state_summary: {
+            build_status: 'resume_prepared',
+            next_stage: null,
+            stop_after: null,
+          },
+          dataset_origins: {
+            processes: 'state',
+            sources: 'state',
+          },
+          counts: {
+            processes: 1,
+            sources: 0,
+            relations: 0,
+          },
+          publish_defaults: {
+            commit: false,
+            publish_lifecyclemodels: false,
+            publish_processes: true,
+            publish_sources: true,
+            publish_relations: true,
+            publish_process_build_runs: false,
+            relation_mode: 'local_manifest_only',
+          },
+          files: {
+            state: path.join(runDir, 'cache', 'process_from_flow_state.json'),
+            handoff_summary: path.join(runDir, 'cache', 'agent_handoff_summary.json'),
+            run_manifest: path.join(runDir, 'manifests', 'run-manifest.json'),
+            invocation_index: path.join(runDir, 'manifests', 'invocation-index.json'),
+            publish_bundle: path.join(runDir, 'stage_outputs', '10_publish', 'publish-bundle.json'),
+            publish_request: path.join(
+              runDir,
+              'stage_outputs',
+              '10_publish',
+              'publish-request.json',
+            ),
+            publish_intent: path.join(runDir, 'stage_outputs', '10_publish', 'publish-intent.json'),
+            report: path.join(runDir, 'reports', 'process-publish-build-report.json'),
+          },
+          next_actions: ['inspect: publish request'],
+        };
+      },
+    });
+
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /prepared_local_process_publish_bundle/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli executes process batch-build with injected implementation', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-batch-build-cli-'));
+  const inputPath = path.join(dir, 'batch-request.json');
+  writeFileSync(inputPath, '{"items":["./request-a.json"]}', 'utf8');
+
+  try {
+    const result = await executeCli(
+      ['process', 'batch-build', '--json', '--input', inputPath, '--out-dir', './batch-root'],
+      {
+        ...makeDeps(),
+        runProcessBatchBuildImpl: async (options) => {
+          assert.equal(options.inputPath, inputPath);
+          assert.equal(options.outDir, './batch-root');
+          return {
+            schema_version: 1,
+            generated_at_utc: '2026-03-29T00:22:00.000Z',
+            status: 'completed',
+            manifest_path: inputPath,
+            batch_id: 'batch-1',
+            batch_root: path.join(dir, 'batch-root'),
+            continue_on_error: true,
+            counts: {
+              total: 1,
+              prepared: 1,
+              failed: 0,
+              skipped: 0,
+            },
+            files: {
+              request_snapshot: path.join(dir, 'batch-root', 'request', 'batch-request.json'),
+              normalized_request: path.join(
+                dir,
+                'batch-root',
+                'request',
+                'request.normalized.json',
+              ),
+              invocation_index: path.join(dir, 'batch-root', 'manifests', 'invocation-index.json'),
+              run_manifest: path.join(dir, 'batch-root', 'manifests', 'run-manifest.json'),
+              report: path.join(dir, 'batch-root', 'reports', 'process-batch-build-report.json'),
+            },
+            items: [
+              {
+                item_id: 'request_a',
+                index: 0,
+                input_path: path.join(dir, 'request-a.json'),
+                out_dir: path.join(dir, 'batch-root', 'runs', '001_request_a'),
+                status: 'prepared',
+                run_id: 'run-1',
+                run_root: path.join(dir, 'batch-root', 'runs', '001_request_a'),
+                request_id: 'req-1',
+                files: {
+                  request_snapshot: path.join(dir, 'item', 'request.json'),
+                  report: path.join(dir, 'item', 'report.json'),
+                  state: path.join(dir, 'item', 'state.json'),
+                  handoff_summary: path.join(dir, 'item', 'handoff.json'),
+                  run_manifest: path.join(dir, 'item', 'run-manifest.json'),
+                },
+                error: null,
+              },
+            ],
+            next_actions: ['inspect: report'],
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /"status":"completed"/u);
+    assert.match(result.stdout, /"batch_id":"batch-1"/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli maps process batch-build failures to exit code 1', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-batch-build-cli-failure-'));
+  const inputPath = path.join(dir, 'batch-request.json');
+  writeFileSync(inputPath, '{"items":["./request-a.json"]}', 'utf8');
+
+  try {
+    const result = await executeCli(['process', 'batch-build', '--input', inputPath], {
+      ...makeDeps(),
+      runProcessBatchBuildImpl: async () => ({
+        schema_version: 1,
+        generated_at_utc: '2026-03-29T00:23:00.000Z',
+        status: 'completed_with_failures',
+        manifest_path: inputPath,
+        batch_id: 'batch-2',
+        batch_root: path.join(dir, 'batch-root'),
+        continue_on_error: true,
+        counts: {
+          total: 1,
+          prepared: 0,
+          failed: 1,
+          skipped: 0,
+        },
+        files: {
+          request_snapshot: path.join(dir, 'batch-root', 'request', 'batch-request.json'),
+          normalized_request: path.join(dir, 'batch-root', 'request', 'request.normalized.json'),
+          invocation_index: path.join(dir, 'batch-root', 'manifests', 'invocation-index.json'),
+          run_manifest: path.join(dir, 'batch-root', 'manifests', 'run-manifest.json'),
+          report: path.join(dir, 'batch-root', 'reports', 'process-batch-build-report.json'),
+        },
+        items: [],
+        next_actions: ['inspect: report'],
+      }),
+    });
+
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stdout, /completed_with_failures/u);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -787,7 +1066,7 @@ test('executeCli returns parsing errors for invalid publish and validation flags
   assert.match(validationResult.stderr, /INVALID_ARGS/u);
 });
 
-test('executeCli returns parsing errors for invalid lifecyclemodel build, process build, resume, and publish flags', async () => {
+test('executeCli returns parsing errors for invalid lifecyclemodel build, process build, resume, publish-build, and batch-build flags', async () => {
   const result = await executeCli(
     ['lifecyclemodel', 'build-resulting-process', '--bad-flag'],
     makeDeps(),
@@ -816,6 +1095,19 @@ test('executeCli returns parsing errors for invalid lifecyclemodel build, proces
   assert.equal(processResumeResult.exitCode, 2);
   assert.equal(processResumeResult.stdout, '');
   assert.match(processResumeResult.stderr, /INVALID_ARGS/u);
+
+  const processPublishResult = await executeCli(
+    ['process', 'publish-build', '--bad-flag'],
+    makeDeps(),
+  );
+  assert.equal(processPublishResult.exitCode, 2);
+  assert.equal(processPublishResult.stdout, '');
+  assert.match(processPublishResult.stderr, /INVALID_ARGS/u);
+
+  const processBatchResult = await executeCli(['process', 'batch-build', '--bad-flag'], makeDeps());
+  assert.equal(processBatchResult.exitCode, 2);
+  assert.equal(processBatchResult.stdout, '');
+  assert.match(processBatchResult.stderr, /INVALID_ARGS/u);
 });
 
 test('executeCli executes validation run with injected implementation and report file', async () => {
@@ -940,10 +1232,10 @@ test('executeCli returns planned command message for lifecyclemodel subcommands 
 });
 
 test('executeCli returns planned command message for process subcommands after help is introduced', async () => {
-  const result = await executeCli(['process', 'publish-build'], makeDeps());
+  const result = await executeCli(['process', 'get'], makeDeps());
   assert.equal(result.exitCode, 2);
   assert.equal(result.stdout, '');
-  assert.match(result.stderr, /Command 'process publish-build'/u);
+  assert.match(result.stderr, /Command 'process get'/u);
 });
 
 test('executeCli returns dedicated help for planned lifecyclemodel subcommands', async () => {
@@ -955,9 +1247,9 @@ test('executeCli returns dedicated help for planned lifecyclemodel subcommands',
 });
 
 test('executeCli returns dedicated help for planned process subcommands', async () => {
-  const result = await executeCli(['process', 'publish-build', '--help'], makeDeps());
+  const result = await executeCli(['process', 'get', '--help'], makeDeps());
   assert.equal(result.exitCode, 0);
-  assert.match(result.stdout, /tiangong process publish-build --run-id <id>/u);
+  assert.match(result.stdout, /tiangong process get --id <process-id>/u);
   assert.match(result.stdout, /Execution is not implemented yet/u);
   assert.equal(result.stderr, '');
 });

--- a/test/process-batch-build.test.ts
+++ b/test/process-batch-build.test.ts
@@ -1,0 +1,525 @@
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { __testInternals, runProcessBatchBuild } from '../src/lib/process-batch-build.js';
+
+function writeJson(filePath: string, value: unknown): void {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function readJson<T = Record<string, unknown>>(filePath: string): T {
+  return JSON.parse(readFileSync(filePath, 'utf8')) as T;
+}
+
+function bundledFlowPayload(): Record<string, unknown> {
+  return readJson(
+    path.resolve(process.cwd(), '../tidas-sdk/test-data/tidas-example-flow.json'),
+  ) as Record<string, unknown>;
+}
+
+function writeFlowFixture(dir: string): string {
+  const filePath = path.join(dir, '01211_3a8d74d8_reference-flow.json');
+  writeJson(filePath, bundledFlowPayload());
+  return filePath;
+}
+
+function writeProcessRequest(
+  dir: string,
+  fileName: string,
+  options?: {
+    flowPath?: string;
+    overrides?: Record<string, unknown>;
+  },
+): string {
+  const flowPath = options?.flowPath ?? writeFlowFixture(dir);
+  const requestPath = path.join(dir, fileName);
+  writeJson(requestPath, {
+    flow_file: `./${path.basename(flowPath)}`,
+    ...(options?.overrides ?? {}),
+  });
+  return requestPath;
+}
+
+test('runProcessBatchBuild prepares multiple process auto-build runs from one batch manifest', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-batch-build-success-'));
+  const flowPath = writeFlowFixture(dir);
+  writeProcessRequest(dir, 'request-a.json', {
+    flowPath,
+  });
+  writeProcessRequest(dir, 'request-b.json', {
+    flowPath,
+  });
+  const manifestPath = path.join(dir, 'batch-request.json');
+  const explicitRunRoot = path.join(dir, 'custom-run-root');
+  writeJson(manifestPath, {
+    batch_id: 'batch-demo',
+    out_dir: './batch-artifacts',
+    items: [
+      './request-a.json',
+      {
+        input_path: './request-b.json',
+        item_id: 'second-item',
+        out_dir: './custom-run-root',
+      },
+    ],
+  });
+
+  try {
+    const report = await runProcessBatchBuild({
+      inputPath: manifestPath,
+      now: new Date('2026-03-29T07:00:00Z'),
+      cwd: '/tmp/process-batch-build-success',
+    });
+
+    assert.equal(report.status, 'completed');
+    assert.equal(report.batch_id, 'batch-demo');
+    assert.equal(realpathSync(report.batch_root), realpathSync(path.join(dir, 'batch-artifacts')));
+    assert.equal(report.continue_on_error, true);
+    assert.deepEqual(report.counts, {
+      total: 2,
+      prepared: 2,
+      failed: 0,
+      skipped: 0,
+    });
+    assert.equal(existsSync(report.files.request_snapshot), true);
+    assert.equal(existsSync(report.files.normalized_request), true);
+    assert.equal(existsSync(report.files.invocation_index), true);
+    assert.equal(existsSync(report.files.run_manifest), true);
+    assert.equal(existsSync(report.files.report), true);
+
+    const firstItem = report.items[0];
+    assert.equal(firstItem?.status, 'prepared');
+    assert.equal(firstItem?.run_id?.endsWith('_b001'), true);
+    assert.equal(firstItem?.request_id, `pff-${firstItem?.run_id}`);
+    assert.equal(
+      realpathSync(firstItem?.run_root ?? ''),
+      realpathSync(path.join(report.batch_root, 'runs', '001_request_a')),
+    );
+
+    const secondItem = report.items[1];
+    assert.equal(secondItem?.status, 'prepared');
+    assert.equal(secondItem?.run_id?.endsWith('_b002'), true);
+    assert.equal(realpathSync(secondItem?.run_root ?? ''), realpathSync(explicitRunRoot));
+    assert.equal(existsSync(secondItem?.files.report ?? ''), true);
+
+    const invocationIndex = readJson<{
+      invocations: Array<Record<string, unknown>>;
+    }>(report.files.invocation_index);
+    assert.equal(invocationIndex.invocations.length, 1);
+    assert.deepEqual(invocationIndex.invocations[0]?.command, [
+      'process',
+      'batch-build',
+      '--input',
+      manifestPath,
+    ]);
+
+    const normalizedRequest = readJson<Record<string, unknown>>(report.files.normalized_request);
+    assert.equal(normalizedRequest.batch_id, 'batch-demo');
+    assert.equal((normalizedRequest.items as unknown[]).length, 2);
+
+    const persistedReport = readJson(report.files.report);
+    assert.deepEqual(persistedReport, report);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessBatchBuild supports partial failures when continue_on_error is true', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-batch-build-continue-'));
+  const flowPath = writeFlowFixture(dir);
+  writeProcessRequest(dir, 'request-a.json', {
+    flowPath,
+  });
+  writeProcessRequest(dir, 'request-b.json', {
+    flowPath,
+    overrides: {
+      request_id: 'req-custom',
+    },
+  });
+  const manifestPath = path.join(dir, 'batch-request.json');
+  writeJson(manifestPath, {
+    batch_id: 'batch-continue',
+    items: ['./request-a.json', './missing.json', './request-b.json'],
+  });
+
+  try {
+    const report = await runProcessBatchBuild({
+      inputPath: manifestPath,
+      now: new Date('2026-03-29T07:30:00Z'),
+      cwd: '/tmp/process-batch-build-continue',
+    });
+
+    assert.equal(report.status, 'completed_with_failures');
+    assert.deepEqual(report.counts, {
+      total: 3,
+      prepared: 2,
+      failed: 1,
+      skipped: 0,
+    });
+    assert.equal(report.items[0]?.status, 'prepared');
+    assert.equal(report.items[1]?.status, 'failed');
+    assert.equal(report.items[1]?.error?.code, 'INPUT_NOT_FOUND');
+    assert.equal(report.items[2]?.status, 'prepared');
+    assert.equal(report.items[2]?.request_id, 'req-custom');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessBatchBuild stops after the first failure when continue_on_error is false', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-batch-build-stop-'));
+  const flowPath = writeFlowFixture(dir);
+  writeProcessRequest(dir, 'request-a.json', {
+    flowPath,
+  });
+  writeProcessRequest(dir, 'request-c.json', {
+    flowPath,
+  });
+  const manifestPath = path.join(dir, 'batch-request.json');
+  writeJson(manifestPath, {
+    batch_id: 'batch-stop',
+    continue_on_error: false,
+    items: ['./request-a.json', './missing.json', './request-c.json'],
+  });
+
+  try {
+    const report = await runProcessBatchBuild({
+      inputPath: manifestPath,
+      now: new Date('2026-03-29T08:00:00Z'),
+      cwd: '/tmp/process-batch-build-stop',
+    });
+
+    assert.equal(report.status, 'completed_with_failures');
+    assert.deepEqual(report.counts, {
+      total: 3,
+      prepared: 1,
+      failed: 1,
+      skipped: 1,
+    });
+    assert.equal(report.items[0]?.status, 'prepared');
+    assert.equal(report.items[1]?.status, 'failed');
+    assert.equal(report.items[2]?.status, 'skipped');
+    assert.equal(existsSync(path.join(report.batch_root, 'runs', '003_request_c')), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessBatchBuild records explicit CLI outDir and handles non-object item requests', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-batch-build-cli-outdir-'));
+  const flowPath = writeFlowFixture(dir);
+  writeProcessRequest(dir, 'request-a.json', {
+    flowPath,
+    overrides: {
+      run_id: 'cli-fixed-run',
+      request_id: 'cli-fixed-request',
+    },
+  });
+  const invalidRequestPath = path.join(dir, 'request-invalid.json');
+  writeJson(invalidRequestPath, 'not-an-object');
+  const manifestPath = path.join(dir, 'batch-request.json');
+  const explicitBatchRoot = path.join(dir, 'cli-batch-root');
+  writeJson(manifestPath, {
+    batch_id: 'batch-cli-outdir',
+    items: ['./request-a.json', './request-invalid.json'],
+  });
+
+  try {
+    const report = await runProcessBatchBuild({
+      inputPath: manifestPath,
+      outDir: explicitBatchRoot,
+      now: new Date('2026-03-29T08:15:00Z'),
+      cwd: '/tmp/process-batch-build-cli-outdir',
+    });
+
+    assert.equal(report.status, 'completed_with_failures');
+    assert.equal(realpathSync(report.batch_root), realpathSync(explicitBatchRoot));
+    assert.equal(report.items[0]?.status, 'prepared');
+    assert.equal(report.items[0]?.run_id, 'cli-fixed-run');
+    assert.equal(report.items[0]?.request_id, 'cli-fixed-request');
+    assert.equal(report.items[1]?.status, 'failed');
+    assert.equal(report.items[1]?.error?.code, 'PROCESS_AUTO_BUILD_REQUEST_INVALID');
+
+    const runManifest = readJson<{
+      command: string[];
+      layout: {
+        runRoot: string;
+      };
+    }>(report.files.run_manifest);
+    assert.deepEqual(runManifest.command, [
+      'process',
+      'batch-build',
+      '--input',
+      manifestPath,
+      '--out-dir',
+      explicitBatchRoot,
+    ]);
+    assert.equal(realpathSync(runManifest.layout.runRoot), realpathSync(explicitBatchRoot));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessBatchBuild rejects invalid manifests and duplicate runtime identifiers', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-batch-build-invalid-'));
+  const flowPath = writeFlowFixture(dir);
+  writeProcessRequest(dir, 'request-a.json', {
+    flowPath,
+    overrides: {
+      run_id: 'fixed-run',
+    },
+  });
+  writeProcessRequest(dir, 'request-b.json', {
+    flowPath,
+    overrides: {
+      run_id: 'fixed-run',
+    },
+  });
+
+  try {
+    const invalidRootPath = path.join(dir, 'invalid-root.json');
+    writeJson(invalidRootPath, 'not-an-object');
+    await assert.rejects(
+      () => runProcessBatchBuild({ inputPath: invalidRootPath }),
+      /request must be a JSON object/u,
+    );
+
+    const missingItemsPath = path.join(dir, 'missing-items.json');
+    writeJson(missingItemsPath, {});
+    await assert.rejects(
+      () => runProcessBatchBuild({ inputPath: missingItemsPath }),
+      /items must be an array/u,
+    );
+
+    const emptyItemsPath = path.join(dir, 'empty-items.json');
+    writeJson(emptyItemsPath, {
+      items: [],
+    });
+    await assert.rejects(
+      () => runProcessBatchBuild({ inputPath: emptyItemsPath }),
+      /items must not be empty/u,
+    );
+
+    const badItemPath = path.join(dir, 'bad-item.json');
+    writeJson(badItemPath, {
+      items: [true],
+    });
+    await assert.rejects(
+      () => runProcessBatchBuild({ inputPath: badItemPath }),
+      /entries must be strings or objects/u,
+    );
+
+    const missingInputPath = path.join(dir, 'missing-input.json');
+    writeJson(missingInputPath, {
+      items: [{}],
+    });
+    await assert.rejects(
+      () => runProcessBatchBuild({ inputPath: missingInputPath }),
+      /missing 'input_path'/u,
+    );
+
+    const duplicateItemIdPath = path.join(dir, 'duplicate-item-id.json');
+    writeJson(duplicateItemIdPath, {
+      items: [
+        { input_path: './request-a.json', item_id: 'same' },
+        { input_path: './request-b.json', item_id: 'same' },
+      ],
+    });
+    await assert.rejects(
+      () => runProcessBatchBuild({ inputPath: duplicateItemIdPath }),
+      /Duplicate process batch-build item_id/u,
+    );
+
+    const duplicateRunIdPath = path.join(dir, 'duplicate-run-id.json');
+    writeJson(duplicateRunIdPath, {
+      batch_id: 'batch-duplicate-runid',
+      items: ['./request-a.json', './request-b.json'],
+    });
+    const duplicateRunIdReport = await runProcessBatchBuild({
+      inputPath: duplicateRunIdPath,
+      now: new Date('2026-03-29T08:30:00Z'),
+      cwd: '/tmp/process-batch-build-duplicate-runid',
+    });
+    assert.equal(duplicateRunIdReport.status, 'completed_with_failures');
+    assert.equal(duplicateRunIdReport.items[0]?.status, 'prepared');
+    assert.equal(duplicateRunIdReport.items[1]?.status, 'failed');
+    assert.equal(
+      duplicateRunIdReport.items[1]?.error?.code,
+      'PROCESS_BATCH_BUILD_RUN_ID_DUPLICATE',
+    );
+
+    const existingRootPath = path.join(dir, 'existing-root.json');
+    const existingRootDir = path.join(dir, 'existing-root');
+    mkdirSync(existingRootDir, { recursive: true });
+    writeFileSync(path.join(existingRootDir, 'keep.txt'), 'busy', 'utf8');
+    writeJson(existingRootPath, {
+      batch_id: 'batch-existing-root',
+      out_dir: './existing-root',
+      items: ['./request-a.json'],
+    });
+    await assert.rejects(
+      () => runProcessBatchBuild({ inputPath: existingRootPath }),
+      /run root already exists and is not empty/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('process batch-build internals cover layout, normalization, and helper fallbacks', () => {
+  const layout = __testInternals.buildLayout('/tmp/process-batch/batch-1', 'batch-1');
+  assert.equal(layout.runId, 'batch-1');
+  assert.equal(layout.requestSnapshotPath, '/tmp/process-batch/batch-1/request/batch-request.json');
+
+  assert.equal(
+    __testInternals.resolveBatchRoot('/tmp/work', 'batch-1', './override', null),
+    path.resolve('/tmp/work', './override'),
+  );
+  assert.equal(
+    __testInternals.resolveBatchRoot('/tmp/work', 'batch-1', null, './request-root'),
+    path.resolve('/tmp/work', './request-root'),
+  );
+  assert.equal(
+    __testInternals.resolveBatchRoot('/tmp/work', 'batch-1', '   ', './request-root'),
+    path.resolve('/tmp/work', './request-root'),
+  );
+
+  const normalized = __testInternals.normalizeProcessBatchBuildRequest(
+    {
+      batch_id: 'batch-inline',
+      continue_on_error: false,
+      items: ['./request-a.json', './request-a.json'],
+    },
+    {
+      inputPath: '/tmp/work/batch-request.json',
+      outDir: './batch-root',
+      now: new Date('2026-03-29T09:00:00Z'),
+    },
+  );
+  assert.equal(normalized.batch_id, 'batch-inline');
+  assert.equal(normalized.continue_on_error, false);
+  assert.equal(normalized.items[0]?.item_id, 'request_a');
+  assert.equal(normalized.items[1]?.item_id, 'request_a_2');
+
+  const normalizedWithoutNow = __testInternals.normalizeProcessBatchBuildRequest(
+    {
+      batch_id: 'batch-inline-default-now',
+      items: ['./request-a.json'],
+    },
+    {
+      inputPath: '/tmp/work/batch-request.json',
+    },
+  );
+  assert.equal(normalizedWithoutNow.batch_id, 'batch-inline-default-now');
+
+  const normalizedWithOccupiedSuffix = __testInternals.normalizeProcessBatchBuildRequest(
+    {
+      batch_id: 'batch-inline-loop',
+      items: [
+        './request-a.json',
+        {
+          input_path: './request-b.json',
+          item_id: 'request_a_2',
+        },
+        './request-a.json',
+      ],
+    },
+    {
+      inputPath: '/tmp/work/batch-request.json',
+      now: new Date('2026-03-29T09:05:00Z'),
+    },
+  );
+  assert.equal(normalizedWithOccupiedSuffix.items[2]?.item_id, 'request_a_3');
+
+  const invocationIndex = __testInternals.buildInvocationIndex(
+    normalized,
+    {
+      inputPath: '/tmp/work/batch-request.json',
+      outDir: './batch-root',
+      cwd: '/tmp/workspace',
+    },
+    layout,
+    new Date('2026-03-29T09:10:00Z'),
+  ) as {
+    invocations: Array<Record<string, unknown>>;
+  };
+  assert.deepEqual(invocationIndex.invocations[0]?.command, [
+    'process',
+    'batch-build',
+    '--input',
+    '/tmp/work/batch-request.json',
+    '--out-dir',
+    './batch-root',
+  ]);
+
+  const invocationIndexWithoutCwd = __testInternals.buildInvocationIndex(
+    normalized,
+    {
+      inputPath: '/tmp/work/batch-request.json',
+    },
+    layout,
+    new Date('2026-03-29T09:15:00Z'),
+  ) as {
+    invocations: Array<Record<string, unknown>>;
+  };
+  assert.equal(invocationIndexWithoutCwd.invocations[0]?.cwd, process.cwd());
+
+  const report = __testInternals.buildReport(
+    normalized,
+    layout,
+    [
+      {
+        item_id: 'request_a',
+        index: 0,
+        input_path: '/tmp/work/request-a.json',
+        out_dir: '/tmp/work/batch-root/runs/001_request_a',
+        status: 'prepared',
+        run_id: 'run-1',
+        run_root: '/tmp/work/batch-root/runs/001_request_a',
+        request_id: 'req-1',
+        files: {
+          request_snapshot: '/tmp/work/req.json',
+          report: '/tmp/work/report.json',
+          state: '/tmp/work/state.json',
+          handoff_summary: '/tmp/work/handoff.json',
+          run_manifest: '/tmp/work/run-manifest.json',
+        },
+        error: null,
+      },
+      {
+        item_id: 'request_b',
+        index: 1,
+        input_path: '/tmp/work/request-b.json',
+        out_dir: '/tmp/work/batch-root/runs/002_request_b',
+        status: 'skipped',
+        run_id: null,
+        run_root: null,
+        request_id: null,
+        files: {
+          request_snapshot: null,
+          report: null,
+          state: null,
+          handoff_summary: null,
+          run_manifest: null,
+        },
+        error: null,
+      },
+    ],
+    new Date('2026-03-29T09:20:00Z'),
+  );
+  assert.equal(report.status, 'completed');
+  assert.equal(report.counts.skipped, 1);
+
+  const nextActions = __testInternals.buildNextActions(layout);
+  assert.match(nextActions[2] ?? '', /consume items\[\]\.run_root/u);
+});

--- a/test/process-publish-build.test.ts
+++ b/test/process-publish-build.test.ts
@@ -1,0 +1,701 @@
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { runProcessAutoBuild } from '../src/lib/process-auto-build.js';
+import { __testInternals, runProcessPublishBuild } from '../src/lib/process-publish-build.js';
+
+function writeJson(filePath: string, value: unknown): void {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function readJson<T = Record<string, unknown>>(filePath: string): T {
+  return JSON.parse(readFileSync(filePath, 'utf8')) as T;
+}
+
+function bundledFlowPayload(): Record<string, unknown> {
+  return readJson(
+    path.resolve(process.cwd(), '../tidas-sdk/test-data/tidas-example-flow.json'),
+  ) as Record<string, unknown>;
+}
+
+function writeFlowFixture(dir: string): string {
+  const filePath = path.join(dir, '01211_3a8d74d8_reference-flow.json');
+  writeJson(filePath, bundledFlowPayload());
+  return filePath;
+}
+
+function makeCanonicalProcess(id: string): Record<string, unknown> {
+  return {
+    processDataSet: {
+      processInformation: {
+        dataSetInformation: {
+          'common:UUID': id,
+        },
+      },
+      administrativeInformation: {
+        publicationAndOwnership: {
+          'common:dataSetVersion': '01.01.000',
+        },
+      },
+    },
+  };
+}
+
+function makeSource(id: string): Record<string, unknown> {
+  return {
+    sourceDataSet: {
+      sourceInformation: {
+        dataSetInformation: {
+          'common:UUID': id,
+        },
+      },
+      administrativeInformation: {
+        publicationAndOwnership: {
+          'common:dataSetVersion': '01.01.000',
+        },
+      },
+    },
+  };
+}
+
+async function createPreparedRun(dir: string): Promise<{
+  requestPath: string;
+  report: Awaited<ReturnType<typeof runProcessAutoBuild>>;
+}> {
+  const flowPath = writeFlowFixture(dir);
+  const requestPath = path.join(dir, 'request.json');
+  writeJson(requestPath, {
+    flow_file: `./${path.basename(flowPath)}`,
+  });
+
+  const report = await runProcessAutoBuild({
+    inputPath: requestPath,
+    now: new Date('2026-03-29T02:00:00Z'),
+    cwd: '/tmp/process-publish-build-auto',
+  });
+
+  return {
+    requestPath,
+    report,
+  };
+}
+
+test('runProcessPublishBuild writes local publish handoff artifacts from run-id using export datasets', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-publish-build-runid-'));
+  const originalCwd = process.cwd();
+
+  try {
+    const { report: autoReport } = await createPreparedRun(dir);
+    const state = readJson<Record<string, unknown>>(autoReport.files.state);
+    state.build_status = 'resume_prepared';
+    state.next_stage = '10_publish';
+    state.stop_after = null;
+    state.process_datasets = [makeCanonicalProcess('proc-state-ignored')];
+    state.source_datasets = [makeSource('src-state-ignored')];
+    state.matched_process_exchanges = [{ id: 'ex-1' }];
+    state.placeholder_resolutions = [{ id: 'placeholder-1' }, { id: 'placeholder-2' }];
+    state.step_markers = {
+      auto_build_prepared: {
+        status: 'completed',
+      },
+    };
+    writeJson(autoReport.files.state, state);
+
+    mkdirSync(path.join(autoReport.run_root, 'exports', 'processes'), { recursive: true });
+    mkdirSync(path.join(autoReport.run_root, 'exports', 'sources'), { recursive: true });
+    writeJson(
+      path.join(autoReport.run_root, 'exports', 'processes', 'proc-export-1.json'),
+      makeCanonicalProcess('proc-export-1'),
+    );
+    writeJson(
+      path.join(autoReport.run_root, 'exports', 'processes', 'proc-export-2.json'),
+      makeCanonicalProcess('proc-export-2'),
+    );
+    writeJson(
+      path.join(autoReport.run_root, 'exports', 'sources', 'source-export-1.json'),
+      makeSource('source-export-1'),
+    );
+
+    process.chdir(dir);
+    const publishReport = await runProcessPublishBuild({
+      runId: autoReport.run_id,
+      now: new Date('2026-03-29T03:00:00Z'),
+      cwd: '/tmp/process-publish-build-runid',
+    });
+
+    assert.equal(publishReport.status, 'prepared_local_process_publish_bundle');
+    assert.equal(realpathSync(publishReport.run_root), realpathSync(autoReport.run_root));
+    assert.equal(publishReport.request_id, autoReport.request_id);
+    assert.deepEqual(publishReport.dataset_origins, {
+      processes: 'exports',
+      sources: 'exports',
+    });
+    assert.deepEqual(publishReport.counts, {
+      processes: 2,
+      sources: 1,
+      relations: 0,
+    });
+    assert.equal(publishReport.publish_defaults.commit, false);
+    assert.equal(publishReport.publish_defaults.publish_lifecyclemodels, false);
+    assert.equal(publishReport.publish_defaults.publish_processes, true);
+    assert.equal(publishReport.publish_defaults.publish_sources, true);
+    assert.equal(publishReport.publish_defaults.publish_relations, true);
+    assert.equal(publishReport.publish_defaults.publish_process_build_runs, false);
+    assert.equal(publishReport.publish_defaults.relation_mode, 'local_manifest_only');
+    assert.equal(existsSync(publishReport.files.publish_bundle), true);
+    assert.equal(existsSync(publishReport.files.publish_request), true);
+    assert.equal(existsSync(publishReport.files.publish_intent), true);
+    assert.equal(existsSync(publishReport.files.report), true);
+
+    const updatedState = readJson<Record<string, unknown>>(publishReport.files.state);
+    assert.equal(updatedState.publish_build_requested_at, '2026-03-29T03:00:00.000Z');
+    const lastPublishBuild = updatedState.last_publish_build as Record<string, unknown>;
+    assert.equal(lastPublishBuild.status, 'prepared_local_process_publish_bundle');
+    assert.equal(lastPublishBuild.process_count, 2);
+    assert.equal(lastPublishBuild.source_count, 1);
+    const stepMarkers = updatedState.step_markers as Record<string, { status?: unknown }>;
+    assert.equal(stepMarkers.publish_handoff_prepared?.status, 'completed');
+
+    const publishBundle = readJson<Record<string, unknown>>(publishReport.files.publish_bundle);
+    assert.equal(publishBundle.generated_at_utc, '2026-03-29T03:00:00.000Z');
+    assert.equal(publishBundle.run_id, autoReport.run_id);
+    assert.equal(publishBundle.request_id, autoReport.request_id);
+    assert.deepEqual(publishBundle.dataset_origins, {
+      processes: 'exports',
+      sources: 'exports',
+    });
+    assert.deepEqual(publishBundle.counts, {
+      processes: 2,
+      sources: 1,
+      relations: 0,
+    });
+    assert.equal((publishBundle.processes as unknown[]).length, 2);
+    assert.equal((publishBundle.sources as unknown[]).length, 1);
+    assert.equal((publishBundle.relations as unknown[]).length, 0);
+
+    const publishRequest = readJson<Record<string, unknown>>(publishReport.files.publish_request);
+    assert.deepEqual(publishRequest, {
+      inputs: {
+        bundle_paths: ['./publish-bundle.json'],
+      },
+      publish: {
+        commit: false,
+        publish_lifecyclemodels: false,
+        publish_processes: true,
+        publish_sources: true,
+        publish_relations: true,
+        publish_process_build_runs: false,
+        relation_mode: 'local_manifest_only',
+      },
+      out_dir: './publish-run',
+    });
+
+    const publishIntent = readJson<Record<string, unknown>>(publishReport.files.publish_intent);
+    assert.equal(publishIntent.command, 'publish run');
+    assert.equal(publishIntent.input_path, publishReport.files.publish_request);
+    assert.equal(publishIntent.process_count, 2);
+    assert.equal(publishIntent.source_count, 1);
+    assert.equal(publishIntent.relation_count, 0);
+
+    const invocationIndex = readJson<{
+      invocations: Array<Record<string, unknown>>;
+    }>(publishReport.files.invocation_index);
+    assert.equal(invocationIndex.invocations.length, 2);
+    assert.deepEqual(invocationIndex.invocations[1]?.command, [
+      'process',
+      'publish-build',
+      '--run-id',
+      autoReport.run_id,
+    ]);
+    assert.equal(invocationIndex.invocations[1]?.cwd, '/tmp/process-publish-build-runid');
+
+    const handoff = readJson<Record<string, unknown>>(publishReport.files.handoff_summary);
+    assert.equal(handoff.command, 'process publish-build');
+    assert.equal(handoff.process_dataset_count, 2);
+    assert.equal(handoff.source_dataset_count, 1);
+    assert.equal(handoff.remaining_placeholder_refs, 2);
+    const extra = handoff.extra as Record<string, unknown>;
+    assert.equal(extra.status, publishReport.status);
+    assert.equal(extra.request_id, autoReport.request_id);
+
+    assert.match(
+      publishReport.next_actions[2] ?? '',
+      new RegExp(`tiangong publish run --input ${publishReport.files.publish_request}`, 'u'),
+    );
+  } finally {
+    process.chdir(originalCwd);
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessPublishBuild supports run-dir mode, falls back to state datasets, and recreates invocation index', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-publish-build-rundir-'));
+
+  try {
+    const { report: autoReport } = await createPreparedRun(dir);
+    const state = readJson<Record<string, unknown>>(autoReport.files.state);
+    state.request_id = '';
+    state.build_status = 'waiting_manual_publish';
+    delete state.next_stage;
+    delete state.run_id;
+    state.process_datasets = [makeCanonicalProcess('proc-state-1')];
+    state.source_datasets = [];
+    state.step_markers = 'bad-shape';
+    writeJson(autoReport.files.state, state);
+    writeJson(autoReport.files.invocation_index, {
+      schema_version: 9,
+    });
+
+    const publishReport = await runProcessPublishBuild({
+      runDir: autoReport.run_root,
+      now: new Date('2026-03-29T04:00:00Z'),
+      cwd: '/tmp/process-publish-build-rundir',
+    });
+
+    assert.equal(publishReport.run_id, autoReport.run_id);
+    assert.equal(publishReport.request_id, null);
+    assert.deepEqual(publishReport.dataset_origins, {
+      processes: 'state',
+      sources: 'state',
+    });
+    assert.deepEqual(publishReport.counts, {
+      processes: 1,
+      sources: 0,
+      relations: 0,
+    });
+    assert.equal(publishReport.state_summary.build_status, 'waiting_manual_publish');
+    assert.equal(publishReport.state_summary.next_stage, null);
+    assert.equal(publishReport.state_summary.stop_after, null);
+
+    const invocationIndex = readJson<{
+      schema_version: unknown;
+      invocations: Array<Record<string, unknown>>;
+    }>(publishReport.files.invocation_index);
+    assert.equal(invocationIndex.schema_version, 1);
+    assert.equal(invocationIndex.invocations.length, 1);
+    assert.deepEqual(invocationIndex.invocations[0]?.command, [
+      'process',
+      'publish-build',
+      '--run-dir',
+      autoReport.run_root,
+    ]);
+
+    const publishBundle = readJson<Record<string, unknown>>(publishReport.files.publish_bundle);
+    assert.equal(publishBundle.request_id, null);
+    assert.equal((publishBundle.processes as unknown[]).length, 1);
+    assert.equal((publishBundle.sources as unknown[]).length, 0);
+
+    const updatedState = readJson<Record<string, unknown>>(publishReport.files.state);
+    const stepMarkers = updatedState.step_markers as Record<string, { status?: unknown }>;
+    assert.equal(stepMarkers.publish_handoff_prepared?.status, 'completed');
+
+    const handoff = readJson<Record<string, unknown>>(publishReport.files.handoff_summary);
+    const extra = handoff.extra as Record<string, unknown>;
+    assert.equal(extra.request_id, null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessPublishBuild recreates a missing invocation index for older runs', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-publish-build-no-invocations-'));
+
+  try {
+    const { report: autoReport } = await createPreparedRun(dir);
+    const state = readJson<Record<string, unknown>>(autoReport.files.state);
+    state.process_datasets = [makeCanonicalProcess('proc-state-recreated')];
+    state.source_datasets = [];
+    writeJson(autoReport.files.state, state);
+    unlinkSync(autoReport.files.invocation_index);
+
+    const publishReport = await runProcessPublishBuild({
+      runDir: autoReport.run_root,
+      now: new Date('2026-03-29T04:30:00Z'),
+      cwd: '/tmp/process-publish-build-no-invocations',
+    });
+
+    const invocationIndex = readJson<{
+      schema_version: unknown;
+      invocations: Array<Record<string, unknown>>;
+    }>(publishReport.files.invocation_index);
+    assert.equal(invocationIndex.schema_version, 1);
+    assert.equal(invocationIndex.invocations.length, 1);
+    assert.deepEqual(invocationIndex.invocations[0]?.command, [
+      'process',
+      'publish-build',
+      '--run-dir',
+      autoReport.run_root,
+    ]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessPublishBuild rejects invalid inputs and corrupted publish-build artifacts', async () => {
+  await assert.rejects(() => runProcessPublishBuild({}), /Missing required --run-id or --run-dir/u);
+
+  const mismatchDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-publish-build-mismatch-'));
+  try {
+    await assert.rejects(
+      () =>
+        runProcessPublishBuild({
+          runId: 'run-a',
+          runDir: path.join(mismatchDir, 'run-b'),
+        }),
+      /run-id does not match run-dir basename/u,
+    );
+  } finally {
+    rmSync(mismatchDir, { recursive: true, force: true });
+  }
+
+  const missingDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-publish-build-missing-'));
+  try {
+    await assert.rejects(
+      () => runProcessPublishBuild({ runDir: path.join(missingDir, 'run-missing') }),
+      /run root not found/u,
+    );
+  } finally {
+    rmSync(missingDir, { recursive: true, force: true });
+  }
+
+  const invalidManifestDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-publish-build-bad-manifest-'),
+  );
+  try {
+    const { report: autoReport } = await createPreparedRun(invalidManifestDir);
+    writeJson(autoReport.files.run_manifest, { runId: 'other-run' });
+    await assert.rejects(
+      () => runProcessPublishBuild({ runDir: autoReport.run_root }),
+      /run manifest runId mismatch/u,
+    );
+  } finally {
+    rmSync(invalidManifestDir, { recursive: true, force: true });
+  }
+
+  const invalidStateDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-publish-build-bad-state-'),
+  );
+  try {
+    const { report: autoReport } = await createPreparedRun(invalidStateDir);
+    writeJson(autoReport.files.state, []);
+    await assert.rejects(
+      () => runProcessPublishBuild({ runDir: autoReport.run_root }),
+      /Expected process publish artifact JSON object/u,
+    );
+  } finally {
+    rmSync(invalidStateDir, { recursive: true, force: true });
+  }
+
+  const mismatchedStateDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-publish-build-state-mismatch-'),
+  );
+  try {
+    const { report: autoReport } = await createPreparedRun(mismatchedStateDir);
+    const state = readJson<Record<string, unknown>>(autoReport.files.state);
+    state.run_id = 'other-run';
+    writeJson(autoReport.files.state, state);
+    await assert.rejects(
+      () => runProcessPublishBuild({ runDir: autoReport.run_root }),
+      /state run_id mismatch/u,
+    );
+  } finally {
+    rmSync(mismatchedStateDir, { recursive: true, force: true });
+  }
+
+  const missingHandoffDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-publish-build-missing-handoff-'),
+  );
+  try {
+    const { report: autoReport } = await createPreparedRun(missingHandoffDir);
+    unlinkSync(autoReport.files.handoff_summary);
+    await assert.rejects(
+      () => runProcessPublishBuild({ runDir: autoReport.run_root }),
+      /Required process publish artifact not found/u,
+    );
+  } finally {
+    rmSync(missingHandoffDir, { recursive: true, force: true });
+  }
+
+  const invalidHandoffDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-publish-build-bad-handoff-'),
+  );
+  try {
+    const { report: autoReport } = await createPreparedRun(invalidHandoffDir);
+    writeJson(autoReport.files.handoff_summary, []);
+    await assert.rejects(
+      () => runProcessPublishBuild({ runDir: autoReport.run_root }),
+      /Expected process publish artifact JSON object/u,
+    );
+  } finally {
+    rmSync(invalidHandoffDir, { recursive: true, force: true });
+  }
+
+  const invalidInvocationDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-publish-build-bad-invocation-'),
+  );
+  try {
+    const { report: autoReport } = await createPreparedRun(invalidInvocationDir);
+    writeJson(autoReport.files.invocation_index, { invocations: {} });
+    await assert.rejects(
+      () => runProcessPublishBuild({ runDir: autoReport.run_root }),
+      /invocations array/u,
+    );
+  } finally {
+    rmSync(invalidInvocationDir, { recursive: true, force: true });
+  }
+
+  const invalidInvocationShapeDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-publish-build-bad-invocation-shape-'),
+  );
+  try {
+    const { report: autoReport } = await createPreparedRun(invalidInvocationShapeDir);
+    writeJson(autoReport.files.invocation_index, []);
+    await assert.rejects(
+      () => runProcessPublishBuild({ runDir: autoReport.run_root }),
+      /invocation index JSON object/u,
+    );
+  } finally {
+    rmSync(invalidInvocationShapeDir, { recursive: true, force: true });
+  }
+
+  const invalidProcessStateDatasetsDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-publish-build-bad-state-datasets-'),
+  );
+  try {
+    const { report: autoReport } = await createPreparedRun(invalidProcessStateDatasetsDir);
+    const state = readJson<Record<string, unknown>>(autoReport.files.state);
+    state.process_datasets = { id: 'not-an-array' };
+    writeJson(autoReport.files.state, state);
+    await assert.rejects(
+      () => runProcessPublishBuild({ runDir: autoReport.run_root }),
+      /expected state\.process_datasets to be an array/u,
+    );
+  } finally {
+    rmSync(invalidProcessStateDatasetsDir, { recursive: true, force: true });
+  }
+
+  const invalidSourceStateDatasetItemDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-publish-build-bad-source-item-'),
+  );
+  try {
+    const { report: autoReport } = await createPreparedRun(invalidSourceStateDatasetItemDir);
+    const state = readJson<Record<string, unknown>>(autoReport.files.state);
+    state.process_datasets = [makeCanonicalProcess('proc-ok')];
+    state.source_datasets = ['bad-item'];
+    writeJson(autoReport.files.state, state);
+    await assert.rejects(
+      () => runProcessPublishBuild({ runDir: autoReport.run_root }),
+      /expected state\.source_datasets\[0\] to be an object/u,
+    );
+  } finally {
+    rmSync(invalidSourceStateDatasetItemDir, { recursive: true, force: true });
+  }
+
+  const invalidExportDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-publish-build-bad-export-'),
+  );
+  try {
+    const { report: autoReport } = await createPreparedRun(invalidExportDir);
+    const state = readJson<Record<string, unknown>>(autoReport.files.state);
+    state.process_datasets = [makeCanonicalProcess('proc-state-ok')];
+    writeJson(autoReport.files.state, state);
+    mkdirSync(path.join(autoReport.run_root, 'exports', 'processes'), { recursive: true });
+    writeJson(path.join(autoReport.run_root, 'exports', 'processes', 'bad.json'), ['bad-export']);
+    await assert.rejects(
+      () => runProcessPublishBuild({ runDir: autoReport.run_root }),
+      /Expected process export JSON object/u,
+    );
+  } finally {
+    rmSync(invalidExportDir, { recursive: true, force: true });
+  }
+
+  const zeroProcessesDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-publish-build-zero-processes-'),
+  );
+  try {
+    const { report: autoReport } = await createPreparedRun(zeroProcessesDir);
+    const state = readJson<Record<string, unknown>>(autoReport.files.state);
+    state.process_datasets = [];
+    state.source_datasets = [];
+    writeJson(autoReport.files.state, state);
+    await assert.rejects(
+      () => runProcessPublishBuild({ runDir: autoReport.run_root }),
+      /does not contain any process datasets to publish/u,
+    );
+  } finally {
+    rmSync(zeroProcessesDir, { recursive: true, force: true });
+  }
+});
+
+test('process publish-build internals cover fallback layout and report helpers', () => {
+  const resolvedLayout = __testInternals.resolveLayout({
+    runDir: '/tmp/process-run/run-123',
+  });
+  assert.equal(resolvedLayout.runId, 'run-123');
+  assert.equal(
+    resolvedLayout.statePath,
+    '/tmp/process-run/run-123/cache/process_from_flow_state.json',
+  );
+  assert.equal(
+    __testInternals.resolveLayout({
+      runId: '   ',
+      runDir: '/tmp/process-run/run-123',
+    }).runId,
+    'run-123',
+  );
+
+  const stateSummary = __testInternals.buildStateSummary({
+    build_status: 'resume_prepared',
+    next_stage: '10_publish',
+    stop_after: null,
+  });
+  assert.deepEqual(stateSummary, {
+    build_status: 'resume_prepared',
+    next_stage: '10_publish',
+    stop_after: null,
+  });
+
+  assert.deepEqual(__testInternals.readDatasetArrayFromState({}, 'process_datasets'), []);
+
+  const stateFallbackDatasets = __testInternals.collectCanonicalDatasets(
+    __testInternals.buildLayout('/tmp/process-run/run-123', 'run-123'),
+    {
+      process_datasets: [makeCanonicalProcess('proc-state-only')],
+      source_datasets: [makeSource('source-state-only')],
+    },
+  );
+  assert.equal(stateFallbackDatasets.processOrigin, 'state');
+  assert.equal(stateFallbackDatasets.sourceOrigin, 'state');
+
+  const publishRequest = __testInternals.buildPublishRequest();
+  assert.deepEqual(publishRequest, {
+    inputs: {
+      bundle_paths: ['./publish-bundle.json'],
+    },
+    publish: {
+      commit: false,
+      publish_lifecyclemodels: false,
+      publish_processes: true,
+      publish_sources: true,
+      publish_relations: true,
+      publish_process_build_runs: false,
+      relation_mode: 'local_manifest_only',
+    },
+    out_dir: './publish-run',
+  });
+
+  const publishIntent = __testInternals.buildPublishIntent(
+    __testInternals.buildLayout('/tmp/process-run/run-123', 'run-123'),
+    {
+      processes: 2,
+      sources: 1,
+      relations: 0,
+    },
+  );
+  assert.equal(publishIntent.command, 'publish run');
+  assert.equal(publishIntent.process_count, 2);
+
+  const updatedState = __testInternals.buildUpdatedState(
+    {
+      build_status: 'resume_prepared',
+      step_markers: 'bad-shape',
+    },
+    __testInternals.buildLayout('/tmp/process-run/run-123', 'run-123'),
+    {
+      processes: 2,
+      sources: 1,
+      relations: 0,
+    },
+    {
+      processes: 'exports',
+      sources: 'state',
+    },
+    new Date('2026-03-29T06:00:00Z'),
+  ) as Record<string, unknown>;
+  assert.equal(updatedState.publish_build_requested_at, '2026-03-29T06:00:00.000Z');
+  const updatedMarkers = updatedState.step_markers as Record<
+    string,
+    { status?: unknown; completed_at?: unknown }
+  >;
+  assert.equal(updatedMarkers.publish_handoff_prepared?.status, 'completed');
+
+  const invocationIndex = __testInternals.buildInvocationIndex(
+    __testInternals.buildLayout('/tmp/process-run/run-123', 'run-123'),
+    {
+      schema_version: 2,
+      invocations: [{ command: ['existing'] }],
+    },
+    {
+      runId: 'run-123',
+      runDir: '/tmp/process-run/run-123',
+      cwd: '/tmp/workspace',
+    },
+    new Date('2026-03-29T06:30:00Z'),
+  ) as {
+    invocations: Array<Record<string, unknown>>;
+  };
+  assert.equal(invocationIndex.invocations.length, 2);
+
+  const fallbackInvocationIndex = __testInternals.buildInvocationIndex(
+    __testInternals.buildLayout('/tmp/process-run/run-123', 'run-123'),
+    {},
+    {
+      runId: 'run-123',
+    },
+    new Date('2026-03-29T06:45:00Z'),
+  ) as {
+    schema_version: unknown;
+    invocations: Array<Record<string, unknown>>;
+  };
+  assert.equal(fallbackInvocationIndex.schema_version, 1);
+  assert.equal(fallbackInvocationIndex.invocations.length, 1);
+  assert.deepEqual(fallbackInvocationIndex.invocations[0]?.command, [
+    'process',
+    'publish-build',
+    '--run-id',
+    'run-123',
+  ]);
+  assert.equal(fallbackInvocationIndex.invocations[0]?.cwd, process.cwd());
+
+  const report = __testInternals.buildReport(
+    __testInternals.buildLayout('/tmp/process-run/run-123', 'run-123'),
+    {},
+    {
+      processes: 2,
+      sources: 1,
+      relations: 0,
+    },
+    {
+      processes: 'exports',
+      sources: 'state',
+    },
+    {
+      commit: false,
+      publish_lifecyclemodels: false,
+      publish_processes: true,
+      publish_sources: true,
+      publish_relations: true,
+      publish_process_build_runs: false,
+      relation_mode: 'local_manifest_only',
+    },
+    new Date('2026-03-29T06:47:00Z'),
+  );
+  assert.equal(report.request_id, null);
+  assert.equal(report.counts.processes, 2);
+
+  const nextActions = __testInternals.buildNextActions(
+    __testInternals.buildLayout('/tmp/process-run/run-123', 'run-123'),
+  );
+  assert.match(nextActions[3] ?? '', /future: wire publish executors/u);
+});


### PR DESCRIPTION
Closes #14

## Summary
- Add `tiangong process resume-build` as the local state handoff slice for existing process build runs.
- Reopen one local run by run id or run dir, validate the required artifacts, and update resume metadata/history through the CLI-owned contract.
- Keep the command local-first and avoid reintroducing Python or MCP into the CLI runtime.

## Key Decisions
- Stack this PR on `feature/issue-13` because resume-build depends on the local run scaffold from `process auto-build`.
- Reuse the shared state lock and run manifest helpers so later workflow slices inherit one contract.

## Validation
- `npm run lint`
- `npm test`
- `npm run test:coverage`
- `npm run test:coverage:assert-full`
- `npm run prepush:gate`

## Risks / Rollback
- This PR only prepares local resume state; it does not run later workflow stages itself.

## Workspace Integration
- Requires a later workspace submodule bump after merge.
