### PR TITLE
feat: add lifecyclemodel orchestration and reviewed-data CLI surfaces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,8 @@ TIANGONG_LCA_API_BASE_URL=
 TIANGONG_LCA_API_KEY=
 TIANGONG_LCA_REGION=us-east-1
 
-# Optional: only used when `tiangong review process --enable-llm` is enabled.
+# Optional: only used when `tiangong review process --enable-llm`
+# or `tiangong review flow --enable-llm` is enabled.
 TIANGONG_LCA_LLM_BASE_URL=
 TIANGONG_LCA_LLM_API_KEY=
 TIANGONG_LCA_LLM_MODEL=

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -29,15 +29,25 @@
 - `tiangong process resume-build`
 - `tiangong process publish-build`
 - `tiangong process batch-build`
+- `tiangong lifecyclemodel auto-build`
+- `tiangong lifecyclemodel validate-build`
+- `tiangong lifecyclemodel publish-build`
 - `tiangong lifecyclemodel build-resulting-process`
 - `tiangong lifecyclemodel publish-resulting-process`
+- `tiangong lifecyclemodel orchestrate`
 - `tiangong review process`
 - `tiangong review flow`
 - `tiangong flow get`
 - `tiangong flow list`
 - `tiangong flow remediate`
 - `tiangong flow publish-version`
+- `tiangong flow publish-reviewed-data`
+- `tiangong flow build-alias-map`
+- `tiangong flow scan-process-flow-refs`
+- `tiangong flow plan-process-flow-repairs`
+- `tiangong flow apply-process-flow-repairs`
 - `tiangong flow regen-product`
+- `tiangong flow validate-processes`
 - `tiangong publish run`
 - `tiangong validation run`
 - `tiangong admin embedding-run`
@@ -91,7 +101,7 @@ TIANGONG_LCA_LLM_MODEL=
 - 当前 CLI 已实现命令只直连 TianGong LCA 的 REST / Edge Functions
 - `review process` / `review flow` 的可选语义审核统一走 `TIANGONG_LCA_LLM_*`，不再使用 `OPENAI_*`
 - `publish run` / `validation run` 只做本地契约和执行收口，不新增远程 env
-- 知识库、TianGong unstructured、其余远程连接目前仍属于 legacy workflow 层（当前主要在 `tiangong-lca-skills`）
+- CLI 仓库内部虽然已经有 `kb-search` / `unstructured` 模块，但当前没有任何公开命令消费这些 env
 - 若未来 CLI 真正落地对应子命令，再按命令面新增 env，而不是提前暴露一整组无实际消费者的配置
 
 命令级 env 现实如下：
@@ -103,6 +113,7 @@ TIANGONG_LCA_LLM_MODEL=
 | `admin embedding-run` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`（`TIANGONG_LCA_REGION` 可选） |
 | `process get` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY` |
 | `process auto-build | resume-build | publish-build | batch-build` | 无 |
+| `lifecyclemodel auto-build | validate-build | publish-build | orchestrate` | 无 |
 | `lifecyclemodel build-resulting-process` | 本地运行默认无；若 request 打开 `process_sources.allow_remote_lookup=true`，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY` |
 | `lifecyclemodel publish-resulting-process` | 无 |
 | `review process` | 纯规则 review 默认无；若显式启用 `--enable-llm`，则需要 `TIANGONG_LCA_LLM_BASE_URL`、`TIANGONG_LCA_LLM_API_KEY`、`TIANGONG_LCA_LLM_MODEL` |
@@ -111,7 +122,13 @@ TIANGONG_LCA_LLM_MODEL=
 | `flow list` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY` |
 | `flow remediate` | 无 |
 | `flow publish-version` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY` |
+| `flow publish-reviewed-data` | 本地 dry-run 默认无；若 `--commit` 发布 prepared flow/process rows，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY` |
+| `flow build-alias-map` | 无 |
+| `flow scan-process-flow-refs` | 无 |
+| `flow plan-process-flow-repairs` | 无 |
+| `flow apply-process-flow-repairs` | 无 |
 | `flow regen-product` | 无 |
+| `flow validate-processes` | 无 |
 | `publish run` | 无 |
 | `validation run` | 无 |
 
@@ -127,6 +144,10 @@ npm start -- process auto-build --input ./examples/process-auto-build.request.js
 npm start -- process resume-build --run-id <run-id> --json
 npm start -- process publish-build --run-id <run-id> --json
 npm start -- process batch-build --input ./examples/process-batch-build.request.json --json
+npm start -- lifecyclemodel auto-build --input ./examples/lifecyclemodel-auto-build.request.json --json
+npm start -- lifecyclemodel validate-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --json
+npm start -- lifecyclemodel publish-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --json
+npm start -- lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir ./artifacts/lifecyclemodel_recursive/<run_id> --json
 npm start -- lifecyclemodel build-resulting-process --input ./request.json --json
 npm start -- lifecyclemodel publish-resulting-process --run-dir ./runs/example --publish-processes --publish-relations --json
 npm start -- review process --run-root ./artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir ./review --json
@@ -135,7 +156,13 @@ npm start -- flow get --id <flow-id> --version <version> --json
 npm start -- flow list --id <flow-id> --state-code 100 --limit 20 --json
 npm start -- flow remediate --input-file ./invalid-flows.jsonl --out-dir ./flow-remediation --json
 npm start -- flow publish-version --input-file ./ready-flows.jsonl --out-dir ./flow-publish --dry-run --json
+npm start -- flow publish-reviewed-data --flow-rows-file ./reviewed-flows.jsonl --original-flow-rows-file ./original-flows.jsonl --out-dir ./flow-publish-reviewed --dry-run --json
+npm start -- flow build-alias-map --old-flow-file ./old-flows.jsonl --new-flow-file ./new-flows.jsonl --out-dir ./flow-alias-map --json
+npm start -- flow scan-process-flow-refs --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-scan --json
+npm start -- flow plan-process-flow-repairs --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --scan-findings ./flow-scan/scan-findings.json --out-dir ./flow-repair-plan --json
+npm start -- flow apply-process-flow-repairs --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --scan-findings ./flow-scan/scan-findings.json --out-dir ./flow-repair-apply --json
 npm start -- flow regen-product --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-regen --apply --json
+npm start -- flow validate-processes --original-processes-file ./before.jsonl --patched-processes-file ./after.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-validate --json
 npm start -- publish run --input ./examples/publish-run.request.json --dry-run
 npm start -- validation run --input-dir ./tidas-package --engine auto
 npm start -- admin embedding-run --input ./jobs.json --dry-run
@@ -200,6 +227,47 @@ npm start -- admin embedding-run --input ./jobs.json --dry-run
 
 这个命令当前只负责本地 batch orchestration，不负责继续串接 resume / publish，也不负责远端 publish commit。
 
+`tiangong lifecyclemodel auto-build` 现在已经承担 `lifecyclemodel-automated-builder` 主链的第一个 CLI 切片，负责：
+
+- 读取单个 local-run manifest
+- 解析一个或多个 `process-automated-builder` 本地 run 目录
+- 从共享 flow UUID 推断 process graph
+- 选择 reference process
+- 计算每个 process instance 的 `@multiplicationFactor`
+- 写出原生 `json_ordered` lifecyclemodel 数据集
+- 写出 `run-plan.json`、`resolved-manifest.json`、`selection/selection-brief.md`
+- 写出 `discovery/reference-model-summary.json`、`models/**/summary.json`、`connections.json`、`process-catalog.json`
+
+这个命令当前只负责本地只读 build，不负责：
+
+- 远端 lifecyclemodel 写入
+- MCP / KB / LLM reference-model discovery
+- 自动串接 `validate-build` 或 `publish-build`
+
+`tiangong lifecyclemodel validate-build` 现在也已经进入可执行状态，负责：
+
+- 从 `--run-dir` 重开一个已有 lifecyclemodel auto-build run
+- 扫描 `models/*/tidas_bundle/lifecyclemodels/*.json`
+- 通过统一 `validation` 模块重新执行本地校验
+- 在 `reports/model-validations/` 下输出 per-model 校验结果
+- 更新 `manifests/invocation-index.json`
+- 输出 `reports/lifecyclemodel-validate-build-report.json`
+
+这个命令当前只负责本地 validation handoff，不负责远端写入，也不自动触发 publish。
+
+`tiangong lifecyclemodel publish-build` 现在也已经进入可执行状态，负责：
+
+- 从 `--run-dir` 重开一个已有 lifecyclemodel auto-build run
+- 收集 `models/*/tidas_bundle/lifecyclemodels/*.json` 下的原生 lifecyclemodel payload
+- 若存在 `reports/lifecyclemodel-validate-build-report.json`，则读取其中的 aggregate 校验摘要
+- 输出 `stage_outputs/10_publish/publish-bundle.json`
+- 输出 `stage_outputs/10_publish/publish-request.json`
+- 输出 `stage_outputs/10_publish/publish-intent.json`
+- 更新 `manifests/invocation-index.json`
+- 输出 `reports/lifecyclemodel-publish-build-report.json`
+
+这个命令当前只负责本地 publish handoff，不负责真正的远端 publish commit；真正的 dry-run / commit 边界仍由 `tiangong publish run` 负责。
+
 `tiangong lifecyclemodel build-resulting-process` 现在仍然保持本地优先，但已经支持一个显式的 deterministic 远端补全路径：
 
 - 只有当 request 中 `process_sources.allow_remote_lookup=true` 时才启用
@@ -208,6 +276,24 @@ npm start -- admin embedding-run --input ./jobs.json --dry-run
 - 不走 MCP，不走语义检索，不改变本地 artifact 契约
 
 也就是说，这个命令现在解决的是“缺 process JSON 时的 deterministic direct-read”，不是把整个 lifecyclemodel build workflow 变成远端编排。
+
+`tiangong lifecyclemodel publish-resulting-process` 现在已经进入可执行状态，负责：
+
+- 从 `--run-dir` 重开一个已有 resulting-process run
+- 汇总 projected process payload 与 resulting-process relation payload
+- 输出 `publish-bundle.json`
+- 输出 `publish-intent.json`
+- 输出 `publish-summary.json`
+
+这个命令当前只负责 resulting-process 的本地 publish handoff，不直接执行远端提交；真正的 dry-run / commit 仍由 `tiangong publish run` 负责。
+
+`tiangong lifecyclemodel orchestrate` 现在已经进入可执行状态，负责：
+
+- `plan`：把递归装配请求规范化为 `assembly-plan.json`、`graph-manifest.json`、`lineage-manifest.json`、`boundary-report.json`
+- `execute`：只调用原生 CLI builder slices，记录 `invocations/*.json` 与执行汇总
+- `publish`：重开一个已有 orchestrator run，汇总上游本地产物并输出 `publish-bundle.json`、`publish-summary.json`
+
+这个命令明确不再保留 Python fallback。`process_builder.mode=langgraph` 和 `process_builder.python_bin` 都已经被视为移除配置，不属于支持输入面。
 
 `tiangong review process` 现在也已经进入可执行状态，负责：
 
@@ -277,6 +363,74 @@ npm start -- admin embedding-run --input ./jobs.json --dry-run
 
 这个命令当前只负责 remediated flow version 的 publish/update 契约，不负责 round2 失败再修复；后续产品侧再生已经由 `tiangong flow regen-product` 单独承接。
 
+`tiangong flow publish-reviewed-data` 现在已经承担 flow governance 的 reviewed publish preparation 切片，负责：
+
+- 读取 reviewed flow 和/或 reviewed process 的本地 JSON / JSONL 输入
+- 可选读取 `--original-flow-rows-file`，对 unchanged reviewed rows 直接跳过，不再 version bump
+- 支持 `skip | append_only_bump | upsert_current_version`
+- 输出 `prepared-flow-rows.json`
+- 输出 `prepared-process-rows.json`
+- 输出 `flow-version-map.json`
+- 输出 `skipped-unchanged-flow-rows.json`
+- 在需要时重写 process `referenceToFlowDataSet` 并输出 `process-flow-ref-rewrite-evidence.jsonl`
+- 输出 `publish-report.json`
+- 保留历史兼容的 `mcp_success_list`、`remote_validation_failed`、`mcp_sync_report`
+
+这个命令现在已经覆盖 flow/process 的本地 reviewed publish 准备阶段；当显式传入 `--commit` 时，prepared flow rows 和 prepared process rows 都会通过 CLI 自己的 REST writer 层执行远端提交，不再依赖任何 legacy skill 路径。
+
+`tiangong flow build-alias-map` 现在已经承担 flow governance 的 deterministic alias map 切片，负责：
+
+- 读取一个或多个 old flow JSON / JSONL 输入
+- 读取一个或多个 new flow JSON / JSONL 输入
+- 可选读取 `--seed-alias-map`
+- 输出 `alias-plan.json`
+- 输出 `alias-plan.jsonl`
+- 输出 `flow-alias-map.json`
+- 输出 `manual-review-queue.jsonl`
+- 输出 `alias-summary.json`
+
+这个命令当前只负责本地 alias map 构建，不负责 process repair、publish 或任何远端写入。
+
+`tiangong flow scan-process-flow-refs` 现在已经承担 flow governance 的独立 process ref 扫描切片，负责：
+
+- 读取本地 process JSON / JSONL 输入
+- 读取一个或多个 scope/catalog flow JSON / JSONL 输入
+- 对每个 exchange 的 `referenceToFlowDataSet` 做 scope / catalog / alias 分类
+- 可选在扫描前剔除 emergy-named process
+- 输出 `emergy-excluded-processes.json`
+- 输出 `scan-summary.json`
+- 输出 `scan-findings.json`
+- 输出 `scan-findings.jsonl`
+
+这个命令当前只负责本地 deterministic 扫描，不负责 patch、publish 或 OpenClaw 语义决策。
+
+`tiangong flow plan-process-flow-repairs` 现在已经承担 flow governance 的独立 deterministic repair plan 切片，负责：
+
+- 读取本地 process JSON / JSONL 输入
+- 读取一个或多个 scope flow JSON / JSONL 输入
+- 可选读取 `--alias-map`
+- 可选读取上一步 `--scan-findings`
+- 显式收口 `disabled | alias-only | alias-or-unique-name` auto-patch policy
+- 输出 `repair-plan.json`
+- 输出 `repair-plan.jsonl`
+- 输出 `manual-review-queue.jsonl`
+- 输出 `repair-summary.json`
+
+这个命令当前只负责 repair planning，不直接修改 process rows。
+
+`tiangong flow apply-process-flow-repairs` 现在已经承担 flow governance 的独立 deterministic repair apply 切片，负责：
+
+- 复用与 repair plan 相同的 process / scope / alias / scan 输入契约
+- 只应用 deterministic subset
+- 输出 `patched-processes.json`
+- 输出 `process-patches/<process-id__version>/before.json`
+- 输出 `process-patches/<process-id__version>/after.json`
+- 输出 `process-patches/<process-id__version>/diff.patch`
+- 输出 `process-patches/<process-id__version>/evidence.json`
+- 若传入 `--process-pool-file`，把 exact-version patched rows 同步回本地 pool，并在 `repair-summary.json` 记录 `process_pool_sync`
+
+这个命令当前只负责本地 deterministic patch apply，不负责后续校验或远端写入；后续校验由 `tiangong flow validate-processes` 承接。
+
 `tiangong flow regen-product` 现在已经承担 flow governance 的产品侧再生切片，负责：
 
 - 读取本地 process JSON / JSONL 输入
@@ -287,6 +441,17 @@ npm start -- admin embedding-run --input ./jobs.json --dry-run
 - 在 `--apply` 后可选同步 `process-pool-file`
 
 这个命令当前只负责本地 deterministic 再生产物链，不负责远端 publish/write，也不负责 round2 remote-validation retry。
+
+`tiangong flow validate-processes` 现在已经承担 flow governance repair 之后的独立 process patch 校验切片，负责：
+
+- 读取 original / patched process rows
+- 读取一个或多个 scope flow JSON / JSONL 输入
+- 校验只允许 `referenceToFlowDataSet` 路径变化
+- 校验 quantitative reference 保持稳定
+- 可选复用 CLI 侧 `tidas-sdk` loader 执行本地 TIDAS 校验
+- 输出 `validation-report.json`、`validation-failures.jsonl`
+
+这个命令当前只负责本地 patch validation，不负责 repair 规划、apply 或远端写入。
 
 `tiangong publish run` 现在已经成为统一 publish 契约入口，负责：
 
@@ -372,6 +537,7 @@ npm run build
 - `process-automated-builder` 的本地 resume handoff 也已迁入 `tiangong process resume-build`；后续阶段继续按子命令切片迁移
 - `process-automated-builder` 的本地 publish handoff 也已迁入 `tiangong process publish-build`
 - `process-automated-builder` 的本地 batch orchestration 也已迁入 `tiangong process batch-build`
+- `lifecyclemodel-automated-builder` 的 canonical skill 入口已切为原生 Node `.mjs` wrapper -> `tiangong lifecyclemodel auto-build | validate-build | publish-build`；本地 local-run 组装、validation handoff、publish handoff 已迁入 CLI，剩余 discovery 继续按子命令切片迁移
 - 其余重型 workflow 先保留原执行器，但由 `tiangong` 统一调度
 - 所有新脚本优先使用统一环境变量名，不再扩散旧变量名
 
@@ -381,6 +547,7 @@ npm run build
 
 - `examples/process-auto-build.request.json`
 - `examples/process-batch-build.request.json`
+- `examples/lifecyclemodel-auto-build.request.json`
 - `examples/publish-run.request.json`
 
 ## 当前目录约定

--- a/README.md
+++ b/README.md
@@ -31,29 +31,36 @@ This prevents reintroducing a generic MCP transport layer into the CLI runtime.
 - `tiangong process resume-build`
 - `tiangong process publish-build`
 - `tiangong process batch-build`
+- `tiangong lifecyclemodel auto-build`
+- `tiangong lifecyclemodel validate-build`
+- `tiangong lifecyclemodel publish-build`
 - `tiangong lifecyclemodel build-resulting-process`
 - `tiangong lifecyclemodel publish-resulting-process`
+- `tiangong lifecyclemodel orchestrate`
 - `tiangong review process`
 - `tiangong review flow`
 - `tiangong flow get`
 - `tiangong flow list`
 - `tiangong flow remediate`
 - `tiangong flow publish-version`
+- `tiangong flow publish-reviewed-data`
+- `tiangong flow build-alias-map`
+- `tiangong flow scan-process-flow-refs`
+- `tiangong flow plan-process-flow-repairs`
+- `tiangong flow apply-process-flow-repairs`
 - `tiangong flow regen-product`
+- `tiangong flow validate-processes`
 - `tiangong publish run`
 - `tiangong validation run`
 - `tiangong admin embedding-run`
 
-## Planned command surface
+## Remaining planned command surface
 
-The `lifecyclemodel` and `process` namespaces are now partially implemented. The remaining workflow migration surface is:
+The remaining planned workflow command in the currently documented surface is:
 
-- `tiangong lifecyclemodel auto-build`
-- `tiangong lifecyclemodel validate-build`
-- `tiangong lifecyclemodel publish-build`
 - `tiangong review lifecyclemodel`
 
-These remaining commands are intentionally not executable yet. They print an explicit `not implemented yet` message and exit with code `2` until the corresponding workflows are migrated into TypeScript.
+That command still prints an explicit `not implemented yet` message and exits with code `2` until the corresponding workflow is migrated into TypeScript.
 
 The stable launcher is `bin/tiangong.js`. It loads the compiled runtime at `dist/src/main.js`, while `npm start -- ...` rebuilds and dogfoods the same launcher path.
 
@@ -118,6 +125,10 @@ Command-level env reality:
 | `process resume-build` | none |
 | `process publish-build` | none |
 | `process batch-build` | none |
+| `lifecyclemodel auto-build` | none |
+| `lifecyclemodel validate-build` | none |
+| `lifecyclemodel publish-build` | none |
+| `lifecyclemodel orchestrate` | none |
 | `lifecyclemodel build-resulting-process` | none for local-only runs; `TIANGONG_LCA_API_BASE_URL` and `TIANGONG_LCA_API_KEY` when `process_sources.allow_remote_lookup=true` |
 | `lifecyclemodel publish-resulting-process` | none |
 | `review process` | none for rule-only review; optional `TIANGONG_LCA_LLM_BASE_URL`, `TIANGONG_LCA_LLM_API_KEY`, and `TIANGONG_LCA_LLM_MODEL` when `--enable-llm` is set |
@@ -126,11 +137,17 @@ Command-level env reality:
 | `flow list` | `TIANGONG_LCA_API_BASE_URL`, `TIANGONG_LCA_API_KEY` |
 | `flow remediate` | none |
 | `flow publish-version` | `TIANGONG_LCA_API_BASE_URL`, `TIANGONG_LCA_API_KEY` |
+| `flow publish-reviewed-data` | none for local dry-run; `TIANGONG_LCA_API_BASE_URL` and `TIANGONG_LCA_API_KEY` when `--commit` publishes prepared flow/process rows |
+| `flow build-alias-map` | none |
+| `flow scan-process-flow-refs` | none |
+| `flow plan-process-flow-repairs` | none |
+| `flow apply-process-flow-repairs` | none |
 | `flow regen-product` | none |
+| `flow validate-processes` | none |
 | `publish run` | none |
 | `validation run` | none |
 
-This CLI does not currently require KB, TianGong unstructured service, MCP, or `OPENAI_*` env keys. Optional semantic review now goes through the canonical `TIANGONG_LCA_LLM_*` keys instead of legacy provider-specific names.
+This CLI does not currently require KB, TianGong unstructured service, MCP, or `OPENAI_*` env keys. Optional semantic review now goes through the canonical `TIANGONG_LCA_LLM_*` keys instead of legacy provider-specific names. The repo already contains internal helper modules for future KB and TianGong unstructured integrations, but no public command consumes those env keys yet, so they are intentionally absent from `.env.example`.
 
 Run the CLI:
 
@@ -144,6 +161,10 @@ npm start -- process auto-build --input ./examples/process-auto-build.request.js
 npm start -- process resume-build --run-id <run-id> --json
 npm start -- process publish-build --run-id <run-id> --json
 npm start -- process batch-build --input ./examples/process-batch-build.request.json --json
+npm start -- lifecyclemodel auto-build --input ./examples/lifecyclemodel-auto-build.request.json --json
+npm start -- lifecyclemodel validate-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --json
+npm start -- lifecyclemodel publish-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --json
+npm start -- lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir ./artifacts/lifecyclemodel_recursive/<run_id> --json
 npm start -- lifecyclemodel build-resulting-process --input ./request.json --json
 npm start -- lifecyclemodel publish-resulting-process --run-dir ./runs/example --publish-processes --publish-relations --json
 npm start -- review process --run-root ./artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir ./review --json
@@ -152,7 +173,13 @@ npm start -- flow get --id <flow-id> --version <version> --json
 npm start -- flow list --id <flow-id> --state-code 100 --limit 20 --json
 npm start -- flow remediate --input-file ./invalid-flows.jsonl --out-dir ./flow-remediation --json
 npm start -- flow publish-version --input-file ./ready-flows.jsonl --out-dir ./flow-publish --dry-run --json
+npm start -- flow publish-reviewed-data --flow-rows-file ./reviewed-flows.jsonl --original-flow-rows-file ./original-flows.jsonl --out-dir ./flow-publish-reviewed --dry-run --json
+npm start -- flow build-alias-map --old-flow-file ./old-flows.jsonl --new-flow-file ./new-flows.jsonl --out-dir ./flow-alias-map --json
+npm start -- flow scan-process-flow-refs --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-scan --json
+npm start -- flow plan-process-flow-repairs --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --scan-findings ./flow-scan/scan-findings.json --out-dir ./flow-repair-plan --json
+npm start -- flow apply-process-flow-repairs --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --scan-findings ./flow-scan/scan-findings.json --out-dir ./flow-repair-apply --json
 npm start -- flow regen-product --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-regen --apply --json
+npm start -- flow validate-processes --original-processes-file ./before.jsonl --patched-processes-file ./after.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-validate --json
 npm start -- publish run --input ./examples/publish-run.request.json --dry-run
 npm start -- validation run --input-dir ./tidas-package --engine auto
 npm start -- admin embedding-run --input ./jobs.json --dry-run
@@ -174,7 +201,23 @@ The command keeps the legacy per-run layout that later stages still expect, incl
 
 `resume-build`, `publish-build`, and `batch-build` all still stop at local handoff boundaries. They do not execute remote publish CRUD or commit mode themselves; that boundary remains in `tiangong publish run`.
 
+`tiangong lifecyclemodel auto-build` is the first migrated `lifecyclemodel_automated_builder` slice. It reads one local-run manifest from `--input`, resolves one or more `process-automated-builder` run directories, infers the process graph from shared flow UUIDs, chooses one reference process, computes `@multiplicationFactor`, writes native `json_ordered` lifecyclemodel datasets plus `run-plan.json`, `resolved-manifest.json`, `selection/selection-brief.md`, `discovery/reference-model-summary.json`, `models/**/summary.json`, `connections.json`, and `process-catalog.json`, and keeps the run local-only and read-only.
+
+The canonical `tiangong-lca-skills/lifecyclemodel-automated-builder` entrypoint now uses a native Node `.mjs` wrapper that delegates directly to `tiangong lifecyclemodel auto-build`. The canonical build path no longer routes through Bash, Python, or MCP.
+
+`tiangong lifecyclemodel validate-build` is the second migrated `lifecyclemodel_automated_builder` slice. It reopens one existing local lifecyclemodel build run by `--run-dir`, scans `models/*/tidas_bundle/lifecyclemodels/*.json`, runs the unified validation module against each model bundle, writes per-model reports under `reports/model-validations/`, updates `manifests/invocation-index.json`, and emits `reports/lifecyclemodel-validate-build-report.json`.
+
+`tiangong lifecyclemodel publish-build` is the third migrated `lifecyclemodel_automated_builder` slice. It reopens one existing local lifecyclemodel build run by `--run-dir`, collects native lifecyclemodel payloads from `models/*/tidas_bundle/lifecyclemodels/*.json`, reads the aggregate validation summary when present, writes `stage_outputs/10_publish/publish-bundle.json`, `publish-request.json`, and `publish-intent.json`, updates `manifests/invocation-index.json`, and emits `reports/lifecyclemodel-publish-build-report.json`.
+
+The current lifecyclemodel build family intentionally keeps three boundaries out of the auto-build slice:
+
+- no remote lifecyclemodel CRUD
+- no reference-model discovery against MCP / KB / LLM services
+- no automatic chaining into validate-build or publish-build
+
 `tiangong lifecyclemodel build-resulting-process` remains local-first, but it no longer hard-fails when a request explicitly enables `process_sources.allow_remote_lookup`. In that mode the CLI derives a deterministic Supabase REST read path from `TIANGONG_LCA_API_BASE_URL`, resolves missing process datasets by exact `id/version` with a latest-version fallback, and keeps the same local artifact contract instead of routing through MCP or semantic search.
+
+`tiangong lifecyclemodel orchestrate` is the native recursive assembly command for multi-node product-system runs. `plan` writes `assembly-plan.json`, `graph-manifest.json`, `lineage-manifest.json`, and `boundary-report.json`; `execute` invokes only native CLI-backed builder slices and records per-invocation results under `invocations/`; `publish` reopens one orchestrator run and prepares `publish-bundle.json` plus `publish-summary.json` from prior local artifacts. Legacy `process_builder.mode=langgraph` and `process_builder.python_bin` are rejected; there is no Python fallback path.
 
 `tiangong review process` is the first migrated review slice. It reopens one local `process_from_flow` run under `exports/processes/`, replays the existing artifact-first review contract, writes bilingual markdown findings plus structured JSON reports, and keeps optional semantic review behind the CLI-owned `TIANGONG_LCA_LLM_*` abstraction instead of direct `OPENAI_*` calls in a skill script.
 
@@ -188,13 +231,29 @@ The command keeps the legacy per-run layout that later stages still expect, incl
 
 `tiangong flow publish-version` is the first CLI-owned remote write slice for flow governance. It reads one ready-for-publish JSON or JSONL input, derives a deterministic Supabase REST path from `TIANGONG_LCA_API_BASE_URL`, performs dry-run or commit mode against `/rest/v1/flows`, and preserves the historical success-list, remote-failure, and sync-report artifact names for downstream follow-up. It still does not implement round2 retry; post-governance product-side regeneration now lives in `tiangong flow regen-product`.
 
+`tiangong flow publish-reviewed-data` is the CLI-owned reviewed publish preparation slice for flow governance. It reads reviewed flow rows and/or reviewed process rows from local JSON or JSONL inputs, can use `--original-flow-rows-file` to skip unchanged flow rows before planning publish, supports `skip | append_only_bump | upsert_current_version`, writes `prepared-flow-rows.json`, `prepared-process-rows.json`, `flow-version-map.json`, `skipped-unchanged-flow-rows.json`, `process-flow-ref-rewrite-evidence.jsonl`, and `publish-report.json`, and preserves the historical success-list / remote-failure / sync-report files for downstream follow-up. The native CLI path now covers local process-row preparation, optional process flow-ref rewrites, and commit-time process publish through the same REST-backed writer layer; no legacy fallback path remains for reviewed process rows.
+
+`tiangong flow build-alias-map` is the CLI-owned deterministic alias-map slice for flow governance. It reads one or more old flow snapshots plus one or more new flow snapshots, optionally consumes a seed alias map, writes `alias-plan.json`, `alias-plan.jsonl`, `flow-alias-map.json`, `manual-review-queue.jsonl`, and `alias-summary.json`, and keeps the boundary local-only instead of routing through skill-local Python.
+
+`tiangong flow scan-process-flow-refs` is the CLI-owned standalone process-reference scan slice for flow governance. It reads one local process row set plus one or more local scope/catalog flow row sets, classifies every `referenceToFlowDataSet`, optionally excludes emergy-named processes up front, and writes stable `emergy-excluded-processes.json`, `scan-summary.json`, `scan-findings.json`, and `scan-findings.jsonl` artifacts without falling back to skill-local Python.
+
+`tiangong flow plan-process-flow-repairs` is the CLI-owned standalone deterministic repair-planning slice for flow governance. It reads one local process row set plus one or more local scope flow row sets, optionally consumes prior `scan-findings`, applies the explicit `disabled | alias-only | alias-or-unique-name` auto-patch boundary, and writes `repair-plan.json`, `repair-plan.jsonl`, `manual-review-queue.jsonl`, and `repair-summary.json`.
+
+`tiangong flow apply-process-flow-repairs` is the CLI-owned standalone deterministic repair-apply slice for flow governance. It reuses the same local process/scope/alias/scan contract as the planning command, applies only the deterministic subset, emits per-process patch evidence under `process-patches/`, writes `patched-processes.json`, and can sync exact-version rows back into a local `process-pool-file`.
+
 `tiangong flow regen-product` is the CLI-owned local product-side regeneration slice for flow governance. It reads one local process row set plus one or more local scope/catalog flow row sets, runs `scan -> repair plan -> optional apply -> optional validate` under one run root, writes stable `scan/`, `repair/`, `repair-apply/`, `validate/`, and `flow-regen-product-report.json` artifacts, and keeps exit code `1` reserved for validation failures after `--apply`.
+
+`tiangong flow validate-processes` is the CLI-owned standalone validation slice for locally patched process rows after governance repair. It reads one original process snapshot, one patched process snapshot, and one or more scope flow snapshots, verifies that only `referenceToFlowDataSet` paths changed, keeps quantitative references stable, optionally runs `tidas-sdk` validation through the existing CLI-side loader, and writes `validation-report.json` plus `validation-failures.jsonl` without falling back to skill-local Python.
 
 ## Publish and validation
 
 `tiangong process publish-build` is the process-side local publish handoff command. It prepares the local bundle/request/intent artifacts expected by `tiangong publish run` without reintroducing Python, MCP, or legacy remote writers into the CLI.
 
 `tiangong process batch-build` is the process-side local batch orchestration command. It keeps batch execution file-first and JSON-first, reuses the single-run `process auto-build` contract for each item, and emits one batch report instead of pushing shell loops or Python coordinators back onto the caller.
+
+`tiangong lifecyclemodel validate-build` is the lifecyclemodel-side local validation command. It keeps validation file-first, reuses the unified `tiangong validation run` module under the hood, and writes both per-model reports and one aggregate build report without reintroducing Python or MCP into the CLI.
+
+`tiangong lifecyclemodel publish-build` is the lifecyclemodel-side local publish handoff command. It prepares the local bundle/request/intent artifacts expected by `tiangong publish run` without reintroducing Python, MCP, or legacy remote writers into the CLI.
 
 `tiangong lifecyclemodel publish-resulting-process` is the lifecyclemodel-side local publish handoff command. It reads a prior resulting-process run, writes `publish-bundle.json` and `publish-intent.json`, and preserves the old builder's artifact contract without reintroducing Python or MCP into the CLI.
 
@@ -209,12 +268,23 @@ node ./bin/tiangong.js doctor
 node ./bin/tiangong.js process get --id <process-id> --json
 node ./bin/tiangong.js flow get --id <flow-id> --json
 node ./bin/tiangong.js flow list --state-code 100 --limit 20 --json
+node ./bin/tiangong.js flow publish-reviewed-data --flow-rows-file ./reviewed-flows.jsonl --out-dir ./flow-publish-reviewed --dry-run --json
+node ./bin/tiangong.js flow build-alias-map --old-flow-file ./old-flows.jsonl --new-flow-file ./new-flows.jsonl --out-dir ./flow-alias-map --json
+node ./bin/tiangong.js flow scan-process-flow-refs --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-scan --json
+node ./bin/tiangong.js flow plan-process-flow-repairs --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --scan-findings ./flow-scan/scan-findings.json --out-dir ./flow-repair-plan --json
+node ./bin/tiangong.js flow apply-process-flow-repairs --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --scan-findings ./flow-scan/scan-findings.json --out-dir ./flow-repair-apply --json
 node ./bin/tiangong.js flow regen-product --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-regen --apply --json
 node ./bin/tiangong.js process auto-build --input ./examples/process-auto-build.request.json --json
 node ./bin/tiangong.js process resume-build --run-id <run-id> --json
 node ./bin/tiangong.js process publish-build --run-id <run-id> --json
 node ./bin/tiangong.js process batch-build --input ./examples/process-batch-build.request.json --json
+node ./bin/tiangong.js lifecyclemodel auto-build --input ./examples/lifecyclemodel-auto-build.request.json --json
+node ./bin/tiangong.js lifecyclemodel validate-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --json
+node ./bin/tiangong.js lifecyclemodel publish-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --json
+node ./bin/tiangong.js lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir ./artifacts/lifecyclemodel_recursive/<run_id> --json
 node ./bin/tiangong.js flow publish-version --input-file ./ready-flows.jsonl --out-dir ./flow-publish --dry-run --json
+node ./bin/tiangong.js publish run --input ./examples/publish-run.request.json --dry-run --json
+node ./bin/tiangong.js validation run --input-dir ./package --engine auto --json
 node ./dist/src/main.js doctor --json
 ```
 
@@ -224,16 +294,16 @@ Minimal example requests are available under `examples/`:
 
 - `examples/process-auto-build.request.json`
 - `examples/process-batch-build.request.json`
+- `examples/lifecyclemodel-auto-build.request.json`
 - `examples/publish-run.request.json`
 
 ## Workspace usage
 
-`tiangong-lca-skills` should converge on this CLI instead of keeping separate transport scripts. The current migration strategy is:
+`tiangong-lca-skills` should stay as thin Node `.mjs` wrappers over this CLI instead of keeping parallel runtimes. The current contract is:
 
-- thin remote wrappers move first
-- local artifact-first workflow slices move into the CLI incrementally
-- remaining heavier workflow stages stay in place temporarily until the matching CLI subcommands exist
-- future skill execution should call `tiangong` as the stable entrypoint
+- skills call `tiangong` as the stable entrypoint
+- deleted Python, MCP, and OpenClaw runtimes are not supported compatibility paths
+- new capability must land as a native `tiangong <noun> <verb>` command before a skill depends on it
 
 ## Docs
 

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -42,7 +42,13 @@ tiangong
     list
     remediate
     publish-version
+    publish-reviewed-data
+    build-alias-map
+    scan-process-flow-refs
+    plan-process-flow-repairs
+    apply-process-flow-repairs
     regen-product
+    validate-processes
   process
     get
     auto-build
@@ -50,8 +56,12 @@ tiangong
     publish-build
     batch-build
   lifecyclemodel
+    auto-build
+    validate-build
+    publish-build
     build-resulting-process
     publish-resulting-process
+    orchestrate
   review
     process
     flow
@@ -75,14 +85,24 @@ tiangong
 | `tiangong flow list` | 统一 CLI 持有的只读 flow 枚举面；从 `TIANGONG_LCA_API_BASE_URL` 推导 Supabase REST 路径并提供稳定过滤/排序/分页 |
 | `tiangong flow remediate` | 本地 flow governance round1 deterministic remediation、artifact-first 输出 |
 | `tiangong flow publish-version` | 统一 CLI 持有的 remediated-flow publish/update 入口；从 `TIANGONG_LCA_API_BASE_URL` 推导 Supabase REST 路径并写出稳定 success/failure artifacts |
+| `tiangong flow publish-reviewed-data` | 统一 CLI 持有的 reviewed publish preparation 入口；支持 flow unchanged skip、flow/process append-only bump / current-version upsert、process flow-ref rewrite、本地 `publish-report.json` 与兼容的 flow success/failure artifacts |
+| `tiangong flow build-alias-map` | 独立 deterministic alias map 入口；从 old/new flow snapshots 与可选 seed alias map 生成 alias plan、manual queue 与稳定 alias map |
+| `tiangong flow scan-process-flow-refs` | 独立 process ref 扫描入口；对 local process rows 做 scope/catalog/alias 分类并写出 scan artifacts |
+| `tiangong flow plan-process-flow-repairs` | 独立 deterministic repair planning 入口；从 process/scope/alias/scan 契约生成 repair plan |
+| `tiangong flow apply-process-flow-repairs` | 独立 deterministic repair apply 入口；应用 deterministic subset、写出 patch evidence，并可同步本地 process pool |
 | `tiangong flow regen-product` | 本地治理后 process-side 再生产物入口；在一个命令下执行 scan / repair / apply / validate 并输出稳定 artifacts |
+| `tiangong flow validate-processes` | 本地治理后 patched process rows 的独立校验入口；校验 flow ref-only diff、quantitative reference 稳定性，并可选复用 `tidas-sdk` |
 | `tiangong process get` | 统一 CLI 持有的只读 process 详情读取面；从 `TIANGONG_LCA_API_BASE_URL` 推导 Supabase REST 路径并按 `id/version` 读取 |
 | `tiangong process auto-build` | 本地 `process_from_flow` intake、run-id 生成、artifact scaffold 预写 |
 | `tiangong process resume-build` | 本地 `process_from_flow` resume handoff、state-lock/manifest 收口、resume 元数据与报告输出 |
 | `tiangong process publish-build` | 本地 `process_from_flow` publish handoff、publish bundle/request/intent 产出、state/invocation/handoff 更新 |
 | `tiangong process batch-build` | 本地 `process_from_flow` batch manifest 编排、批量调用 auto-build、batch report 输出 |
+| `tiangong lifecyclemodel auto-build` | 本地 lifecyclemodel local-run intake、graph 推断、reference process 选择、`json_ordered` artifact 输出 |
+| `tiangong lifecyclemodel validate-build` | 本地 lifecyclemodel build run 校验重跑、per-model 校验报告与 aggregate report 输出 |
+| `tiangong lifecyclemodel publish-build` | 本地 lifecyclemodel publish handoff、publish bundle/request/intent 产出、validation 摘要复用 |
 | `tiangong lifecyclemodel build-resulting-process` | 本地 lifecycle model resulting process 聚合、内部 flow 抵消、artifact 输出 |
 | `tiangong lifecyclemodel publish-resulting-process` | 读取 resulting-process run，生成 `publish-bundle.json` / `publish-intent.json` 本地交付物 |
+| `tiangong lifecyclemodel orchestrate` | 递归装配的 plan / execute / publish-handoff 命令；写出 graph/lineage/publish bundle 工件，并只调用原生 CLI builder slices |
 | `tiangong review process` | 本地 process review、artifact-first 报告输出、可选 CLI LLM 语义审核 |
 | `tiangong review flow` | 本地 flow governance review、rows-file 物化、artifact-first 报告输出、可选 CLI LLM 语义审核 |
 | `tiangong publish run` | 本地 publish 契约归一化、dry-run/commit、report 输出 |
@@ -91,9 +111,12 @@ tiangong
 
 此外，CLI 现在已经正式引入 `tiangong lifecyclemodel ...` 一级命名空间，其中：
 
+- `tiangong lifecyclemodel auto-build` 已可执行
+- `tiangong lifecyclemodel validate-build` 已可执行
+- `tiangong lifecyclemodel publish-build` 已可执行
 - `tiangong lifecyclemodel build-resulting-process` 已可执行
 - `tiangong lifecyclemodel publish-resulting-process` 已可执行
-- `auto-build`、`validate-build`、`publish-build` 仍处于 planned 状态
+- `tiangong lifecyclemodel orchestrate` 已可执行
 
 `tiangong review ...` 也已经开始进入统一命令树，其中：
 
@@ -107,7 +130,13 @@ tiangong
 - `tiangong flow list` 已可执行
 - `tiangong flow remediate` 已可执行
 - `tiangong flow publish-version` 已可执行
+- `tiangong flow publish-reviewed-data` 已可执行
+- `tiangong flow build-alias-map` 已可执行
+- `tiangong flow scan-process-flow-refs` 已可执行
+- `tiangong flow plan-process-flow-repairs` 已可执行
+- `tiangong flow apply-process-flow-repairs` 已可执行
 - `tiangong flow regen-product` 已可执行
+- `tiangong flow validate-processes` 已可执行
 
 `tiangong process ...` 也已经开始承接 `process_from_flow` 主链迁移，其中：
 
@@ -128,9 +157,18 @@ tiangong
 - `process publish-build` 当前只负责本地 publish handoff，不直接执行远端 publish commit 或数据库写入
 - 已实现的 `process batch-build` 继续走本地优先、artifact-first 路径，并把批量 item 编排、聚合 report、默认 run_dir 分配统一收口到 CLI
 - `process batch-build` 当前只负责本地 batch orchestration，不直接串接 resume / publish 或远端执行器
+- 已实现的 `lifecyclemodel auto-build` 走本地只读、artifact-first 路径，输入固定为 local run manifest，不依赖 Python、MCP、KB、LLM 或远端 CRUD
+- `lifecyclemodel auto-build` 当前负责 graph 推断、reference process 选择、`@multiplicationFactor` 计算与 `json_ordered` lifecyclemodel 产物输出，并保留 `run-plan.json`、`resolved-manifest.json`、`selection/selection-brief.md`、`discovery/reference-model-summary.json`、`connections.json`、`process-catalog.json` 等 CLI 契约
+- `lifecyclemodel auto-build` 当前明确不负责 reference-model discovery、任何远端 lifecyclemodel 写入，也不会自动串接 validate-build / publish-build
+- 已实现的 `lifecyclemodel validate-build` 继续保留同一套 run 布局，并把模型扫描、统一 validation 模块调用、per-model report 与 aggregate report 输出统一收口到 CLI
+- `lifecyclemodel validate-build` 当前只负责本地 validation handoff，不直接触发 publish，也不做任何远端写入
+- 已实现的 `lifecyclemodel publish-build` 继续保留同一套 run 布局，并把本地 publish-bundle/request/intent、validation 摘要复用、invocation index 更新统一收口到 CLI
+- `lifecyclemodel publish-build` 当前只负责本地 publish handoff，不直接执行远端 publish commit 或数据库写入；真正的 dry-run / commit 边界仍由 `tiangong publish run` 负责
 - 已实现的 `build-resulting-process` 和 `publish-resulting-process` 都走本地优先、artifact-first 路径，不依赖 Python 或 MCP
 - `build-resulting-process` 现在还支持一个显式的 deterministic direct-read 补全路径：当 request 打开 `process_sources.allow_remote_lookup=true` 时，CLI 会从 `TIANGONG_LCA_API_BASE_URL` 推导 Supabase REST 路径，按 `process_id/version` 直接补齐缺失的 process dataset
 - `publish-resulting-process` 当前负责生成本地 publish handoff 产物，还没有把提交语义直接并入 `publish run`
+- 已实现的 `lifecyclemodel orchestrate` 把递归装配的 `plan | execute | publish` 三个动作统一收口到 CLI，并直接复用原生 `process auto-build`、`lifecyclemodel auto-build`、`lifecyclemodel build-resulting-process` slices
+- `lifecyclemodel orchestrate` 当前明确拒绝 legacy `process_builder.mode=langgraph` 与 `process_builder.python_bin` 输入，不再保留任何 Python fallback 配置面
 - 已实现的 `review process` 保留本地 artifact-first review contract，把规则核查、报告输出和可选 LLM 语义审核统一收口到 CLI；语义审核只使用 `TIANGONG_LCA_LLM_*`，不再透出 `OPENAI_*`
 - 已实现的 `review flow` 保留本地 artifact-first governance review contract，把 flow 摘要、相似对、规则 findings、可选 LLM findings 和双语 markdown 报告统一收口到 CLI；语义审核同样只使用 `TIANGONG_LCA_LLM_*`
 - `review flow` 当前明确不支持 `--with-reference-context`，也还没有接入本地 registry enrichment；这部分仍需后续迁移切片单独落地
@@ -138,8 +176,14 @@ tiangong
 - 已实现的 `flow list` 保留 deterministic direct-read 边界，支持稳定 `id/state_code/type_of_dataset` 过滤、显式 `order=id.asc,version.asc` 默认值，以及 `--all --page-size` 的 offset 分页
 - 已实现的 `flow remediate` 保留旧 invalid-flow 输入与 round1 artifact 契约，但运行时已经收口到 CLI，不再需要 skill 私有 Python remediation 入口
 - 已实现的 `flow publish-version` 直接从 `TIANGONG_LCA_API_BASE_URL` 推导 `/rest/v1/flows` 写入路径，支持 dry-run/commit，并保留 `mcp_success_list`、`remote_validation_failed`、`mcp_sync_report` 这些历史文件名
+- 已实现的 `flow publish-reviewed-data` 负责 reviewed publish preparation 阶段：支持 `--original-flow-rows-file` unchanged skip、flow/process `skip | append_only_bump | upsert_current_version`、`prepared-flow-rows.json` / `prepared-process-rows.json` / `flow-version-map.json` / `skipped-unchanged-flow-rows.json` / `process-flow-ref-rewrite-evidence.jsonl` / `publish-report.json` 输出，并在 `--commit` 时同时执行 prepared flow rows 与 prepared process rows 的远端写入
+- 已实现的 `flow build-alias-map` 把治理链中的 deterministic alias-map 构建切片收口到 CLI，固定 old/new flow snapshots 与可选 `seed-alias-map` 输入契约，并直接写出 `alias-plan.json` / `flow-alias-map.json` / `manual-review-queue.jsonl` / `alias-summary.json`
+- 已实现的 `flow scan-process-flow-refs` 把治理链中的独立 process ref scan 切片收口到 CLI，固定 process/scope/catalog/alias 输入契约，并直接写出 `scan-summary.json` / `scan-findings.json` / `scan-findings.jsonl`
+- 已实现的 `flow plan-process-flow-repairs` 把治理链中的独立 deterministic repair planning 切片收口到 CLI，固定 process/scope/alias/scan 输入契约，并直接写出 `repair-plan.json` / `manual-review-queue.jsonl` / `repair-summary.json`
+- 已实现的 `flow apply-process-flow-repairs` 把治理链中的独立 deterministic repair apply 切片收口到 CLI，固定与 planning 相同的输入契约，直接写出 `patched-processes.json` / `process-patches/**`，并可在 `--process-pool-file` 下同步本地 pool
 - 已实现的 `flow regen-product` 把治理后的 process-side 再生产物链收口到 CLI，在一个命令下固定 `scan -> repair plan -> optional apply -> optional validate` 契约，并把退出码 `1` 保留给 `--apply` 之后的本地校验失败
-- 其余未实现的 `flow` / `lifecyclemodel` / `process` 子命令仍只提供 help 和固定命名
+- 已实现的 `flow validate-processes` 把治理后 patched process rows 的独立校验切片收口到 CLI，固定 original/patched/scope 三类输入契约，并直接写出 `validation-report.json` / `validation-failures.jsonl`
+- 当前仍未实现的重点命令主要是 `review lifecyclemodel`；其余未迁移子命令继续只提供 help 和固定命名
 - 这样做的目的不是“假装已完成”，而是先固定命令树，再逐个把 workflow 迁入 TypeScript CLI
 
 ### 2.2 已经固定的工程约束
@@ -317,6 +361,62 @@ tiangong admin embedding-run --input ./jobs.json --dry-run
 - 并发调度、daemon、远端 CRUD、历史 Python orchestrator 复刻
 - `process get`
 
+`lifecyclemodel auto-build` 现在固定的是“本地 lifecyclemodel local-run 组装契约层”。
+
+它负责：
+
+- 读取单个 request JSON
+- 解析一个或多个 `process-automated-builder` 本地 run
+- 从共享 flow UUID 推断 process graph
+- 选择 reference process
+- 计算各 process instance 的 `@multiplicationFactor`
+- 写出原生 `json_ordered` lifecyclemodel 数据集
+- 写出 `run-plan.json`、`resolved-manifest.json`、`selection/selection-brief.md`
+- 写出 `discovery/reference-model-summary.json`、`models/**/summary.json`、`connections.json`、`process-catalog.json`
+- 产出 `lifecyclemodel-auto-build-report.json`
+
+它现在还不负责：
+
+- reference-model discovery
+- 任何远端 lifecyclemodel CRUD
+- MCP / KB / LLM / OCR runtime
+
+`lifecyclemodel validate-build` 现在固定的是“本地 lifecyclemodel validation handoff 契约层”。
+
+它负责：
+
+- 从 `--run-dir` 重开已有 lifecyclemodel auto-build run
+- 扫描 `models/*/tidas_bundle/lifecyclemodels/*.json`
+- 通过统一 `validation` 模块重跑每个 model bundle 的本地校验
+- 在 `reports/model-validations/` 下输出 per-model 校验报告
+- 更新 `manifests/invocation-index.json`
+- 产出 `reports/lifecyclemodel-validate-build-report.json`
+
+它现在还不负责：
+
+- 远端 lifecyclemodel CRUD
+- 自动触发 `publish-build`
+- MCP / KB / LLM / OCR runtime
+
+`lifecyclemodel publish-build` 现在固定的是“本地 lifecyclemodel publish handoff 契约层”。
+
+它负责：
+
+- 从 `--run-dir` 重开已有 lifecyclemodel auto-build run
+- 收集 `models/*/tidas_bundle/lifecyclemodels/*.json` 下的原生 lifecyclemodel payload
+- 若存在 `reports/lifecyclemodel-validate-build-report.json`，则复用其中的 aggregate 校验摘要
+- 写出 `stage_outputs/10_publish/publish-bundle.json`
+- 写出 `stage_outputs/10_publish/publish-request.json`
+- 写出 `stage_outputs/10_publish/publish-intent.json`
+- 更新 `manifests/invocation-index.json`
+- 产出 `reports/lifecyclemodel-publish-build-report.json`
+
+它现在还不负责：
+
+- 直接执行远端 publish commit 或数据库 CRUD
+- 重新实现历史 MCP transport
+- reference-model discovery
+
 `review process` 现在固定的是“本地 process review 契约层”。
 
 它负责：
@@ -420,6 +520,90 @@ tiangong admin embedding-run --input ./jobs.json --dry-run
 - 其他治理后处理
 - 任何 MCP transport
 
+`flow build-alias-map` 现在固定的是“治理链中的独立 deterministic alias-map 构建契约层”。
+
+它负责：
+
+- 读取一个或多个 old flow JSON / JSONL 输入
+- 读取一个或多个 new flow JSON / JSONL 输入
+- 可选读取 `seed-alias-map`
+- 对每个 old flow 生成 `no_alias_needed | alias_map_entry | manual_review` 决策
+- 输出 `alias-plan.json`
+- 输出 `alias-plan.jsonl`
+- 输出 `flow-alias-map.json`
+- 输出 `manual-review-queue.jsonl`
+- 输出 `alias-summary.json`
+
+它现在还不负责：
+
+- process ref 扫描
+- repair planning / apply
+- 任何远端 publish/write
+- 任何 MCP transport
+
+`flow scan-process-flow-refs` 现在固定的是“治理链中的独立 process ref scan 契约层”。
+
+它负责：
+
+- 读取 process JSON / JSONL 输入
+- 读取一个或多个 scope flow JSON / JSONL 输入
+- 可选读取 catalog flow 与 alias map
+- 对每个 exchange 的 `referenceToFlowDataSet` 做 deterministic 分类
+- 可选先剔除 emergy-named process
+- 输出 `emergy-excluded-processes.json`
+- 输出 `scan-summary.json`
+- 输出 `scan-findings.json`
+- 输出 `scan-findings.jsonl`
+
+它现在还不负责：
+
+- 修复计划
+- patch apply
+- 后续本地校验
+- 任何远端 publish/write
+- 任何 MCP transport
+
+`flow plan-process-flow-repairs` 现在固定的是“治理链中的独立 deterministic repair planning 契约层”。
+
+它负责：
+
+- 读取 process JSON / JSONL 输入
+- 读取一个或多个 scope flow JSON / JSONL 输入
+- 可选读取 alias map
+- 可选读取 `scan-findings`
+- 显式执行 `disabled | alias-only | alias-or-unique-name` auto-patch boundary
+- 输出 `repair-plan.json`
+- 输出 `repair-plan.jsonl`
+- 输出 `manual-review-queue.jsonl`
+- 输出 `repair-summary.json`
+
+它现在还不负责：
+
+- 真正修改 process rows
+- 后续本地校验
+- 任何远端 publish/write
+- 任何 MCP transport
+
+`flow apply-process-flow-repairs` 现在固定的是“治理链中的独立 deterministic repair apply 契约层”。
+
+它负责：
+
+- 复用 planning 相同的 process / scope / alias / scan 输入契约
+- 只应用 deterministic subset
+- 输出 `patched-processes.json`
+- 输出 `process-patches/<process-id__version>/before.json`
+- 输出 `process-patches/<process-id__version>/after.json`
+- 输出 `process-patches/<process-id__version>/diff.patch`
+- 输出 `process-patches/<process-id__version>/evidence.json`
+- 若显式传入 `--process-pool-file`，把 exact-version patched rows 同步回本地 pool，并在 `repair-summary.json` 记录 `process_pool_sync`
+
+它现在还不负责：
+
+- 后续本地校验
+- 任何远端 publish/write
+- round2 remote-validation retry
+- 任何 MCP transport
+
 `flow regen-product` 现在固定的是“治理后 process-side 再生产物契约层”。
 
 它负责：
@@ -489,7 +673,7 @@ TIANGONG_LCA_LLM_MODEL=
 
 - 只为当前已实现的命令暴露 env
 - 不为了历史实现或未来猜测保留 alias
-- 某类能力如果还停留在 skills / Python workflow 层，就继续由那一层自己管理 env
+- CLI 仓库内部即使已经有预备模块，也要等到公开命令真正消费时才把对应 env 纳入契约
 - `review process` 的可选语义审核统一走 `TIANGONG_LCA_LLM_*`，不再引入 `OPENAI_*`
 - `review flow` 的可选语义审核也统一走 `TIANGONG_LCA_LLM_*`，不再引入 `OPENAI_*`
 - `publish run` / `validation run` 都是本地契约与执行收口，不新增远程 env
@@ -504,6 +688,7 @@ TIANGONG_LCA_LLM_MODEL=
 | `admin embedding-run` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`（`TIANGONG_LCA_REGION` 可选） |
 | `process get` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY` |
 | `process auto-build | resume-build | publish-build | batch-build` | 无 |
+| `lifecyclemodel auto-build | validate-build | publish-build | orchestrate` | 无 |
 | `lifecyclemodel build-resulting-process` | 本地运行默认无；若 request 开启 `process_sources.allow_remote_lookup=true`，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY` |
 | `lifecyclemodel publish-resulting-process` | 无 |
 | `review process` | 纯规则 review 默认无；若显式开启 `--enable-llm`，则需要 `TIANGONG_LCA_LLM_BASE_URL`、`TIANGONG_LCA_LLM_API_KEY`、`TIANGONG_LCA_LLM_MODEL` |
@@ -512,6 +697,10 @@ TIANGONG_LCA_LLM_MODEL=
 | `flow list` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY` |
 | `flow remediate` | 无 |
 | `flow publish-version` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY` |
+| `flow publish-reviewed-data` | 本地 dry-run 默认无；若 `--commit` 发布 prepared flow/process rows，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY` |
+| `flow scan-process-flow-refs` | 无 |
+| `flow plan-process-flow-repairs` | 无 |
+| `flow apply-process-flow-repairs` | 无 |
 | `flow regen-product` | 无 |
 | `publish run` | 无 |
 | `validation run` | 无 |
@@ -564,32 +753,50 @@ npm run prepush:gate
 | `lifecyclemodel-hybrid-search` | `tiangong search lifecyclemodel` |
 | `embedding-ft`                 | `tiangong admin embedding-run`   |
 
-### 7.3 已启动但未完成迁移的对象
+### 7.3 已完成 CLI 收口的 workflow skills
 
-这类能力已经进入 CLI 迁移路线，但还没有完全变成纯 TS 主链：
+当前 canonical path 已经固定为 `skill -> 原生 Node .mjs wrapper -> tiangong CLI`：
 
 - `process-automated-builder`
-  - 已落地 `tiangong process auto-build`
-  - 已落地 `tiangong process resume-build`
-  - 已落地 `tiangong process publish-build`
-  - 已落地 `tiangong process batch-build`
+  - `tiangong process auto-build`
+  - `tiangong process resume-build`
+  - `tiangong process publish-build`
+  - `tiangong process batch-build`
+  - skill 侧不再保留 Python / LangGraph / MCP / KB / OCR fallback
+- `lifecyclemodel-automated-builder`
+  - `tiangong lifecyclemodel auto-build`
+  - `tiangong lifecyclemodel validate-build`
+  - `tiangong lifecyclemodel publish-build`
+  - skill 侧不再保留 shell 兼容壳或 Python / MCP runtime
 - `lifecycleinventory-review`
-  - 已落地 `tiangong review process`
-  - `review lifecyclemodel` 仍处于 planned 状态
+  - `tiangong review process`
+  - 仍保留 `review lifecyclemodel` 作为未来原生 CLI 增量，不属于遗留 Python runtime
 - `flow-governance-review`
-  - 已落地 `tiangong review flow`（覆盖 `review-flows` slice）
-  - 已落地 `tiangong flow get`（覆盖治理链中的 deterministic direct-read detail slice）
-  - 已落地 `tiangong flow list`（覆盖治理链中的 deterministic direct-read list slice）
-  - 已落地 `tiangong flow remediate`（覆盖 `remediate-flows` / round1 deterministic remediation slice）
-  - 已落地 `tiangong flow publish-version`（覆盖 remediated-flow publish/update slice，并保留历史 sync artifacts）
-  - 已落地 `tiangong flow regen-product`（覆盖治理后的 process-side 再生产物 slice）
-- 其他重型 Python workflow
+  - `tiangong review flow`
+  - `tiangong flow get`
+  - `tiangong flow list`
+  - `tiangong flow remediate`
+  - `tiangong flow publish-version`
+  - `tiangong flow publish-reviewed-data`
+  - `tiangong flow build-alias-map`
+  - `tiangong flow scan-process-flow-refs`
+  - `tiangong flow plan-process-flow-repairs`
+  - `tiangong flow apply-process-flow-repairs`
+  - `tiangong flow regen-product`
+  - `tiangong flow validate-processes`
+  - OpenClaw / dedup / legacy Python orchestration 已从 supported path 中移除
+- `lifecyclemodel-recursive-orchestrator`
+  - `tiangong lifecyclemodel orchestrate`
+  - skill wrapper 只保留对 `plan | execute | publish` 的薄调用
+- `lca-publish-executor`
+  - `tiangong publish run`
+  - publish contract 已不再保留私有 Python 实现
 
-更合理的路径是：
+当前更合理的扩展路径是：
 
-1. 先让 CLI 成为统一入口
-2. 由 CLI 调度现有本地执行器
-3. 再逐步把值得平台化的环节抽成 REST 能力
+1. 先在 CLI 命令树定义稳定动作
+2. 再让 skill 只做薄调用
+3. 最后才判断是否值得继续下沉成 REST/Edge Function 能力
 
 ## 8. 推荐的 skills 调用方式
 
@@ -599,6 +806,7 @@ npm run prepush:gate
 
 - 默认路径：`${WORKSPACE_ROOT}/tiangong-lca-cli`
 - 可覆盖路径：`TIANGONG_LCA_CLI_DIR`
+- skill wrapper 直接使用原生 Node `.mjs`，不再保留 shell 兼容壳
 
 调用方式优先顺序：
 
@@ -610,25 +818,19 @@ npm run prepush:gate
 
 ## 9. 下一阶段路线
 
-### Phase 1
+### 当前已经完成
 
-- 完成当前薄远程命令
-- 完成 skills 对这批命令的收敛
-- 固定统一环境变量名和帮助文本
+- 统一 CLI 命令树已经固定
+- skills 已切为原生 Node `.mjs` 薄 wrapper
+- 旧 Python / MCP / shell runtime 已不再是 supported path
+- publish / validation / governance / orchestrate 都已经有统一 CLI 边界
 
-### Phase 2
+### 后续只保留原生增量，不再叫“遗留迁移”
 
-- 切 `process-automated-builder` 到 CLI-only wrapper
-- 引入 `review` / `job` / `flow` / `process` 的更多业务子命令
-- 用 CLI 接管现有 workflow 的稳定 contract 层
-- 统一 run-dir / artifact / manifest 输入输出格式
-
-### Phase 3
-
-- 把重型 workflow 中真正稳定的执行阶段逐步迁成纯 TS CLI
-- 把其中适合服务化的远程能力逐步服务化
-- 继续减少 skill 仓库里的 transport logic
-- 让 agent 主要理解 `tiangong` 命令树，而不是 repo 内部脚本细节
+- `review lifecyclemodel` 何时实现，取决于是否真的形成稳定业务动作
+- lifecyclemodel 的 discovery / AI 选择逻辑，只有在产品面确认需要时才继续抽象成新的 CLI 子命令
+- `auth` / `job` 之类 placeholder surface 只有在真实场景出现时才补齐，而不是为了对称性先做
+- 任何新增能力都必须先定义成 `tiangong <noun> <verb>`，再决定是否要进一步服务化
 
 ## 10. 结论
 

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -1,26 +1,31 @@
 # TianGong Skills -> CLI 迁移清单
 
-## 1. 目标结论
+## 1. 最终结论
 
-这份清单服务于一个明确判断：
+这轮迁移已经固定成一个明确结果：
 
-- `tiangong-lca-cli` 应该成为唯一执行入口
-- 业务执行逻辑应以 TypeScript 为主，收敛到 CLI
-- `tiangong-lca-skills` 最终只保留安装面、提示面、调用约定
-- Python workflow 只能视为迁移中的遗留层，不再是目标架构
+- `tiangong-lca-cli` 是唯一执行入口
+- 业务执行逻辑以 TypeScript / Node 24 为主，收敛到 CLI
+- `tiangong-lca-skills` 只保留 `SKILL.md`、参考文档、示例输入、原生 Node `.mjs` 薄 wrapper
+- Python、MCP、shell 兼容壳、私有 env parsing 都不再是 supported path
 
-换句话说，未来不应该再有“skill 自己维护一套 transport / env / orchestration / publish 逻辑”的情况。
+MCP 替代策略也已经固定，不再反复讨论：
+
+- 策略 1：直接调用 `tiangong-lca-edge-functions` 的 Edge Function / REST
+- 策略 2：直接访问 Supabase；复杂 CRUD 走官方 Supabase JS SDK，窄读路径允许 deterministic REST
+
+这份文档现在记录的是“迁移已完成后的完成态”，不是待做路线图。
 
 ## 2. 硬规则
 
-- [ ] 不再新增任何 Python 业务 workflow
-- [ ] 不再新增任何 skill 自带 HTTP / MCP / env parsing
-- [ ] 不再新增任何基于 MCP 的 CLI 内部传输层
-- [ ] 不再新增任何 shell 兼容壳 wrapper；新 wrapper 直接使用原生 Node `.mjs`
-- [ ] 所有新能力只能先定义成 `tiangong <noun> <verb>` 命令，再实现
-- [ ] `tiangong-lca-skills` 中的 wrapper 只能调用 `tiangong`，不能再直接 `curl`、直接调 MCP、直接跑业务 Python
-- [ ] CLI 的 env 只能按实际已实现命令逐步增加，不预埋未来猜测接口
-- [x] CLI 内部不再保留 “MCP 传输层” 作为技术路径；MCP 替代策略已明确为 Edge Functions/REST 或 Supabase JS CRUD
+- [x] 不再新增任何 Python 业务 workflow
+- [x] 不再新增任何 skill 自带 HTTP / MCP / env parsing
+- [x] 不再新增任何基于 MCP 的 CLI 内部传输层
+- [x] 不再新增任何 shell 兼容壳 wrapper；canonical wrapper 统一为原生 Node `.mjs`
+- [x] 所有新能力必须先定义成 `tiangong <noun> <verb>` 命令，再实现
+- [x] `tiangong-lca-skills` 中的 wrapper 只能调用 `tiangong`
+- [x] CLI 的 env 只按真实已实现命令暴露，不预埋未来猜测接口
+- [x] CLI 内部不再保留 “MCP 传输层” 作为技术路径
 
 ## 3. Repo 边界
 
@@ -31,21 +36,21 @@
 - 命令树
 - 参数解析
 - env 合同
-- REST 客户端
-- 本地运行态管理
-- artifact / manifest / run-id / job 输出契约
-- 测试与 100% 覆盖率质量门
+- REST / Edge Function / Supabase 访问
+- 本地运行态与 artifact 契约
+- 测试、lint、100% 覆盖率质量门
 
 ### 3.2 `tiangong-lca-skills`
 
-最终只负责：
+只负责：
 
 - `SKILL.md`
 - 使用说明
 - 示例输入
+- 原生 Node `.mjs` wrapper
 - 对 `tiangong` 的薄调用
 
-最终不负责：
+不再负责：
 
 - transport
 - CRUD 逻辑
@@ -55,421 +60,200 @@
 
 ### 3.3 `tidas-sdk` / `tidas-tools`
 
-继续作为库层存在，不需要把它们“并入 CLI 仓库”。
-
-正确做法是：
+继续作为库层存在：
 
 - CLI 调用这些库
-- 不在 skills 里重复实现一遍
-- 不在 CLI 里手抄 schema / validation / export 逻辑
+- skills 不再重复实现一遍
+- CLI 不手抄 schema / validation / export 逻辑
 
-## 4. 当前 Skill 盘点
+## 4. 当前 Skill 映射
 
-| Skill | 当前状态 | 当前技术形态 | 目标状态 | 优先级 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `flow-hybrid-search` | 已完成 CLI 收口 | 原生 Node `.mjs` wrapper -> `tiangong search flow`，不再保留 shell shim | 只保留 skill 文档，调用 `tiangong search flow` | P0 |
-| `process-hybrid-search` | 已完成 CLI 收口 | 原生 Node `.mjs` wrapper -> `tiangong search process`，不再保留 shell shim | 只保留 skill 文档，调用 `tiangong search process` | P0 |
-| `lifecyclemodel-hybrid-search` | 已完成 CLI 收口 | 原生 Node `.mjs` wrapper -> `tiangong search lifecyclemodel`，不再保留 shell shim | 只保留 skill 文档，调用 `tiangong search lifecyclemodel` | P0 |
-| `embedding-ft` | 已完成 CLI 收口 | 原生 Node `.mjs` wrapper -> `tiangong admin embedding-run`，不再保留 shell shim | 只保留 skill 文档，调用 `tiangong admin embedding-run` | P0 |
-| `process-automated-builder` | 已进入 CLI 化，canonical skill 入口切为原生 Node `.mjs`；CLI 先接管本地 build/publish handoff slices | `node wrapper (.mjs) -> tiangong process auto-build | resume-build | publish-build | batch-build`已落地；legacy Python/LangGraph/MCP/OpenAI/AI edge search/TianGong unstructured 仅保留在显式`legacy` 子命令后 | 继续把剩余 LangGraph/Python 阶段迁入 CLI 模块，并持续缩小 legacy 路径 | P1 |
-| `lifecyclemodel-automated-builder` | 仍是重 workflow | shell + Python + MCP + OpenAI | 迁成 `tiangong lifecyclemodel ...` 主链 | P1 |
-| `lifecyclemodel-resulting-process-builder` | CLI 本地 build/publish handoff + direct REST lookup 已落地，Node wrapper 已切换 | `node wrapper -> tiangong lifecyclemodel build/publish-resulting-process` | 保持薄 wrapper，作为 lifecyclemodel CLI 化参考模板 | P1 |
-| `lifecycleinventory-review` | 已进入 CLI 化，`review process` 已落地 | `node wrapper -> tiangong review process`，`review lifecyclemodel` 仍 planned | 保持薄 wrapper，并为后续 `review lifecyclemodel` 预留统一入口 | P2 |
-| `flow-governance-review` | 已进入 CLI 化；CLI 已落地 `review-flows` / `remediate-flows` / `publish-version` / `regen-product`，但 skill 侧只完成到 `review/remediate/publish/get/list` wrapper | `node wrapper -> tiangong review flow | flow get | flow list | flow remediate | flow publish-version` + shell/Python repair helpers；`flow regen-product` 仍未成为 skill 主入口 | 继续把 skill 内剩余治理子命令改走 `tiangong flow ...`，并缩小剩余 Python 治理面 | P2 |
-| `lifecyclemodel-recursive-orchestrator` | 仍是 orchestrator | Python orchestrator，串联多个技能 | 迁成 CLI 编排命令 | P3 |
-| `lca-publish-executor` | 已切到 CLI 收口，canonical 入口为 Node wrapper -> `tiangong publish run` | `skill -> tiangong publish run` | 仅保留薄 wrapper 与请求文档 | P2 |
+| Skill | Canonical 调用链 | 当前状态 | 说明 |
+| --- | --- | --- | --- |
+| `flow-hybrid-search` | `node wrapper (.mjs) -> tiangong search flow` | 已完成 | 薄 wrapper 模板 |
+| `process-hybrid-search` | `node wrapper (.mjs) -> tiangong search process` | 已完成 | 薄 wrapper 模板 |
+| `lifecyclemodel-hybrid-search` | `node wrapper (.mjs) -> tiangong search lifecyclemodel` | 已完成 | 薄 wrapper 模板 |
+| `embedding-ft` | `node wrapper (.mjs) -> tiangong admin embedding-run` | 已完成 | 薄 wrapper 模板 |
+| `process-automated-builder` | `node wrapper (.mjs) -> tiangong process auto-build / resume-build / publish-build / batch-build` | 已完成当前 CLI 收口 | skill 侧已无 Python / LangGraph / MCP fallback |
+| `lifecyclemodel-automated-builder` | `node wrapper (.mjs) -> tiangong lifecyclemodel auto-build / validate-build / publish-build` | 已完成当前 CLI 收口 | discovery / AI 选择若未来需要，按新的 CLI 特性处理，不再算遗留债务 |
+| `lifecyclemodel-resulting-process-builder` | `node wrapper (.mjs) -> tiangong lifecyclemodel build-resulting-process / publish-resulting-process` | 已完成 | resulting-process 模板 |
+| `lifecycleinventory-review` | `node wrapper (.mjs) -> tiangong review process` | 已完成当前 CLI 收口 | `review lifecyclemodel` 是未来原生增量，不是 Python 遗留 |
+| `flow-governance-review` | `node wrapper (.mjs) -> tiangong review flow / flow ...` | 已完成当前 CLI 收口 | reviewed publish、repair、regen、validate 均已进入 CLI |
+| `lifecyclemodel-recursive-orchestrator` | `node wrapper (.mjs) -> tiangong lifecyclemodel orchestrate` | 已完成 | plan / execute / publish-handoff 已原生化 |
+| `lca-publish-executor` | `node wrapper (.mjs) -> tiangong publish run` | 已完成 | 不再保留私有 publish Python contract |
 
-## 5. 现状证据
-
-当前 workspace 的状态已经进一步推进，但重逻辑仍未完全离开 skills / Python 层：
-
-- `flow-hybrid-search`、`process-hybrid-search`、`lifecyclemodel-hybrid-search`、`embedding-ft` 已切成 Node wrapper -> CLI，并完成了一轮 dry-run smoke check；这批技能已经不再以 Bash 作为 canonical path。
-- `lifecyclemodel-resulting-process-builder` 已切成 Node wrapper -> CLI；远端 lookup 现在也已经收口到 CLI 的 deterministic direct-read 路径。[`tiangong-lca-cli/src/lib/lifecyclemodel-resulting-process.ts`](../src/lib/lifecyclemodel-resulting-process.ts)
-- `lca-publish-executor` 已切成 Node wrapper -> `tiangong publish run`，不再把 publish contract 主逻辑继续留在 skill 自己的 Python 入口里。
-- `lifecycleinventory-review` 已切成统一 review 命令面：`tiangong review process` 在 CLI 中落地，skill 后续只应保留对该命令的薄调用；可选语义审核统一改走 `TIANGONG_LCA_LLM_*`，不再暴露 `OPENAI_*`。
-- `flow-governance-review` 的 `review-flows`、`remediate-flows`、`publish-version` 已切成 Node wrapper -> CLI，`flow get` / `flow list` CLI 读面也已落地；CLI 侧虽然已经落地 `tiangong flow regen-product`，但 skill 侧仍未把它暴露成 canonical wrapper，其他治理/修复相关子命令也仍在本地 shell/Python helper 中，且部分路径仍依赖 MCP。
-- `process-automated-builder` 的 canonical wrapper 已切成原生 Node `.mjs` -> `tiangong process ...`，并且不再保留 shell 兼容壳；但剩余 LangGraph/Python/MCP/OpenAI/KB/TianGong unstructured 业务阶段仍在显式 `legacy` 子命令后面，尚未迁入 CLI 模块。[`tiangong-lca-skills/process-automated-builder/tiangong_lca_spec/core/config.py`](../../tiangong-lca-skills/process-automated-builder/tiangong_lca_spec/core/config.py)
-- `lifecyclemodel-automated-builder` 仍是 Python 脚本 + MCP/OpenAI 路径。[`tiangong-lca-skills/lifecyclemodel-automated-builder/SKILL.md`](../../tiangong-lca-skills/lifecyclemodel-automated-builder/SKILL.md)
-
-这说明：
-
-- “应该统一到 CLI”是目标态
-- “现在还有 Python / skills 逻辑”是现状债务
-- 但 `process_from_flow` 的 intake/scaffold 已经开始被 CLI 接管，后续应该沿同一路径继续削减遗留层
-
-## 6. 可执行迁移路线
-
-下面这部分不是“方向建议”，而是可以直接排期和建 issue 的执行顺序。
-
-总原则只有一句：
-
-> 先让 CLI 成为唯一真实入口，再把每个 skill 逐个改成 `skill -> tiangong`，最后删除 Python / MCP / 旧 env 遗留层。
+## 5. 迁移完成清单
 
 ### Phase 0：冻结旧世界
 
-目标：
+- [x] 新需求默认先定义 CLI 命令，而不是先写 skill 脚本
+- [x] 不再新增 Python workflow、MCP client、独立 env parser
+- [x] “skills 最终只保留文档、示例、薄 wrapper” 已写进仓库文档
 
-- 停止继续制造新的 Python / MCP 债务
+### Phase 1：让 CLI 成为诚实入口
 
-ToDo：
+- [x] CLI help 只暴露真实已实现命令，未实现能力明确标为 planned
+- [x] `lifecyclemodel` 已成为正式一级命名空间
+- [x] README / `DEV_CN.md` / 实施指南 / 迁移清单 与真实命令面对齐
 
-- [ ] 明确宣布：不再新增任何 Python 业务 workflow
-- [ ] 明确宣布：不再新增任何 skill 自带 transport / env parsing
-- [ ] 明确宣布：不再新增任何基于 MCP 的 CLI 内部能力
-- [ ] 将 `tiangong-lca-skills` 中所有新需求默认路由到 CLI issue
-- [ ] 将“skills 最终只保留文档、示例、薄 wrapper”写成明确约束，而不是口头共识
+### Phase 2：收口薄 remote skills
 
-完成定义：
+- [x] `flow-hybrid-search` -> `tiangong search flow`
+- [x] `process-hybrid-search` -> `tiangong search process`
+- [x] `lifecyclemodel-hybrid-search` -> `tiangong search lifecyclemodel`
+- [x] `embedding-ft` -> `tiangong admin embedding-run`
+- [x] 这批 wrapper 已固定为原生 Node `.mjs`
+- [x] 技术路径只剩 `skill -> tiangong`
 
-- [ ] 新需求默认先问“CLI 命令叫什么”，而不是“再加一个 skill 脚本吗”
-- [ ] 新提交里不再出现新的 Python workflow、MCP client、独立 env parser
+### Phase 3：把 CLI 基础模块变成统一依赖面
 
-### Phase 1：收口 CLI 当前事实
-
-目标：
-
-- 先把 CLI 变成“诚实的入口”，避免命令帮助和真实能力脱节
-
-ToDo：
-
-- [x] 整理 `tiangong-lca-cli` 当前命令面，只保留真实可用命令，或把未实现命令明确标成 `planned`
-- [x] 决定 `lifecyclemodel` 是否作为 CLI 一级命名空间正式引入
-- [x] 把当前真实已实现能力和计划中能力分开写清楚
-- [x] 清理明显的文档残留，例如 `TIANGONG_CLI_DIR` -> `TIANGONG_LCA_CLI_DIR`
-- [x] 确保 agent 看完 `--help` 后不会误以为某个关键命令已经可用
-
-交付物：
-
-- [x] 更新后的 CLI help
-- [x] 更新后的 CLI 实施文档
-- [x] 更新后的 skills 说明文档
-
-完成定义：
-
-- [x] “命令面”与“实际实现”一致
-- [x] 当前阶段需要调用的能力，都能从 CLI 文档直接找到
-
-### Phase 2：清掉薄 remote skills
-
-目标：
-
-- 完成第一批已经有 CLI 等价能力的 skill 收口
-
-ToDo：
-
-- [x] `flow-hybrid-search` wrapper 改为只调用 `tiangong search flow`
-- [x] `process-hybrid-search` wrapper 改为只调用 `tiangong search process`
-- [x] `lifecyclemodel-hybrid-search` wrapper 改为只调用 `tiangong search lifecyclemodel`
-- [x] `embedding-ft` wrapper 改为只调用 `tiangong admin embedding-run`
-- [x] 再做一轮 smoke check，确认这些 wrapper 不再保留旧 token / env / HTTP 分支
-- [x] 全量文档中统一 skill 调用路径变量为 `TIANGONG_LCA_CLI_DIR`
-
-完成定义：
-
-- [x] 调用链只剩 `skill -> tiangong`
-- [x] 不再出现 `TIANGONG_API_KEY`、`TIANGONG_LCA_APIKEY`、`SUPABASE_FUNCTIONS_URL` 之类旧名
-- [x] 不再出现 skill 自己解析 HTTP header / base URL
-- [x] 这 4 个 skill 可以被视为“迁移模板”
-
-### Phase 3：把 CLI 基础模块正式变成 workflow 依赖面
-
-目标：
-
-- 不再让重 workflow 自己管理运行态、artifact、校验、LLM、KB、OCR、publish
-
-当前已具备：
-
-- [x] `run` 基础模块：`run_id`、目录布局、manifest、resume 元数据
+- [x] `run` 模块：`run_id`、目录布局、manifest、resume 元数据
 - [x] `artifacts` 模块：统一 JSON / JSONL / audit / report 输出
 - [x] `state-lock` 模块：本地单写者锁
-- [x] `http` / `rest-client` 模块：统一 REST 调用、重试、超时、错误格式
-- [x] `llm` 模块：统一模型调用抽象，不再直接暴露 `OPENAI_*`
-- [x] `kb-search` 模块：统一 `tiangong-ai-edge-function` 检索客户端
-- [x] `unstructured` 模块：统一 TianGong unstructured OCR / SI 解析客户端
+- [x] `http` / `rest-client` 模块：统一 REST 调用、错误格式、超时与重试
+- [x] `llm` 模块：统一 `TIANGONG_LCA_LLM_*`
+- [x] `kb-search` 模块：作为 CLI 内部预备模块存在，但还没有公开命令消费它
+- [x] `unstructured` 模块：作为 CLI 内部预备模块存在，但还没有公开命令消费它
 - [x] `publish` 模块：统一 dry-run / commit / publish report
-- [x] `validation` 模块：把 `tidas-sdk` / `tidas-tools` 校验调用收口到 CLI
+- [x] `validation` 模块：统一 `tidas-sdk` / `tidas-tools` 调用
 
-还需要做：
-
-- [ ] 明确哪些模块已经允许 workflow 直接依赖，哪些仍是内部预备模块
-- [ ] 为后续 workflow 命令确定稳定的输入输出契约
-- [ ] 确保未来不会再在 skill 里复制一份这些能力
-
-完成定义：
-
-- [ ] 重 workflow 迁移时，只需要编排 CLI 模块，而不需要重新设计 transport / cache / validation / publish
-
-### Phase 4：先迁 `lifecyclemodel-resulting-process-builder`
-
-这一步不是因为它最重要，而是因为它最适合作为“第一个完整 CLI 化重 workflow 模板”。
-
-当前状态：
-
-- `tiangong lifecyclemodel build-resulting-process` 已在 CLI 中落地，且通过 `npm run prepush:gate`
-- `tiangong lifecyclemodel publish-resulting-process` 已在 CLI 中落地，且通过 `npm run prepush:gate`
-- 仍未完成 skill wrapper 文档面收口和更上层 workflow 迁移，但远程 lookup 已不再是 CLI 阻塞项
-
-目标命令：
+### Phase 4：迁 resulting-process builder
 
 - [x] `tiangong lifecyclemodel build-resulting-process`
 - [x] `tiangong lifecyclemodel publish-resulting-process`
+- [x] resulting-process 远端 lookup 已改为 deterministic direct-read
+- [x] skill wrapper 已改成纯 CLI 路径
+- [x] Python build / publish 主入口已删除
 
-ToDo：
+### Phase 5：统一 publish / validation
 
-- [x] 在 CLI 中补齐 `lifecyclemodel` 顶层命名空间
-- [x] 将 lifecycle model 读取、拓扑解析、聚合投影逻辑迁到 TS
-- [x] 将 process catalog / local run 解析改为复用 CLI 模块
-- [x] 将 resulting-process publish handoff 生成迁到 TS CLI
-- [x] 将远程 process lookup 从可选 MCP lookup 改为直接 REST 查询
-- [ ] 保留 `publish-bundle.json` 契约，但发布入口统一走 CLI publish
-- [x] skill wrapper 改为只调用 CLI
-- [x] 删除 Python build / publish 主入口
-
-交付物：
-
-- [x] CLI 子命令实现
-- [x] CLI 测试
-- [x] 对应文档
-- [x] skills 薄 wrapper
-
-完成定义：
-
-- [x] 这个 skill 不再需要 Python builder
-- [x] 这个 skill 不再需要 MCP lookup
-- [x] 这个 skill 成为后续其它重 workflow CLI 化的参考模板
-
-### Phase 5：收口 publish / validation，清掉交付层并行实现
-
-目标：
-
-- 不再允许某个 skill 自带一套 publish 或 validation 逻辑
-
-ToDo：
-
-- [ ] 所有需要本地校验的 skill，统一改走 `tiangong validation run`
-- [ ] 所有需要 publish handoff 的 skill，统一改走 `tiangong publish run`
-- [ ] 若 `publish run` 还缺少远端 commit executor，则在 CLI 里补，不在 skills 里补
-- [x] 将 `lca-publish-executor` 改成 CLI wrapper 或直接废弃
-- [ ] 明确 relation manifest / deferred publish / dry-run / commit 的唯一语义
-
-完成定义：
-
-- [x] `lca-publish-executor` 不再是 canonical Python publish contract layer
-- [ ] 没有任何 skill 再维护独立 publish 契约
-- [ ] 没有任何 skill 再自行判断用 `tidas-sdk` 还是 `tidas-tools`
+- [x] 所有本地校验统一收口到 `tiangong validation run`
+- [x] 所有 publish handoff 统一收口到 `tiangong publish run`
+- [x] `lca-publish-executor` 已收口成 CLI wrapper
+- [x] relation manifest / deferred publish / dry-run / commit 的唯一语义已写进 CLI 文档
+- [x] skills 不再自行判断使用 `tidas-sdk` 还是 `tidas-tools`
 
 ### Phase 6：迁 `process-automated-builder`
-
-这是最大的债务，也是最关键的主链迁移。
-
-目标命令：
 
 - [x] `tiangong process auto-build`
 - [x] `tiangong process resume-build`
 - [x] `tiangong process publish-build`
 - [x] `tiangong process batch-build`
+- [x] intake / run-id / scaffold / state-lock / publish handoff / batch orchestration 已迁入 CLI
+- [x] skill runtime 中的业务 Python / LangGraph / MCP / OpenAI / KB / TianGong unstructured 依赖已删除
+- [x] 当前 skill 只剩 `skill -> tiangong process ...`
 
-建议拆成 4 个连续小步骤，而不是一次性大迁移：
+说明：
 
-- [x] 6.1 先实现 `auto-build` 的本地产物路径，不做 publish
-- [x] 6.2 再实现 `resume-build`，把 state-lock / run manifest 彻底收口到 CLI
-- [x] 6.3 再实现 `publish-build`，接到统一 publish 模块的本地 handoff 契约
-- [x] 6.4 最后实现 `batch-build`
-
-迁移内容：
-
-- [x] intake request normalization / flow 归一化 / run-id / local artifact scaffold 迁到 TS CLI
-- [x] 本地状态锁、cache、resume handoff 逻辑迁到 CLI
-- [x] 本地 publish handoff、publish-bundle/request/intent 契约迁到 CLI
-- [x] 本地 batch manifest orchestration、aggregate report、default run_dir 分配迁到 CLI
-- [ ] 流程编排迁到 TS
-- [ ] flow search 改为直接 REST，而不是 MCP
-- [ ] publish 改为直接 REST / CLI publish，而不是 MCP CRUD
-- [ ] LLM 调用改为 CLI 的 provider abstraction
-- [ ] KB 检索改为 CLI 的 AI edge search client
-- [ ] unstructured 调用改为 CLI 的 client
-- [ ] 保留 artifact 契约，不保留 Python 实现
-
-迁移完成后应删除：
-
-- [ ] `scripts/origin/process_from_flow_langgraph.py`
-- [ ] 对 LangGraph 的硬依赖
-- [ ] 对 `OPENAI_*`、`TIANGONG_LCA_REMOTE_*`、`TIANGONG_KB_REMOTE_*`、`TIANGONG_MINERU_WITH_IMAGE_*` 的依赖
-
-完成定义：
-
-- [ ] `process-automated-builder` 只剩 `skill -> tiangong process ...`
-- [ ] agent 不再需要知道 LangGraph / MCP / OpenAI / TianGong unstructured 细节
+- 当前 CLI 只保留真实已落地的本地 artifact-first slices
+- 旧的端到端 Python 主链没有被“兼容保留”，而是直接移出 supported path
+- 若未来需要新的远端或 AI 阶段，必须作为新的原生 `tiangong process ...` 命令重建
 
 ### Phase 7：迁 `lifecyclemodel-automated-builder`
 
-目标命令：
+- [x] `tiangong lifecyclemodel auto-build`
+- [x] `tiangong lifecyclemodel validate-build`
+- [x] `tiangong lifecyclemodel publish-build`
+- [x] 本地 `json_ordered` 组装改为 TS
+- [x] 本地校验统一改为 CLI 调用 `tidas-sdk` / `tidas-tools`
+- [x] publish handoff 改为统一 publish 模块
+- [x] canonical skill 入口切为原生 Node `.mjs` -> CLI
+- [x] 不再保留 shell 兼容壳或 Python / MCP runtime
 
-- [ ] `tiangong lifecyclemodel auto-build`
-- [ ] `tiangong lifecyclemodel validate-build`
-- [ ] `tiangong lifecyclemodel publish-build`
+说明：
 
-ToDo：
-
-- [ ] process discovery 改为 CLI 统一查询面
-- [ ] AI 选择逻辑改为 CLI LLM 模块
-- [ ] 本地 `json_ordered` 组装改为 TS
-- [ ] 本地校验改为 CLI 调用 `tidas-sdk` / `tidas-tools`
-- [ ] publish 改为统一 publish 模块
-- [ ] 去掉只为 MCP insert 保留的分支
-
-完成定义：
-
-- [ ] lifecycle model 自动构建不再依赖 Python 和 MCP
-- [ ] 与 resulting-process / process build 的运行态契约一致
+- reference-model discovery / AI 选择如果未来要做，属于新的原生 CLI 特性
+- 它不再是“迁移遗留项”，也不应该通过 skill 私有 runtime 补回去
 
 ### Phase 8：迁 review / governance
 
-目标：
-
-- 把 review 与治理能力收口到统一 CLI，而不是分散脚本
-
-ToDo：
-
 - [x] `lifecycleinventory-review` -> `tiangong review process`
-- [x] `flow-governance-review` 的 `review-flows` slice -> `tiangong review flow`
-- [x] `flow-governance-review` 的 `remediate-flows` slice -> `tiangong flow remediate`
-- [x] `flow-governance-review` 的只读治理子命令 -> `tiangong flow get|list`
-- [x] `flow-governance-review` 的再生产物子命令 -> `tiangong flow regen-product`
+- [x] `flow-governance-review` 的 review slice -> `tiangong review flow`
+- [x] `flow-governance-review` 的 read / remediate / publish / alias / repair / regen / validate slices 全部进入 `tiangong flow ...`
+- [x] `tiangong flow publish-reviewed-data --commit` 已覆盖 prepared process rows 的远端提交
 - [x] review 输出继续保持本地 artifact-first
-- [ ] 去掉剩余治理 / 修复脚本中的直接 MCP 路径
+- [x] OpenClaw / dedup / legacy Python orchestration 已从 supported path 中移除
 
-完成定义：
+### Phase 9：迁 orchestrator
 
-- [x] review / governance 的核心 review + read + remediate + publish 能力已经可以直接从 CLI 命令树被发现
-- [x] 剩余 regen-product / repair 子链也能直接从 CLI 命令树被发现
-- [x] agent 不再需要进入某个 skill 内部脚本目录才能执行治理任务
-
-### Phase 9：最后迁 orchestrator
-
-只有在前面的构建、publish、review 子命令都稳定后，才应该做这一步。
-
-ToDo：
-
-- [ ] `lifecyclemodel-recursive-orchestrator` 迁成 CLI 编排命令
-- [ ] 所有子步骤只通过 `tiangong` 子命令调用
-- [ ] orchestrator 只负责编排，不再承载业务实现
-- [ ] 不再保留 Python orchestrator 作为总入口
-
-完成定义：
-
-- [ ] 总控层只编排 CLI
-- [ ] 没有新的“第二套入口”
+- [x] `lifecyclemodel-recursive-orchestrator` 已迁成 `tiangong lifecyclemodel orchestrate`
+- [x] `plan | execute | publish` 已原生进入 CLI
+- [x] orchestrator 只编排 CLI-native builder slices，不再承载 Python 业务实现
+- [x] 不再保留 Python orchestrator 作为总入口
 
 ### Phase 10：删除遗留层
 
-目标：
+- [x] 删除 skills 中的业务 Python runtime
+- [x] 删除 skills 中的业务 shell 实现，仅保留原生 Node `.mjs` wrapper
+- [x] 删除 skills 中的 transport / env parsing 逻辑
+- [x] 删除 skills 中的 MCP-only 实现
+- [x] 删除旧 env 名的 runtime 依赖与文档残留
+- [x] 删除对 `TIANGONG_CLI_DIR` 旧变量名的依赖，统一为 `TIANGONG_LCA_CLI_DIR`
 
-- 在代码层面真正完成“skills 全部只使用 CLI”
+## 6. Env 收敛清单
 
-ToDo：
-
-- [ ] 删除 skills 中的业务 Python 运行时
-- [ ] 删除 skills 中的业务 shell 实现，只保留薄 wrapper
-- [ ] 删除 skills 中的 transport / env parsing 逻辑
-- [ ] 删除 skills 中的 MCP-only 实现
-- [ ] 删除所有旧 env 名文档
-- [ ] 删除对 `TIANGONG_CLI_DIR` 旧变量名的依赖
-- [ ] 每个相关 repo merge 后，更新 `lca-workspace` 子模块指针
-
-最终 `skills` 仓库应只剩：
-
-- [ ] `SKILL.md`
-- [ ] 示例 request / assets
-- [ ] 参考文档
-- [ ] 对 `tiangong` 的薄调用
-
-## 7. Env 收敛清单
-
-### 7.1 已经落地
+### 6.1 当前 CLI 公开 env
 
 - [x] `TIANGONG_LCA_API_BASE_URL`
 - [x] `TIANGONG_LCA_API_KEY`
 - [x] `TIANGONG_LCA_REGION`
-
-### 7.2 后续若 CLI 真正实现对应模块，再增加
-
+- [x] `TIANGONG_LCA_LLM_BASE_URL`
 - [x] `TIANGONG_LCA_LLM_API_KEY`
 - [x] `TIANGONG_LCA_LLM_MODEL`
-- [x] `TIANGONG_LCA_LLM_BASE_URL`
-- [x] `TIANGONG_LCA_KB_SEARCH_API_BASE_URL`
-- [x] `TIANGONG_LCA_KB_SEARCH_API_KEY`
-- [x] `TIANGONG_LCA_KB_SEARCH_REGION`
-- [x] `TIANGONG_LCA_UNSTRUCTURED_API_BASE_URL`
-- [x] `TIANGONG_LCA_UNSTRUCTURED_API_KEY`
-- [x] `TIANGONG_LCA_UNSTRUCTURED_PROVIDER`
-- [x] `TIANGONG_LCA_UNSTRUCTURED_MODEL`
-- [x] `TIANGONG_LCA_UNSTRUCTURED_CHUNK_TYPE`
-- [x] `TIANGONG_LCA_UNSTRUCTURED_RETURN_TXT`
-- [ ] `TIANGONG_LCA_CLI_DIR`
 
-### 7.3 应彻底淘汰
+### 6.2 当前 wrapper 约定变量
 
-- [ ] `TIANGONG_API_BASE_URL`
-- [ ] `TIANGONG_API_KEY`
-- [ ] `TIANGONG_REGION`
-- [ ] `TIANGONG_LCA_APIKEY`
-- [ ] `SUPABASE_FUNCTIONS_URL`
-- [ ] `SUPABASE_FUNCTION_REGION`
-- [ ] `OPENAI_*`
-- [ ] `LCA_OPENAI_*`
-- [ ] `TIANGONG_KB_*`（旧直连命名）
-- [ ] `TIANGONG_LCA_REMOTE_*`
-- [ ] `TIANGONG_KB_REMOTE_*`
-- [ ] `TIANGONG_MINERU_WITH_IMAGE_*`
-- [ ] `MINERU_*`
-- [ ] `MINERU_WITH_IMAGES_*`
+- [x] `TIANGONG_LCA_CLI_DIR`
 
-## 8. 每个 Skill 的完成定义
+### 6.3 已从 runtime / 文档中淘汰的旧命名
 
-一个 skill 只有在满足下面条件后，才算迁移完成：
+- [x] `TIANGONG_API_BASE_URL`
+- [x] `TIANGONG_API_KEY`
+- [x] `TIANGONG_REGION`
+- [x] `TIANGONG_LCA_APIKEY`
+- [x] `SUPABASE_FUNCTIONS_URL`
+- [x] `SUPABASE_FUNCTION_REGION`
+- [x] `OPENAI_*`
+- [x] `LCA_OPENAI_*`
+- [x] `TIANGONG_KB_*`（旧直连命名）
+- [x] `TIANGONG_LCA_REMOTE_*`
+- [x] `TIANGONG_KB_REMOTE_*`
+- [x] `TIANGONG_MINERU_WITH_IMAGE_*`
+- [x] `MINERU_*`
+- [x] `MINERU_WITH_IMAGES_*`
 
-- [ ] skill 不再直接执行业务 Python
-- [ ] skill 不再直接访问 REST / MCP
-- [ ] skill 不再解析 env
-- [ ] skill 不再持有独立 publish 逻辑
-- [ ] skill 只调用统一 `tiangong` 命令
-- [ ] 对应 CLI 子命令有测试
-- [ ] 对应 CLI 子命令有文档
-- [ ] 对应 CLI 子命令纳入 `npm run prepush:gate`
-- [ ] 对应 skill 文档已改成 CLI 用法
+说明：
 
-## 9. 立即执行的短清单
+- `kb-search` / `unstructured` 虽然已经有 CLI 内部模块，但当前没有公开命令消费它们
+- 因此这些 env 不应进入 `.env.example`，也不应该被 skill wrapper 私自解析
 
-当前已经完成：
+## 7. 每个 Skill 的完成定义
 
-1. `tiangong process auto-build` / `resume-build` / `publish-build` / `batch-build`（Phase 6.1 / 6.2 / 6.3 / 6.4）。
-2. `tiangong process get` 已落地，并成为 lifecyclemodel resulting-process / 后续 review/governance 迁移可复用的只读远端 process 详情面。
-3. `tiangong lifecyclemodel build-resulting-process` / `publish-resulting-process` 子命令落地。
-4. `tiangong publish run` 与 `tiangong validation run` 作为统一契约边界落地。
-5. thin remote skills 已切为 Node wrapper -> CLI，并完成一轮 smoke check。
-6. `process-automated-builder` canonical wrapper 已切为原生 Node `.mjs` -> CLI；不再保留 shell 兼容壳。
-7. `lca-publish-executor` 已切为 Node wrapper -> `tiangong publish run`；publish skill 不再继续扩张私有 Python contract。
+一个 skill 在当前架构下只有满足下面条件，才算迁移完成：
 
-下一轮建议严格做这 5 件事（从当前状态继续推进）：
+- [x] skill 不再直接执行业务 Python
+- [x] skill 不再直接访问 REST / MCP
+- [x] skill 不再解析 env
+- [x] skill 不再持有独立 publish 逻辑
+- [x] skill 只调用统一 `tiangong` 命令
+- [x] 对应 CLI 子命令有测试
+- [x] 对应 CLI 子命令有文档
+- [x] 对应 CLI 子命令纳入 `npm run prepush:gate`
+- [x] 对应 skill 文档已改成 CLI 用法
 
-1. 完成 `lifecyclemodel-automated-builder` 的 CLI 子命令切片设计（`auto-build` / `validate-build` / `publish-build`）。
-2. 继续把 `flow-governance-review` 剩余治理 / 修复子链收口到 `tiangong flow ...`，以已经落地的 `tiangong review flow`、`tiangong flow get`、`tiangong flow list`、`tiangong flow remediate`、`tiangong flow publish-version`、`tiangong flow regen-product` 为统一入口。
-3. 明确 publish commit 的唯一执行边界：`tiangong publish run` executor，不回流到 skill 私有实现。
-4. 继续迁掉 `process-automated-builder` 剩余 LangGraph/Python 阶段，而不是只停在 local handoff wrapper。
-5. 每个里程碑 merge 后，回到 `lca-workspace` 做子模块指针 bump。
+## 8. 未来原生增量候选（不再算迁移 TODO）
 
-## 10. 不应该做的事
+下面这些可以做，但它们已经不是“清遗留”的待办，而是新的产品能力：
 
-- [ ] 不要先迁 orchestrator
-- [ ] 不要保留 Python 主逻辑，只包一层 TS 壳就算完成
-- [ ] 不要继续在 skills 里加新 env、新 transport、新 publish 约定
-- [ ] 不要为了兼容旧实现，把 MCP 重新带回 CLI
+- `tiangong review lifecyclemodel`
+- lifecyclemodel 的 discovery / AI 选择逻辑
+- `auth` / `job` 等只有在真实场景出现时才应该补齐的命令面
+- 更深的 KB / TianGong unstructured 能力，前提是先形成稳定的 CLI 业务动作
 
-## 11. 一句话标准
+## 9. 一句话标准
 
-判断迁移是否走在正确方向上，只问一句：
+只问一句：
 
-> 一个 agent 要完成工作时，是否只需要知道 `tiangong` 命令树，而不需要知道 skills 内部 shell、Python、MCP、OpenAI、AI edge search、unstructured 的实现细节？
+> 一个 agent 要完成工作时，是否只需要知道 `tiangong` 命令树，而不需要知道 skills 内部的 Python、MCP、shell、OpenAI、KB、OCR 实现细节？
 
-如果答案还是“否”，说明迁移还没完成。
+当前答案已经是“是”。

--- a/examples/lifecyclemodel-auto-build.request.json
+++ b/examples/lifecyclemodel-auto-build.request.json
@@ -1,0 +1,6 @@
+{
+  "run_label": "demo-lifecyclemodel-local-build",
+  "local_runs": [
+    "./process-build-run"
+  ]
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,11 @@ import { CliError, toErrorPayload } from './lib/errors.js';
 import type { FetchLike } from './lib/http.js';
 import { stringifyJson } from './lib/io.js';
 import {
+  runLifecyclemodelAutoBuild,
+  type LifecyclemodelAutoBuildReport,
+  type RunLifecyclemodelAutoBuildOptions,
+} from './lib/lifecyclemodel-auto-build.js';
+import {
   runLifecyclemodelBuildResultingProcess,
   type LifecyclemodelResultingProcessReport,
   type RunLifecyclemodelResultingProcessOptions,
@@ -14,6 +19,21 @@ import {
   type LifecyclemodelPublishResultingProcessReport,
   type RunLifecyclemodelPublishResultingProcessOptions,
 } from './lib/lifecyclemodel-publish-resulting-process.js';
+import {
+  runLifecyclemodelValidateBuild,
+  type LifecyclemodelValidateBuildReport,
+  type RunLifecyclemodelValidateBuildOptions,
+} from './lib/lifecyclemodel-validate-build.js';
+import {
+  runLifecyclemodelPublishBuild,
+  type LifecyclemodelPublishBuildReport,
+  type RunLifecyclemodelPublishBuildOptions,
+} from './lib/lifecyclemodel-publish-build.js';
+import {
+  runLifecyclemodelOrchestrate,
+  type LifecyclemodelOrchestrateReport,
+  type RunLifecyclemodelOrchestrateOptions,
+} from './lib/lifecyclemodel-orchestrate.js';
 import {
   runProcessAutoBuild,
   type ProcessAutoBuildReport,
@@ -63,9 +83,31 @@ import {
   type RunFlowPublishVersionOptions,
 } from './lib/flow-publish-version.js';
 import {
+  runFlowReviewedPublishData,
+  type FlowReviewedPublishDataReport,
+  type RunFlowReviewedPublishDataOptions,
+} from './lib/flow-publish-reviewed-data.js';
+import {
+  runFlowBuildAliasMap,
+  type FlowBuildAliasMapReport,
+  type RunFlowBuildAliasMapOptions,
+} from './lib/flow-build-alias-map.js';
+import {
+  runFlowApplyProcessFlowRepairs,
+  runFlowPlanProcessFlowRepairs,
   runFlowRegenProduct,
+  runFlowScanProcessFlowRefs,
+  runFlowValidateProcesses,
+  type FlowApplyProcessFlowRepairsReport,
+  type FlowPlanProcessFlowRepairsReport,
   type FlowRegenProductReport,
+  type FlowScanProcessFlowRefsReport,
+  type FlowValidateProcessesReport,
+  type RunFlowApplyProcessFlowRepairsOptions,
+  type RunFlowPlanProcessFlowRepairsOptions,
   type RunFlowRegenProductOptions,
+  type RunFlowScanProcessFlowRefsOptions,
+  type RunFlowValidateProcessesOptions,
 } from './lib/flow-regen-product.js';
 import { executeRemoteCommand, getRemoteCommandHelp } from './lib/remote.js';
 import {
@@ -80,12 +122,24 @@ export type CliDeps = {
   fetchImpl: FetchLike;
   runPublishImpl?: (options: RunPublishOptions) => Promise<PublishReport>;
   runValidationImpl?: (options: RunValidationOptions) => Promise<ValidationRunReport>;
+  runLifecyclemodelAutoBuildImpl?: (
+    options: RunLifecyclemodelAutoBuildOptions,
+  ) => Promise<LifecyclemodelAutoBuildReport>;
   runLifecyclemodelBuildResultingProcessImpl?: (
     options: RunLifecyclemodelResultingProcessOptions,
   ) => Promise<LifecyclemodelResultingProcessReport>;
   runLifecyclemodelPublishResultingProcessImpl?: (
     options: RunLifecyclemodelPublishResultingProcessOptions,
   ) => Promise<LifecyclemodelPublishResultingProcessReport>;
+  runLifecyclemodelValidateBuildImpl?: (
+    options: RunLifecyclemodelValidateBuildOptions,
+  ) => Promise<LifecyclemodelValidateBuildReport>;
+  runLifecyclemodelPublishBuildImpl?: (
+    options: RunLifecyclemodelPublishBuildOptions,
+  ) => Promise<LifecyclemodelPublishBuildReport>;
+  runLifecyclemodelOrchestrateImpl?: (
+    options: RunLifecyclemodelOrchestrateOptions,
+  ) => Promise<LifecyclemodelOrchestrateReport>;
   runProcessGetImpl?: (options: RunProcessGetOptions) => Promise<ProcessGetReport>;
   runProcessAutoBuildImpl?: (
     options: RunProcessAutoBuildOptions,
@@ -107,9 +161,27 @@ export type CliDeps = {
   runFlowPublishVersionImpl?: (
     options: RunFlowPublishVersionOptions,
   ) => Promise<FlowPublishVersionReport>;
+  runFlowReviewedPublishDataImpl?: (
+    options: RunFlowReviewedPublishDataOptions,
+  ) => Promise<FlowReviewedPublishDataReport>;
+  runFlowBuildAliasMapImpl?: (
+    options: RunFlowBuildAliasMapOptions,
+  ) => Promise<FlowBuildAliasMapReport>;
+  runFlowScanProcessFlowRefsImpl?: (
+    options: RunFlowScanProcessFlowRefsOptions,
+  ) => Promise<FlowScanProcessFlowRefsReport>;
+  runFlowPlanProcessFlowRepairsImpl?: (
+    options: RunFlowPlanProcessFlowRepairsOptions,
+  ) => Promise<FlowPlanProcessFlowRepairsReport>;
+  runFlowApplyProcessFlowRepairsImpl?: (
+    options: RunFlowApplyProcessFlowRepairsOptions,
+  ) => Promise<FlowApplyProcessFlowRepairsReport>;
   runFlowRegenProductImpl?: (
     options: RunFlowRegenProductOptions,
   ) => Promise<FlowRegenProductReport>;
+  runFlowValidateProcessesImpl?: (
+    options: RunFlowValidateProcessesOptions,
+  ) => Promise<FlowValidateProcessesReport>;
 };
 
 export type CliResult = {
@@ -142,8 +214,8 @@ Implemented Commands:
   doctor     show environment diagnostics
   search     flow | process | lifecyclemodel
   process    get | auto-build | resume-build | publish-build | batch-build
-  flow       get | list | remediate | publish-version | regen-product
-  lifecyclemodel build-resulting-process | publish-resulting-process
+  flow       get | list | remediate | publish-version | publish-reviewed-data | build-alias-map | scan-process-flow-refs | plan-process-flow-repairs | apply-process-flow-repairs | regen-product | validate-processes
+  lifecyclemodel auto-build | validate-build | publish-build | build-resulting-process | publish-resulting-process | orchestrate
   review     process | flow
   publish    run
   validation run
@@ -151,7 +223,6 @@ Implemented Commands:
 
 Planned Surface (not implemented yet):
   auth       whoami | doctor-auth
-  lifecyclemodel auto-build | validate-build | publish-build
   review     lifecyclemodel
   job        get | wait | logs
 
@@ -166,11 +237,21 @@ Examples:
   tiangong process resume-build --run-id <id>
   tiangong process publish-build --run-id <id>
   tiangong process batch-build --input ./batch-request.json
+  tiangong lifecyclemodel auto-build --input ./lifecyclemodel-auto-build.request.json
+  tiangong lifecyclemodel validate-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id>
+  tiangong lifecyclemodel publish-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id>
+  tiangong lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir ./artifacts/lifecyclemodel_recursive/run-001
   tiangong flow get --id <flow-id> --version <version>
   tiangong flow list --id <flow-id> --state-code 100 --limit 20
   tiangong flow remediate --input-file ./invalid-flows.jsonl --out-dir ./flow-remediation
   tiangong flow publish-version --input-file ./ready-flows.jsonl --out-dir ./flow-publish --commit
+  tiangong flow publish-reviewed-data --flow-rows-file ./reviewed-flows.jsonl --original-flow-rows-file ./original-flows.jsonl --out-dir ./flow-publish-review
+  tiangong flow build-alias-map --old-flow-file ./old-flows.jsonl --new-flow-file ./new-flows.jsonl --out-dir ./flow-alias-map
+  tiangong flow scan-process-flow-refs --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-scan
+  tiangong flow plan-process-flow-repairs --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-repair-plan
+  tiangong flow apply-process-flow-repairs --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-repair-apply
   tiangong flow regen-product --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-regeneration --apply
+  tiangong flow validate-processes --original-processes-file ./before.jsonl --patched-processes-file ./after.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-validation
   tiangong review process --run-root ./artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir ./review
   tiangong review flow --rows-file ./flows.json --out-dir ./review
   tiangong publish run --input ./publish-request.json --dry-run
@@ -259,7 +340,13 @@ Implemented Subcommands:
   list         Enumerate flow datasets through direct Supabase REST with deterministic filters
   remediate    Deterministically repair invalid local flow rows and emit artifact-first outputs
   publish-version Publish remediated flow versions through the unified CLI surface
+  publish-reviewed-data Prepare reviewed flow rows, skip unchanged snapshots, and optionally publish the resulting versions
+  build-alias-map Build a deterministic flow alias map from old/new local flow snapshots
+  scan-process-flow-refs Classify process exchange references against the current flow scope
+  plan-process-flow-repairs Plan deterministic repairs for local process-flow references
+  apply-process-flow-repairs Apply deterministic process-flow reference repairs and emit patch artifacts
   regen-product Regenerate local process-side artifacts after flow governance changes
+  validate-processes Validate locally patched process rows against allowed flow-reference-only changes
 
 Examples:
   tiangong flow --help
@@ -267,7 +354,13 @@ Examples:
   tiangong flow list --help
   tiangong flow remediate --help
   tiangong flow publish-version --help
+  tiangong flow publish-reviewed-data --help
+  tiangong flow build-alias-map --help
+  tiangong flow scan-process-flow-refs --help
+  tiangong flow plan-process-flow-repairs --help
+  tiangong flow apply-process-flow-repairs --help
   tiangong flow regen-product --help
+  tiangong flow validate-processes --help
 `.trim();
 }
 
@@ -365,6 +458,131 @@ Outputs written under --out-dir:
 `.trim();
 }
 
+function renderFlowPublishReviewedDataHelp(): string {
+  return `Usage:
+  tiangong flow publish-reviewed-data --out-dir <dir> [--flow-rows-file <file>] [--process-rows-file <file>] [options]
+
+Options:
+  --flow-rows-file <file>           Reviewed flow rows as JSON or JSONL
+  --original-flow-rows-file <file>  Optional original flow snapshot used to skip unchanged reviewed rows
+  --process-rows-file <file>        Optional reviewed process rows as JSON or JSONL
+  --flow-publish-policy <mode>      skip | append_only_bump | upsert_current_version (default: append_only_bump)
+  --process-publish-policy <mode>   skip | append_only_bump | upsert_current_version (default: append_only_bump)
+  --no-rewrite-process-flow-refs    Keep process flow references unchanged during local preparation
+  --commit                          Execute remote writes for prepared flow and process rows
+  --dry-run                         Keep the command local-only and write prepared artifacts without remote writes
+  --max-workers <n>                 Parallel worker count for the flow commit step (default: 4)
+  --target-user-id <id>             Override the target owner when prepared flow rows omit user_id
+  --json                            Print compact JSON
+  -h, --help
+
+Environment:
+  none for local dry-run
+  TIANGONG_LCA_API_BASE_URL and TIANGONG_LCA_API_KEY when --commit publishes prepared rows
+
+Outputs written under --out-dir:
+  - prepared-flow-rows.json
+  - prepared-process-rows.json
+  - flow-version-map.json
+  - skipped-unchanged-flow-rows.json
+  - process-flow-ref-rewrite-evidence.jsonl
+  - publish-report.json
+  - flows_tidas_sdk_plus_classification_mcp_success_list.json
+  - flows_tidas_sdk_plus_classification_remote_validation_failed.jsonl
+  - flows_tidas_sdk_plus_classification_mcp_sync_report.json
+`.trim();
+}
+
+function renderFlowBuildAliasMapHelp(): string {
+  return `Usage:
+  tiangong flow build-alias-map --old-flow-file <file> --new-flow-file <file> --out-dir <dir> [options]
+
+Options:
+  --old-flow-file <file>          Repeatable pre-governance flow snapshot as JSON or JSONL
+  --new-flow-file <file>          Repeatable post-governance flow snapshot as JSON or JSONL
+  --seed-alias-map <file>         Optional existing alias map JSON object used as deterministic seed input
+  --out-dir <dir>                 Output directory for alias-plan artifacts
+  --json                          Print compact JSON
+  -h, --help
+
+Outputs written under --out-dir:
+  - alias-plan.json
+  - alias-plan.jsonl
+  - flow-alias-map.json
+  - manual-review-queue.jsonl
+  - alias-summary.json
+`.trim();
+}
+
+function renderFlowScanProcessFlowRefsHelp(): string {
+  return `Usage:
+  tiangong flow scan-process-flow-refs --processes-file <file> --scope-flow-file <file> --out-dir <dir> [options]
+
+Options:
+  --processes-file <file>         Process rows as JSON or JSONL
+  --scope-flow-file <file>        Repeatable target flow scope file as JSON or JSONL
+  --catalog-flow-file <file>      Repeatable catalog flow file; defaults to the scope files
+  --alias-map <file>              Optional flow alias map JSON object
+  --exclude-emergy                Exclude emergy-named processes before reference scanning
+  --out-dir <dir>                 Output directory for scan artifacts
+  --json                          Print compact JSON
+  -h, --help
+
+Outputs written under --out-dir:
+  - emergy-excluded-processes.json
+  - scan-summary.json
+  - scan-findings.json
+  - scan-findings.jsonl
+`.trim();
+}
+
+function renderFlowPlanProcessFlowRepairsHelp(): string {
+  return `Usage:
+  tiangong flow plan-process-flow-repairs --processes-file <file> --scope-flow-file <file> --out-dir <dir> [options]
+
+Options:
+  --processes-file <file>         Process rows as JSON or JSONL
+  --scope-flow-file <file>        Repeatable target flow scope file as JSON or JSONL
+  --alias-map <file>              Optional flow alias map JSON object
+  --scan-findings <file>          Optional scan-findings JSON or JSONL from a prior scan step
+  --auto-patch-policy <mode>      disabled | alias-only | alias-or-unique-name (default: alias-only)
+  --out-dir <dir>                 Output directory for repair plan artifacts
+  --json                          Print compact JSON
+  -h, --help
+
+Outputs written under --out-dir:
+  - repair-plan.json
+  - repair-plan.jsonl
+  - manual-review-queue.jsonl
+  - repair-summary.json
+`.trim();
+}
+
+function renderFlowApplyProcessFlowRepairsHelp(): string {
+  return `Usage:
+  tiangong flow apply-process-flow-repairs --processes-file <file> --scope-flow-file <file> --out-dir <dir> [options]
+
+Options:
+  --processes-file <file>         Process rows as JSON or JSONL
+  --scope-flow-file <file>        Repeatable target flow scope file as JSON or JSONL
+  --alias-map <file>              Optional flow alias map JSON object
+  --scan-findings <file>          Optional scan-findings JSON or JSONL from a prior scan step
+  --auto-patch-policy <mode>      disabled | alias-only | alias-or-unique-name (default: alias-only)
+  --process-pool-file <file>      Optional process pool file to sync after patch application
+  --out-dir <dir>                 Output directory for repair apply artifacts
+  --json                          Print compact JSON
+  -h, --help
+
+Outputs written under --out-dir:
+  - repair-plan.json
+  - repair-plan.jsonl
+  - manual-review-queue.jsonl
+  - repair-summary.json
+  - patched-processes.json
+  - process-patches/
+`.trim();
+}
+
 function renderFlowRegenProductHelp(): string {
   return `Usage:
   tiangong flow regen-product --processes-file <file> --scope-flow-file <file> --out-dir <dir> [options]
@@ -389,6 +607,25 @@ Outputs written under --out-dir:
   - repair/
   - repair-apply/ (only with --apply)
   - validate/ (only with --apply)
+`.trim();
+}
+
+function renderFlowValidateProcessesHelp(): string {
+  return `Usage:
+  tiangong flow validate-processes --original-processes-file <file> --patched-processes-file <file> --scope-flow-file <file> --out-dir <dir> [options]
+
+Options:
+  --original-processes-file <file>  Original process rows before repair as JSON or JSONL
+  --patched-processes-file <file>   Patched process rows after repair as JSON or JSONL
+  --scope-flow-file <file>          Repeatable target flow scope file as JSON or JSONL
+  --out-dir <dir>                   Output directory for validation-report.json and validation-failures.jsonl
+  --tidas-mode <mode>               auto | required | skip (default: auto)
+  --json                            Print compact JSON
+  -h, --help
+
+Outputs written under --out-dir:
+  - validation-report.json
+  - validation-failures.jsonl
 `.trim();
 }
 
@@ -488,18 +725,103 @@ function renderLifecyclemodelHelp(): string {
   tiangong lifecyclemodel <subcommand> [options]
 
 Implemented Subcommands:
+  auto-build                Build native lifecyclemodel json_ordered artifacts from local process run exports
+  validate-build            Re-run local validation on one lifecyclemodel build run
+  publish-build             Prepare lifecyclemodel publish handoff artifacts from one local build run
   build-resulting-process   Deterministically aggregate a lifecycle model into a resulting process bundle
   publish-resulting-process Prepare publish-bundle.json and publish-intent.json from a prior resulting-process run
-
-Planned Subcommands:
-  auto-build                Assemble lifecycle models from discovered candidate processes
-  validate-build            Re-run local validation on a lifecycle model build run
-  publish-build             Publish a lifecycle model build run through the unified publish layer
+  orchestrate               Plan, execute, or publish a recursive lifecyclemodel assembly run
 
 Examples:
   tiangong lifecyclemodel --help
-  tiangong lifecyclemodel build-resulting-process --help
   tiangong lifecyclemodel auto-build --help
+  tiangong lifecyclemodel validate-build --help
+  tiangong lifecyclemodel publish-build --help
+  tiangong lifecyclemodel build-resulting-process --help
+  tiangong lifecyclemodel orchestrate --help
+`.trim();
+}
+
+function renderLifecyclemodelOrchestrateHelp(): string {
+  return `Usage:
+  tiangong lifecyclemodel orchestrate <plan|execute|publish> [options]
+
+Plan / execute options:
+  --input <file>                           JSON request file
+  --request <file>                         Alias for --input
+  --out-dir <dir>                          Output run directory
+  --allow-process-build                    Override orchestration.allow_process_build=true during execute
+  --allow-submodel-build                   Override orchestration.allow_submodel_build=true during execute
+  --json                                   Print compact JSON
+  -h, --help
+
+Publish options:
+  --run-dir <dir>                          Existing orchestrator run directory
+  --publish-lifecyclemodels                Include built lifecyclemodels in publish-bundle.json
+  --publish-resulting-process-relations    Include projected processes and resulting-process relations in publish-bundle.json
+  --json                                   Print compact JSON
+  -h, --help
+
+This command:
+  - normalizes a recursive request into assembly-plan.json, graph-manifest.json, lineage-manifest.json, and boundary-report.json
+  - executes only native CLI-backed builders; no Python fallback path remains
+  - prepares a local publish-bundle.json from prior invocation artifacts
+`.trim();
+}
+
+function renderLifecyclemodelAutoBuildHelp(): string {
+  return `Usage:
+  tiangong lifecyclemodel auto-build --input <file> [options]
+
+Options:
+  --input <file>     JSON request file
+  --out-dir <dir>    Override the default lifecyclemodel build run root
+  --json             Print compact JSON
+  -h, --help
+
+Minimal request contract:
+  {
+    "local_runs": ["/abs/path/to/process-build-run"]
+  }
+
+This first CLI slice is local-only and read-only:
+  - loads local process build run directories
+  - infers the process graph from shared flow UUIDs
+  - emits native lifecyclemodel json_ordered artifacts
+  - leaves follow-up validation and publish handoff to the companion validate-build and publish-build commands
+`.trim();
+}
+
+function renderLifecyclemodelValidateBuildHelp(): string {
+  return `Usage:
+  tiangong lifecyclemodel validate-build --run-dir <dir> [options]
+
+Options:
+  --run-dir <dir>    Existing lifecyclemodel auto-build run directory
+  --engine <mode>    auto | sdk | tools | all (default: auto)
+  --json             Print compact JSON
+  -h, --help
+
+This command:
+  - scans models/*/tidas_bundle from one lifecyclemodel auto-build run
+  - re-runs local validation through the unified validation module
+  - writes per-model validation reports plus one aggregate report
+`.trim();
+}
+
+function renderLifecyclemodelPublishBuildHelp(): string {
+  return `Usage:
+  tiangong lifecyclemodel publish-build --run-dir <dir> [options]
+
+Options:
+  --run-dir <dir>    Existing lifecyclemodel auto-build run directory
+  --json             Print compact JSON
+  -h, --help
+
+This command:
+  - collects native lifecyclemodel json_ordered payloads from one local build run
+  - writes publish-bundle.json, publish-request.json, and publish-intent.json
+  - keeps actual dry-run / commit execution in tiangong publish run
 `.trim();
 }
 
@@ -591,42 +913,6 @@ Examples:
 `.trim();
 }
 
-const lifecyclemodelPlannedHelp = {
-  'auto-build': `Usage:
-  tiangong lifecyclemodel auto-build --input <file> [options]
-
-Planned contract:
-  - read one lifecycle model build manifest from --input
-  - discover candidate processes through CLI query surfaces
-  - assemble native json_ordered lifecycle model artifacts locally
-
-Status:
-  Planned command. Execution is not implemented yet.
-`.trim(),
-  'validate-build': `Usage:
-  tiangong lifecyclemodel validate-build --run-dir <dir> [options]
-
-Planned contract:
-  - load one lifecycle model build run directory
-  - re-run local validation through the unified validation module
-  - write a structured validation report into the run artifacts
-
-Status:
-  Planned command. Execution is not implemented yet.
-`.trim(),
-  'publish-build': `Usage:
-  tiangong lifecyclemodel publish-build --run-dir <dir> [options]
-
-Planned contract:
-  - load one lifecycle model build run directory
-  - publish lifecycle model artifacts through the unified publish module
-  - preserve dry-run and commit semantics from tiangong publish run
-
-Status:
-  Planned command. Execution is not implemented yet.
-`.trim(),
-} as const;
-
 const reviewPlannedHelp = {
   lifecyclemodel: `Usage:
   tiangong review lifecyclemodel --input <file> [options]
@@ -641,14 +927,7 @@ Status:
 `.trim(),
 } as const;
 
-type LifecyclemodelPlannedSubcommand = keyof typeof lifecyclemodelPlannedHelp;
 type ReviewPlannedSubcommand = keyof typeof reviewPlannedHelp;
-
-function isLifecyclemodelPlannedSubcommand(
-  value: string | null,
-): value is LifecyclemodelPlannedSubcommand {
-  return Boolean(value && value in lifecyclemodelPlannedHelp);
-}
 
 function isReviewPlannedSubcommand(value: string | null): value is ReviewPlannedSubcommand {
   return Boolean(value && value in reviewPlannedHelp);
@@ -1036,6 +1315,361 @@ function parseFlowPublishVersionFlags(args: string[]): {
   };
 }
 
+function parseFlowPublishReviewedDataFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  flowRowsFile: string;
+  originalFlowRowsFile: string | null;
+  processRowsFile: string | null;
+  flowPublishPolicy: 'skip' | 'append_only_bump' | 'upsert_current_version';
+  processPublishPolicy: 'skip' | 'append_only_bump' | 'upsert_current_version';
+  rewriteProcessFlowRefs: boolean;
+  outDir: string;
+  commit: boolean;
+  maxWorkers: number | undefined;
+  targetUserId: string | null;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        'flow-rows-file': { type: 'string' },
+        'original-flow-rows-file': { type: 'string' },
+        'process-rows-file': { type: 'string' },
+        'flow-publish-policy': { type: 'string' },
+        'process-publish-policy': { type: 'string' },
+        'no-rewrite-process-flow-refs': { type: 'boolean' },
+        'out-dir': { type: 'string' },
+        commit: { type: 'boolean' },
+        'dry-run': { type: 'boolean' },
+        'max-workers': { type: 'string' },
+        'target-user-id': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  if (values.commit && values['dry-run']) {
+    throw new CliError('Cannot pass both --commit and --dry-run.', {
+      code: 'FLOW_PUBLISH_REVIEWED_MODE_CONFLICT',
+      exitCode: 2,
+    });
+  }
+
+  const processPublishPolicy =
+    typeof values['process-publish-policy'] === 'string'
+      ? values['process-publish-policy']
+      : 'append_only_bump';
+  if (
+    processPublishPolicy !== 'skip' &&
+    processPublishPolicy !== 'append_only_bump' &&
+    processPublishPolicy !== 'upsert_current_version'
+  ) {
+    throw new CliError(
+      'Expected --process-publish-policy to be one of: skip, append_only_bump, upsert_current_version.',
+      {
+        code: 'FLOW_PUBLISH_REVIEWED_PROCESS_POLICY_INVALID',
+        exitCode: 2,
+      },
+    );
+  }
+
+  const flowPublishPolicy =
+    typeof values['flow-publish-policy'] === 'string'
+      ? values['flow-publish-policy']
+      : 'append_only_bump';
+  if (
+    flowPublishPolicy !== 'skip' &&
+    flowPublishPolicy !== 'append_only_bump' &&
+    flowPublishPolicy !== 'upsert_current_version'
+  ) {
+    throw new CliError(
+      'Expected --flow-publish-policy to be one of: skip, append_only_bump, upsert_current_version.',
+      {
+        code: 'FLOW_PUBLISH_REVIEWED_FLOW_POLICY_INVALID',
+        exitCode: 2,
+      },
+    );
+  }
+
+  const parsePositiveIntegerFlag = (
+    value: unknown,
+    label: string,
+    code: string,
+  ): number | undefined => {
+    if (typeof value !== 'string') {
+      return undefined;
+    }
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      throw new CliError(`Expected ${label} to be a positive integer.`, {
+        code,
+        exitCode: 2,
+      });
+    }
+    return parsed;
+  };
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    flowRowsFile: typeof values['flow-rows-file'] === 'string' ? values['flow-rows-file'] : '',
+    originalFlowRowsFile:
+      typeof values['original-flow-rows-file'] === 'string'
+        ? values['original-flow-rows-file']
+        : null,
+    processRowsFile:
+      typeof values['process-rows-file'] === 'string' ? values['process-rows-file'] : null,
+    flowPublishPolicy,
+    processPublishPolicy,
+    rewriteProcessFlowRefs: !values['no-rewrite-process-flow-refs'],
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : '',
+    commit: Boolean(values.commit),
+    maxWorkers: parsePositiveIntegerFlag(
+      values['max-workers'],
+      '--max-workers',
+      'INVALID_FLOW_PUBLISH_REVIEWED_MAX_WORKERS',
+    ),
+    targetUserId: typeof values['target-user-id'] === 'string' ? values['target-user-id'] : null,
+  };
+}
+
+function parseFlowBuildAliasMapFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  oldFlowFiles: string[];
+  newFlowFiles: string[];
+  seedAliasMapFile: string | null;
+  outDir: string;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        'old-flow-file': { type: 'string', multiple: true },
+        'new-flow-file': { type: 'string', multiple: true },
+        'seed-alias-map': { type: 'string' },
+        'out-dir': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    oldFlowFiles: Array.isArray(values['old-flow-file'])
+      ? values['old-flow-file'].filter((value): value is string => typeof value === 'string')
+      : [],
+    newFlowFiles: Array.isArray(values['new-flow-file'])
+      ? values['new-flow-file'].filter((value): value is string => typeof value === 'string')
+      : [],
+    seedAliasMapFile:
+      typeof values['seed-alias-map'] === 'string' ? values['seed-alias-map'] : null,
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : '',
+  };
+}
+
+function parseFlowScanProcessFlowRefsFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  processesFile: string;
+  scopeFlowFiles: string[];
+  catalogFlowFiles: string[];
+  aliasMapFile: string | null;
+  excludeEmergy: boolean;
+  outDir: string;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        'processes-file': { type: 'string' },
+        'scope-flow-file': { type: 'string', multiple: true },
+        'catalog-flow-file': { type: 'string', multiple: true },
+        'alias-map': { type: 'string' },
+        'exclude-emergy': { type: 'boolean' },
+        'out-dir': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    processesFile: typeof values['processes-file'] === 'string' ? values['processes-file'] : '',
+    scopeFlowFiles: Array.isArray(values['scope-flow-file'])
+      ? values['scope-flow-file'].filter((value): value is string => typeof value === 'string')
+      : [],
+    catalogFlowFiles: Array.isArray(values['catalog-flow-file'])
+      ? values['catalog-flow-file'].filter((value): value is string => typeof value === 'string')
+      : [],
+    aliasMapFile: typeof values['alias-map'] === 'string' ? values['alias-map'] : null,
+    excludeEmergy: Boolean(values['exclude-emergy']),
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : '',
+  };
+}
+
+function parseFlowPlanProcessFlowRepairsFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  processesFile: string;
+  scopeFlowFiles: string[];
+  aliasMapFile: string | null;
+  scanFindingsFile: string | null;
+  autoPatchPolicy: 'disabled' | 'alias-only' | 'alias-or-unique-name';
+  outDir: string;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        'processes-file': { type: 'string' },
+        'scope-flow-file': { type: 'string', multiple: true },
+        'alias-map': { type: 'string' },
+        'scan-findings': { type: 'string' },
+        'auto-patch-policy': { type: 'string' },
+        'out-dir': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  const autoPatchPolicy =
+    typeof values['auto-patch-policy'] === 'string' ? values['auto-patch-policy'] : 'alias-only';
+  if (
+    autoPatchPolicy !== 'disabled' &&
+    autoPatchPolicy !== 'alias-only' &&
+    autoPatchPolicy !== 'alias-or-unique-name'
+  ) {
+    throw new CliError(
+      'Expected --auto-patch-policy to be one of disabled, alias-only, or alias-or-unique-name.',
+      {
+        code: 'INVALID_FLOW_PLAN_PROCESS_FLOW_REPAIRS_AUTO_PATCH_POLICY',
+        exitCode: 2,
+      },
+    );
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    processesFile: typeof values['processes-file'] === 'string' ? values['processes-file'] : '',
+    scopeFlowFiles: Array.isArray(values['scope-flow-file'])
+      ? values['scope-flow-file'].filter((value): value is string => typeof value === 'string')
+      : [],
+    aliasMapFile: typeof values['alias-map'] === 'string' ? values['alias-map'] : null,
+    scanFindingsFile: typeof values['scan-findings'] === 'string' ? values['scan-findings'] : null,
+    autoPatchPolicy,
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : '',
+  };
+}
+
+function parseFlowApplyProcessFlowRepairsFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  processesFile: string;
+  scopeFlowFiles: string[];
+  aliasMapFile: string | null;
+  scanFindingsFile: string | null;
+  autoPatchPolicy: 'disabled' | 'alias-only' | 'alias-or-unique-name';
+  processPoolFile: string | null;
+  outDir: string;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        'processes-file': { type: 'string' },
+        'scope-flow-file': { type: 'string', multiple: true },
+        'alias-map': { type: 'string' },
+        'scan-findings': { type: 'string' },
+        'auto-patch-policy': { type: 'string' },
+        'process-pool-file': { type: 'string' },
+        'out-dir': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  const autoPatchPolicy =
+    typeof values['auto-patch-policy'] === 'string' ? values['auto-patch-policy'] : 'alias-only';
+  if (
+    autoPatchPolicy !== 'disabled' &&
+    autoPatchPolicy !== 'alias-only' &&
+    autoPatchPolicy !== 'alias-or-unique-name'
+  ) {
+    throw new CliError(
+      'Expected --auto-patch-policy to be one of disabled, alias-only, or alias-or-unique-name.',
+      {
+        code: 'INVALID_FLOW_APPLY_PROCESS_FLOW_REPAIRS_AUTO_PATCH_POLICY',
+        exitCode: 2,
+      },
+    );
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    processesFile: typeof values['processes-file'] === 'string' ? values['processes-file'] : '',
+    scopeFlowFiles: Array.isArray(values['scope-flow-file'])
+      ? values['scope-flow-file'].filter((value): value is string => typeof value === 'string')
+      : [],
+    aliasMapFile: typeof values['alias-map'] === 'string' ? values['alias-map'] : null,
+    scanFindingsFile: typeof values['scan-findings'] === 'string' ? values['scan-findings'] : null,
+    autoPatchPolicy,
+    processPoolFile:
+      typeof values['process-pool-file'] === 'string' ? values['process-pool-file'] : null,
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : '',
+  };
+}
+
 function parseFlowRegenProductFlags(args: string[]): {
   help: boolean;
   json: boolean;
@@ -1125,6 +1759,63 @@ function parseFlowRegenProductFlags(args: string[]): {
     apply: Boolean(values.apply),
     processPoolFile:
       typeof values['process-pool-file'] === 'string' ? values['process-pool-file'] : null,
+    tidasMode,
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : '',
+  };
+}
+
+function parseFlowValidateProcessesFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  originalProcessesFile: string;
+  patchedProcessesFile: string;
+  scopeFlowFiles: string[];
+  tidasMode: 'auto' | 'required' | 'skip';
+  outDir: string;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        'original-processes-file': { type: 'string' },
+        'patched-processes-file': { type: 'string' },
+        'scope-flow-file': { type: 'string', multiple: true },
+        'tidas-mode': { type: 'string' },
+        'out-dir': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  const tidasMode = typeof values['tidas-mode'] === 'string' ? values['tidas-mode'] : 'auto';
+  if (tidasMode !== 'auto' && tidasMode !== 'required' && tidasMode !== 'skip') {
+    throw new CliError('Expected --tidas-mode to be one of auto, required, or skip.', {
+      code: 'INVALID_FLOW_VALIDATE_TIDAS_MODE',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    originalProcessesFile:
+      typeof values['original-processes-file'] === 'string'
+        ? values['original-processes-file']
+        : '',
+    patchedProcessesFile:
+      typeof values['patched-processes-file'] === 'string' ? values['patched-processes-file'] : '',
+    scopeFlowFiles: Array.isArray(values['scope-flow-file'])
+      ? values['scope-flow-file'].filter((value): value is string => typeof value === 'string')
+      : [],
     tidasMode,
     outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : '',
   };
@@ -1538,6 +2229,71 @@ function parseLifecyclemodelPublishFlags(args: string[]): {
   };
 }
 
+function parseLifecyclemodelValidateBuildFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  runDir: string;
+  engine: string | undefined;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        'run-dir': { type: 'string' },
+        engine: { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    runDir: typeof values['run-dir'] === 'string' ? values['run-dir'] : '',
+    engine: typeof values.engine === 'string' ? values.engine : undefined,
+  };
+}
+
+function parseLifecyclemodelPublishBuildFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  runDir: string;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        'run-dir': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    runDir: typeof values['run-dir'] === 'string' ? values['run-dir'] : '',
+  };
+}
+
 function parseLifecyclemodelBuildFlags(args: string[]): {
   help: boolean;
   json: boolean;
@@ -1569,6 +2325,60 @@ function parseLifecyclemodelBuildFlags(args: string[]): {
     json: Boolean(values.json),
     inputPath: typeof values.input === 'string' ? values.input : '',
     outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : null,
+  };
+}
+
+function parseLifecyclemodelOrchestrateFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  action: string;
+  inputPath: string;
+  outDir: string | null;
+  runDir: string;
+  allowProcessBuild: boolean;
+  allowSubmodelBuild: boolean;
+  publishLifecyclemodels: boolean;
+  publishResultingProcessRelations: boolean;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  let positionals: string[];
+  try {
+    ({ values, positionals } = parseArgs({
+      args,
+      allowPositionals: true,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        input: { type: 'string' },
+        request: { type: 'string' },
+        'out-dir': { type: 'string' },
+        'run-dir': { type: 'string' },
+        'allow-process-build': { type: 'boolean' },
+        'allow-submodel-build': { type: 'boolean' },
+        'publish-lifecyclemodels': { type: 'boolean' },
+        'publish-resulting-process-relations': { type: 'boolean' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  const inputAlias = typeof values.request === 'string' ? values.request : '';
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    action: positionals[0] ?? '',
+    inputPath: typeof values.input === 'string' ? values.input : inputAlias,
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : null,
+    runDir: typeof values['run-dir'] === 'string' ? values['run-dir'] : '',
+    allowProcessBuild: Boolean(values['allow-process-build']),
+    allowSubmodelBuild: Boolean(values['allow-submodel-build']),
+    publishLifecyclemodels: Boolean(values['publish-lifecyclemodels']),
+    publishResultingProcessRelations: Boolean(values['publish-resulting-process-relations']),
   };
 }
 
@@ -1769,10 +2579,18 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
     const { flags, command, subcommand, commandArgs } = parseCommandLine(argv);
     const publishImpl = deps.runPublishImpl ?? runPublish;
     const validationImpl = deps.runValidationImpl ?? runValidation;
+    const lifecyclemodelAutoBuildImpl =
+      deps.runLifecyclemodelAutoBuildImpl ?? runLifecyclemodelAutoBuild;
     const lifecyclemodelBuildImpl =
       deps.runLifecyclemodelBuildResultingProcessImpl ?? runLifecyclemodelBuildResultingProcess;
     const lifecyclemodelPublishImpl =
       deps.runLifecyclemodelPublishResultingProcessImpl ?? runLifecyclemodelPublishResultingProcess;
+    const lifecyclemodelValidateImpl =
+      deps.runLifecyclemodelValidateBuildImpl ?? runLifecyclemodelValidateBuild;
+    const lifecyclemodelPublishBuildImpl =
+      deps.runLifecyclemodelPublishBuildImpl ?? runLifecyclemodelPublishBuild;
+    const lifecyclemodelOrchestrateImpl =
+      deps.runLifecyclemodelOrchestrateImpl ?? runLifecyclemodelOrchestrate;
     const processGetImpl = deps.runProcessGetImpl ?? runProcessGet;
     const processAutoBuildImpl = deps.runProcessAutoBuildImpl ?? runProcessAutoBuild;
     const processBatchBuildImpl = deps.runProcessBatchBuildImpl ?? runProcessBatchBuild;
@@ -1784,7 +2602,17 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
     const flowGetImpl = deps.runFlowGetImpl ?? runFlowGet;
     const flowListImpl = deps.runFlowListImpl ?? runFlowList;
     const flowPublishVersionImpl = deps.runFlowPublishVersionImpl ?? runFlowPublishVersion;
+    const flowReviewedPublishDataImpl =
+      deps.runFlowReviewedPublishDataImpl ?? runFlowReviewedPublishData;
+    const flowBuildAliasMapImpl = deps.runFlowBuildAliasMapImpl ?? runFlowBuildAliasMap;
+    const flowScanProcessFlowRefsImpl =
+      deps.runFlowScanProcessFlowRefsImpl ?? runFlowScanProcessFlowRefs;
+    const flowPlanProcessFlowRepairsImpl =
+      deps.runFlowPlanProcessFlowRepairsImpl ?? runFlowPlanProcessFlowRepairs;
+    const flowApplyProcessFlowRepairsImpl =
+      deps.runFlowApplyProcessFlowRepairsImpl ?? runFlowApplyProcessFlowRepairs;
     const flowRegenProductImpl = deps.runFlowRegenProductImpl ?? runFlowRegenProduct;
+    const flowValidateProcessesImpl = deps.runFlowValidateProcessesImpl ?? runFlowValidateProcesses;
 
     if (flags.version) {
       return { exitCode: 0, stdout: '0.0.1\n', stderr: '' };
@@ -1840,6 +2668,29 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
       return { exitCode: 0, stdout: `${renderLifecyclemodelHelp()}\n`, stderr: '' };
     }
 
+    if (command === 'lifecyclemodel' && subcommand === 'auto-build') {
+      const lifecyclemodelFlags = parseLifecyclemodelBuildFlags(commandArgs);
+      if (lifecyclemodelFlags.help) {
+        return {
+          exitCode: 0,
+          stdout: `${renderLifecyclemodelAutoBuildHelp()}\n`,
+          stderr: '',
+        };
+      }
+
+      const report = await lifecyclemodelAutoBuildImpl({
+        inputPath: lifecyclemodelFlags.inputPath,
+        outDir: lifecyclemodelFlags.outDir,
+        cwd: process.cwd(),
+      });
+
+      return {
+        exitCode: 0,
+        stdout: stringifyJson(report, lifecyclemodelFlags.json),
+        stderr: '',
+      };
+    }
+
     if (command === 'lifecyclemodel' && subcommand === 'build-resulting-process') {
       const lifecyclemodelFlags = parseLifecyclemodelBuildFlags(commandArgs);
       if (lifecyclemodelFlags.help) {
@@ -1887,15 +2738,92 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
       };
     }
 
-    if (command === 'lifecyclemodel' && isLifecyclemodelPlannedSubcommand(subcommand)) {
-      if (commandArgs.includes('--help') || commandArgs.includes('-h')) {
+    if (command === 'lifecyclemodel' && subcommand === 'validate-build') {
+      const lifecyclemodelFlags = parseLifecyclemodelValidateBuildFlags(commandArgs);
+      if (lifecyclemodelFlags.help) {
         return {
           exitCode: 0,
-          stdout: `${lifecyclemodelPlannedHelp[subcommand]}\n`,
+          stdout: `${renderLifecyclemodelValidateBuildHelp()}\n`,
           stderr: '',
         };
       }
-      return plannedCommand(command, subcommand);
+
+      const report = await lifecyclemodelValidateImpl({
+        runDir: lifecyclemodelFlags.runDir,
+        engine: lifecyclemodelFlags.engine,
+        cwd: process.cwd(),
+      });
+
+      return {
+        exitCode: report.ok ? 0 : 1,
+        stdout: stringifyJson(report, lifecyclemodelFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'lifecyclemodel' && subcommand === 'publish-build') {
+      const lifecyclemodelFlags = parseLifecyclemodelPublishBuildFlags(commandArgs);
+      if (lifecyclemodelFlags.help) {
+        return {
+          exitCode: 0,
+          stdout: `${renderLifecyclemodelPublishBuildHelp()}\n`,
+          stderr: '',
+        };
+      }
+
+      const report = await lifecyclemodelPublishBuildImpl({
+        runDir: lifecyclemodelFlags.runDir,
+        cwd: process.cwd(),
+      });
+
+      return {
+        exitCode: 0,
+        stdout: stringifyJson(report, lifecyclemodelFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'lifecyclemodel' && subcommand === 'orchestrate') {
+      const lifecyclemodelFlags = parseLifecyclemodelOrchestrateFlags(commandArgs);
+      if (lifecyclemodelFlags.help || !lifecyclemodelFlags.action) {
+        return {
+          exitCode: 0,
+          stdout: `${renderLifecyclemodelOrchestrateHelp()}\n`,
+          stderr: '',
+        };
+      }
+      if (
+        lifecyclemodelFlags.action !== 'plan' &&
+        lifecyclemodelFlags.action !== 'execute' &&
+        lifecyclemodelFlags.action !== 'publish'
+      ) {
+        throw new CliError(
+          "lifecyclemodel orchestrate action must be 'plan', 'execute', or 'publish'.",
+          {
+            code: 'INVALID_ARGS',
+            exitCode: 2,
+          },
+        );
+      }
+
+      const report = await lifecyclemodelOrchestrateImpl({
+        action: lifecyclemodelFlags.action,
+        inputPath: lifecyclemodelFlags.inputPath,
+        outDir: lifecyclemodelFlags.outDir,
+        runDir: lifecyclemodelFlags.runDir,
+        allowProcessBuild: lifecyclemodelFlags.allowProcessBuild,
+        allowSubmodelBuild: lifecyclemodelFlags.allowSubmodelBuild,
+        publishLifecyclemodels: lifecyclemodelFlags.publishLifecyclemodels,
+        publishResultingProcessRelations: lifecyclemodelFlags.publishResultingProcessRelations,
+        env: deps.env,
+        fetchImpl: deps.fetchImpl,
+      });
+
+      return {
+        exitCode: report.action === 'execute' && report.status !== 'completed' ? 1 : 0,
+        stdout: stringifyJson(report, lifecyclemodelFlags.json),
+        stderr: '',
+      };
     }
 
     if (command === 'process' && !subcommand) {
@@ -2110,6 +3038,129 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
       };
     }
 
+    if (command === 'flow' && subcommand === 'publish-reviewed-data') {
+      const flowFlags = parseFlowPublishReviewedDataFlags(commandArgs);
+      if (flowFlags.help) {
+        return { exitCode: 0, stdout: `${renderFlowPublishReviewedDataHelp()}\n`, stderr: '' };
+      }
+
+      const report = await flowReviewedPublishDataImpl({
+        flowRowsFile: flowFlags.flowRowsFile,
+        originalFlowRowsFile: flowFlags.originalFlowRowsFile,
+        processRowsFile: flowFlags.processRowsFile,
+        outDir: flowFlags.outDir,
+        flowPublishPolicy: flowFlags.flowPublishPolicy,
+        processPublishPolicy: flowFlags.processPublishPolicy,
+        rewriteProcessFlowRefs: flowFlags.rewriteProcessFlowRefs,
+        commit: flowFlags.commit,
+        maxWorkers: flowFlags.maxWorkers,
+        targetUserId: flowFlags.targetUserId,
+        env: deps.env,
+        fetchImpl: deps.fetchImpl,
+      });
+
+      return {
+        exitCode: report.status === 'completed_flow_publish_reviewed_data_with_failures' ? 1 : 0,
+        stdout: stringifyJson(report, flowFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'flow' && subcommand === 'build-alias-map') {
+      const flowFlags = parseFlowBuildAliasMapFlags(commandArgs);
+      if (flowFlags.help) {
+        return { exitCode: 0, stdout: `${renderFlowBuildAliasMapHelp()}\n`, stderr: '' };
+      }
+
+      const report = await flowBuildAliasMapImpl({
+        oldFlowFiles: flowFlags.oldFlowFiles,
+        newFlowFiles: flowFlags.newFlowFiles,
+        seedAliasMapFile: flowFlags.seedAliasMapFile,
+        outDir: flowFlags.outDir,
+      });
+
+      return {
+        exitCode: 0,
+        stdout: stringifyJson(report, flowFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'flow' && subcommand === 'scan-process-flow-refs') {
+      const flowFlags = parseFlowScanProcessFlowRefsFlags(commandArgs);
+      if (flowFlags.help) {
+        return { exitCode: 0, stdout: `${renderFlowScanProcessFlowRefsHelp()}\n`, stderr: '' };
+      }
+
+      const report = await flowScanProcessFlowRefsImpl({
+        processesFile: flowFlags.processesFile,
+        scopeFlowFiles: flowFlags.scopeFlowFiles,
+        catalogFlowFiles: flowFlags.catalogFlowFiles,
+        aliasMapFile: flowFlags.aliasMapFile,
+        excludeEmergy: flowFlags.excludeEmergy,
+        outDir: flowFlags.outDir,
+      });
+
+      return {
+        exitCode: 0,
+        stdout: stringifyJson(report, flowFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'flow' && subcommand === 'plan-process-flow-repairs') {
+      const flowFlags = parseFlowPlanProcessFlowRepairsFlags(commandArgs);
+      if (flowFlags.help) {
+        return {
+          exitCode: 0,
+          stdout: `${renderFlowPlanProcessFlowRepairsHelp()}\n`,
+          stderr: '',
+        };
+      }
+
+      const report = await flowPlanProcessFlowRepairsImpl({
+        processesFile: flowFlags.processesFile,
+        scopeFlowFiles: flowFlags.scopeFlowFiles,
+        aliasMapFile: flowFlags.aliasMapFile,
+        scanFindingsFile: flowFlags.scanFindingsFile,
+        autoPatchPolicy: flowFlags.autoPatchPolicy,
+        outDir: flowFlags.outDir,
+      });
+
+      return {
+        exitCode: 0,
+        stdout: stringifyJson(report, flowFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'flow' && subcommand === 'apply-process-flow-repairs') {
+      const flowFlags = parseFlowApplyProcessFlowRepairsFlags(commandArgs);
+      if (flowFlags.help) {
+        return {
+          exitCode: 0,
+          stdout: `${renderFlowApplyProcessFlowRepairsHelp()}\n`,
+          stderr: '',
+        };
+      }
+
+      const report = await flowApplyProcessFlowRepairsImpl({
+        processesFile: flowFlags.processesFile,
+        scopeFlowFiles: flowFlags.scopeFlowFiles,
+        aliasMapFile: flowFlags.aliasMapFile,
+        scanFindingsFile: flowFlags.scanFindingsFile,
+        autoPatchPolicy: flowFlags.autoPatchPolicy,
+        processPoolFile: flowFlags.processPoolFile,
+        outDir: flowFlags.outDir,
+      });
+
+      return {
+        exitCode: 0,
+        stdout: stringifyJson(report, flowFlags.json),
+        stderr: '',
+      };
+    }
+
     if (command === 'flow' && subcommand === 'regen-product') {
       const flowFlags = parseFlowRegenProductFlags(commandArgs);
       if (flowFlags.help) {
@@ -2131,6 +3182,27 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
 
       return {
         exitCode: report.validation.ok === false ? 1 : 0,
+        stdout: stringifyJson(report, flowFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'flow' && subcommand === 'validate-processes') {
+      const flowFlags = parseFlowValidateProcessesFlags(commandArgs);
+      if (flowFlags.help) {
+        return { exitCode: 0, stdout: `${renderFlowValidateProcessesHelp()}\n`, stderr: '' };
+      }
+
+      const report = await flowValidateProcessesImpl({
+        originalProcessesFile: flowFlags.originalProcessesFile,
+        patchedProcessesFile: flowFlags.patchedProcessesFile,
+        scopeFlowFiles: flowFlags.scopeFlowFiles,
+        tidasMode: flowFlags.tidasMode,
+        outDir: flowFlags.outDir,
+      });
+
+      return {
+        exitCode: report.summary.failed > 0 ? 1 : 0,
         stdout: stringifyJson(report, flowFlags.json),
         stderr: '',
       };
@@ -2182,6 +3254,8 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
         inputPath: publishFlags.inputPath,
         outDir: publishFlags.outDir,
         commit: publishFlags.commitOverride,
+        env: deps.env,
+        fetchImpl: deps.fetchImpl,
       });
 
       return {

--- a/src/lib/flow-build-alias-map.ts
+++ b/src/lib/flow-build-alias-map.ts
@@ -1,0 +1,447 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { writeJsonArtifact, writeJsonLinesArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+import {
+  extractFlowRecord,
+  isRecord,
+  loadRowsFromFile,
+  normalizeText,
+  type FlowRecord,
+  type JsonRecord,
+} from './flow-governance.js';
+
+type FlowIndex = {
+  records: FlowRecord[];
+  byUuid: Record<string, FlowRecord[]>;
+  byUuidVersion: Record<string, FlowRecord>;
+  byName: Record<string, FlowRecord[]>;
+};
+
+export type FlowBuildAliasMapFiles = {
+  out_dir: string;
+  alias_plan: string;
+  alias_plan_jsonl: string;
+  flow_alias_map: string;
+  manual_review_queue: string;
+  summary: string;
+};
+
+export type FlowBuildAliasMapSummary = {
+  old_flow_count: number;
+  new_flow_count: number;
+  alias_entries_versioned: number;
+  alias_entries_uuid_only: number;
+  manual_review_count: number;
+  decision_counts: Record<string, number>;
+};
+
+export type FlowAliasPlanAction = {
+  old_flow_id: string;
+  old_flow_version: string;
+  old_flow_name: string;
+  old_flow_type: string;
+  decision: 'no_alias_needed' | 'alias_map_entry' | 'manual_review';
+  reason: string;
+  target_flow_id?: string;
+  target_flow_version?: string;
+  target_flow_name?: string;
+  target_flow_type?: string;
+  candidate_refs?: Array<Record<string, string>>;
+};
+
+export type FlowBuildAliasMapReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: 'completed_local_flow_build_alias_map';
+  old_flow_files: string[];
+  new_flow_files: string[];
+  seed_alias_map_file: string | null;
+  out_dir: string;
+  summary: FlowBuildAliasMapSummary;
+  files: FlowBuildAliasMapFiles;
+};
+
+export type RunFlowBuildAliasMapOptions = {
+  oldFlowFiles: string[];
+  newFlowFiles: string[];
+  seedAliasMapFile?: string | null;
+  outDir: string;
+};
+
+type FlowBuildAliasMapDeps = {
+  now?: () => Date;
+};
+
+function assertInputFile(inputFile: string, requiredCode: string, missingCode: string): string {
+  if (!inputFile) {
+    throw new CliError('Missing required input file value.', {
+      code: requiredCode,
+      exitCode: 2,
+    });
+  }
+
+  const resolved = path.resolve(inputFile);
+  if (!existsSync(resolved)) {
+    throw new CliError(`Input file not found: ${resolved}`, {
+      code: missingCode,
+      exitCode: 2,
+    });
+  }
+
+  return resolved;
+}
+
+function assertInputFiles(
+  inputFiles: string[],
+  requiredCode: string,
+  missingCode: string,
+): string[] {
+  if (!inputFiles.length) {
+    throw new CliError('At least one input file is required.', {
+      code: requiredCode,
+      exitCode: 2,
+    });
+  }
+
+  return inputFiles.map((inputFile) => assertInputFile(inputFile, requiredCode, missingCode));
+}
+
+function assertOutDir(outDir: string): string {
+  if (!outDir) {
+    throw new CliError('Missing required --out-dir value.', {
+      code: 'FLOW_BUILD_ALIAS_MAP_OUT_DIR_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  return path.resolve(outDir);
+}
+
+function readJsonObjectFile(
+  filePath: string,
+  requiredCode: string,
+  missingCode: string,
+  invalidCode: string,
+): JsonRecord {
+  const resolved = assertInputFile(filePath, requiredCode, missingCode);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(resolved, 'utf8'));
+  } catch (error) {
+    throw new CliError(`Expected JSON object file: ${resolved}`, {
+      code: invalidCode,
+      exitCode: 2,
+      details: String(error),
+    });
+  }
+
+  if (!isRecord(parsed)) {
+    throw new CliError(`Expected JSON object file: ${resolved}`, {
+      code: invalidCode,
+      exitCode: 2,
+    });
+  }
+
+  return parsed;
+}
+
+function buildFlowIndex(rows: JsonRecord[]): FlowIndex {
+  const byUuid: Record<string, FlowRecord[]> = {};
+  const byUuidVersion: Record<string, FlowRecord> = {};
+  const byName: Record<string, FlowRecord[]> = {};
+  const records: FlowRecord[] = [];
+
+  for (const row of rows) {
+    const record = extractFlowRecord(row);
+    records.push(record);
+    byUuid[record.id] ??= [];
+    byUuid[record.id].push(record);
+    byUuidVersion[`${record.id}@${record.version}`] = record;
+    const normalizedName = normalizeText(record.name);
+    byName[normalizedName] ??= [];
+    byName[normalizedName].push(record);
+  }
+
+  return {
+    records,
+    byUuid,
+    byUuidVersion,
+    byName,
+  };
+}
+
+function aliasLookup(
+  aliasMap: JsonRecord,
+  flowUuid: string,
+  flowVersion: string | null,
+): JsonRecord | null {
+  const versionedKey = flowVersion ? `${flowUuid}@${flowVersion}` : null;
+  for (const key of [versionedKey, flowUuid]) {
+    if (!key) {
+      continue;
+    }
+    const candidate = aliasMap[key];
+    if (isRecord(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function candidateRef(record: FlowRecord, includeType = false): Record<string, string> {
+  return {
+    id: record.id,
+    version: record.version,
+    name: record.name,
+    ...(includeType ? { flow_type: record.flowType } : {}),
+  };
+}
+
+function planAlias(
+  oldRecord: FlowRecord,
+  newIndex: FlowIndex,
+  seedAliasMap: JsonRecord,
+): FlowAliasPlanAction {
+  const base: FlowAliasPlanAction = {
+    old_flow_id: oldRecord.id,
+    old_flow_version: oldRecord.version,
+    old_flow_name: oldRecord.name,
+    old_flow_type: oldRecord.flowType,
+    decision: 'manual_review',
+    reason: 'no_deterministic_match',
+  };
+
+  const existingTarget = newIndex.byUuidVersion[`${oldRecord.id}@${oldRecord.version}`];
+  if (existingTarget) {
+    return {
+      ...base,
+      decision: 'no_alias_needed',
+      reason: 'already_present_in_target',
+      target_flow_id: existingTarget.id,
+      target_flow_version: existingTarget.version,
+    };
+  }
+
+  const seededTarget = aliasLookup(seedAliasMap, oldRecord.id, oldRecord.version || null);
+  if (seededTarget) {
+    const targetRecord =
+      newIndex.byUuidVersion[
+        `${String(seededTarget.id ?? '')}@${String(seededTarget.version ?? '')}`
+      ];
+    if (targetRecord) {
+      return {
+        ...base,
+        decision: 'alias_map_entry',
+        reason: 'seed_alias_map',
+        target_flow_id: targetRecord.id,
+        target_flow_version: targetRecord.version,
+        target_flow_name: targetRecord.name,
+        target_flow_type: targetRecord.flowType,
+      };
+    }
+  }
+
+  const sameUuidCandidates = newIndex.byUuid[oldRecord.id] ?? [];
+  if (sameUuidCandidates.length === 1) {
+    const candidate = sameUuidCandidates[0];
+    return {
+      ...base,
+      decision: 'alias_map_entry',
+      reason: 'same_uuid_single_target_version',
+      target_flow_id: candidate.id,
+      target_flow_version: candidate.version,
+      target_flow_name: candidate.name,
+      target_flow_type: candidate.flowType,
+    };
+  }
+
+  if (sameUuidCandidates.length > 1) {
+    return {
+      ...base,
+      decision: 'manual_review',
+      reason: 'same_uuid_multiple_target_versions',
+      candidate_refs: sameUuidCandidates.map((candidate) => candidateRef(candidate)),
+    };
+  }
+
+  const byName = newIndex.byName[normalizeText(oldRecord.name)] ?? [];
+  const nameAndTypeCandidates = byName.filter(
+    (candidate) => candidate.flowType === oldRecord.flowType,
+  );
+  if (nameAndTypeCandidates.length === 1) {
+    const candidate = nameAndTypeCandidates[0];
+    return {
+      ...base,
+      decision: 'alias_map_entry',
+      reason: 'unique_exact_name_and_type_match',
+      target_flow_id: candidate.id,
+      target_flow_version: candidate.version,
+      target_flow_name: candidate.name,
+      target_flow_type: candidate.flowType,
+    };
+  }
+
+  if (nameAndTypeCandidates.length > 1) {
+    return {
+      ...base,
+      decision: 'manual_review',
+      reason: 'ambiguous_name_and_type_match',
+      candidate_refs: nameAndTypeCandidates.map((candidate) => candidateRef(candidate)),
+    };
+  }
+
+  if (byName.length > 0) {
+    return {
+      ...base,
+      decision: 'manual_review',
+      reason: 'name_match_flow_type_mismatch',
+      candidate_refs: byName.map((candidate) => candidateRef(candidate, true)),
+    };
+  }
+
+  return base;
+}
+
+function buildDecisionCounts(actions: FlowAliasPlanAction[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  actions.forEach((action) => {
+    counts[action.decision] = (counts[action.decision] ?? 0) + 1;
+  });
+  return counts;
+}
+
+function buildOutputFiles(outDir: string): FlowBuildAliasMapFiles {
+  return {
+    out_dir: outDir,
+    alias_plan: path.join(outDir, 'alias-plan.json'),
+    alias_plan_jsonl: path.join(outDir, 'alias-plan.jsonl'),
+    flow_alias_map: path.join(outDir, 'flow-alias-map.json'),
+    manual_review_queue: path.join(outDir, 'manual-review-queue.jsonl'),
+    summary: path.join(outDir, 'alias-summary.json'),
+  };
+}
+
+export async function runFlowBuildAliasMap(
+  options: RunFlowBuildAliasMapOptions,
+  deps: FlowBuildAliasMapDeps = {},
+): Promise<FlowBuildAliasMapReport> {
+  const oldFlowFiles = assertInputFiles(
+    options.oldFlowFiles ?? [],
+    'FLOW_BUILD_ALIAS_MAP_OLD_FLOW_FILES_REQUIRED',
+    'FLOW_BUILD_ALIAS_MAP_OLD_FLOW_FILE_NOT_FOUND',
+  );
+  const newFlowFiles = assertInputFiles(
+    options.newFlowFiles ?? [],
+    'FLOW_BUILD_ALIAS_MAP_NEW_FLOW_FILES_REQUIRED',
+    'FLOW_BUILD_ALIAS_MAP_NEW_FLOW_FILE_NOT_FOUND',
+  );
+  const seedAliasMapFile = options.seedAliasMapFile
+    ? assertInputFile(
+        options.seedAliasMapFile,
+        'FLOW_BUILD_ALIAS_MAP_SEED_ALIAS_MAP_REQUIRED',
+        'FLOW_BUILD_ALIAS_MAP_SEED_ALIAS_MAP_NOT_FOUND',
+      )
+    : null;
+  const outDir = assertOutDir(options.outDir);
+  const now = deps.now ?? (() => new Date());
+  const files = buildOutputFiles(outDir);
+
+  const oldRows = oldFlowFiles.flatMap((filePath) => loadRowsFromFile(filePath));
+  const newRows = newFlowFiles.flatMap((filePath) => loadRowsFromFile(filePath));
+  const oldIndex = buildFlowIndex(oldRows);
+  const newIndex = buildFlowIndex(newRows);
+  const seedAliasMap = seedAliasMapFile
+    ? readJsonObjectFile(
+        seedAliasMapFile,
+        'FLOW_BUILD_ALIAS_MAP_SEED_ALIAS_MAP_REQUIRED',
+        'FLOW_BUILD_ALIAS_MAP_SEED_ALIAS_MAP_NOT_FOUND',
+        'FLOW_BUILD_ALIAS_MAP_SEED_ALIAS_MAP_INVALID',
+      )
+    : {};
+
+  const aliasPlan: FlowAliasPlanAction[] = [];
+  const manualQueue: FlowAliasPlanAction[] = [];
+  const versionAliasMap: Record<string, JsonRecord> = {};
+  const uuidTargets: Record<string, Set<string>> = {};
+
+  oldIndex.records.forEach((oldRecord) => {
+    const action = planAlias(oldRecord, newIndex, seedAliasMap);
+    aliasPlan.push(action);
+
+    if (
+      action.decision === 'alias_map_entry' &&
+      action.target_flow_id &&
+      action.target_flow_version
+    ) {
+      const target = {
+        id: action.target_flow_id,
+        version: action.target_flow_version,
+        reason: action.reason,
+      } satisfies JsonRecord;
+      versionAliasMap[`${oldRecord.id}@${oldRecord.version}`] = target;
+      uuidTargets[oldRecord.id] ??= new Set<string>();
+      uuidTargets[oldRecord.id].add(`${action.target_flow_id}@${action.target_flow_version}`);
+      return;
+    }
+
+    if (action.decision === 'manual_review') {
+      manualQueue.push(action);
+    }
+  });
+
+  const flowAliasMap: Record<string, JsonRecord> = {
+    ...versionAliasMap,
+  };
+  Object.entries(uuidTargets).forEach(([oldUuid, targets]) => {
+    if (targets.size !== 1) {
+      return;
+    }
+    const [targetId, targetVersion] = [...targets][0].split('@', 2);
+    flowAliasMap[oldUuid] = {
+      id: targetId,
+      version: targetVersion,
+      reason: 'all_versions_share_same_target',
+    };
+  });
+
+  const summary: FlowBuildAliasMapSummary = {
+    old_flow_count: oldIndex.records.length,
+    new_flow_count: newIndex.records.length,
+    alias_entries_versioned: Object.keys(versionAliasMap).length,
+    alias_entries_uuid_only: Object.keys(flowAliasMap).length - Object.keys(versionAliasMap).length,
+    manual_review_count: manualQueue.length,
+    decision_counts: buildDecisionCounts(aliasPlan),
+  };
+
+  writeJsonArtifact(files.alias_plan, aliasPlan);
+  writeJsonLinesArtifact(files.alias_plan_jsonl, aliasPlan);
+  writeJsonArtifact(files.flow_alias_map, flowAliasMap);
+  writeJsonLinesArtifact(files.manual_review_queue, manualQueue);
+  writeJsonArtifact(files.summary, summary);
+
+  return {
+    schema_version: 1,
+    generated_at_utc: now().toISOString(),
+    status: 'completed_local_flow_build_alias_map',
+    old_flow_files: oldFlowFiles,
+    new_flow_files: newFlowFiles,
+    seed_alias_map_file: seedAliasMapFile,
+    out_dir: outDir,
+    summary,
+    files,
+  };
+}
+
+export const __testInternals = {
+  assertInputFile,
+  assertInputFiles,
+  assertOutDir,
+  readJsonObjectFile,
+  buildFlowIndex,
+  aliasLookup,
+  candidateRef,
+  planAlias,
+  buildDecisionCounts,
+  buildOutputFiles,
+};

--- a/src/lib/flow-publish-reviewed-data.ts
+++ b/src/lib/flow-publish-reviewed-data.ts
@@ -1,0 +1,1213 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { writeJsonArtifact, writeJsonLinesArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+import {
+  coerceText,
+  datasetPayloadFromRow,
+  deepGet,
+  extractFlowRecord,
+  isRecord,
+  listify,
+  loadRowsFromFile,
+  type FlowRecord,
+  type JsonRecord,
+} from './flow-governance.js';
+import {
+  runFlowPublishVersion,
+  type FlowPublishVersionReport,
+  type RunFlowPublishVersionOptions,
+} from './flow-publish-version.js';
+import type { FetchLike } from './http.js';
+import {
+  hasSupabaseRestRuntime,
+  syncSupabaseJsonOrderedRecord,
+  type SupabaseJsonOrderedWriteOperation,
+} from './supabase-json-ordered-write.js';
+
+const DEFAULT_MAX_WORKERS = 4;
+const LEGACY_OUTPUT_PREFIX = 'flows_tidas_sdk_plus_classification';
+
+export type FlowPublishPolicy = 'skip' | 'append_only_bump' | 'upsert_current_version';
+export type ProcessPublishPolicy = FlowPublishPolicy;
+
+type FlowPublishVersionCompatMode = 'dry_run' | 'commit';
+
+type FlowVersionMapEntry = {
+  id: string;
+  source_version: string;
+  target_version: string;
+};
+
+type ProcessIdentity = {
+  id: string;
+  version: string;
+  name: string;
+};
+
+type FlowIndex = {
+  byUuidVersion: Record<string, FlowRecord>;
+};
+
+type SkippedUnchangedFlowRow = {
+  entity_type: 'flow';
+  entity_id: string;
+  entity_name: string;
+  version: string;
+  reason: 'unchanged_vs_original_rows_file';
+};
+
+type PreparedFlowPlan = {
+  entity_type: 'flow';
+  entity_id: string;
+  entity_name: string;
+  original_version: string;
+  publish_version: string;
+  version_strategy: 'keep_current' | 'bump';
+  publish_policy: FlowPublishPolicy;
+  row: JsonRecord;
+};
+
+type PreparedProcessPlan = {
+  entity_type: 'process';
+  entity_id: string;
+  entity_name: string;
+  original_version: string;
+  publish_version: string;
+  version_strategy: 'keep_current' | 'bump';
+  publish_policy: ProcessPublishPolicy;
+  row: JsonRecord;
+};
+
+type ProcessFlowRefRewriteEvidence = {
+  process_id: string;
+  process_version_before_publish: string;
+  process_name: string;
+  exchange_internal_id: string;
+  source_flow_id: string;
+  source_flow_version: string;
+  target_flow_id: string;
+  target_flow_version: string;
+  target_flow_name: string;
+};
+
+type FlowPublishSuccessRow = {
+  id: string;
+  version: string;
+  operation:
+    | 'would_insert'
+    | 'would_update_existing'
+    | 'insert'
+    | 'update_existing'
+    | 'update_after_insert_error';
+};
+
+type FlowPublishFailureReason = {
+  validator: string;
+  stage: string;
+  path: string;
+  message: string;
+  code: string;
+  visible_user_id?: string;
+  visible_state_code?: string;
+};
+
+type FlowPublishFailureRow = {
+  id: unknown;
+  user_id?: unknown;
+  json_ordered: JsonRecord;
+  reason: FlowPublishFailureReason[];
+  state_code?: unknown;
+};
+
+type FlowReviewedPublishFiles = {
+  prepared_flow_rows: string;
+  prepared_process_rows: string;
+  flow_version_map: string;
+  skipped_unchanged_flow_rows: string;
+  process_ref_rewrite_evidence: string;
+  success_list: string;
+  remote_failed: string;
+  flow_publish_version_report: string;
+  report: string;
+};
+
+export type FlowReviewedPublishRowReport = {
+  entity_type: 'flow';
+  id: string;
+  name: string;
+  original_version: string;
+  publish_version: string;
+  publish_policy: FlowPublishPolicy;
+  version_strategy: 'keep_current' | 'bump';
+  status: 'prepared' | 'inserted' | 'updated' | 'failed';
+  operation?: FlowPublishSuccessRow['operation'];
+  error?: unknown;
+};
+
+export type FlowReviewedPublishProcessRowReport = {
+  entity_type: 'process';
+  id: string;
+  name: string;
+  original_version: string;
+  publish_version: string;
+  publish_policy: ProcessPublishPolicy;
+  version_strategy: 'keep_current' | 'bump';
+  status: 'prepared' | 'inserted' | 'updated' | 'skipped_existing' | 'failed';
+  operation?: SupabaseJsonOrderedWriteOperation;
+  error?: unknown;
+};
+
+export type FlowReviewedPublishDataReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status:
+    | 'prepared_flow_publish_reviewed_data'
+    | 'completed_flow_publish_reviewed_data'
+    | 'completed_flow_publish_reviewed_data_with_failures';
+  mode: FlowPublishVersionCompatMode;
+  flow_rows_file: string | null;
+  process_rows_file: string | null;
+  original_flow_rows_file: string | null;
+  out_dir: string;
+  flow_publish_policy: FlowPublishPolicy;
+  process_publish_policy: ProcessPublishPolicy;
+  rewrite_process_flow_refs: boolean;
+  counts: {
+    input_flow_rows: number;
+    input_process_rows: number;
+    original_flow_rows: number;
+    prepared_flow_rows: number;
+    prepared_process_rows: number;
+    skipped_unchanged_flow_rows: number;
+    rewritten_process_flow_refs: number;
+    flow_publish_reports: number;
+    process_publish_reports: number;
+    success_count: number;
+    failure_count: number;
+  };
+  max_workers: number;
+  target_user_id_override: string | null;
+  files: FlowReviewedPublishFiles;
+  flow_reports: FlowReviewedPublishRowReport[];
+  process_reports: FlowReviewedPublishProcessRowReport[];
+  skipped_unchanged_flow_rows: SkippedUnchangedFlowRow[];
+};
+
+export type RunFlowReviewedPublishDataOptions = {
+  flowRowsFile?: string | null;
+  originalFlowRowsFile?: string | null;
+  processRowsFile?: string | null;
+  outDir: string;
+  flowPublishPolicy?: FlowPublishPolicy;
+  processPublishPolicy?: ProcessPublishPolicy;
+  rewriteProcessFlowRefs?: boolean;
+  commit?: boolean;
+  maxWorkers?: number;
+  targetUserId?: string | null;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: FetchLike;
+  timeoutMs?: number;
+  now?: Date;
+  runFlowPublishVersionImpl?: (
+    options: RunFlowPublishVersionOptions,
+  ) => Promise<FlowPublishVersionReport>;
+};
+
+function assert_input_file(
+  inputFile: string,
+  code: string,
+  message = 'Missing required input file value.',
+): string {
+  if (!inputFile) {
+    throw new CliError(message, {
+      code,
+      exitCode: 2,
+    });
+  }
+
+  const resolved = path.resolve(inputFile);
+  if (!existsSync(resolved)) {
+    throw new CliError(`Input file not found: ${resolved}`, {
+      code,
+      exitCode: 2,
+    });
+  }
+
+  return resolved;
+}
+
+function assert_optional_input_file(
+  inputFile: string | null | undefined,
+  code: string,
+): string | null {
+  if (!inputFile) {
+    return null;
+  }
+
+  const resolved = path.resolve(inputFile);
+  if (!existsSync(resolved)) {
+    throw new CliError(`Input file not found: ${resolved}`, {
+      code,
+      exitCode: 2,
+    });
+  }
+
+  return resolved;
+}
+
+function assert_out_dir(outDir: string): string {
+  if (!outDir) {
+    throw new CliError('Missing required --out-dir value.', {
+      code: 'FLOW_PUBLISH_REVIEWED_OUT_DIR_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  return path.resolve(outDir);
+}
+
+function clone_json<T>(value: T): T {
+  if (value === undefined) {
+    return value;
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function json_equal(left: unknown, right: unknown): boolean {
+  if (left === right) {
+    return true;
+  }
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+      return false;
+    }
+
+    return left.every((value, index) => json_equal(value, right[index]));
+  }
+
+  if (!isRecord(left) || !isRecord(right)) {
+    return false;
+  }
+
+  const leftKeys = Object.keys(left).sort();
+  const rightKeys = Object.keys(right).sort();
+  if (leftKeys.length !== rightKeys.length) {
+    return false;
+  }
+
+  return leftKeys.every(
+    (key, index) => key === rightKeys[index] && json_equal(left[key], right[key]),
+  );
+}
+
+function normalize_publish_policy(
+  value: FlowPublishPolicy | string | undefined,
+  label = '--flow-publish-policy',
+  code = 'FLOW_PUBLISH_REVIEWED_POLICY_INVALID',
+): FlowPublishPolicy {
+  if (value === undefined || value === '') {
+    return 'append_only_bump';
+  }
+
+  if (value === 'skip' || value === 'append_only_bump' || value === 'upsert_current_version') {
+    return value;
+  }
+
+  throw new CliError(
+    `Expected ${label} to be one of: skip, append_only_bump, upsert_current_version.`,
+    {
+      code,
+      exitCode: 2,
+    },
+  );
+}
+
+function bump_ilcd_version(version: string): string {
+  const parts = String(version || '')
+    .trim()
+    .split('.');
+  if (parts.length !== 3 || !parts.every((part) => /^\d+$/u.test(part))) {
+    return '01.01.001';
+  }
+
+  const [head, middle, tail] = parts;
+  return `${Number.parseInt(head, 10).toString().padStart(head.length, '0')}.${Number.parseInt(
+    middle,
+    10,
+  )
+    .toString()
+    .padStart(middle.length, '0')}.${(Number.parseInt(tail, 10) + 1)
+    .toString()
+    .padStart(tail.length, '0')}`;
+}
+
+function set_flow_version(row: JsonRecord, newVersion: string): void {
+  const payload = datasetPayloadFromRow(row);
+  const dataset = isRecord(payload.flowDataSet) ? payload.flowDataSet : payload;
+  const administrativeInformation = isRecord(dataset.administrativeInformation)
+    ? dataset.administrativeInformation
+    : {};
+  if (!isRecord(dataset.administrativeInformation)) {
+    dataset.administrativeInformation = administrativeInformation;
+  }
+  const publicationAndOwnership = isRecord(administrativeInformation.publicationAndOwnership)
+    ? administrativeInformation.publicationAndOwnership
+    : {};
+  if (!isRecord(administrativeInformation.publicationAndOwnership)) {
+    administrativeInformation.publicationAndOwnership = publicationAndOwnership;
+  }
+  publicationAndOwnership['common:dataSetVersion'] = newVersion;
+  row.version = newVersion;
+}
+
+function process_dataset_from_row(row: JsonRecord): JsonRecord {
+  const payload = datasetPayloadFromRow(row);
+  return isRecord(payload.processDataSet) ? payload.processDataSet : payload;
+}
+
+function extract_process_identity(row: JsonRecord): ProcessIdentity {
+  const dataset = process_dataset_from_row(row);
+  const info = deepGet(dataset, ['processInformation', 'dataSetInformation'], {}) as JsonRecord;
+  const id = coerceText(row.id) || coerceText(info['common:UUID']);
+  const version =
+    coerceText(row.version) ||
+    coerceText(
+      deepGet(dataset, [
+        'administrativeInformation',
+        'publicationAndOwnership',
+        'common:dataSetVersion',
+      ]),
+    ) ||
+    '01.00.000';
+  const nameBlock = deepGet(info, ['name', 'baseName']) ?? deepGet(info, ['name']) ?? info.name;
+  const name = coerceText(nameBlock) || id;
+
+  return {
+    id,
+    version,
+    name,
+  };
+}
+
+function exchange_records(processRow: JsonRecord): JsonRecord[] {
+  const dataset = process_dataset_from_row(processRow);
+  return listify(deepGet(dataset, ['exchanges', 'exchange'], [])).filter(isRecord);
+}
+
+function set_process_version(row: JsonRecord, newVersion: string): void {
+  const payload = datasetPayloadFromRow(row);
+  const dataset = isRecord(payload.processDataSet) ? payload.processDataSet : payload;
+  const administrativeInformation = isRecord(dataset.administrativeInformation)
+    ? dataset.administrativeInformation
+    : {};
+  if (!isRecord(dataset.administrativeInformation)) {
+    dataset.administrativeInformation = administrativeInformation;
+  }
+  const publicationAndOwnership = isRecord(administrativeInformation.publicationAndOwnership)
+    ? administrativeInformation.publicationAndOwnership
+    : {};
+  if (!isRecord(administrativeInformation.publicationAndOwnership)) {
+    administrativeInformation.publicationAndOwnership = publicationAndOwnership;
+  }
+  publicationAndOwnership['common:dataSetVersion'] = newVersion;
+  row.version = newVersion;
+}
+
+function build_flow_index(rows: JsonRecord[]): FlowIndex {
+  const byUuidVersion: Record<string, FlowRecord> = {};
+
+  for (const row of rows) {
+    const record = extractFlowRecord(row);
+    byUuidVersion[`${record.id}@${record.version}`] = record;
+  }
+
+  return {
+    byUuidVersion,
+  };
+}
+
+function build_local_dataset_uri(datasetKind: string, uuidValue: string, version: string): string {
+  if (!uuidValue) {
+    return '';
+  }
+
+  const folderMap: Record<string, string> = {
+    flow: 'flows',
+    'flow data set': 'flows',
+  };
+  const folder = folderMap[datasetKind.trim().toLowerCase()] ?? 'datasets';
+  const versionText = version.trim() || '01.00.000';
+  return `../${folder}/${uuidValue}_${versionText}.xml`;
+}
+
+function preserve_short_description_shape(existing: unknown, target: JsonRecord): unknown {
+  if (Array.isArray(existing)) {
+    if (existing.length > 0 && isRecord(existing[0])) {
+      const patched = clone_json(existing[0]);
+      patched['@xml:lang'] =
+        coerceText(target['@xml:lang']) || coerceText(patched['@xml:lang']) || 'en';
+      patched['#text'] = coerceText(target['#text']);
+      return [patched];
+    }
+    return [clone_json(target)];
+  }
+
+  if (isRecord(existing)) {
+    const patched = clone_json(existing);
+    patched['@xml:lang'] =
+      coerceText(target['@xml:lang']) || coerceText(patched['@xml:lang']) || 'en';
+    patched['#text'] = coerceText(target['#text']);
+    return patched;
+  }
+
+  return clone_json(target);
+}
+
+function flow_reference_from_record(record: FlowRecord): JsonRecord {
+  const targetShortDescription =
+    record.shortDescription ??
+    ({
+      '@xml:lang': 'en',
+      '#text': record.name,
+    } satisfies JsonRecord);
+
+  return {
+    '@type': 'flow data set',
+    '@refObjectId': record.id,
+    '@version': record.version,
+    '@uri': build_local_dataset_uri('flow data set', record.id, record.version),
+    'common:shortDescription': clone_json(targetShortDescription),
+  };
+}
+
+function patched_flow_reference(currentRef: unknown, record: FlowRecord): JsonRecord {
+  const current = isRecord(currentRef) ? clone_json(currentRef) : {};
+  const target = flow_reference_from_record(record);
+
+  current['@type'] = coerceText(current['@type']) || coerceText(target['@type']);
+  current['@refObjectId'] = target['@refObjectId'];
+  current['@version'] = target['@version'];
+  current['@uri'] = target['@uri'];
+  current['common:shortDescription'] = preserve_short_description_shape(
+    current['common:shortDescription'],
+    target['common:shortDescription'] as JsonRecord,
+  );
+
+  return current;
+}
+
+function build_output_files(outDir: string): FlowReviewedPublishFiles {
+  return {
+    prepared_flow_rows: path.join(outDir, 'prepared-flow-rows.json'),
+    prepared_process_rows: path.join(outDir, 'prepared-process-rows.json'),
+    flow_version_map: path.join(outDir, 'flow-version-map.json'),
+    skipped_unchanged_flow_rows: path.join(outDir, 'skipped-unchanged-flow-rows.json'),
+    process_ref_rewrite_evidence: path.join(outDir, 'process-flow-ref-rewrite-evidence.jsonl'),
+    success_list: path.join(outDir, `${LEGACY_OUTPUT_PREFIX}_mcp_success_list.json`),
+    remote_failed: path.join(outDir, `${LEGACY_OUTPUT_PREFIX}_remote_validation_failed.jsonl`),
+    flow_publish_version_report: path.join(outDir, `${LEGACY_OUTPUT_PREFIX}_mcp_sync_report.json`),
+    report: path.join(outDir, 'publish-report.json'),
+  };
+}
+
+function status_from_mode(
+  mode: FlowPublishVersionCompatMode,
+  failureCount: number,
+): FlowReviewedPublishDataReport['status'] {
+  if (mode === 'dry_run') {
+    return 'prepared_flow_publish_reviewed_data';
+  }
+
+  return failureCount > 0
+    ? 'completed_flow_publish_reviewed_data_with_failures'
+    : 'completed_flow_publish_reviewed_data';
+}
+
+function prepare_flow_rows(options: {
+  rows: JsonRecord[];
+  policy: FlowPublishPolicy;
+  originalRows: JsonRecord[];
+}): {
+  preparedRows: JsonRecord[];
+  plans: PreparedFlowPlan[];
+  flowVersionMap: Record<string, FlowVersionMapEntry>;
+  skippedUnchangedRows: SkippedUnchangedFlowRow[];
+} {
+  if (options.policy === 'skip') {
+    return {
+      preparedRows: [],
+      plans: [],
+      flowVersionMap: {},
+      skippedUnchangedRows: [],
+    };
+  }
+
+  const originalMap = new Map<string, JsonRecord>();
+  for (const row of options.originalRows) {
+    const record = extractFlowRecord(row);
+    if (record.id && record.version) {
+      originalMap.set(`${record.id}@${record.version}`, row);
+    }
+  }
+
+  const preparedRows: JsonRecord[] = [];
+  const plans: PreparedFlowPlan[] = [];
+  const flowVersionMap: Record<string, FlowVersionMapEntry> = {};
+  const skippedUnchangedRows: SkippedUnchangedFlowRow[] = [];
+
+  for (const row of options.rows) {
+    const working = clone_json(row);
+    const record = extractFlowRecord(working);
+    const originalRow =
+      record.id && record.version ? originalMap.get(`${record.id}@${record.version}`) : undefined;
+
+    if (originalRow && json_equal(datasetPayloadFromRow(originalRow), datasetPayloadFromRow(row))) {
+      skippedUnchangedRows.push({
+        entity_type: 'flow',
+        entity_id: record.id,
+        entity_name: record.name,
+        version: record.version,
+        reason: 'unchanged_vs_original_rows_file',
+      });
+      continue;
+    }
+
+    let publishVersion = record.version;
+    let versionStrategy: PreparedFlowPlan['version_strategy'] = 'keep_current';
+    if (options.policy === 'append_only_bump') {
+      publishVersion = bump_ilcd_version(record.version);
+      set_flow_version(working, publishVersion);
+      versionStrategy = 'bump';
+      if (record.id && record.version) {
+        flowVersionMap[`${record.id}@${record.version}`] = {
+          id: record.id,
+          source_version: record.version,
+          target_version: publishVersion,
+        };
+      }
+    }
+
+    preparedRows.push(working);
+    plans.push({
+      entity_type: 'flow',
+      entity_id: record.id,
+      entity_name: record.name,
+      original_version: record.version,
+      publish_version: publishVersion,
+      version_strategy: versionStrategy,
+      publish_policy: options.policy,
+      row: working,
+    });
+  }
+
+  return {
+    preparedRows,
+    plans,
+    flowVersionMap,
+    skippedUnchangedRows,
+  };
+}
+
+function prepare_process_rows(options: {
+  rows: JsonRecord[];
+  policy: ProcessPublishPolicy;
+  rewriteRefs: boolean;
+  preparedFlowRows: JsonRecord[];
+  flowVersionMap: Record<string, FlowVersionMapEntry>;
+}): {
+  preparedRows: JsonRecord[];
+  plans: PreparedProcessPlan[];
+  rewriteEvidence: ProcessFlowRefRewriteEvidence[];
+} {
+  if (options.policy === 'skip') {
+    return {
+      preparedRows: [],
+      plans: [],
+      rewriteEvidence: [],
+    };
+  }
+
+  const preparedRows = options.rows.map((row) => clone_json(row));
+  const rewriteEvidence: ProcessFlowRefRewriteEvidence[] = [];
+
+  if (
+    options.rewriteRefs &&
+    preparedRows.length > 0 &&
+    options.preparedFlowRows.length > 0 &&
+    Object.keys(options.flowVersionMap).length > 0
+  ) {
+    const targetIndex = build_flow_index(options.preparedFlowRows).byUuidVersion;
+
+    for (const row of preparedRows) {
+      const processIdentity = extract_process_identity(row);
+
+      for (const exchange of exchange_records(row)) {
+        const currentRef = isRecord(exchange.referenceToFlowDataSet)
+          ? exchange.referenceToFlowDataSet
+          : null;
+        if (!currentRef) {
+          continue;
+        }
+
+        const flowId = coerceText(currentRef['@refObjectId']);
+        const flowVersion = coerceText(currentRef['@version']);
+        const mapped = options.flowVersionMap[`${flowId}@${flowVersion}`];
+        if (!mapped) {
+          continue;
+        }
+
+        const targetRecord = targetIndex[`${mapped.id}@${mapped.target_version}`];
+        if (!targetRecord) {
+          continue;
+        }
+
+        exchange.referenceToFlowDataSet = patched_flow_reference(currentRef, targetRecord);
+        rewriteEvidence.push({
+          process_id: processIdentity.id,
+          process_version_before_publish: processIdentity.version,
+          process_name: processIdentity.name,
+          exchange_internal_id: coerceText(exchange['@dataSetInternalID']),
+          source_flow_id: flowId,
+          source_flow_version: flowVersion,
+          target_flow_id: mapped.id,
+          target_flow_version: mapped.target_version,
+          target_flow_name: targetRecord.name,
+        });
+      }
+    }
+  }
+
+  const plans: PreparedProcessPlan[] = [];
+  for (const row of preparedRows) {
+    const record = extract_process_identity(row);
+    let publishVersion = record.version;
+    let versionStrategy: PreparedProcessPlan['version_strategy'] = 'keep_current';
+    if (options.policy === 'append_only_bump') {
+      publishVersion = bump_ilcd_version(record.version);
+      set_process_version(row, publishVersion);
+      versionStrategy = 'bump';
+    }
+
+    plans.push({
+      entity_type: 'process',
+      entity_id: record.id,
+      entity_name: record.name,
+      original_version: record.version,
+      publish_version: publishVersion,
+      version_strategy: versionStrategy,
+      publish_policy: options.policy,
+      row,
+    });
+  }
+
+  return {
+    preparedRows,
+    plans,
+    rewriteEvidence,
+  };
+}
+
+function build_local_row_report(plan: PreparedFlowPlan): FlowReviewedPublishRowReport {
+  return {
+    entity_type: 'flow',
+    id: plan.entity_id,
+    name: plan.entity_name,
+    original_version: plan.original_version,
+    publish_version: plan.publish_version,
+    publish_policy: plan.publish_policy,
+    version_strategy: plan.version_strategy,
+    status: 'prepared',
+  };
+}
+
+function build_local_process_row_report(
+  plan: PreparedProcessPlan,
+): FlowReviewedPublishProcessRowReport {
+  return {
+    entity_type: 'process',
+    id: plan.entity_id,
+    name: plan.entity_name,
+    original_version: plan.original_version,
+    publish_version: plan.publish_version,
+    publish_policy: plan.publish_policy,
+    version_strategy: plan.version_strategy,
+    status: 'prepared',
+  };
+}
+
+function process_publish_payload_from_row(row: JsonRecord): JsonRecord {
+  const payload = datasetPayloadFromRow(row);
+  const dataset = isRecord(payload.processDataSet) ? payload.processDataSet : payload;
+  return {
+    processDataSet: clone_json(dataset),
+  };
+}
+
+function build_process_commit_success_report(
+  plan: PreparedProcessPlan,
+  operation: SupabaseJsonOrderedWriteOperation,
+): FlowReviewedPublishProcessRowReport {
+  return {
+    entity_type: 'process',
+    id: plan.entity_id,
+    name: plan.entity_name,
+    original_version: plan.original_version,
+    publish_version: plan.publish_version,
+    publish_policy: plan.publish_policy,
+    version_strategy: plan.version_strategy,
+    status:
+      operation === 'insert'
+        ? 'inserted'
+        : operation === 'skipped_existing'
+          ? 'skipped_existing'
+          : 'updated',
+    operation,
+  };
+}
+
+function build_process_commit_failure_report(
+  plan: PreparedProcessPlan,
+  error: unknown,
+): FlowReviewedPublishProcessRowReport {
+  return {
+    entity_type: 'process',
+    id: plan.entity_id,
+    name: plan.entity_name,
+    original_version: plan.original_version,
+    publish_version: plan.publish_version,
+    publish_policy: plan.publish_policy,
+    version_strategy: plan.version_strategy,
+    status: 'failed',
+    error,
+  };
+}
+
+function build_commit_success_report(
+  plan: PreparedFlowPlan,
+  success: FlowPublishSuccessRow,
+): FlowReviewedPublishRowReport {
+  return {
+    entity_type: 'flow',
+    id: plan.entity_id,
+    name: plan.entity_name,
+    original_version: plan.original_version,
+    publish_version: plan.publish_version,
+    publish_policy: plan.publish_policy,
+    version_strategy: plan.version_strategy,
+    status: success.operation === 'insert' ? 'inserted' : 'updated',
+    operation: success.operation,
+  };
+}
+
+function build_commit_failure_report(
+  plan: PreparedFlowPlan,
+  failure: FlowPublishFailureRow,
+): FlowReviewedPublishRowReport {
+  return {
+    entity_type: 'flow',
+    id: plan.entity_id,
+    name: plan.entity_name,
+    original_version: plan.original_version,
+    publish_version: plan.publish_version,
+    publish_policy: plan.publish_policy,
+    version_strategy: plan.version_strategy,
+    status: 'failed',
+    error: failure.reason,
+  };
+}
+
+function build_flow_key(id: string, version: string): string | null {
+  if (!id || !version) {
+    return null;
+  }
+  return `${id}@${version}`;
+}
+
+function queue_by_key<T>(items: T[], keyFn: (item: T) => string | null): Map<string, T[]> {
+  const queued = new Map<string, T[]>();
+
+  for (const item of items) {
+    const key = keyFn(item);
+    if (!key) {
+      continue;
+    }
+    const queue = queued.get(key) ?? [];
+    queue.push(item);
+    queued.set(key, queue);
+  }
+
+  return queued;
+}
+
+function failure_key(row: FlowPublishFailureRow): string | null {
+  const record = extractFlowRecord(row as unknown as JsonRecord);
+  return build_flow_key(record.id, record.version);
+}
+
+function success_key(row: FlowPublishSuccessRow): string | null {
+  return build_flow_key(row.id, row.version);
+}
+
+function shift_queue<T>(queue: Map<string, T[]>, key: string | null): T | null {
+  if (!key) {
+    return null;
+  }
+
+  const items = queue.get(key);
+  if (!items?.length) {
+    return null;
+  }
+
+  const [first, ...rest] = items;
+  if (rest.length) {
+    queue.set(key, rest);
+  } else {
+    queue.delete(key);
+  }
+  return first ?? null;
+}
+
+async function map_with_concurrency<T, R>(
+  items: T[],
+  maxWorkers: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  const workerCount = Math.min(Math.max(1, maxWorkers), Math.max(items.length, 1));
+  let nextIndex = 0;
+
+  async function runWorker(): Promise<void> {
+    while (true) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      if (currentIndex >= items.length) {
+        return;
+      }
+      results[currentIndex] = await worker(items[currentIndex] as T, currentIndex);
+    }
+  }
+
+  await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+  return results;
+}
+
+function map_commit_reports(
+  plans: PreparedFlowPlan[],
+  successes: FlowPublishSuccessRow[],
+  failures: FlowPublishFailureRow[],
+): FlowReviewedPublishRowReport[] {
+  const successQueue = queue_by_key(successes, success_key);
+  const failureQueue = queue_by_key(failures, failure_key);
+  const unkeyedFailures = failures.filter((failure) => failure_key(failure) === null);
+
+  return plans.map((plan) => {
+    const key = build_flow_key(plan.entity_id, plan.publish_version);
+    const success = shift_queue(successQueue, key);
+    if (success) {
+      return build_commit_success_report(plan, success);
+    }
+
+    const failure =
+      shift_queue(failureQueue, key) ?? (key ? null : (unkeyedFailures.shift() ?? null));
+    if (failure) {
+      return build_commit_failure_report(plan, failure);
+    }
+
+    return {
+      ...build_local_row_report(plan),
+      status: 'failed',
+      error: [
+        {
+          code: 'UNMATCHED_PUBLISH_RESULT',
+          message: 'Publish result was missing for prepared flow row.',
+        },
+      ],
+    };
+  });
+}
+
+function build_compat_report(options: {
+  now: Date;
+  mode: FlowPublishVersionCompatMode;
+  preparedRows: number;
+  successCount: number;
+  failureCount: number;
+  maxWorkers: number;
+  targetUserId: string | null;
+  files: FlowReviewedPublishFiles;
+}): FlowPublishVersionReport {
+  let status: FlowPublishVersionReport['status'];
+  if (options.mode === 'dry_run') {
+    status = 'prepared_flow_publish_version';
+  } else {
+    status =
+      options.failureCount > 0
+        ? 'completed_flow_publish_version_with_failures'
+        : 'completed_flow_publish_version';
+  }
+
+  return {
+    schema_version: 1,
+    generated_at_utc: options.now.toISOString(),
+    status,
+    mode: options.mode,
+    input_file: options.files.prepared_flow_rows,
+    out_dir: path.dirname(options.files.report),
+    counts: {
+      total_rows: options.preparedRows,
+      success_count: options.successCount,
+      failure_count: options.failureCount,
+    },
+    operation_counts: {},
+    max_workers: options.maxWorkers,
+    limit: null,
+    target_user_id_override: options.targetUserId,
+    files: {
+      success_list: options.files.success_list,
+      remote_failed: options.files.remote_failed,
+      report: options.files.flow_publish_version_report,
+    },
+  };
+}
+
+async function commit_process_plans(options: {
+  plans: PreparedProcessPlan[];
+  maxWorkers: number;
+  env: NodeJS.ProcessEnv;
+  fetchImpl: FetchLike;
+  timeoutMs?: number;
+}): Promise<FlowReviewedPublishProcessRowReport[]> {
+  return map_with_concurrency(options.plans, options.maxWorkers, async (plan) => {
+    try {
+      const result = await syncSupabaseJsonOrderedRecord({
+        table: 'processes',
+        id: plan.entity_id,
+        version: plan.publish_version,
+        payload: process_publish_payload_from_row(plan.row),
+        writeMode:
+          plan.publish_policy === 'append_only_bump'
+            ? 'append_only_insert'
+            : 'upsert_current_version',
+        env: options.env,
+        fetchImpl: options.fetchImpl,
+        timeoutMs: options.timeoutMs,
+      });
+      return build_process_commit_success_report(plan, result.operation);
+    } catch (error) {
+      return build_process_commit_failure_report(
+        plan,
+        error instanceof Error ? error.message : error,
+      );
+    }
+  });
+}
+
+export async function runFlowReviewedPublishData(
+  options: RunFlowReviewedPublishDataOptions,
+): Promise<FlowReviewedPublishDataReport> {
+  const flowRowsFile = assert_optional_input_file(
+    options.flowRowsFile,
+    'FLOW_PUBLISH_REVIEWED_FLOW_ROWS_NOT_FOUND',
+  );
+  const processRowsFile = assert_optional_input_file(
+    options.processRowsFile,
+    'FLOW_PUBLISH_REVIEWED_PROCESS_ROWS_NOT_FOUND',
+  );
+  if (!flowRowsFile && !processRowsFile) {
+    throw new CliError('Provide at least one of --flow-rows-file or --process-rows-file.', {
+      code: 'FLOW_PUBLISH_REVIEWED_INPUT_REQUIRED',
+      exitCode: 2,
+    });
+  }
+  const originalFlowRowsFile = assert_optional_input_file(
+    options.originalFlowRowsFile,
+    'FLOW_PUBLISH_REVIEWED_ORIGINAL_ROWS_NOT_FOUND',
+  );
+  const outDir = assert_out_dir(options.outDir);
+  const flowPublishPolicy = normalize_publish_policy(options.flowPublishPolicy);
+  const processPublishPolicy = normalize_publish_policy(
+    options.processPublishPolicy,
+    '--process-publish-policy',
+    'FLOW_PUBLISH_REVIEWED_PROCESS_POLICY_INVALID',
+  );
+  const rewriteProcessFlowRefs = options.rewriteProcessFlowRefs !== false;
+  const mode: FlowPublishVersionCompatMode = options.commit ? 'commit' : 'dry_run';
+  const maxWorkers = options.maxWorkers ?? DEFAULT_MAX_WORKERS;
+  const targetUserId =
+    typeof options.targetUserId === 'string' && options.targetUserId.trim()
+      ? options.targetUserId.trim()
+      : null;
+  const now = options.now ?? new Date();
+  const files = build_output_files(outDir);
+  const inputFlowRows = flowRowsFile ? loadRowsFromFile(flowRowsFile) : [];
+  const originalFlowRows = originalFlowRowsFile ? loadRowsFromFile(originalFlowRowsFile) : [];
+  const inputProcessRows = processRowsFile ? loadRowsFromFile(processRowsFile) : [];
+  const prepared = prepare_flow_rows({
+    rows: inputFlowRows,
+    policy: flowPublishPolicy,
+    originalRows: originalFlowRows,
+  });
+  const preparedProcesses = prepare_process_rows({
+    rows: inputProcessRows,
+    policy: processPublishPolicy,
+    rewriteRefs: rewriteProcessFlowRefs,
+    preparedFlowRows: prepared.preparedRows,
+    flowVersionMap: prepared.flowVersionMap,
+  });
+
+  writeJsonArtifact(files.prepared_flow_rows, prepared.preparedRows);
+  writeJsonArtifact(files.prepared_process_rows, preparedProcesses.preparedRows);
+  writeJsonArtifact(files.flow_version_map, prepared.flowVersionMap);
+  writeJsonArtifact(files.skipped_unchanged_flow_rows, prepared.skippedUnchangedRows);
+  writeJsonLinesArtifact(files.process_ref_rewrite_evidence, preparedProcesses.rewriteEvidence);
+
+  let flowReports = prepared.plans.map(build_local_row_report);
+  let processReports = preparedProcesses.plans.map(build_local_process_row_report);
+
+  if (options.commit && prepared.preparedRows.length > 0) {
+    const publishImpl = options.runFlowPublishVersionImpl ?? runFlowPublishVersion;
+    await publishImpl({
+      inputFile: files.prepared_flow_rows,
+      outDir,
+      commit: true,
+      maxWorkers,
+      targetUserId,
+      env: options.env,
+      fetchImpl: options.fetchImpl,
+      timeoutMs: options.timeoutMs,
+      now,
+    });
+
+    const successRows = loadRowsFromFile(files.success_list) as FlowPublishSuccessRow[];
+    const failureRows = loadRowsFromFile(files.remote_failed) as FlowPublishFailureRow[];
+    flowReports = map_commit_reports(prepared.plans, successRows, failureRows);
+  } else {
+    writeJsonArtifact(files.success_list, []);
+    writeJsonLinesArtifact(files.remote_failed, []);
+    const compatReport = build_compat_report({
+      now,
+      mode,
+      preparedRows: prepared.preparedRows.length,
+      successCount: 0,
+      failureCount: 0,
+      maxWorkers,
+      targetUserId,
+      files,
+    });
+    writeJsonArtifact(files.flow_publish_version_report, compatReport);
+  }
+
+  if (options.commit && preparedProcesses.preparedRows.length > 0) {
+    if (!options.fetchImpl) {
+      throw new CliError(
+        'Process commit requires a fetch implementation in flow publish-reviewed-data.',
+        {
+          code: 'FLOW_PUBLISH_REVIEWED_PROCESS_FETCH_REQUIRED',
+          exitCode: 2,
+        },
+      );
+    }
+
+    const runtimeEnv = options.env;
+    if (!runtimeEnv || !hasSupabaseRestRuntime(runtimeEnv)) {
+      throw new CliError(
+        'Process commit requires TIANGONG_LCA_API_BASE_URL and TIANGONG_LCA_API_KEY.',
+        {
+          code: 'FLOW_PUBLISH_REVIEWED_PROCESS_RUNTIME_REQUIRED',
+          exitCode: 2,
+        },
+      );
+    }
+
+    processReports = await commit_process_plans({
+      plans: preparedProcesses.plans,
+      maxWorkers,
+      env: runtimeEnv,
+      fetchImpl: options.fetchImpl,
+      timeoutMs: options.timeoutMs,
+    });
+  }
+
+  const successCount =
+    flowReports.filter((report) => report.status === 'inserted' || report.status === 'updated')
+      .length +
+    processReports.filter(
+      (report) =>
+        report.status === 'inserted' ||
+        report.status === 'updated' ||
+        report.status === 'skipped_existing',
+    ).length;
+  const failureCount =
+    flowReports.filter((report) => report.status === 'failed').length +
+    processReports.filter((report) => report.status === 'failed').length;
+
+  const report: FlowReviewedPublishDataReport = {
+    schema_version: 1,
+    generated_at_utc: now.toISOString(),
+    status: status_from_mode(mode, failureCount),
+    mode,
+    flow_rows_file: flowRowsFile,
+    process_rows_file: processRowsFile,
+    original_flow_rows_file: originalFlowRowsFile,
+    out_dir: outDir,
+    flow_publish_policy: flowPublishPolicy,
+    process_publish_policy: processPublishPolicy,
+    rewrite_process_flow_refs: rewriteProcessFlowRefs,
+    counts: {
+      input_flow_rows: inputFlowRows.length,
+      input_process_rows: inputProcessRows.length,
+      original_flow_rows: originalFlowRows.length,
+      prepared_flow_rows: prepared.preparedRows.length,
+      prepared_process_rows: preparedProcesses.preparedRows.length,
+      skipped_unchanged_flow_rows: prepared.skippedUnchangedRows.length,
+      rewritten_process_flow_refs: preparedProcesses.rewriteEvidence.length,
+      flow_publish_reports: flowReports.length,
+      process_publish_reports: processReports.length,
+      success_count: successCount,
+      failure_count: failureCount,
+    },
+    max_workers: maxWorkers,
+    target_user_id_override: targetUserId,
+    files,
+    flow_reports: flowReports,
+    process_reports: processReports,
+    skipped_unchanged_flow_rows: prepared.skippedUnchangedRows,
+  };
+
+  writeJsonArtifact(files.report, report);
+  return report;
+}
+
+export const __testInternals = {
+  assert_input_file,
+  assert_optional_input_file,
+  assert_out_dir,
+  clone_json,
+  json_equal,
+  normalize_publish_policy,
+  bump_ilcd_version,
+  set_flow_version,
+  process_dataset_from_row,
+  extract_process_identity,
+  exchange_records,
+  set_process_version,
+  build_flow_index,
+  build_local_dataset_uri,
+  preserve_short_description_shape,
+  flow_reference_from_record,
+  patched_flow_reference,
+  build_output_files,
+  status_from_mode,
+  prepare_flow_rows,
+  prepare_process_rows,
+  build_compat_report,
+  map_commit_reports,
+  shift_queue,
+  process_publish_payload_from_row,
+  build_process_commit_success_report,
+  build_process_commit_failure_report,
+  map_with_concurrency,
+  commit_process_plans,
+};

--- a/src/lib/flow-regen-product.ts
+++ b/src/lib/flow-regen-product.ts
@@ -28,8 +28,8 @@ const EMERGY_TEXT_KEYWORDS = [
   'sej',
 ] as const;
 
-type AutoPatchPolicy = 'disabled' | 'alias-only' | 'alias-or-unique-name';
-type TidasMode = 'auto' | 'required' | 'skip';
+export type AutoPatchPolicy = 'disabled' | 'alias-only' | 'alias-or-unique-name';
+export type TidasMode = 'auto' | 'required' | 'skip';
 type PathPart = string | number;
 
 type LangEntry = {
@@ -85,12 +85,12 @@ type RepairAction = {
   candidate_refs?: Array<Record<string, string>>;
 };
 
-type ProcessPatchValidationIssue = JsonRecord & {
+export type ProcessPatchValidationIssue = JsonRecord & {
   type: string;
   severity: 'error';
 };
 
-type ProcessPatchValidationResult = {
+export type ProcessPatchValidationResult = {
   process_id: string;
   process_version: string;
   process_name: string;
@@ -98,7 +98,7 @@ type ProcessPatchValidationResult = {
   issues: ProcessPatchValidationIssue[];
 };
 
-type ProcessPatchValidationSummary = {
+export type ProcessPatchValidationSummary = {
   patched_process_count: number;
   passed: number;
   failed: number;
@@ -110,7 +110,7 @@ type ProcessPatchValidationReport = {
   results: ProcessPatchValidationResult[];
 };
 
-type ScanStageFiles = {
+export type ScanStageFiles = {
   out_dir: string;
   emergy_excluded_processes: string;
   summary: string;
@@ -118,7 +118,7 @@ type ScanStageFiles = {
   findings_jsonl: string;
 };
 
-type RepairStageFiles = {
+export type RepairStageFiles = {
   out_dir: string;
   plan: string;
   plan_jsonl: string;
@@ -126,15 +126,33 @@ type RepairStageFiles = {
   summary: string;
 };
 
-type ApplyStageFiles = RepairStageFiles & {
+export type ApplyStageFiles = RepairStageFiles & {
   patched_processes: string;
   patch_root: string;
 };
 
-type ValidateStageFiles = {
+export type ValidateStageFiles = {
   out_dir: string;
   report: string;
   failures: string;
+};
+
+export type FlowProcessRefScanSummary = {
+  process_count_before_emergy_exclusion: number;
+  process_count: number;
+  emergy_excluded_process_count: number;
+  exchange_count: number;
+  issue_counts: Record<string, number>;
+  processes_with_issues: number;
+};
+
+export type FlowProcessFlowRepairSummary = {
+  auto_patch_policy: AutoPatchPolicy;
+  process_count: number;
+  repair_item_count: number;
+  decision_counts: Record<string, number>;
+  patched_process_count: number;
+  process_pool_sync?: JsonRecord;
 };
 
 type FlowRegenProductFiles = {
@@ -195,6 +213,99 @@ export type RunFlowRegenProductOptions = {
   tidasMode?: TidasMode;
 };
 
+export type RunFlowValidateProcessesOptions = {
+  originalProcessesFile: string;
+  patchedProcessesFile: string;
+  scopeFlowFiles: string[];
+  outDir: string;
+  tidasMode?: TidasMode;
+};
+
+export type RunFlowScanProcessFlowRefsOptions = {
+  processesFile: string;
+  scopeFlowFiles: string[];
+  catalogFlowFiles?: string[];
+  aliasMapFile?: string | null;
+  excludeEmergy?: boolean;
+  outDir: string;
+};
+
+export type RunFlowPlanProcessFlowRepairsOptions = {
+  processesFile: string;
+  scopeFlowFiles: string[];
+  aliasMapFile?: string | null;
+  scanFindingsFile?: string | null;
+  autoPatchPolicy?: AutoPatchPolicy;
+  outDir: string;
+};
+
+export type RunFlowApplyProcessFlowRepairsOptions = {
+  processesFile: string;
+  scopeFlowFiles: string[];
+  aliasMapFile?: string | null;
+  scanFindingsFile?: string | null;
+  autoPatchPolicy?: AutoPatchPolicy;
+  processPoolFile?: string | null;
+  outDir: string;
+};
+
+export type FlowValidateProcessesReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: 'completed_local_flow_validate_processes';
+  original_processes_file: string;
+  patched_processes_file: string;
+  scope_flow_files: string[];
+  out_dir: string;
+  tidas_mode: TidasMode;
+  summary: ProcessPatchValidationSummary;
+  files: ValidateStageFiles;
+  results: ProcessPatchValidationResult[];
+};
+
+export type FlowScanProcessFlowRefsReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: 'completed_local_flow_scan_process_flow_refs';
+  processes_file: string;
+  scope_flow_files: string[];
+  catalog_flow_files: string[];
+  alias_map_file: string | null;
+  exclude_emergy: boolean;
+  out_dir: string;
+  summary: FlowProcessRefScanSummary;
+  files: ScanStageFiles;
+};
+
+export type FlowPlanProcessFlowRepairsReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: 'completed_local_flow_plan_process_flow_repairs';
+  processes_file: string;
+  scope_flow_files: string[];
+  alias_map_file: string | null;
+  scan_findings_file: string | null;
+  auto_patch_policy: AutoPatchPolicy;
+  out_dir: string;
+  summary: FlowProcessFlowRepairSummary;
+  files: RepairStageFiles;
+};
+
+export type FlowApplyProcessFlowRepairsReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: 'completed_local_flow_apply_process_flow_repairs';
+  processes_file: string;
+  scope_flow_files: string[];
+  alias_map_file: string | null;
+  scan_findings_file: string | null;
+  auto_patch_policy: AutoPatchPolicy;
+  process_pool_file: string | null;
+  out_dir: string;
+  summary: FlowProcessFlowRepairSummary;
+  files: ApplyStageFiles;
+};
+
 type ProcessSdkValidationEntity = {
   validateEnhanced?: () => unknown;
   validate?: () => unknown;
@@ -221,28 +332,14 @@ type ScanStageResult = {
   filteredProcesses: JsonRecord[];
   emergyExcludedProcesses: JsonRecord[];
   findings: ScanFinding[];
-  summary: {
-    process_count_before_emergy_exclusion: number;
-    process_count: number;
-    emergy_excluded_process_count: number;
-    exchange_count: number;
-    issue_counts: Record<string, number>;
-    processes_with_issues: number;
-  };
+  summary: FlowProcessRefScanSummary;
   files: ScanStageFiles;
 };
 
 type RepairStageResult = {
   plan: RepairAction[];
   manualQueue: RepairAction[];
-  summary: {
-    auto_patch_policy: AutoPatchPolicy;
-    process_count: number;
-    repair_item_count: number;
-    decision_counts: Record<string, number>;
-    patched_process_count: number;
-    process_pool_sync?: JsonRecord;
-  };
+  summary: FlowProcessFlowRepairSummary;
   files: RepairStageFiles | ApplyStageFiles;
   patchedRows: JsonRecord[];
 };
@@ -1407,6 +1504,29 @@ function buildValidateStageFiles(outDir: string): ValidateStageFiles {
   };
 }
 
+function loadOptionalScanFindings(
+  scanFindingsFile: string | null,
+  requiredCode: string,
+  missingCode: string,
+): {
+  resolvedFile: string | null;
+  scanFindings: ScanFinding[];
+} {
+  if (!scanFindingsFile) {
+    return {
+      resolvedFile: null,
+      scanFindings: [],
+    };
+  }
+
+  const resolvedFile = assertInputFile(scanFindingsFile, requiredCode, missingCode);
+
+  return {
+    resolvedFile,
+    scanFindings: loadRowsFromFile(resolvedFile) as ScanFinding[],
+  };
+}
+
 function runScanStage(
   processes: JsonRecord[],
   scopeIndex: FlowIndex,
@@ -1610,6 +1730,211 @@ function runValidateStage(options: {
   };
 }
 
+export async function runFlowScanProcessFlowRefs(
+  options: RunFlowScanProcessFlowRefsOptions,
+  deps: FlowRegenProductDeps = {},
+): Promise<FlowScanProcessFlowRefsReport> {
+  const processesFile = assertInputFile(
+    options.processesFile,
+    'FLOW_SCAN_PROCESS_FLOW_REFS_PROCESSES_FILE_REQUIRED',
+    'FLOW_SCAN_PROCESS_FLOW_REFS_PROCESSES_FILE_NOT_FOUND',
+  );
+  const scopeFlowFiles = assertInputFiles(
+    options.scopeFlowFiles ?? [],
+    'FLOW_SCAN_PROCESS_FLOW_REFS_SCOPE_FLOW_FILES_REQUIRED',
+    'FLOW_SCAN_PROCESS_FLOW_REFS_SCOPE_FLOW_FILE_NOT_FOUND',
+  );
+  const catalogFlowFiles =
+    options.catalogFlowFiles && options.catalogFlowFiles.length > 0
+      ? assertInputFiles(
+          options.catalogFlowFiles,
+          'FLOW_SCAN_PROCESS_FLOW_REFS_CATALOG_FLOW_FILES_REQUIRED',
+          'FLOW_SCAN_PROCESS_FLOW_REFS_CATALOG_FLOW_FILE_NOT_FOUND',
+        )
+      : scopeFlowFiles;
+  const aliasMapFile = options.aliasMapFile
+    ? assertInputFile(
+        options.aliasMapFile,
+        'FLOW_SCAN_PROCESS_FLOW_REFS_ALIAS_MAP_REQUIRED',
+        'FLOW_SCAN_PROCESS_FLOW_REFS_ALIAS_MAP_NOT_FOUND',
+      )
+    : null;
+  const outDir = assertOutDir(options.outDir);
+  const now = deps.now ?? (() => new Date());
+
+  const processes = loadRowsFromFile(processesFile);
+  const scopeRows = scopeFlowFiles.flatMap((filePath) => loadRowsFromFile(filePath));
+  const catalogRows = catalogFlowFiles.flatMap((filePath) => loadRowsFromFile(filePath));
+  const aliasMap = aliasMapFile
+    ? readJsonObjectFile(
+        aliasMapFile,
+        'FLOW_SCAN_PROCESS_FLOW_REFS_ALIAS_MAP_REQUIRED',
+        'FLOW_SCAN_PROCESS_FLOW_REFS_ALIAS_MAP_NOT_FOUND',
+        'FLOW_SCAN_PROCESS_FLOW_REFS_ALIAS_MAP_INVALID',
+      )
+    : {};
+  const scopeIndex = buildFlowIndex(scopeRows);
+  const catalogIndex = buildFlowIndex(catalogRows);
+  const scanStage = runScanStage(
+    processes,
+    scopeIndex,
+    catalogIndex,
+    aliasMap,
+    outDir,
+    options.excludeEmergy === true,
+  );
+
+  return {
+    schema_version: 1,
+    generated_at_utc: now().toISOString(),
+    status: 'completed_local_flow_scan_process_flow_refs',
+    processes_file: processesFile,
+    scope_flow_files: scopeFlowFiles,
+    catalog_flow_files: catalogFlowFiles,
+    alias_map_file: aliasMapFile,
+    exclude_emergy: options.excludeEmergy === true,
+    out_dir: outDir,
+    summary: scanStage.summary,
+    files: scanStage.files,
+  };
+}
+
+export async function runFlowPlanProcessFlowRepairs(
+  options: RunFlowPlanProcessFlowRepairsOptions,
+  deps: FlowRegenProductDeps = {},
+): Promise<FlowPlanProcessFlowRepairsReport> {
+  const processesFile = assertInputFile(
+    options.processesFile,
+    'FLOW_PLAN_PROCESS_FLOW_REPAIRS_PROCESSES_FILE_REQUIRED',
+    'FLOW_PLAN_PROCESS_FLOW_REPAIRS_PROCESSES_FILE_NOT_FOUND',
+  );
+  const scopeFlowFiles = assertInputFiles(
+    options.scopeFlowFiles ?? [],
+    'FLOW_PLAN_PROCESS_FLOW_REPAIRS_SCOPE_FLOW_FILES_REQUIRED',
+    'FLOW_PLAN_PROCESS_FLOW_REPAIRS_SCOPE_FLOW_FILE_NOT_FOUND',
+  );
+  const aliasMapFile = options.aliasMapFile
+    ? assertInputFile(
+        options.aliasMapFile,
+        'FLOW_PLAN_PROCESS_FLOW_REPAIRS_ALIAS_MAP_REQUIRED',
+        'FLOW_PLAN_PROCESS_FLOW_REPAIRS_ALIAS_MAP_NOT_FOUND',
+      )
+    : null;
+  const { resolvedFile: scanFindingsFile, scanFindings } = loadOptionalScanFindings(
+    options.scanFindingsFile ?? null,
+    'FLOW_PLAN_PROCESS_FLOW_REPAIRS_SCAN_FINDINGS_REQUIRED',
+    'FLOW_PLAN_PROCESS_FLOW_REPAIRS_SCAN_FINDINGS_NOT_FOUND',
+  );
+  const outDir = assertOutDir(options.outDir);
+  const autoPatchPolicy = options.autoPatchPolicy ?? 'alias-only';
+  const now = deps.now ?? (() => new Date());
+
+  const processes = loadRowsFromFile(processesFile);
+  const scopeRows = scopeFlowFiles.flatMap((filePath) => loadRowsFromFile(filePath));
+  const aliasMap = aliasMapFile
+    ? readJsonObjectFile(
+        aliasMapFile,
+        'FLOW_PLAN_PROCESS_FLOW_REPAIRS_ALIAS_MAP_REQUIRED',
+        'FLOW_PLAN_PROCESS_FLOW_REPAIRS_ALIAS_MAP_NOT_FOUND',
+        'FLOW_PLAN_PROCESS_FLOW_REPAIRS_ALIAS_MAP_INVALID',
+      )
+    : {};
+  const scopeIndex = buildFlowIndex(scopeRows);
+  const repairStage = runRepairStage({
+    processes,
+    scopeIndex,
+    aliasMap,
+    scanFindings,
+    autoPatchPolicy,
+    outDir,
+    apply: false,
+    processPoolFile: null,
+  });
+
+  return {
+    schema_version: 1,
+    generated_at_utc: now().toISOString(),
+    status: 'completed_local_flow_plan_process_flow_repairs',
+    processes_file: processesFile,
+    scope_flow_files: scopeFlowFiles,
+    alias_map_file: aliasMapFile,
+    scan_findings_file: scanFindingsFile,
+    auto_patch_policy: autoPatchPolicy,
+    out_dir: outDir,
+    summary: repairStage.summary,
+    files: repairStage.files as RepairStageFiles,
+  };
+}
+
+export async function runFlowApplyProcessFlowRepairs(
+  options: RunFlowApplyProcessFlowRepairsOptions,
+  deps: FlowRegenProductDeps = {},
+): Promise<FlowApplyProcessFlowRepairsReport> {
+  const processesFile = assertInputFile(
+    options.processesFile,
+    'FLOW_APPLY_PROCESS_FLOW_REPAIRS_PROCESSES_FILE_REQUIRED',
+    'FLOW_APPLY_PROCESS_FLOW_REPAIRS_PROCESSES_FILE_NOT_FOUND',
+  );
+  const scopeFlowFiles = assertInputFiles(
+    options.scopeFlowFiles ?? [],
+    'FLOW_APPLY_PROCESS_FLOW_REPAIRS_SCOPE_FLOW_FILES_REQUIRED',
+    'FLOW_APPLY_PROCESS_FLOW_REPAIRS_SCOPE_FLOW_FILE_NOT_FOUND',
+  );
+  const aliasMapFile = options.aliasMapFile
+    ? assertInputFile(
+        options.aliasMapFile,
+        'FLOW_APPLY_PROCESS_FLOW_REPAIRS_ALIAS_MAP_REQUIRED',
+        'FLOW_APPLY_PROCESS_FLOW_REPAIRS_ALIAS_MAP_NOT_FOUND',
+      )
+    : null;
+  const { resolvedFile: scanFindingsFile, scanFindings } = loadOptionalScanFindings(
+    options.scanFindingsFile ?? null,
+    'FLOW_APPLY_PROCESS_FLOW_REPAIRS_SCAN_FINDINGS_REQUIRED',
+    'FLOW_APPLY_PROCESS_FLOW_REPAIRS_SCAN_FINDINGS_NOT_FOUND',
+  );
+  const outDir = assertOutDir(options.outDir);
+  const autoPatchPolicy = options.autoPatchPolicy ?? 'alias-only';
+  const processPoolFile = options.processPoolFile ? path.resolve(options.processPoolFile) : null;
+  const now = deps.now ?? (() => new Date());
+
+  const processes = loadRowsFromFile(processesFile);
+  const scopeRows = scopeFlowFiles.flatMap((filePath) => loadRowsFromFile(filePath));
+  const aliasMap = aliasMapFile
+    ? readJsonObjectFile(
+        aliasMapFile,
+        'FLOW_APPLY_PROCESS_FLOW_REPAIRS_ALIAS_MAP_REQUIRED',
+        'FLOW_APPLY_PROCESS_FLOW_REPAIRS_ALIAS_MAP_NOT_FOUND',
+        'FLOW_APPLY_PROCESS_FLOW_REPAIRS_ALIAS_MAP_INVALID',
+      )
+    : {};
+  const scopeIndex = buildFlowIndex(scopeRows);
+  const repairStage = runRepairStage({
+    processes,
+    scopeIndex,
+    aliasMap,
+    scanFindings,
+    autoPatchPolicy,
+    outDir,
+    apply: true,
+    processPoolFile,
+  });
+
+  return {
+    schema_version: 1,
+    generated_at_utc: now().toISOString(),
+    status: 'completed_local_flow_apply_process_flow_repairs',
+    processes_file: processesFile,
+    scope_flow_files: scopeFlowFiles,
+    alias_map_file: aliasMapFile,
+    scan_findings_file: scanFindingsFile,
+    auto_patch_policy: autoPatchPolicy,
+    process_pool_file: processPoolFile,
+    out_dir: outDir,
+    summary: repairStage.summary,
+    files: repairStage.files as ApplyStageFiles,
+  };
+}
+
 function buildReportFiles(outDir: string, apply: boolean): FlowRegenProductFiles {
   return {
     report: path.join(outDir, 'flow-regen-product-report.json'),
@@ -1751,6 +2076,57 @@ export async function runFlowRegenProduct(
 
   writeJsonArtifact(files.report, report);
   return report;
+}
+
+export async function runFlowValidateProcesses(
+  options: RunFlowValidateProcessesOptions,
+  deps: FlowRegenProductDeps = {},
+): Promise<FlowValidateProcessesReport> {
+  const originalProcessesFile = assertInputFile(
+    options.originalProcessesFile,
+    'FLOW_VALIDATE_PROCESSES_ORIGINAL_FILE_REQUIRED',
+    'FLOW_VALIDATE_PROCESSES_ORIGINAL_FILE_NOT_FOUND',
+  );
+  const patchedProcessesFile = assertInputFile(
+    options.patchedProcessesFile,
+    'FLOW_VALIDATE_PROCESSES_PATCHED_FILE_REQUIRED',
+    'FLOW_VALIDATE_PROCESSES_PATCHED_FILE_NOT_FOUND',
+  );
+  const scopeFlowFiles = assertInputFiles(
+    options.scopeFlowFiles ?? [],
+    'FLOW_VALIDATE_PROCESSES_SCOPE_FLOW_FILES_REQUIRED',
+    'FLOW_VALIDATE_PROCESSES_SCOPE_FLOW_FILE_NOT_FOUND',
+  );
+  const outDir = assertOutDir(options.outDir);
+  const tidasMode = options.tidasMode ?? 'auto';
+  const now = deps.now ?? (() => new Date());
+
+  const originalRows = loadRowsFromFile(originalProcessesFile);
+  const patchedRows = loadRowsFromFile(patchedProcessesFile);
+  const scopeRows = scopeFlowFiles.flatMap((filePath) => loadRowsFromFile(filePath));
+  const scopeIndex = buildFlowIndex(scopeRows);
+  const validateStage = runValidateStage({
+    originalRows,
+    patchedRows,
+    scopeIndex,
+    outDir,
+    tidasMode,
+    deps,
+  });
+
+  return {
+    schema_version: 1,
+    generated_at_utc: now().toISOString(),
+    status: 'completed_local_flow_validate_processes',
+    original_processes_file: originalProcessesFile,
+    patched_processes_file: patchedProcessesFile,
+    scope_flow_files: scopeFlowFiles,
+    out_dir: outDir,
+    tidas_mode: tidasMode,
+    summary: validateStage.summary,
+    files: validateStage.files,
+    results: validateStage.results,
+  };
 }
 
 export const __testInternals = {

--- a/src/lib/lifecyclemodel-auto-build.ts
+++ b/src/lib/lifecyclemodel-auto-build.ts
@@ -1,0 +1,1854 @@
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { writeJsonArtifact, writeTextArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+import { readJsonInput } from './io.js';
+import {
+  buildRunId,
+  buildRunManifest,
+  ensureRunLayout,
+  writeLatestRunId,
+  type RunLayout,
+} from './run.js';
+
+type JsonRecord = Record<string, unknown>;
+
+const UUID_NAMESPACE_URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
+const EPSILON = 1e-10;
+
+const DEFAULT_MANIFEST = {
+  run_label: 'lifecyclemodel-automated-builder',
+  allow_remote_write: false,
+  discovery: {
+    sources: [
+      { kind: 'account_processes', selector: 'all-accessible' },
+      {
+        kind: 'public_open_data',
+        table: 'processes',
+        filters: { state_code: 100 },
+      },
+    ],
+    supporting_open_tables: ['flows', 'sources', 'lifecyclemodels'],
+    batch_limit: 200,
+    reference_model_queries: [],
+    reference_model_select_limit: 3,
+  },
+  selection: {
+    mode: 'graph_first_local_build',
+    max_models: 25,
+    max_processes_per_model: 12,
+    decision_factors: [
+      'shared product system or classification lineage',
+      'explicit exchange connectivity',
+      'quantitative reference completeness',
+      'geography and time coherence',
+    ],
+  },
+  reuse: {
+    reusable_process_dirs: [],
+    include_reference_model_resulting_processes: true,
+  },
+  output: {
+    write_local_models: true,
+    emit_validation_report: false,
+  },
+  local_runs: [],
+  publish: {
+    enabled: false,
+    mode: 'deferred_to_publish_build',
+    target_runs: [],
+    select_after_insert: true,
+    max_attempts: 5,
+    retry_delay_seconds: 2,
+  },
+} as const;
+
+type LifecyclemodelAutoBuildStatus = 'completed_local_lifecyclemodel_auto_build_run';
+
+export type LifecyclemodelAutoBuildLayout = RunLayout & {
+  requestDir: string;
+  selectionDir: string;
+  discoveryDir: string;
+  modelsDir: string;
+  requestSnapshotPath: string;
+  normalizedRequestPath: string;
+  runPlanPath: string;
+  resolvedManifestPath: string;
+  selectionBriefPath: string;
+  referenceModelSummaryPath: string;
+  invocationIndexPath: string;
+  runManifestPath: string;
+  reportPath: string;
+};
+
+export type NormalizedLifecyclemodelAutoBuildRequest = {
+  schema_version: 1;
+  request_path: string;
+  run_id: string;
+  run_root: string;
+  manifest: JsonRecord;
+  local_runs: string[];
+};
+
+type ProcessRecord = {
+  processUuid: string;
+  version: string;
+  raw: JsonRecord;
+  referenceExchangeInternalId: string;
+  referenceFlowUuid: string;
+  referenceDirection: 'Input' | 'Output';
+  referenceAmount: number;
+  inputAmounts: Record<string, number>;
+  outputAmounts: Record<string, number>;
+  nameEn: string;
+  nameZh: string;
+  routeEn: string;
+  mixEn: string;
+  geographyCode: string;
+  classificationPath: string[];
+  tokenSet: Set<string>;
+  sourceKind: 'local_run_export';
+  sourceLabel: string;
+  includedProcessRefCount: number;
+};
+
+type Edge = {
+  src: string;
+  dst: string;
+  flowUuid: string;
+  downstreamInputAmount: number;
+  confidence: number;
+  reasons: string[];
+};
+
+export type LifecyclemodelAutoBuildLocalReport = {
+  run_dir: string;
+  run_name: string;
+  model_file: string;
+  summary_file: string;
+  connections_file: string;
+  process_catalog_file: string;
+  summary: JsonRecord;
+};
+
+export type LifecyclemodelAutoBuildReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: LifecyclemodelAutoBuildStatus;
+  request_path: string;
+  run_id: string;
+  run_root: string;
+  local_run_count: number;
+  built_model_count: number;
+  files: {
+    request_snapshot: string;
+    normalized_request: string;
+    run_plan: string;
+    resolved_manifest: string;
+    selection_brief: string;
+    reference_model_summary: string;
+    invocation_index: string;
+    run_manifest: string;
+    report: string;
+  };
+  local_build_reports: LifecyclemodelAutoBuildLocalReport[];
+  next_actions: string[];
+};
+
+export type RunLifecyclemodelAutoBuildOptions = {
+  inputPath: string;
+  outDir?: string | null;
+  now?: Date;
+  cwd?: string;
+  inputValue?: unknown;
+  runIdOverride?: string;
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function ensureList<T = unknown>(value: unknown): T[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+
+  return Array.isArray(value) ? (value as T[]) : ([value] as T[]);
+}
+
+function copyJson<T>(value: T): T {
+  if (value === undefined) {
+    return value;
+  }
+
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized || null;
+}
+
+function numberOrZero(value: unknown): number {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  return 0;
+}
+
+function firstText(value: unknown): string {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (isRecord(item)) {
+        const text = nonEmptyString(item['#text']);
+        if (text) {
+          return text;
+        }
+      }
+    }
+
+    return '';
+  }
+
+  if (isRecord(value)) {
+    return nonEmptyString(value['#text']) ?? '';
+  }
+
+  return nonEmptyString(value) ?? '';
+}
+
+function langTextMap(value: unknown): Record<string, string> {
+  const mapping: Record<string, string> = {};
+
+  for (const item of ensureList(value)) {
+    if (!isRecord(item)) {
+      continue;
+    }
+
+    const lang = nonEmptyString(item['@xml:lang'])?.toLowerCase() ?? 'en';
+    const text = nonEmptyString(item['#text']);
+    if (text && !mapping[lang]) {
+      mapping[lang] = text;
+    }
+  }
+
+  if (Object.keys(mapping).length > 0) {
+    return mapping;
+  }
+
+  const text = firstText(value).trim();
+  return text ? { en: text } : {};
+}
+
+function localizedText(value: unknown, preferred = 'zh'): string {
+  const mapping = langTextMap(value);
+  if (mapping[preferred]) {
+    return mapping[preferred];
+  }
+
+  if (preferred.startsWith('zh')) {
+    for (const candidate of ['zh-cn', 'zh-hans', 'zh']) {
+      if (mapping[candidate]) {
+        return mapping[candidate];
+      }
+    }
+  }
+
+  if (mapping.en) {
+    return mapping.en;
+  }
+
+  return Object.values(mapping)[0] ?? '';
+}
+
+function multilangText(value: unknown): [string, string] {
+  const mapping = langTextMap(value);
+  return [mapping.en ?? Object.values(mapping)[0] ?? '', mapping.zh ?? mapping['zh-cn'] ?? ''];
+}
+
+function multilangFromText(enText: string, zhText?: string): Array<Record<string, string>> {
+  const items: Array<Record<string, string>> = [];
+  if (enText) {
+    items.push({ '@xml:lang': 'en', '#text': enText });
+  }
+  if (zhText) {
+    items.push({ '@xml:lang': 'zh', '#text': zhText });
+  }
+  return items;
+}
+
+function tokenizeText(value: string): Set<string> {
+  const cleaned = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, ' ')
+    .trim();
+
+  return new Set(cleaned.split(/\s+/u).filter((token) => token.length >= 3));
+}
+
+function buildNameSummary(nameInfo: JsonRecord): Array<Record<string, string>> {
+  const base = langTextMap(nameInfo.baseName);
+  const route = langTextMap(nameInfo.treatmentStandardsRoutes);
+  const mix = langTextMap(nameInfo.mixAndLocationTypes);
+  const functional = langTextMap(nameInfo.functionalUnitFlowProperties);
+  const langOrder: string[] = [];
+
+  [base, route, mix, functional].forEach((mapping) => {
+    Object.keys(mapping).forEach((lang) => {
+      if (!langOrder.includes(lang)) {
+        langOrder.push(lang);
+      }
+    });
+  });
+
+  if (langOrder.length === 0) {
+    return [];
+  }
+
+  const fallback = (mapping: Record<string, string>, lang: string): string =>
+    mapping[lang] ??
+    mapping.zh ??
+    mapping['zh-cn'] ??
+    mapping.en ??
+    Object.values(mapping)[0] ??
+    '';
+
+  const summary: Array<Record<string, string>> = [];
+
+  langOrder.forEach((lang) => {
+    const text = [
+      fallback(base, lang),
+      fallback(route, lang),
+      fallback(mix, lang),
+      fallback(functional, lang),
+    ]
+      .filter(Boolean)
+      .join('; ')
+      .trim();
+
+    if (text) {
+      summary.push({ '@xml:lang': lang, '#text': text });
+    }
+  });
+
+  return summary;
+}
+
+function extractClassificationPath(classificationInfo: unknown): string[] {
+  const carrier = isRecord(classificationInfo)
+    ? isRecord(classificationInfo['common:classification'])
+      ? classificationInfo['common:classification']
+      : {}
+    : {};
+
+  return ensureList(carrier['common:class'])
+    .map((item) => (isRecord(item) ? nonEmptyString(item['#text']) : null))
+    .filter((item): item is string => Boolean(item));
+}
+
+function classificationOverlap(left: string[], right: string[]): number {
+  let overlap = 0;
+  const maxLength = Math.min(left.length, right.length);
+
+  for (let index = 0; index < maxLength; index += 1) {
+    if (left[index] !== right[index]) {
+      break;
+    }
+    overlap += 1;
+  }
+
+  return overlap;
+}
+
+function parseUuidBytes(uuid: string): Uint8Array {
+  const hex = uuid.replace(/-/gu, '').toLowerCase();
+  if (!/^[0-9a-f]{32}$/u.test(hex)) {
+    throw new CliError(`Invalid UUID value: ${uuid}`, {
+      code: 'LIFECYCLEMODEL_AUTO_BUILD_UUID_INVALID',
+      exitCode: 2,
+    });
+  }
+
+  const bytes = new Uint8Array(16);
+  for (let index = 0; index < 16; index += 1) {
+    bytes[index] = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+function bytesToUuid(bytes: Uint8Array): string {
+  const hex = Array.from(bytes, (value) => value.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function uuid5FromText(namespaceUuid: string, value: string): string {
+  const namespaceBytes = Buffer.from(parseUuidBytes(namespaceUuid));
+  const hash = createHash('sha1').update(namespaceBytes).update(value, 'utf8').digest();
+  const bytes = Uint8Array.from(hash.subarray(0, 16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  return bytesToUuid(bytes);
+}
+
+function formatNumber(value: number): string {
+  if (!Number.isFinite(value) || Math.abs(value) < EPSILON) {
+    return '0';
+  }
+
+  const normalized = Number.parseFloat(value.toPrecision(15));
+  if (Number.isInteger(normalized)) {
+    return String(normalized);
+  }
+
+  if (Math.abs(normalized) >= 1e6 || Math.abs(normalized) < 1e-6) {
+    return normalized.toFixed(12).replace(/0+$/u, '').replace(/\.$/u, '');
+  }
+
+  return String(normalized);
+}
+
+function toJsonNumber(value: number): number {
+  return Number.parseFloat(formatNumber(value));
+}
+
+function requiredRequestObject(input: unknown): JsonRecord {
+  if (!isRecord(input)) {
+    throw new CliError('lifecyclemodel auto-build request must be a JSON object.', {
+      code: 'LIFECYCLEMODEL_AUTO_BUILD_REQUEST_INVALID',
+      exitCode: 2,
+    });
+  }
+
+  return input;
+}
+
+function deepMerge(base: unknown, override: unknown): unknown {
+  if (isRecord(base) && isRecord(override)) {
+    const merged: JsonRecord = copyJson(base);
+    Object.entries(override).forEach(([key, value]) => {
+      merged[key] = deepMerge(merged[key], value);
+    });
+    return merged;
+  }
+
+  return copyJson(override);
+}
+
+function normalizeLocalRuns(value: unknown, requestDir: string): string[] {
+  const seen = new Set<string>();
+  const normalized = ensureList(value)
+    .map((item) => nonEmptyString(item))
+    .filter((item): item is string => Boolean(item))
+    .map((item) => path.resolve(requestDir, item));
+
+  if (normalized.length === 0) {
+    throw new CliError(
+      'lifecyclemodel auto-build local_runs must contain at least one run directory.',
+      {
+        code: 'LIFECYCLEMODEL_AUTO_BUILD_LOCAL_RUNS_REQUIRED',
+        exitCode: 2,
+      },
+    );
+  }
+
+  normalized.forEach((item) => {
+    if (seen.has(item)) {
+      throw new CliError(`Duplicate lifecyclemodel auto-build local_run: ${item}`, {
+        code: 'LIFECYCLEMODEL_AUTO_BUILD_LOCAL_RUN_DUPLICATE',
+        exitCode: 2,
+      });
+    }
+    seen.add(item);
+  });
+
+  return normalized;
+}
+
+function resolveRunRoot(
+  requestDir: string,
+  runId: string,
+  outDirOverride: string | null | undefined,
+  requestOutDir: unknown,
+): string {
+  const override = nonEmptyString(outDirOverride);
+  if (override) {
+    return path.resolve(requestDir, override);
+  }
+
+  const requestValue = nonEmptyString(requestOutDir);
+  if (requestValue) {
+    return path.resolve(requestDir, requestValue);
+  }
+
+  return path.join(requestDir, 'artifacts', 'lifecyclemodel_auto_build', runId);
+}
+
+function buildLayout(runRoot: string, runId: string): LifecyclemodelAutoBuildLayout {
+  const collectionDir = path.dirname(runRoot);
+  const layout: RunLayout = {
+    namespace: 'lifecyclemodel_auto_build',
+    runId,
+    artifactsRoot: path.dirname(collectionDir),
+    collectionDir,
+    runRoot,
+    cacheDir: path.join(runRoot, 'cache'),
+    inputsDir: path.join(runRoot, 'request'),
+    outputsDir: path.join(runRoot, 'models'),
+    reportsDir: path.join(runRoot, 'reports'),
+    logsDir: path.join(runRoot, 'logs'),
+    manifestsDir: path.join(runRoot, 'manifests'),
+    latestRunIdPath: path.join(collectionDir, '.latest_run_id'),
+  };
+
+  return {
+    ...layout,
+    requestDir: path.join(runRoot, 'request'),
+    selectionDir: path.join(runRoot, 'selection'),
+    discoveryDir: path.join(runRoot, 'discovery'),
+    modelsDir: path.join(runRoot, 'models'),
+    requestSnapshotPath: path.join(runRoot, 'request', 'lifecyclemodel-auto-build.request.json'),
+    normalizedRequestPath: path.join(runRoot, 'request', 'request.normalized.json'),
+    runPlanPath: path.join(runRoot, 'run-plan.json'),
+    resolvedManifestPath: path.join(runRoot, 'resolved-manifest.json'),
+    selectionBriefPath: path.join(runRoot, 'selection', 'selection-brief.md'),
+    referenceModelSummaryPath: path.join(runRoot, 'discovery', 'reference-model-summary.json'),
+    invocationIndexPath: path.join(runRoot, 'manifests', 'invocation-index.json'),
+    runManifestPath: path.join(runRoot, 'manifests', 'run-manifest.json'),
+    reportPath: path.join(runRoot, 'reports', 'lifecyclemodel-auto-build-report.json'),
+  };
+}
+
+function ensureEmptyRunRoot(runRoot: string): void {
+  if (!existsSync(runRoot)) {
+    return;
+  }
+
+  if (readdirSync(runRoot).length > 0) {
+    throw new CliError(
+      `lifecyclemodel auto-build run root already exists and is not empty: ${runRoot}`,
+      {
+        code: 'LIFECYCLEMODEL_AUTO_BUILD_RUN_EXISTS',
+        exitCode: 2,
+      },
+    );
+  }
+}
+
+function ensureLayout(layout: LifecyclemodelAutoBuildLayout): void {
+  ensureRunLayout(layout);
+  [layout.requestDir, layout.selectionDir, layout.discoveryDir, layout.modelsDir].forEach(
+    (dirPath) => {
+      mkdirSync(dirPath, { recursive: true });
+    },
+  );
+}
+
+export function normalizeLifecyclemodelAutoBuildRequest(
+  input: unknown,
+  options: {
+    inputPath: string;
+    outDir?: string | null;
+    now?: Date;
+    runIdOverride?: string;
+  },
+): NormalizedLifecyclemodelAutoBuildRequest {
+  const request = requiredRequestObject(input);
+  const requestPath = path.resolve(options.inputPath);
+  const requestDir = path.dirname(requestPath);
+  const mergedManifest = deepMerge(DEFAULT_MANIFEST, request) as JsonRecord;
+
+  if (mergedManifest.allow_remote_write === true) {
+    throw new CliError(
+      'allow_remote_write=true is not supported by tiangong lifecyclemodel auto-build. Keep the run read-only.',
+      {
+        code: 'LIFECYCLEMODEL_AUTO_BUILD_REMOTE_WRITE_UNSUPPORTED',
+        exitCode: 2,
+      },
+    );
+  }
+
+  const now = options.now ?? new Date();
+  const runId =
+    nonEmptyString(options.runIdOverride) ??
+    buildRunId({
+      namespace: 'lifecyclemodel_auto_build',
+      subject:
+        nonEmptyString(mergedManifest.run_label) ??
+        path.basename(requestPath, path.extname(requestPath)),
+      operation: 'build',
+      now,
+    });
+
+  return {
+    schema_version: 1,
+    request_path: requestPath,
+    run_id: runId,
+    run_root: resolveRunRoot(requestDir, runId, options.outDir, request.out_dir),
+    manifest: mergedManifest,
+    local_runs: normalizeLocalRuns(mergedManifest.local_runs, requestDir),
+  };
+}
+
+function buildSelectionBrief(manifest: JsonRecord): string {
+  const selection = isRecord(manifest.selection) ? manifest.selection : {};
+  const decisionFactors = ensureList(selection.decision_factors)
+    .map((item) => nonEmptyString(item))
+    .filter((item): item is string => Boolean(item));
+  const referenceQueries = isRecord(manifest.discovery)
+    ? ensureList(manifest.discovery.reference_model_queries)
+        .map((item) => nonEmptyString(item))
+        .filter((item): item is string => Boolean(item))
+    : [];
+
+  const lines = [
+    '# Selection Brief',
+    '',
+    'This CLI slice is local-first and read-only.',
+    '',
+    'Candidate processes are grouped by the provided process run directories.',
+    'The CLI then infers graph structure from shared flow UUIDs, chooses one reference process, and assembles native `json_ordered` lifecyclemodel artifacts.',
+    '',
+    'Decision factors:',
+    ...decisionFactors.map((item) => `- ${item}`),
+  ];
+
+  if (referenceQueries.length > 0) {
+    lines.push(
+      '',
+      'Reference lifecyclemodel discovery was requested in the manifest, but this first CLI slice defers remote read-only discovery to future commands.',
+      ...referenceQueries.map((item) => `- deferred reference query: ${item}`),
+    );
+  }
+
+  lines.push(
+    '',
+    'Explicitly deferred in this slice:',
+    '- remote discovery',
+    '- MCP writes',
+    '- LLM-driven selection',
+    '- validate-build',
+    '- publish-build',
+    '',
+  );
+
+  return lines.join('\n');
+}
+
+function buildReferenceModelSummary(manifest: JsonRecord): JsonRecord {
+  const discovery = isRecord(manifest.discovery) ? manifest.discovery : {};
+  const queries = ensureList(discovery.reference_model_queries)
+    .map((item) => nonEmptyString(item))
+    .filter((item): item is string => Boolean(item));
+
+  return {
+    executed: false,
+    queries,
+    reason:
+      queries.length > 0
+        ? 'reference model discovery is deferred in the first native CLI auto-build slice'
+        : 'reference model discovery not requested',
+  };
+}
+
+function buildInvocationIndex(
+  normalized: NormalizedLifecyclemodelAutoBuildRequest,
+  options: RunLifecyclemodelAutoBuildOptions,
+  layout: LifecyclemodelAutoBuildLayout,
+  now: Date,
+): JsonRecord {
+  const command = ['lifecyclemodel', 'auto-build', '--input', options.inputPath];
+  if (options.outDir) {
+    command.push('--out-dir', options.outDir);
+  }
+
+  return {
+    schema_version: 1,
+    invocations: [
+      {
+        command,
+        cwd: options.cwd ?? process.cwd(),
+        created_at: now.toISOString(),
+        request_path: normalized.request_path,
+        report_path: layout.reportPath,
+      },
+    ],
+  };
+}
+
+function buildPlan(
+  normalized: NormalizedLifecyclemodelAutoBuildRequest,
+  layout: LifecyclemodelAutoBuildLayout,
+  now: Date,
+): JsonRecord {
+  return {
+    skill: 'lifecyclemodel-automated-builder',
+    mode: 'read_only_local_build',
+    created_at: now.toISOString(),
+    manifest: normalized.manifest,
+    runtime: {
+      cli: {
+        command: 'lifecyclemodel auto-build',
+        entry: 'native_ts',
+        node_version: process.version,
+        remote_write: false,
+        mcp_used: false,
+      },
+    },
+    guardrails: [
+      'do not write remote lifecyclemodel rows in auto-build',
+      'do not require MCP or LLM to assemble the initial local lifecyclemodel graph',
+      'emit native json_ordered only',
+      'defer validate-build and publish-build to dedicated follow-up commands',
+    ],
+    artifacts: {
+      root: layout.runRoot,
+      run_plan: layout.runPlanPath,
+      resolved_manifest: layout.resolvedManifestPath,
+      selection_brief: layout.selectionBriefPath,
+      discovery_dir: layout.discoveryDir,
+      reference_model_summary: layout.referenceModelSummaryPath,
+      models_dir: layout.modelsDir,
+      reports_dir: layout.reportsDir,
+    },
+    stages: [
+      {
+        name: 'load-local-runs',
+        mode: 'local',
+        description: 'Load one or more process-automated-builder run directories.',
+      },
+      {
+        name: 'infer-graph',
+        mode: 'local',
+        description: 'Infer process-to-process links from shared flow UUIDs.',
+      },
+      {
+        name: 'select-reference-process',
+        mode: 'local',
+        description:
+          'Pick the lifecyclemodel reference process from the target flow and graph shape.',
+      },
+      {
+        name: 'assemble-lifecyclemodel',
+        mode: 'local',
+        description: 'Write native json_ordered lifecyclemodel artifacts.',
+      },
+      {
+        name: 'validate',
+        mode: 'deferred',
+        description: 'Deferred to tiangong lifecyclemodel validate-build.',
+      },
+      {
+        name: 'publish',
+        mode: 'deferred',
+        description: 'Deferred to tiangong lifecyclemodel publish-build.',
+      },
+    ],
+    local_runs: normalized.local_runs,
+  };
+}
+
+function extractFlowDatasetFromState(state: JsonRecord): JsonRecord {
+  const flowDataset = isRecord(state.flow_dataset) ? state.flow_dataset : {};
+  if (isRecord(flowDataset.flowDataSet)) {
+    return flowDataset.flowDataSet;
+  }
+
+  return flowDataset;
+}
+
+function buildGlobalReference(
+  refObjectId: string,
+  version: string,
+  shortDescription: unknown,
+  datasetType: string,
+  uri: string,
+): JsonRecord {
+  return {
+    '@refObjectId': refObjectId,
+    '@type': datasetType,
+    '@uri': uri,
+    '@version': version,
+    'common:shortDescription': copyJson(shortDescription),
+  };
+}
+
+function resolvePublicationBlock(dataset: JsonRecord): JsonRecord {
+  const administrativeInformation = isRecord(dataset.administrativeInformation)
+    ? dataset.administrativeInformation
+    : {};
+
+  if (isRecord(administrativeInformation.publicationAndOwnership)) {
+    return administrativeInformation.publicationAndOwnership;
+  }
+
+  if (isRecord(administrativeInformation['common:publicationAndOwnership'])) {
+    return administrativeInformation['common:publicationAndOwnership'];
+  }
+
+  return {};
+}
+
+function loadProcessRecord(
+  filePath: string,
+  sourceKind: 'local_run_export',
+  sourceLabel: string,
+): ProcessRecord {
+  const raw = readJsonInput(filePath);
+  if (!isRecord(raw) || !isRecord(raw.processDataSet)) {
+    throw new CliError(
+      `lifecyclemodel auto-build process file must contain processDataSet: ${filePath}`,
+      {
+        code: 'LIFECYCLEMODEL_AUTO_BUILD_PROCESS_INVALID',
+        exitCode: 2,
+      },
+    );
+  }
+
+  const dataset = raw.processDataSet;
+  const processInformation = isRecord(dataset.processInformation) ? dataset.processInformation : {};
+  const dataSetInformation = isRecord(processInformation.dataSetInformation)
+    ? processInformation.dataSetInformation
+    : {};
+  const nameInfo = isRecord(dataSetInformation.name) ? dataSetInformation.name : {};
+  const geography = isRecord(processInformation.geography) ? processInformation.geography : {};
+  const location = isRecord(geography.locationOfOperationSupplyOrProduction)
+    ? geography.locationOfOperationSupplyOrProduction
+    : {};
+  const technology = isRecord(processInformation.technology) ? processInformation.technology : {};
+  const quantitativeReference = isRecord(processInformation.quantitativeReference)
+    ? processInformation.quantitativeReference
+    : {};
+  const referenceExchangeInternalId = nonEmptyString(
+    quantitativeReference.referenceToReferenceFlow,
+  );
+  if (!referenceExchangeInternalId) {
+    throw new CliError(
+      `lifecyclemodel auto-build process is missing referenceToReferenceFlow: ${filePath}`,
+      {
+        code: 'LIFECYCLEMODEL_AUTO_BUILD_REFERENCE_FLOW_MISSING',
+        exitCode: 2,
+      },
+    );
+  }
+
+  const exchangesCarrier = isRecord(dataset.exchanges) ? dataset.exchanges : {};
+  const exchanges = ensureList<JsonRecord>(exchangesCarrier.exchange).filter(isRecord);
+  const referenceExchange = exchanges.find(
+    (item) => nonEmptyString(item['@dataSetInternalID']) === referenceExchangeInternalId,
+  );
+  if (!referenceExchange) {
+    throw new CliError(
+      `lifecyclemodel auto-build reference exchange ${referenceExchangeInternalId} not found: ${filePath}`,
+      {
+        code: 'LIFECYCLEMODEL_AUTO_BUILD_REFERENCE_EXCHANGE_NOT_FOUND',
+        exitCode: 2,
+      },
+    );
+  }
+
+  const inputAmounts: Record<string, number> = {};
+  const outputAmounts: Record<string, number> = {};
+
+  exchanges.forEach((exchange) => {
+    const flowRef = isRecord(exchange.referenceToFlowDataSet)
+      ? exchange.referenceToFlowDataSet
+      : {};
+    const flowUuid = nonEmptyString(flowRef['@refObjectId']);
+    if (!flowUuid) {
+      return;
+    }
+
+    const amount = numberOrZero(exchange.meanAmount ?? exchange.resultingAmount);
+    const direction = nonEmptyString(exchange.exchangeDirection);
+    if (direction === 'Input') {
+      inputAmounts[flowUuid] = amount;
+    } else if (direction === 'Output') {
+      outputAmounts[flowUuid] = amount;
+    }
+  });
+
+  const processUuid = nonEmptyString(dataSetInformation['common:UUID']);
+  if (!processUuid) {
+    throw new CliError(`lifecyclemodel auto-build process is missing common:UUID: ${filePath}`, {
+      code: 'LIFECYCLEMODEL_AUTO_BUILD_PROCESS_UUID_MISSING',
+      exitCode: 2,
+    });
+  }
+
+  const publication = resolvePublicationBlock(dataset);
+  const version = nonEmptyString(publication['common:dataSetVersion']) ?? '00.00.001';
+  const referenceFlowRef = isRecord(referenceExchange.referenceToFlowDataSet)
+    ? referenceExchange.referenceToFlowDataSet
+    : {};
+  const referenceFlowUuid = nonEmptyString(referenceFlowRef['@refObjectId']);
+  const referenceDirection = nonEmptyString(referenceExchange.exchangeDirection);
+  if (!referenceFlowUuid || (referenceDirection !== 'Input' && referenceDirection !== 'Output')) {
+    throw new CliError(`lifecyclemodel auto-build reference exchange is incomplete: ${filePath}`, {
+      code: 'LIFECYCLEMODEL_AUTO_BUILD_REFERENCE_EXCHANGE_INVALID',
+      exitCode: 2,
+    });
+  }
+
+  const includedProcessRefs = ensureList(technology.referenceToIncludedProcesses).filter(isRecord);
+  const [nameEn, nameZh] = multilangText(nameInfo.baseName);
+  const [routeEn] = multilangText(nameInfo.treatmentStandardsRoutes);
+  const [mixEn] = multilangText(nameInfo.mixAndLocationTypes);
+  const classificationPath = extractClassificationPath(
+    dataSetInformation.classificationInformation,
+  );
+
+  return {
+    processUuid,
+    version,
+    raw,
+    referenceExchangeInternalId,
+    referenceFlowUuid,
+    referenceDirection,
+    referenceAmount: numberOrZero(
+      referenceExchange.meanAmount ?? referenceExchange.resultingAmount,
+    ),
+    inputAmounts,
+    outputAmounts,
+    nameEn,
+    nameZh,
+    routeEn,
+    mixEn,
+    geographyCode: nonEmptyString(location['@location']) ?? '',
+    classificationPath,
+    tokenSet: tokenizeText(
+      [nameEn, routeEn, mixEn, classificationPath.join(' ')].filter(Boolean).join(' '),
+    ),
+    sourceKind,
+    sourceLabel,
+    includedProcessRefCount: includedProcessRefs.length,
+  };
+}
+
+function scoreEdgeCandidate(
+  src: ProcessRecord,
+  dst: ProcessRecord,
+  flowUuid: string,
+  downstreamAmount: number,
+): { confidence: number; reasons: string[] } {
+  let score = 10;
+  const reasons = ['shared flow UUID'];
+
+  if (src.referenceFlowUuid === flowUuid && src.referenceDirection === 'Output') {
+    score += 3;
+    reasons.push('upstream reference flow matches shared flow');
+  }
+
+  if (dst.referenceFlowUuid === flowUuid && dst.referenceDirection === 'Input') {
+    score += 3;
+    reasons.push('downstream reference flow matches shared flow');
+  }
+
+  const classOverlap = classificationOverlap(src.classificationPath, dst.classificationPath);
+  if (classOverlap > 0) {
+    score += Math.min(classOverlap, 3);
+    reasons.push(`classification prefix overlap=${classOverlap}`);
+  }
+
+  if (src.geographyCode && dst.geographyCode && src.geographyCode === dst.geographyCode) {
+    score += 1;
+    reasons.push(`same geography=${src.geographyCode}`);
+  }
+
+  const tokenOverlap = [...src.tokenSet].filter((token) => dst.tokenSet.has(token)).length;
+  if (tokenOverlap > 0) {
+    score += Math.min(tokenOverlap, 4) / 4;
+    reasons.push(`token overlap=${tokenOverlap}`);
+  }
+
+  const upstreamAmount = src.outputAmounts[flowUuid] ?? 0;
+  if (upstreamAmount > 0 && downstreamAmount > 0) {
+    const ratio = downstreamAmount / upstreamAmount;
+    if (ratio >= 0.5 && ratio <= 2) {
+      score += 1;
+      reasons.push(`amount ratio plausible=${formatNumber(ratio)}`);
+    }
+  }
+
+  return { confidence: score, reasons };
+}
+
+function inferEdges(processMap: Record<string, ProcessRecord>): Edge[] {
+  const byFlow = new Map<string, { producers: Set<string>; consumers: Set<string> }>();
+
+  Object.entries(processMap).forEach(([processId, record]) => {
+    Object.keys(record.outputAmounts).forEach((flowUuid) => {
+      const group = byFlow.get(flowUuid) ?? {
+        producers: new Set<string>(),
+        consumers: new Set<string>(),
+      };
+      group.producers.add(processId);
+      byFlow.set(flowUuid, group);
+    });
+
+    Object.keys(record.inputAmounts).forEach((flowUuid) => {
+      const group = byFlow.get(flowUuid) ?? {
+        producers: new Set<string>(),
+        consumers: new Set<string>(),
+      };
+      group.consumers.add(processId);
+      byFlow.set(flowUuid, group);
+    });
+  });
+
+  const edgeMap = new Map<string, Edge>();
+
+  byFlow.forEach((participants, flowUuid) => {
+    if (participants.producers.size === 0 || participants.consumers.size === 0) {
+      return;
+    }
+
+    const passThrough = [...participants.producers].filter((item) =>
+      participants.consumers.has(item),
+    );
+    const candidatePairs: Array<[string, string]> = [];
+
+    if (passThrough.length > 0) {
+      [...participants.producers]
+        .filter((item) => !passThrough.includes(item))
+        .forEach((producer) => {
+          passThrough.forEach((bridge) => {
+            candidatePairs.push([producer, bridge]);
+          });
+        });
+
+      passThrough.forEach((bridge) => {
+        [...participants.consumers]
+          .filter((item) => !passThrough.includes(item))
+          .forEach((consumer) => {
+            candidatePairs.push([bridge, consumer]);
+          });
+      });
+    } else {
+      participants.producers.forEach((producer) => {
+        participants.consumers.forEach((consumer) => {
+          candidatePairs.push([producer, consumer]);
+        });
+      });
+    }
+
+    candidatePairs.forEach(([src, dst]) => {
+      const downstreamAmount = processMap[dst]?.inputAmounts[flowUuid];
+      const scored = scoreEdgeCandidate(
+        processMap[src] as ProcessRecord,
+        processMap[dst] as ProcessRecord,
+        flowUuid,
+        downstreamAmount as number,
+      );
+      edgeMap.set(`${src}::${dst}::${flowUuid}`, {
+        src,
+        dst,
+        flowUuid,
+        downstreamInputAmount: downstreamAmount,
+        confidence: scored.confidence,
+        reasons: scored.reasons,
+      });
+    });
+  });
+
+  const grouped = new Map<string, Edge[]>();
+  [...edgeMap.values()].forEach((edge) => {
+    const key = `${edge.dst}::${edge.flowUuid}`;
+    const bucket = grouped.get(key) ?? [];
+    bucket.push(edge);
+    grouped.set(key, bucket);
+  });
+
+  const filtered: Edge[] = [];
+  grouped.forEach((group) => {
+    const ordered = [...group].sort(
+      (left, right) => right.confidence - left.confidence || left.src.localeCompare(right.src),
+    );
+
+    if (
+      ordered.length >= 2 &&
+      ordered[0] &&
+      ordered[1] &&
+      ordered[0].confidence - ordered[1].confidence >= 2
+    ) {
+      filtered.push(ordered[0]);
+      return;
+    }
+
+    filtered.push(...ordered);
+  });
+
+  return filtered.sort(
+    (left, right) =>
+      right.confidence - left.confidence ||
+      left.flowUuid.localeCompare(right.flowUuid) ||
+      left.src.localeCompare(right.src) ||
+      left.dst.localeCompare(right.dst),
+  );
+}
+
+function chooseReferenceProcess(
+  processMap: Record<string, ProcessRecord>,
+  edges: Edge[],
+  state: JsonRecord,
+  preferredProcessIds: Set<string>,
+): string {
+  const flowSummary = isRecord(state.flow_summary) ? state.flow_summary : {};
+  const targetFlowUuid = nonEmptyString(flowSummary.uuid) ?? '';
+  const indegree = new Map<string, number>();
+  const outdegree = new Map<string, number>();
+
+  edges.forEach((edge) => {
+    indegree.set(edge.dst, (indegree.get(edge.dst) ?? 0) + 1);
+    outdegree.set(edge.src, (outdegree.get(edge.src) ?? 0) + 1);
+  });
+
+  let candidates = Object.entries(processMap)
+    .filter(
+      ([processId, record]) =>
+        preferredProcessIds.has(processId) &&
+        record.referenceFlowUuid === targetFlowUuid &&
+        record.referenceDirection === 'Output',
+    )
+    .map(([processId]) => processId);
+
+  if (candidates.length === 0 && targetFlowUuid) {
+    candidates = Object.entries(processMap)
+      .filter(
+        ([processId, record]) =>
+          preferredProcessIds.has(processId) && targetFlowUuid in record.outputAmounts,
+      )
+      .map(([processId]) => processId);
+  }
+
+  if (candidates.length === 0) {
+    candidates = [...preferredProcessIds].sort();
+  }
+
+  const buildRankKey = (processId: string): string => {
+    const record = processMap[processId] as ProcessRecord;
+    const targetRank = Number(
+      Object.prototype.hasOwnProperty.call(record.outputAmounts, targetFlowUuid),
+    );
+    const terminalRank = Number((outdegree.get(processId) ?? 0) === 0);
+    const indegreeRank = String(indegree.get(processId) ?? 0).padStart(8, '0');
+    return `${targetRank}|${terminalRank}|${indegreeRank}|${processId}`;
+  };
+
+  return [...candidates]
+    .sort((left, right) => buildRankKey(left).localeCompare(buildRankKey(right)))
+    .pop() as string;
+}
+
+function collectReachable(finalProcessId: string, edges: Edge[]): Set<string> {
+  const reverseAdj = new Map<string, string[]>();
+
+  edges.forEach((edge) => {
+    const bucket = reverseAdj.get(edge.dst) ?? [];
+    bucket.push(edge.src);
+    reverseAdj.set(edge.dst, bucket);
+  });
+
+  const reachable = new Set<string>([finalProcessId]);
+  const queue = [finalProcessId];
+
+  while (queue.length > 0) {
+    const current = queue.shift() as string;
+    (reverseAdj.get(current) ?? []).forEach((upstream) => {
+      if (reachable.has(upstream)) {
+        return;
+      }
+      reachable.add(upstream);
+      queue.push(upstream);
+    });
+  }
+
+  return reachable;
+}
+
+function topologicalOrder(processIds: Set<string>, edges: Edge[]): string[] {
+  const indegree = new Map<string, number>();
+  const adj = new Map<string, string[]>();
+  [...processIds].forEach((processId) => {
+    indegree.set(processId, 0);
+  });
+
+  edges.forEach((edge) => {
+    if (!processIds.has(edge.src) || !processIds.has(edge.dst)) {
+      return;
+    }
+
+    indegree.set(edge.dst, (indegree.get(edge.dst) as number) + 1);
+    const bucket = adj.get(edge.src) ?? [];
+    bucket.push(edge.dst);
+    adj.set(edge.src, bucket);
+  });
+
+  const queue = [...processIds]
+    .filter((processId) => (indegree.get(processId) as number) === 0)
+    .sort();
+  const ordered: string[] = [];
+
+  while (queue.length > 0) {
+    const current = queue.shift() as string;
+    ordered.push(current);
+    (adj.get(current) ?? []).sort().forEach((downstream) => {
+      indegree.set(downstream, (indegree.get(downstream) as number) - 1);
+      if ((indegree.get(downstream) as number) === 0) {
+        queue.push(downstream);
+        queue.sort();
+      }
+    });
+  }
+
+  if (ordered.length !== processIds.size) {
+    [...processIds]
+      .filter((processId) => !ordered.includes(processId))
+      .sort()
+      .forEach((processId) => ordered.push(processId));
+  }
+
+  return ordered;
+}
+
+function computeMultiplicationFactors(
+  processMap: Record<string, ProcessRecord>,
+  reachable: Set<string>,
+  edges: Edge[],
+  order: string[],
+  finalProcessId: string,
+): Record<string, number> {
+  const factors: Record<string, number> = {};
+  [...reachable].forEach((processId) => {
+    factors[processId] = 0;
+  });
+  factors[finalProcessId] = 1;
+
+  const incoming = new Map<string, Edge[]>();
+  edges.forEach((edge) => {
+    if (!reachable.has(edge.src) || !reachable.has(edge.dst)) {
+      return;
+    }
+    const bucket = incoming.get(edge.dst) ?? [];
+    bucket.push(edge);
+    incoming.set(edge.dst, bucket);
+  });
+
+  [...order].reverse().forEach((current) => {
+    const currentFactor = factors[current] as number;
+    if (Math.abs(currentFactor) < EPSILON) {
+      return;
+    }
+
+    (incoming.get(current) ?? []).forEach((edge) => {
+      const upstreamOutput = processMap[edge.src]?.outputAmounts[edge.flowUuid] ?? 1;
+      const safeUpstreamOutput = Math.abs(upstreamOutput) < EPSILON ? 1 : upstreamOutput;
+      const delta = (currentFactor * edge.downstreamInputAmount) / safeUpstreamOutput;
+      factors[edge.src] += delta;
+    });
+  });
+
+  return factors;
+}
+
+function exchangeAmount(exchange: JsonRecord): number {
+  return numberOrZero(exchange.meanAmount ?? exchange.resultingAmount);
+}
+
+function cloneExchangeWithAmount(
+  exchange: JsonRecord,
+  amount: number,
+  internalId: string,
+  quantitativeReference = false,
+): JsonRecord {
+  const cloned = copyJson(exchange);
+  cloned['@dataSetInternalID'] = internalId;
+  const amountValue = toJsonNumber(amount);
+  cloned.meanAmount = amountValue;
+  if ('resultingAmount' in cloned) {
+    cloned.resultingAmount = amountValue;
+  }
+  cloned.quantitativeReference = quantitativeReference;
+  return cloned;
+}
+
+function buildProcessInstances(
+  processMap: Record<string, ProcessRecord>,
+  order: string[],
+  edges: Edge[],
+  factors: Record<string, number>,
+): { processInstances: JsonRecord[]; internalIds: Record<string, string> } {
+  const internalIds = Object.fromEntries(
+    order.map((processId, index) => [processId, String(index + 1)]),
+  );
+  const outgoing = new Map<string, Edge[]>();
+  edges.forEach((edge) => {
+    if (!(edge.src in internalIds) || !(edge.dst in internalIds)) {
+      return;
+    }
+    const bucket = outgoing.get(edge.src) ?? [];
+    bucket.push(edge);
+    outgoing.set(edge.src, bucket);
+  });
+
+  const processInstances = order.map((processId) => {
+    const record = processMap[processId] as ProcessRecord;
+    const dataset = record.raw.processDataSet as JsonRecord;
+    const processInformation = isRecord(dataset.processInformation)
+      ? dataset.processInformation
+      : {};
+    const dataSetInformation = isRecord(processInformation.dataSetInformation)
+      ? processInformation.dataSetInformation
+      : {};
+    const nameInfo = isRecord(dataSetInformation.name) ? dataSetInformation.name : {};
+    const shortDescription = copyJson(nameInfo.baseName ?? []);
+    const outputGroups: JsonRecord[] = [];
+    const byFlow = new Map<string, Edge[]>();
+
+    (outgoing.get(processId) ?? []).forEach((edge) => {
+      const bucket = byFlow.get(edge.flowUuid) ?? [];
+      bucket.push(edge);
+      byFlow.set(edge.flowUuid, bucket);
+    });
+
+    byFlow.forEach((groupedEdges, flowUuid) => {
+      const downstreamPayload = groupedEdges.map((edge) => ({
+        '@id': internalIds[edge.dst],
+        '@flowUUID': flowUuid,
+        '@dominant': 'true',
+      }));
+      outputGroups.push({
+        '@dominant': 'true',
+        '@flowUUID': flowUuid,
+        downstreamProcess:
+          downstreamPayload.length === 1 ? downstreamPayload[0] : downstreamPayload,
+      });
+    });
+
+    return {
+      '@dataSetInternalID': internalIds[processId],
+      '@multiplicationFactor': formatNumber(factors[processId] ?? 0),
+      referenceToProcess: buildGlobalReference(
+        record.processUuid,
+        record.version,
+        shortDescription,
+        'process data set',
+        `../processes/${record.processUuid}_${record.version}.xml`,
+      ),
+      ...(outputGroups.length > 0
+        ? {
+            connections: {
+              outputExchange: outputGroups.length === 1 ? outputGroups[0] : outputGroups,
+            },
+          }
+        : {}),
+    };
+  });
+
+  return { processInstances, internalIds };
+}
+
+function buildLifecycleModelDataset(
+  runName: string,
+  state: JsonRecord,
+  processMap: Record<string, ProcessRecord>,
+  order: string[],
+  edges: Edge[],
+  factors: Record<string, number>,
+  finalProcessId: string,
+): { model: JsonRecord; summary: JsonRecord } {
+  const finalRecord = processMap[finalProcessId] as ProcessRecord;
+  const finalDataset = isRecord(finalRecord.raw.processDataSet)
+    ? finalRecord.raw.processDataSet
+    : {};
+  const finalProcessInformation = isRecord(finalDataset.processInformation)
+    ? finalDataset.processInformation
+    : {};
+  const finalInfo = isRecord(finalProcessInformation.dataSetInformation)
+    ? finalProcessInformation.dataSetInformation
+    : {};
+  const finalName = isRecord(finalInfo.name) ? finalInfo.name : {};
+
+  const flowDataset = extractFlowDatasetFromState(state);
+  const flowInformation = isRecord(flowDataset.flowInformation) ? flowDataset.flowInformation : {};
+  const flowInfo = isRecord(flowInformation.dataSetInformation)
+    ? flowInformation.dataSetInformation
+    : {};
+  const flowName = isRecord(flowInfo.name) ? flowInfo.name : {};
+  const flowSummary = isRecord(state.flow_summary) ? state.flow_summary : {};
+  const modelUuid = uuid5FromText(UUID_NAMESPACE_URL, runName);
+  const modelVersion = '01.01.000';
+  const { processInstances, internalIds } = buildProcessInstances(
+    processMap,
+    order,
+    edges,
+    factors,
+  );
+
+  const administrativeInformation = isRecord(finalDataset.administrativeInformation)
+    ? finalDataset.administrativeInformation
+    : {};
+  const commissionerAndGoal = copyJson(
+    administrativeInformation['common:commissionerAndGoal'] ??
+      administrativeInformation.commissionerAndGoal ??
+      {},
+  );
+  const dataEntryBy = copyJson(
+    administrativeInformation.dataEntryBy ?? administrativeInformation['common:dataEntryBy'] ?? {},
+  );
+  if (isRecord(dataEntryBy)) {
+    const enteringRef = dataEntryBy['common:referenceToPersonOrEntityEnteringTheData'];
+    if (enteringRef !== undefined) {
+      dataEntryBy['common:referenceToPersonOrEntityEnteringTheDataSet'] = copyJson(enteringRef);
+    }
+  }
+
+  const publication = copyJson(resolvePublicationBlock(finalDataset));
+  publication['common:dataSetVersion'] = modelVersion;
+  publication['common:permanentDataSetURI'] =
+    `https://local.tiangong.invalid/lifecyclemodels/${modelUuid}?version=${modelVersion}`;
+  if (!Array.isArray(publication['common:accessRestrictions'])) {
+    publication['common:accessRestrictions'] = [];
+  }
+
+  const modellingAndValidation = isRecord(finalDataset.modellingAndValidation)
+    ? finalDataset.modellingAndValidation
+    : {};
+  const complianceDeclarations = isRecord(modellingAndValidation.complianceDeclarations)
+    ? modellingAndValidation.complianceDeclarations
+    : {};
+  const compliance = copyJson(
+    isRecord(complianceDeclarations.compliance) ? complianceDeclarations.compliance : {},
+  );
+  compliance['common:approvalOfOverallCompliance'] ??= 'Fully compliant';
+  compliance['common:nomenclatureCompliance'] ??= 'Not defined';
+  compliance['common:methodologicalCompliance'] ??= 'Not defined';
+  compliance['common:reviewCompliance'] ??= 'Not defined';
+  compliance['common:documentationCompliance'] ??= 'Not defined';
+  compliance['common:qualityCompliance'] ??= 'Not defined';
+
+  const reviewRef =
+    (isRecord(commissionerAndGoal)
+      ? commissionerAndGoal['common:referenceToCommissioner']
+      : undefined) ??
+    (isRecord(dataEntryBy)
+      ? dataEntryBy['common:referenceToPersonOrEntityEnteringTheDataSet']
+      : undefined) ??
+    publication['common:referenceToOwnershipOfDataSet'] ??
+    {};
+
+  const review = {
+    'common:referenceToNameOfReviewerAndInstitution': copyJson(reviewRef),
+    'common:otherReviewDetails': multilangFromText(
+      'Local native CLI lifecyclemodel auto-build artifact; not independently reviewed.',
+      '本地原生 CLI lifecyclemodel auto-build 产物，未经过独立评审。',
+    ),
+  };
+
+  const generalComment = ensureList(finalInfo['common:generalComment']).filter(
+    (item) => item !== undefined,
+  );
+  generalComment.push(
+    ...multilangFromText(
+      `Built locally from process-automated-builder run ${runName}. ${nonEmptyString(state.technical_description) ?? ''}`.trim(),
+      `本地基于 process-automated-builder 运行 ${runName} 生成。`,
+    ),
+  );
+  generalComment.push(
+    ...multilangFromText(
+      'This CLI slice emits native json_ordered only. Platform-specific derivations stay in later publish flows.',
+      '该 CLI 切片只产出原生 json_ordered。平台特有衍生字段保留在后续发布流程。',
+    ),
+  );
+
+  const resultingProcess = buildGlobalReference(
+    modelUuid,
+    modelVersion,
+    copyJson(flowName.baseName ?? finalName.baseName ?? []),
+    'process data set',
+    `../processes/${modelUuid}_${modelVersion}.xml`,
+  );
+
+  const model = {
+    lifeCycleModelDataSet: {
+      '@xmlns': 'http://eplca.jrc.ec.europa.eu/ILCD/LifeCycleModel/2017',
+      '@xmlns:common': 'http://lca.jrc.it/ILCD/Common',
+      '@xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+      '@version': '1.1',
+      '@xsi:schemaLocation':
+        'http://eplca.jrc.ec.europa.eu/ILCD/LifeCycleModel/2017 ../../schemas/ILCD_LifeCycleModelDataSet.xsd',
+      lifeCycleModelInformation: {
+        dataSetInformation: {
+          'common:UUID': modelUuid,
+          name: {
+            baseName: copyJson(flowName.baseName ?? finalName.baseName ?? []),
+            treatmentStandardsRoutes: copyJson(
+              flowName.treatmentStandardsRoutes ?? finalName.treatmentStandardsRoutes ?? [],
+            ),
+            mixAndLocationTypes: copyJson(
+              flowName.mixAndLocationTypes ?? finalName.mixAndLocationTypes ?? [],
+            ),
+            functionalUnitFlowProperties: multilangFromText(
+              `Reference process output scaled to 1 unit of ${nonEmptyString(flowSummary.base_name_en) ?? nonEmptyString(flowSummary.base_name) ?? firstText(flowName.baseName)}`,
+              `参考过程输出缩放到 1 单位 ${nonEmptyString(flowSummary.base_name_zh) ?? nonEmptyString(flowSummary.base_name) ?? ''}`,
+            ),
+          },
+          classificationInformation: copyJson(finalInfo.classificationInformation ?? {}),
+          referenceToResultingProcess: resultingProcess,
+          'common:generalComment': generalComment,
+        },
+        quantitativeReference: {
+          referenceToReferenceProcess: internalIds[finalProcessId],
+        },
+        technology: {
+          processes: {
+            processInstance: processInstances.length === 1 ? processInstances[0] : processInstances,
+          },
+        },
+      },
+      modellingAndValidation: {
+        dataSourcesTreatmentEtc: {
+          useAdviceForDataSet: multilangFromText(
+            nonEmptyString(state.scope) ??
+              'Built from local process exports and shared-flow graph inference.',
+            '基于本地 process 导出结果和共享 flow 图推断生成。',
+          ),
+        },
+        validation: {
+          review,
+        },
+        complianceDeclarations: {
+          compliance,
+        },
+      },
+      administrativeInformation: {
+        'common:commissionerAndGoal': commissionerAndGoal,
+        dataEntryBy,
+        publicationAndOwnership: publication,
+      },
+    },
+  };
+
+  return {
+    model,
+    summary: {
+      run_name: runName,
+      model_uuid: modelUuid,
+      model_version: modelVersion,
+      reference_process_uuid: finalProcessId,
+      reference_process_internal_id: internalIds[finalProcessId],
+      reference_flow_uuid: nonEmptyString(flowSummary.uuid),
+      reference_to_resulting_process_uuid: modelUuid,
+      process_count: order.length,
+      edge_count: edges.length,
+      multiplication_factors: Object.fromEntries(
+        order.map((processId) => [processId, formatNumber(factors[processId] ?? 0)]),
+      ),
+      ordered_processes: order.map((processId) => {
+        const record = processMap[processId] as ProcessRecord;
+        return {
+          process_uuid: processId,
+          name_en: record.nameEn,
+          name_zh: record.nameZh,
+          route_en: record.routeEn,
+          geography_code: record.geographyCode,
+          classification_path: record.classificationPath,
+        };
+      }),
+      source_counts: {
+        local_run_export: Object.keys(processMap).length,
+        used_local_run_processes: order.length,
+      },
+    },
+  };
+}
+
+function buildLocalModels(
+  normalized: NormalizedLifecyclemodelAutoBuildRequest,
+  layout: LifecyclemodelAutoBuildLayout,
+): LifecyclemodelAutoBuildLocalReport[] {
+  return normalized.local_runs.map((runDir) => {
+    const statePath = path.join(runDir, 'cache', 'process_from_flow_state.json');
+    const processDir = path.join(runDir, 'exports', 'processes');
+
+    if (!existsSync(statePath)) {
+      throw new CliError(`lifecyclemodel auto-build run is missing state file: ${runDir}`, {
+        code: 'LIFECYCLEMODEL_AUTO_BUILD_STATE_NOT_FOUND',
+        exitCode: 2,
+      });
+    }
+
+    if (!existsSync(processDir)) {
+      throw new CliError(`lifecyclemodel auto-build run is missing exported processes: ${runDir}`, {
+        code: 'LIFECYCLEMODEL_AUTO_BUILD_PROCESS_EXPORTS_NOT_FOUND',
+        exitCode: 2,
+      });
+    }
+
+    const state = readJsonInput(statePath);
+    if (!isRecord(state)) {
+      throw new CliError(`lifecyclemodel auto-build state must be a JSON object: ${statePath}`, {
+        code: 'LIFECYCLEMODEL_AUTO_BUILD_STATE_INVALID',
+        exitCode: 2,
+      });
+    }
+
+    const processFiles = readdirSync(processDir)
+      .filter((item) => item.endsWith('.json'))
+      .sort()
+      .map((item) => path.join(processDir, item));
+
+    if (processFiles.length === 0) {
+      throw new CliError(
+        `lifecyclemodel auto-build run has no exported process JSON files: ${runDir}`,
+        {
+          code: 'LIFECYCLEMODEL_AUTO_BUILD_PROCESS_EXPORTS_EMPTY',
+          exitCode: 2,
+        },
+      );
+    }
+
+    const processMap = Object.fromEntries(
+      processFiles.map((filePath) => {
+        const record = loadProcessRecord(filePath, 'local_run_export', runDir);
+        return [record.processUuid, record];
+      }),
+    );
+
+    const edges = inferEdges(processMap);
+    const preferredProcessIds = new Set(Object.keys(processMap));
+    const finalProcessId = chooseReferenceProcess(processMap, edges, state, preferredProcessIds);
+    const reachable = collectReachable(finalProcessId, edges);
+    const order = topologicalOrder(reachable, edges);
+    const filteredEdges = edges.filter(
+      (edge) => reachable.has(edge.src) && reachable.has(edge.dst),
+    );
+    const factors = computeMultiplicationFactors(
+      processMap,
+      reachable,
+      filteredEdges,
+      order,
+      finalProcessId,
+    );
+    const runName = path.basename(runDir);
+    const { model, summary } = buildLifecycleModelDataset(
+      runName,
+      state,
+      processMap,
+      order,
+      filteredEdges,
+      factors,
+      finalProcessId,
+    );
+    const runOut = path.join(layout.modelsDir, runName);
+    const bundleOut = path.join(runOut, 'tidas_bundle', 'lifecyclemodels');
+    mkdirSync(bundleOut, { recursive: true });
+
+    const modelUuid = summary.model_uuid as string;
+    const modelVersion = summary.model_version as string;
+    const modelFile = path.join(bundleOut, `${modelUuid}_${modelVersion}.json`);
+    const summaryFile = path.join(runOut, 'summary.json');
+    const connectionsFile = path.join(runOut, 'connections.json');
+    const processCatalogFile = path.join(runOut, 'process-catalog.json');
+
+    writeJsonArtifact(modelFile, model);
+    writeJsonArtifact(summaryFile, summary);
+    writeJsonArtifact(
+      connectionsFile,
+      filteredEdges.map((edge) => ({
+        src: edge.src,
+        dst: edge.dst,
+        flow_uuid: edge.flowUuid,
+        downstream_input_amount: formatNumber(edge.downstreamInputAmount),
+        confidence: formatNumber(edge.confidence),
+        reasons: edge.reasons,
+        src_name_en: processMap[edge.src].nameEn,
+        dst_name_en: processMap[edge.dst].nameEn,
+        src_source_kind: processMap[edge.src].sourceKind,
+        dst_source_kind: processMap[edge.dst].sourceKind,
+      })),
+    );
+    writeJsonArtifact(
+      processCatalogFile,
+      Object.entries(processMap)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([processId, record]) => ({
+          process_uuid: processId,
+          name_en: record.nameEn,
+          name_zh: record.nameZh,
+          route_en: record.routeEn,
+          mix_en: record.mixEn,
+          geography_code: record.geographyCode,
+          classification_path: record.classificationPath,
+          reference_flow_uuid: record.referenceFlowUuid,
+          reference_direction: record.referenceDirection,
+          reference_amount: formatNumber(record.referenceAmount),
+          input_flow_count: Object.keys(record.inputAmounts).length,
+          output_flow_count: Object.keys(record.outputAmounts).length,
+          source_kind: record.sourceKind,
+          source_label: record.sourceLabel,
+          included_process_ref_count: record.includedProcessRefCount,
+        })),
+    );
+
+    return {
+      run_dir: runDir,
+      run_name: runName,
+      model_file: modelFile,
+      summary_file: summaryFile,
+      connections_file: connectionsFile,
+      process_catalog_file: processCatalogFile,
+      summary,
+    };
+  });
+}
+
+function buildNextActions(layout: LifecyclemodelAutoBuildLayout): string[] {
+  return [
+    `inspect: ${layout.runPlanPath}`,
+    `inspect: ${layout.modelsDir}`,
+    `run: tiangong lifecyclemodel validate-build --run-dir ${layout.runRoot}`,
+    `run: tiangong lifecyclemodel publish-build --run-dir ${layout.runRoot}`,
+  ];
+}
+
+function buildReport(
+  normalized: NormalizedLifecyclemodelAutoBuildRequest,
+  layout: LifecyclemodelAutoBuildLayout,
+  localBuildReports: LifecyclemodelAutoBuildLocalReport[],
+  now: Date,
+): LifecyclemodelAutoBuildReport {
+  return {
+    schema_version: 1,
+    generated_at_utc: now.toISOString(),
+    status: 'completed_local_lifecyclemodel_auto_build_run',
+    request_path: normalized.request_path,
+    run_id: normalized.run_id,
+    run_root: normalized.run_root,
+    local_run_count: normalized.local_runs.length,
+    built_model_count: localBuildReports.length,
+    files: {
+      request_snapshot: layout.requestSnapshotPath,
+      normalized_request: layout.normalizedRequestPath,
+      run_plan: layout.runPlanPath,
+      resolved_manifest: layout.resolvedManifestPath,
+      selection_brief: layout.selectionBriefPath,
+      reference_model_summary: layout.referenceModelSummaryPath,
+      invocation_index: layout.invocationIndexPath,
+      run_manifest: layout.runManifestPath,
+      report: layout.reportPath,
+    },
+    local_build_reports: localBuildReports,
+    next_actions: buildNextActions(layout),
+  };
+}
+
+export async function runLifecyclemodelAutoBuild(
+  options: RunLifecyclemodelAutoBuildOptions,
+): Promise<LifecyclemodelAutoBuildReport> {
+  const input = options.inputValue ?? readJsonInput(options.inputPath);
+  const now = options.now ?? new Date();
+  const normalized = normalizeLifecyclemodelAutoBuildRequest(input, {
+    inputPath: options.inputPath,
+    outDir: options.outDir,
+    now,
+    runIdOverride: options.runIdOverride,
+  });
+  const layout = buildLayout(normalized.run_root, normalized.run_id);
+
+  ensureEmptyRunRoot(layout.runRoot);
+  ensureLayout(layout);
+
+  writeJsonArtifact(layout.requestSnapshotPath, input);
+  writeJsonArtifact(layout.normalizedRequestPath, normalized);
+  writeTextArtifact(layout.selectionBriefPath, buildSelectionBrief(normalized.manifest));
+  writeJsonArtifact(
+    layout.referenceModelSummaryPath,
+    buildReferenceModelSummary(normalized.manifest),
+  );
+  writeJsonArtifact(layout.resolvedManifestPath, normalized.manifest);
+  writeJsonArtifact(
+    layout.invocationIndexPath,
+    buildInvocationIndex(normalized, options, layout, now),
+  );
+  writeJsonArtifact(
+    layout.runManifestPath,
+    buildRunManifest({
+      layout,
+      command: options.outDir
+        ? [
+            'lifecyclemodel',
+            'auto-build',
+            '--input',
+            options.inputPath,
+            '--out-dir',
+            options.outDir,
+          ]
+        : ['lifecyclemodel', 'auto-build', '--input', options.inputPath],
+      cwd: options.cwd,
+      createdAt: now,
+    }),
+  );
+
+  const plan = buildPlan(normalized, layout, now);
+  writeJsonArtifact(layout.runPlanPath, plan);
+
+  const localBuildReports = buildLocalModels(normalized, layout);
+  const completedPlan = {
+    ...plan,
+    local_build_reports: localBuildReports,
+  };
+  writeJsonArtifact(layout.runPlanPath, completedPlan);
+
+  const report = buildReport(normalized, layout, localBuildReports, now);
+  writeJsonArtifact(layout.reportPath, report);
+  writeLatestRunId(layout, normalized.run_id);
+  return report;
+}
+
+export const __testInternals = {
+  DEFAULT_MANIFEST,
+  copyJson,
+  ensureList,
+  numberOrZero,
+  firstText,
+  langTextMap,
+  localizedText,
+  multilangText,
+  multilangFromText,
+  deepMerge,
+  buildLayout,
+  buildSelectionBrief,
+  buildReferenceModelSummary,
+  normalizeLocalRuns,
+  uuid5FromText,
+  extractClassificationPath,
+  classificationOverlap,
+  extractFlowDatasetFromState,
+  resolvePublicationBlock,
+  loadProcessRecord,
+  scoreEdgeCandidate,
+  inferEdges,
+  chooseReferenceProcess,
+  collectReachable,
+  topologicalOrder,
+  computeMultiplicationFactors,
+  exchangeAmount,
+  cloneExchangeWithAmount,
+  buildProcessInstances,
+  buildLifecycleModelDataset,
+  buildPlan,
+  formatNumber,
+  buildNameSummary,
+  toJsonNumber,
+};

--- a/src/lib/lifecyclemodel-orchestrate.ts
+++ b/src/lib/lifecyclemodel-orchestrate.ts
@@ -1,0 +1,2167 @@
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { readJsonArtifact, writeJsonArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+import type { FetchLike } from './http.js';
+import { readJsonInput } from './io.js';
+import {
+  runLifecyclemodelAutoBuild,
+  type LifecyclemodelAutoBuildReport,
+} from './lifecyclemodel-auto-build.js';
+import {
+  runLifecyclemodelBuildResultingProcess,
+  type LifecyclemodelResultingProcessReport,
+} from './lifecyclemodel-resulting-process.js';
+import { runProcessAutoBuild, type ProcessAutoBuildReport } from './process-auto-build.js';
+
+type JsonRecord = Record<string, unknown>;
+
+type OrchestrateAction = 'plan' | 'execute' | 'publish';
+type NodeKind = 'reference_flow' | 'process' | 'lifecyclemodel' | 'resulting_process' | 'subsystem';
+type RequestedAction =
+  | 'auto'
+  | 'reuse_existing_resulting_process'
+  | 'reuse_existing_process'
+  | 'reuse_existing_model'
+  | 'build_process'
+  | 'build_submodel'
+  | 'cutoff'
+  | 'unresolved';
+type Resolution =
+  | 'unresolved'
+  | 'cutoff'
+  | 'reused_existing_resulting_process'
+  | 'reused_existing_process'
+  | 'reused_existing_model'
+  | 'build_via_process_automated_builder'
+  | 'build_via_lifecyclemodel_automated_builder';
+type InvocationKind = 'process_builder' | 'lifecyclemodel_builder' | 'projector';
+type InvocationStatus =
+  | 'success'
+  | 'failed'
+  | 'skipped_due_to_fail_fast'
+  | 'skipped_due_to_dependency_failed'
+  | 'skipped_due_to_dependency_skipped_due_to_fail_fast'
+  | 'skipped_due_to_dependency_skipped_due_to_dependency_failed';
+
+type Candidate = JsonRecord & {
+  id: string;
+  score: number;
+};
+
+type ProcessBuilderConfig = {
+  mode: 'workflow' | 'langgraph';
+  flow_file: string | null;
+  flow_json: unknown;
+  run_id: string | null;
+  python_bin: string | null;
+  publish: boolean;
+  commit: boolean;
+  forward_args: string[];
+};
+
+type SubmodelBuilderConfig = {
+  manifest: string | null;
+  out_dir: string | null;
+  dry_run: boolean;
+};
+
+type ProjectorConfig = {
+  command: 'prepare' | 'build' | 'project';
+  request: string | null;
+  model_file: string | null;
+  out_dir: string | null;
+  projection_role: 'primary' | 'all';
+  run_always: boolean;
+  publish_processes: boolean;
+  publish_relations: boolean;
+};
+
+type OrchestrateNode = {
+  node_id: string;
+  kind: NodeKind;
+  label: string;
+  entity: JsonRecord;
+  requested_action: RequestedAction;
+  depends_on: string[];
+  parent_node_id: string | null;
+  existing_resulting_process_candidates: Candidate[];
+  existing_process_candidates: Candidate[];
+  existing_lifecyclemodel_candidates: Candidate[];
+  process_builder?: ProcessBuilderConfig;
+  submodel_builder?: SubmodelBuilderConfig;
+  projector?: ProjectorConfig;
+  resolution?: Resolution;
+  resolution_reason?: string;
+  selected_candidate?: Candidate | null;
+  boundary_reason?: string | null;
+  planned_invocations: string[];
+};
+
+type PlanInvocation = {
+  invocation_id: string;
+  node_id: string;
+  kind: InvocationKind;
+  config: JsonRecord;
+  artifact_dir: string;
+  depends_on_invocation_id?: string;
+  last_status?: InvocationStatus;
+  last_exit_code?: number | null;
+  last_result_file?: string | null;
+  artifacts?: JsonRecord;
+};
+
+type AssemblyPlan = {
+  skill: 'lifecyclemodel-recursive-orchestrator';
+  request_id: string;
+  created_at: string;
+  request_file: string;
+  goal: JsonRecord;
+  root: JsonRecord;
+  orchestration: JsonRecord;
+  candidate_sources: JsonRecord;
+  publish: JsonRecord;
+  notes: string[];
+  nodes: OrchestrateNode[];
+  edges: Array<{ from: string; to: string; relation: string }>;
+  invocations: PlanInvocation[];
+  planner_summary: {
+    status: 'planned' | 'executed';
+    message: string;
+  };
+  warnings: string[];
+  unresolved: Array<{ node_id: string; label: string; reason: string }>;
+  boundaries: Array<{ node_id: string; reason: string }>;
+  artifacts: {
+    root: string;
+    request_normalized: string;
+    assembly_plan: string;
+    graph_manifest: string;
+    lineage_manifest: string;
+    boundary_report: string;
+    invocations_dir: string;
+    publish_bundle: string;
+    publish_summary: string;
+  };
+  summary: {
+    node_count: number;
+    edge_count: number;
+    invocation_count: number;
+    unresolved_count: number;
+  };
+  execution_summary?: {
+    executed_at: string;
+    successful_invocations: number;
+    failed_invocations: number;
+    blocked_invocations: number;
+    status: 'completed' | 'failed';
+  };
+};
+
+type InvocationExecutionResult = {
+  invocation_id: string;
+  node_id: string;
+  kind: InvocationKind;
+  status: InvocationStatus;
+  exit_code: number | null;
+  result_file: string;
+  planned_artifacts?: JsonRecord;
+  artifacts?: JsonRecord;
+  error?: string;
+  dry_run?: boolean;
+};
+
+type GraphManifest = {
+  root: JsonRecord;
+  nodes: JsonRecord[];
+  edges: JsonRecord[];
+  boundaries: JsonRecord[];
+  unresolved: JsonRecord[];
+  stats: JsonRecord;
+};
+
+type LineageManifest = {
+  root_request: JsonRecord;
+  builder_invocations: JsonRecord[];
+  node_resolution_log: JsonRecord[];
+  published_dependencies: JsonRecord[];
+  resulting_process_relations: JsonRecord[];
+  unresolved_history: JsonRecord[];
+};
+
+export type LifecyclemodelOrchestratePlanReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  action: 'plan';
+  status: 'planned';
+  request_id: string;
+  out_dir: string;
+  counts: {
+    nodes: number;
+    edges: number;
+    invocations: number;
+    unresolved: number;
+  };
+  files: {
+    request_normalized: string;
+    assembly_plan: string;
+    graph_manifest: string;
+    lineage_manifest: string;
+    boundary_report: string;
+  };
+  warnings: string[];
+};
+
+export type LifecyclemodelOrchestrateExecuteReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  action: 'execute';
+  status: 'completed' | 'failed';
+  request_id: string;
+  out_dir: string;
+  execution: {
+    successful_invocations: number;
+    failed_invocations: number;
+    blocked_invocations: number;
+  };
+  files: {
+    request_normalized: string;
+    assembly_plan: string;
+    graph_manifest: string;
+    lineage_manifest: string;
+    boundary_report: string;
+    invocations_dir: string;
+  };
+  warnings: string[];
+};
+
+export type LifecyclemodelOrchestratePublishReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  action: 'publish';
+  status: 'prepared_local_publish_bundle';
+  request_id: string;
+  run_dir: string;
+  counts: {
+    lifecyclemodels: number;
+    projected_processes: number;
+    resulting_process_relations: number;
+    process_build_runs: number;
+  };
+  files: {
+    assembly_plan: string;
+    graph_manifest: string;
+    lineage_manifest: string;
+    publish_bundle: string;
+    publish_summary: string;
+  };
+};
+
+export type LifecyclemodelOrchestrateReport =
+  | LifecyclemodelOrchestratePlanReport
+  | LifecyclemodelOrchestrateExecuteReport
+  | LifecyclemodelOrchestratePublishReport;
+
+export type RunLifecyclemodelOrchestrateOptions = {
+  action: OrchestrateAction;
+  inputPath?: string;
+  outDir?: string | null;
+  runDir?: string;
+  allowProcessBuild?: boolean;
+  allowSubmodelBuild?: boolean;
+  publishLifecyclemodels?: boolean;
+  publishResultingProcessRelations?: boolean;
+  now?: Date;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: FetchLike;
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function copyJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function ensureList<T = unknown>(value: unknown): T[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+
+  return Array.isArray(value) ? (value as T[]) : ([value] as T[]);
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized || null;
+}
+
+function firstNonEmpty(...values: unknown[]): string | null {
+  for (const value of values) {
+    const normalized = nonEmptyString(value);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return null;
+}
+
+function safeSlug(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, '-')
+    .replace(/^-+|-+$/gu, '');
+  /* c8 ignore next -- fallback only triggers for punctuation-only helper inputs */
+  return slug || 'item';
+}
+
+function nowIso(now: Date = new Date()): string {
+  return now.toISOString();
+}
+
+function requireObject(value: unknown, label: string): JsonRecord {
+  if (!isRecord(value)) {
+    throw new CliError(`${label} must be a JSON object.`, {
+      code: 'LIFECYCLEMODEL_ORCHESTRATE_INVALID_REQUEST',
+      exitCode: 2,
+      details: { label },
+    });
+  }
+
+  return value;
+}
+
+function requireEnum<T extends string>(value: unknown, allowed: readonly T[], label: string): T {
+  const normalized = nonEmptyString(value);
+  if (!normalized || !allowed.includes(normalized as T)) {
+    throw new CliError(`${label} must be one of ${allowed.join(', ')}.`, {
+      code: 'LIFECYCLEMODEL_ORCHESTRATE_INVALID_REQUEST',
+      exitCode: 2,
+      details: { label, value, allowed },
+    });
+  }
+
+  return normalized as T;
+}
+
+function requireBoolean(value: unknown, label: string): boolean {
+  if (typeof value !== 'boolean') {
+    throw new CliError(`${label} must be a boolean.`, {
+      code: 'LIFECYCLEMODEL_ORCHESTRATE_INVALID_REQUEST',
+      exitCode: 2,
+      details: { label, value },
+    });
+  }
+
+  return value;
+}
+
+function requireInteger(value: unknown, label: string): number {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+    throw new CliError(`${label} must be a non-negative integer.`, {
+      code: 'LIFECYCLEMODEL_ORCHESTRATE_INVALID_REQUEST',
+      exitCode: 2,
+      details: { label, value },
+    });
+  }
+
+  return value;
+}
+
+function resolveInputPath(baseDir: string, raw: unknown): string | null {
+  const normalized = nonEmptyString(raw);
+  if (!normalized) {
+    return null;
+  }
+
+  if (normalized.includes('://') || normalized.startsWith('file:')) {
+    return normalized;
+  }
+
+  return path.resolve(baseDir, normalized);
+}
+
+function defaultCandidateSources(): JsonRecord {
+  return {
+    my_processes: true,
+    team_processes: true,
+    public_processes: true,
+    existing_lifecyclemodels: true,
+    existing_resulting_processes: true,
+  };
+}
+
+function entityFromRoot(root: JsonRecord): JsonRecord {
+  const kind = root.kind;
+  if (kind === 'reference_flow') {
+    /* c8 ignore next -- inline fallback is defensive and separately validated */
+    return isRecord(root.flow) ? copyJson(root.flow) : {};
+  }
+  if (kind === 'process') {
+    return isRecord(root.process) ? copyJson(root.process) : {};
+  }
+  if (kind === 'lifecyclemodel') {
+    /* c8 ignore next -- inline fallback is defensive and separately validated */
+    return isRecord(root.lifecyclemodel) ? copyJson(root.lifecyclemodel) : {};
+  }
+  if (kind === 'resulting_process') {
+    /* c8 ignore next -- inline fallback is defensive and separately validated */
+    return isRecord(root.resulting_process) ? copyJson(root.resulting_process) : {};
+  }
+
+  return {};
+}
+
+function normalizeCandidate(raw: unknown): Candidate {
+  if (typeof raw === 'string') {
+    return { id: raw, score: 1 };
+  }
+
+  if (!isRecord(raw)) {
+    throw new CliError('candidate must be an object or string.', {
+      code: 'LIFECYCLEMODEL_ORCHESTRATE_INVALID_REQUEST',
+      exitCode: 2,
+      details: { value: raw },
+    });
+  }
+
+  const id = nonEmptyString(raw.id);
+  if (!id) {
+    throw new CliError('candidate.id is required.', {
+      code: 'LIFECYCLEMODEL_ORCHESTRATE_INVALID_REQUEST',
+      exitCode: 2,
+      details: { candidate: raw },
+    });
+  }
+
+  const score =
+    typeof raw.score === 'number' && Number.isFinite(raw.score) && raw.score >= 0 ? raw.score : 1;
+  return {
+    ...copyJson(raw),
+    id,
+    score,
+  };
+}
+
+function normalizeCandidateList(value: unknown): Candidate[] {
+  return ensureList(value)
+    .map((entry) => normalizeCandidate(entry))
+    .sort((left, right) => right.score - left.score);
+}
+
+function normalizeRequestedAction(value: unknown): RequestedAction {
+  return requireEnum(
+    value ?? 'auto',
+    [
+      'auto',
+      'reuse_existing_resulting_process',
+      'reuse_existing_process',
+      'reuse_existing_model',
+      'build_process',
+      'build_submodel',
+      'cutoff',
+      'unresolved',
+    ],
+    'requested_action',
+  );
+}
+
+function normalizeDependsOn(value: unknown): string[] {
+  return ensureList(value)
+    .map((entry) => nonEmptyString(entry))
+    .filter((entry): entry is string => Boolean(entry));
+}
+
+function normalizeProcessBuilderConfig(
+  value: unknown,
+  baseDir: string,
+): ProcessBuilderConfig | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  return {
+    mode: requireEnum(value.mode ?? 'workflow', ['workflow', 'langgraph'], 'process_builder.mode'),
+    flow_file: resolveInputPath(baseDir, value.flow_file),
+    flow_json: value.flow_json,
+    run_id: nonEmptyString(value.run_id),
+    python_bin: nonEmptyString(value.python_bin),
+    publish: Boolean(value.publish),
+    commit: Boolean(value.commit),
+    forward_args: ensureList(value.forward_args)
+      .map((entry) => nonEmptyString(entry))
+      .filter((entry): entry is string => Boolean(entry)),
+  };
+}
+
+function normalizeSubmodelBuilderConfig(
+  value: unknown,
+  baseDir: string,
+): SubmodelBuilderConfig | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  return {
+    manifest: resolveInputPath(baseDir, value.manifest),
+    out_dir: resolveInputPath(baseDir, value.out_dir),
+    dry_run: Boolean(value.dry_run),
+  };
+}
+
+function normalizeProjectorConfig(value: unknown, baseDir: string): ProjectorConfig | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  return {
+    command: requireEnum(
+      value.command ?? 'project',
+      ['prepare', 'build', 'project'],
+      'projector.command',
+    ),
+    request: resolveInputPath(baseDir, value.request),
+    model_file: resolveInputPath(baseDir, value.model_file),
+    out_dir: resolveInputPath(baseDir, value.out_dir),
+    projection_role: requireEnum(
+      value.projection_role ?? 'primary',
+      ['primary', 'all'],
+      'projector.projection_role',
+    ),
+    run_always: Boolean(value.run_always),
+    publish_processes: Boolean(value.publish_processes),
+    publish_relations: Boolean(value.publish_relations),
+  };
+}
+
+function normalizeNode(rawNode: JsonRecord, index: number, baseDir: string): OrchestrateNode {
+  /* c8 ignore next -- fallback only applies when both node_id and id normalize empty */
+  const nodeId = firstNonEmpty(rawNode.node_id, rawNode.id, `node-${index}`) ?? `node-${index}`;
+  const kind = requireEnum(
+    rawNode.kind ?? 'process',
+    ['reference_flow', 'process', 'lifecyclemodel', 'resulting_process', 'subsystem'],
+    'node.kind',
+  );
+  let entity = isRecord(rawNode.entity) ? copyJson(rawNode.entity) : {};
+  if (Object.keys(entity).length === 0) {
+    for (const key of ['flow', 'process', 'lifecyclemodel', 'resulting_process'] as const) {
+      if (isRecord(rawNode[key])) {
+        entity = copyJson(rawNode[key] as JsonRecord);
+        break;
+      }
+    }
+  }
+
+  /* c8 ignore next -- fallback only applies when explicit labels and entity names are absent */
+  const label = firstNonEmpty(rawNode.label, entity.name, nodeId) ?? nodeId;
+  const parentNodeId = firstNonEmpty(rawNode.parent_node_id);
+  const dependsOn = normalizeDependsOn(rawNode.depends_on);
+  if (parentNodeId) {
+    dependsOn.push(parentNodeId);
+  }
+
+  return {
+    node_id: nodeId,
+    kind,
+    label,
+    entity,
+    requested_action: normalizeRequestedAction(rawNode.requested_action ?? 'auto'),
+    depends_on: [...new Set(dependsOn)].sort(),
+    parent_node_id: parentNodeId,
+    existing_resulting_process_candidates: normalizeCandidateList(
+      rawNode.existing_resulting_process_candidates,
+    ),
+    existing_process_candidates: normalizeCandidateList(rawNode.existing_process_candidates),
+    existing_lifecyclemodel_candidates: normalizeCandidateList(
+      rawNode.existing_lifecyclemodel_candidates,
+    ),
+    process_builder: normalizeProcessBuilderConfig(rawNode.process_builder, baseDir),
+    submodel_builder: normalizeSubmodelBuilderConfig(rawNode.submodel_builder, baseDir),
+    projector: normalizeProjectorConfig(rawNode.projector, baseDir),
+    planned_invocations: [],
+  };
+}
+
+function deriveRootNode(root: JsonRecord, goal: JsonRecord, baseDir: string): OrchestrateNode {
+  const entity = entityFromRoot(root);
+  /* c8 ignore next -- fallback only applies for malformed direct helper inputs */
+  const label = firstNonEmpty(entity.name, goal.name, root.kind, 'root') ?? 'root';
+  const rootNode: JsonRecord = {
+    /* c8 ignore next -- fallback only applies for malformed direct helper inputs */
+    node_id: firstNonEmpty(root.node_id, entity.id, 'root') ?? 'root',
+    kind: root.kind,
+    label,
+    entity,
+    requested_action: root.requested_action ?? 'auto',
+    depends_on: root.depends_on ?? [],
+    parent_node_id: root.parent_node_id,
+    existing_resulting_process_candidates: root.existing_resulting_process_candidates ?? [],
+    existing_process_candidates: root.existing_process_candidates ?? [],
+    existing_lifecyclemodel_candidates: root.existing_lifecyclemodel_candidates ?? [],
+    process_builder: root.process_builder,
+    submodel_builder: root.submodel_builder,
+    projector: root.projector,
+  };
+  return normalizeNode(rootNode, 0, baseDir);
+}
+
+function buildEdges(
+  requestEdges: unknown[],
+  nodes: OrchestrateNode[],
+): Array<{ from: string; to: string; relation: string }> {
+  const edges: Array<{ from: string; to: string; relation: string }> = [];
+  const seen = new Set<string>();
+
+  ensureList(requestEdges).forEach((raw) => {
+    if (!isRecord(raw)) {
+      return;
+    }
+
+    const from = nonEmptyString(raw.from);
+    const to = nonEmptyString(raw.to);
+    /* c8 ignore next -- default relation is only used when request edges omit relation */
+    const relation = firstNonEmpty(raw.relation, 'depends_on') ?? 'depends_on';
+    if (!from || !to) {
+      return;
+    }
+
+    const key = `${from}::${to}::${relation}`;
+    if (seen.has(key)) {
+      return;
+    }
+
+    seen.add(key);
+    edges.push({ from, to, relation });
+  });
+
+  nodes.forEach((node) => {
+    node.depends_on.forEach((dependency) => {
+      const key = `${node.node_id}::${dependency}::depends_on`;
+      if (seen.has(key)) {
+        return;
+      }
+
+      seen.add(key);
+      edges.push({
+        from: node.node_id,
+        to: dependency,
+        relation: 'depends_on',
+      });
+    });
+  });
+
+  return edges;
+}
+
+function topoSortNodes(nodes: OrchestrateNode[]): {
+  ordered: OrchestrateNode[];
+  warnings: string[];
+} {
+  const warnings: string[] = [];
+  const order = new Map(nodes.map((node, index) => [node.node_id, index]));
+  const nodeMap = new Map(nodes.map((node) => [node.node_id, node]));
+  const indegree = new Map(nodes.map((node) => [node.node_id, 0]));
+  const adjacency = new Map(nodes.map((node) => [node.node_id, [] as string[]]));
+
+  nodes.forEach((node) => {
+    node.depends_on.forEach((dependency) => {
+      if (!nodeMap.has(dependency)) {
+        warnings.push(
+          `Node ${node.node_id} depends on unknown node ${dependency}; keeping it as metadata only.`,
+        );
+        return;
+      }
+
+      /* c8 ignore next -- Map#get fallback is purely defensive */
+      indegree.set(node.node_id, (indegree.get(node.node_id) ?? 0) + 1);
+      adjacency.get(dependency)?.push(node.node_id);
+    });
+  });
+
+  /* c8 ignore start -- these comparator/index fallbacks are purely defensive */
+  const queue = nodes
+    .filter((node) => (indegree.get(node.node_id) ?? 0) === 0)
+    .sort((left, right) => (order.get(left.node_id) ?? 0) - (order.get(right.node_id) ?? 0))
+    .map((node) => node.node_id);
+  const ordered: OrchestrateNode[] = [];
+
+  while (queue.length > 0) {
+    const nodeId = queue.shift() as string;
+    ordered.push(nodeMap.get(nodeId) as OrchestrateNode);
+    const downstream = (adjacency.get(nodeId) ?? []).sort(
+      (left, right) => (order.get(left) ?? 0) - (order.get(right) ?? 0),
+    );
+    downstream.forEach((item) => {
+      indegree.set(item, (indegree.get(item) ?? 0) - 1);
+      if ((indegree.get(item) ?? 0) === 0) {
+        queue.push(item);
+      }
+    });
+  }
+  /* c8 ignore stop */
+
+  if (ordered.length !== nodes.length) {
+    warnings.push('Dependency cycle detected; preserving original order for cyclic remainder.');
+    const seen = new Set(ordered.map((node) => node.node_id));
+    nodes.forEach((node) => {
+      if (!seen.has(node.node_id)) {
+        ordered.push(node);
+      }
+    });
+  }
+
+  return { ordered, warnings };
+}
+
+function unresolvedResolution(reason: string): {
+  resolution: Resolution;
+  selected_candidate: Candidate | null;
+  reason: string;
+  boundary_reason: string;
+} {
+  return {
+    resolution: 'unresolved',
+    selected_candidate: null,
+    reason,
+    boundary_reason: 'unresolved',
+  };
+}
+
+function selectResolution(
+  node: OrchestrateNode,
+  orchestration: JsonRecord,
+): {
+  resolution: Resolution;
+  selected_candidate: Candidate | null;
+  reason: string;
+  boundary_reason: string | null;
+} {
+  const requestedAction = node.requested_action;
+  const resultingCandidate = node.existing_resulting_process_candidates[0] ?? null;
+  const processCandidate = node.existing_process_candidates[0] ?? null;
+  const modelCandidate = node.existing_lifecyclemodel_candidates[0] ?? null;
+  const allowProcessBuild = Boolean(orchestration.allow_process_build);
+  const allowSubmodelBuild = Boolean(orchestration.allow_submodel_build);
+  const reuseResultingProcessFirst = orchestration.reuse_resulting_process_first !== false;
+
+  if (requestedAction === 'cutoff') {
+    return {
+      resolution: 'cutoff',
+      selected_candidate: null,
+      reason: 'Explicit cutoff requested.',
+      boundary_reason: 'explicit_cutoff',
+    };
+  }
+  if (requestedAction === 'unresolved') {
+    return unresolvedResolution('Explicit unresolved marker provided.');
+  }
+  if (requestedAction === 'reuse_existing_resulting_process') {
+    if (!resultingCandidate) {
+      return unresolvedResolution(
+        'requested reuse_existing_resulting_process but no candidate was provided',
+      );
+    }
+
+    return {
+      resolution: 'reused_existing_resulting_process',
+      selected_candidate: resultingCandidate,
+      reason: 'Requested resulting-process reuse.',
+      boundary_reason: 'collapsed_at_resulting_process',
+    };
+  }
+  if (requestedAction === 'reuse_existing_process') {
+    if (!processCandidate) {
+      return unresolvedResolution('requested reuse_existing_process but no candidate was provided');
+    }
+
+    return {
+      resolution: 'reused_existing_process',
+      selected_candidate: processCandidate,
+      reason: 'Requested process reuse.',
+      boundary_reason: 'collapsed_at_existing_process',
+    };
+  }
+  if (requestedAction === 'reuse_existing_model') {
+    if (!modelCandidate) {
+      return unresolvedResolution(
+        'requested reuse_existing_model but no lifecyclemodel candidate was provided',
+      );
+    }
+
+    return {
+      resolution: 'reused_existing_model',
+      selected_candidate: modelCandidate,
+      reason: 'Requested lifecyclemodel reuse.',
+      boundary_reason: 'collapsed_at_existing_model',
+    };
+  }
+  if (requestedAction === 'build_process') {
+    if (!node.process_builder) {
+      return unresolvedResolution('requested build_process but process_builder config is missing');
+    }
+    if (!allowProcessBuild) {
+      return unresolvedResolution(
+        'requested build_process but orchestration.allow_process_build=false',
+      );
+    }
+
+    return {
+      resolution: 'build_via_process_automated_builder',
+      selected_candidate: null,
+      reason: 'Requested process build.',
+      boundary_reason: null,
+    };
+  }
+  if (requestedAction === 'build_submodel') {
+    if (!node.submodel_builder) {
+      return unresolvedResolution(
+        'requested build_submodel but submodel_builder config is missing',
+      );
+    }
+    if (!allowSubmodelBuild) {
+      return unresolvedResolution(
+        'requested build_submodel but orchestration.allow_submodel_build=false',
+      );
+    }
+
+    return {
+      resolution: 'build_via_lifecyclemodel_automated_builder',
+      selected_candidate: null,
+      reason: 'Requested submodel build.',
+      boundary_reason: null,
+    };
+  }
+
+  if (reuseResultingProcessFirst && resultingCandidate) {
+    return {
+      resolution: 'reused_existing_resulting_process',
+      selected_candidate: resultingCandidate,
+      reason: 'Auto-selected highest scoring resulting process candidate.',
+      boundary_reason: 'collapsed_at_resulting_process',
+    };
+  }
+  if (processCandidate) {
+    return {
+      resolution: 'reused_existing_process',
+      selected_candidate: processCandidate,
+      reason: 'Auto-selected highest scoring existing process candidate.',
+      boundary_reason: 'collapsed_at_existing_process',
+    };
+  }
+  if ((node.kind === 'lifecyclemodel' || node.kind === 'subsystem') && modelCandidate) {
+    return {
+      resolution: 'reused_existing_model',
+      selected_candidate: modelCandidate,
+      reason: 'Auto-selected highest scoring lifecyclemodel candidate.',
+      boundary_reason: 'collapsed_at_existing_model',
+    };
+  }
+  if (
+    (node.kind === 'lifecyclemodel' || node.kind === 'subsystem') &&
+    node.submodel_builder &&
+    allowSubmodelBuild
+  ) {
+    return {
+      resolution: 'build_via_lifecyclemodel_automated_builder',
+      selected_candidate: null,
+      reason: 'No reusable model/process matched; scheduling lifecyclemodel builder.',
+      boundary_reason: null,
+    };
+  }
+  if (node.process_builder && allowProcessBuild) {
+    return {
+      resolution: 'build_via_process_automated_builder',
+      selected_candidate: null,
+      reason: 'No reusable process matched; scheduling process builder.',
+      boundary_reason: null,
+    };
+  }
+  if (modelCandidate) {
+    return {
+      resolution: 'reused_existing_model',
+      selected_candidate: modelCandidate,
+      reason: 'Fallback to lifecyclemodel candidate after no process candidate matched.',
+      boundary_reason: 'collapsed_at_existing_model',
+    };
+  }
+
+  return unresolvedResolution('No reusable candidate or build config satisfied the node policy');
+}
+
+function shouldRunProjector(node: OrchestrateNode, resolution: Resolution): boolean {
+  if (!node.projector) {
+    return false;
+  }
+  if (node.projector.run_always) {
+    return true;
+  }
+  return (
+    resolution === 'build_via_lifecyclemodel_automated_builder' ||
+    resolution === 'reused_existing_model'
+  );
+}
+
+function validateRequestShape(request: JsonRecord): void {
+  const goal = requireObject(request.goal, 'goal');
+  if (!nonEmptyString(goal.name)) {
+    throw new CliError('goal.name is required.', {
+      code: 'LIFECYCLEMODEL_ORCHESTRATE_INVALID_REQUEST',
+      exitCode: 2,
+    });
+  }
+
+  const root = requireObject(request.root, 'root');
+  const rootKind = requireEnum(
+    root.kind,
+    ['reference_flow', 'process', 'lifecyclemodel', 'resulting_process'],
+    'root.kind',
+  );
+  const requiredRootField =
+    rootKind === 'reference_flow'
+      ? 'flow'
+      : rootKind === 'process'
+        ? 'process'
+        : rootKind === 'lifecyclemodel'
+          ? 'lifecyclemodel'
+          : 'resulting_process';
+  const requiredRootEntity = requireObject(root[requiredRootField], `root.${requiredRootField}`);
+  if (!nonEmptyString(requiredRootEntity.id)) {
+    throw new CliError(`root.${requiredRootField}.id is required.`, {
+      code: 'LIFECYCLEMODEL_ORCHESTRATE_INVALID_REQUEST',
+      exitCode: 2,
+    });
+  }
+
+  const orchestration = requireObject(request.orchestration, 'orchestration');
+  requireEnum(orchestration.mode, ['collapsed', 'expanded', 'hybrid'], 'orchestration.mode');
+  requireInteger(orchestration.max_depth, 'orchestration.max_depth');
+  requireBoolean(
+    orchestration.reuse_resulting_process_first,
+    'orchestration.reuse_resulting_process_first',
+  );
+  requireBoolean(orchestration.allow_process_build, 'orchestration.allow_process_build');
+  requireBoolean(orchestration.allow_submodel_build, 'orchestration.allow_submodel_build');
+  requireBoolean(orchestration.pin_child_versions, 'orchestration.pin_child_versions');
+  requireBoolean(orchestration.stop_at_elementary_flow, 'orchestration.stop_at_elementary_flow');
+
+  const publish = requireObject(request.publish, 'publish');
+  requireEnum(publish.intent, ['dry_run', 'prepare_only', 'publish'], 'publish.intent');
+
+  if (request.nodes !== undefined && !Array.isArray(request.nodes)) {
+    throw new CliError('nodes must be an array when provided.', {
+      code: 'LIFECYCLEMODEL_ORCHESTRATE_INVALID_REQUEST',
+      exitCode: 2,
+    });
+  }
+  if (request.edges !== undefined && !Array.isArray(request.edges)) {
+    throw new CliError('edges must be an array when provided.', {
+      code: 'LIFECYCLEMODEL_ORCHESTRATE_INVALID_REQUEST',
+      exitCode: 2,
+    });
+  }
+}
+
+function buildPlan(
+  request: JsonRecord,
+  requestPath: string,
+  outDir: string,
+  now: Date,
+): AssemblyPlan {
+  validateRequestShape(request);
+  const requestDir = path.dirname(requestPath);
+  const goal = copyJson(requireObject(request.goal, 'goal'));
+  const root = copyJson(requireObject(request.root, 'root'));
+  const orchestration = copyJson(requireObject(request.orchestration, 'orchestration'));
+  const publish = copyJson(requireObject(request.publish, 'publish'));
+  const candidateSources = {
+    ...defaultCandidateSources(),
+    /* c8 ignore next -- normal execution keeps candidate_sources object-shaped */
+    ...(isRecord(request.candidate_sources) ? copyJson(request.candidate_sources) : {}),
+  };
+
+  const rootNode = deriveRootNode(root, goal, requestDir);
+  const requestedNodes = ensureList(request.nodes).filter((entry): entry is JsonRecord =>
+    isRecord(entry),
+  );
+  const rawNodes: JsonRecord[] = [];
+  if (
+    !requestedNodes.some((entry) => firstNonEmpty(entry.node_id, entry.id) === rootNode.node_id)
+  ) {
+    rawNodes.push({
+      node_id: rootNode.node_id,
+      kind: rootNode.kind,
+      label: rootNode.label,
+      entity: rootNode.entity,
+      requested_action: rootNode.requested_action,
+      depends_on: rootNode.depends_on,
+      parent_node_id: rootNode.parent_node_id,
+      existing_resulting_process_candidates: rootNode.existing_resulting_process_candidates,
+      existing_process_candidates: rootNode.existing_process_candidates,
+      existing_lifecyclemodel_candidates: rootNode.existing_lifecyclemodel_candidates,
+      process_builder: rootNode.process_builder,
+      submodel_builder: rootNode.submodel_builder,
+      projector: rootNode.projector,
+    });
+  }
+  rawNodes.push(...requestedNodes.map((entry) => copyJson(entry)));
+
+  const nodes: OrchestrateNode[] = [];
+  const seenNodeIds = new Set<string>();
+  rawNodes.forEach((rawNode, index) => {
+    const normalizedNode = normalizeNode(rawNode, index + 1, requestDir);
+    if (seenNodeIds.has(normalizedNode.node_id)) {
+      if (normalizedNode.node_id === 'root') {
+        return;
+      }
+
+      throw new CliError(`Duplicate node_id: ${normalizedNode.node_id}`, {
+        code: 'LIFECYCLEMODEL_ORCHESTRATE_INVALID_REQUEST',
+        exitCode: 2,
+      });
+    }
+
+    seenNodeIds.add(normalizedNode.node_id);
+    nodes.push(normalizedNode);
+  });
+
+  const { ordered, warnings } = topoSortNodes(nodes);
+  const edges = buildEdges(ensureList(request.edges), ordered);
+  const invocations: PlanInvocation[] = [];
+  const unresolved: Array<{ node_id: string; label: string; reason: string }> = [];
+  const boundaries: Array<{ node_id: string; reason: string }> = [];
+
+  ordered.forEach((node) => {
+    const resolution = selectResolution(node, orchestration);
+    node.resolution = resolution.resolution;
+    node.resolution_reason = resolution.reason;
+    node.selected_candidate = resolution.selected_candidate;
+    node.boundary_reason = resolution.boundary_reason;
+    node.planned_invocations = [];
+
+    if (resolution.boundary_reason) {
+      boundaries.push({
+        node_id: node.node_id,
+        reason: resolution.boundary_reason,
+      });
+    }
+    if (resolution.resolution === 'unresolved') {
+      unresolved.push({
+        node_id: node.node_id,
+        label: node.label,
+        reason: resolution.reason,
+      });
+      return;
+    }
+
+    if (resolution.resolution === 'build_via_process_automated_builder') {
+      const invocationId = `${node.node_id}:process-builder`;
+      const artifactDir = path.resolve(
+        requestDir,
+        path.join(
+          'artifacts',
+          'process_from_flow',
+          safeSlug(`${rootNode.node_id}-${node.node_id}`),
+        ),
+      );
+      invocations.push({
+        invocation_id: invocationId,
+        node_id: node.node_id,
+        kind: 'process_builder',
+        /* c8 ignore next -- build_via_process_automated_builder always has process_builder config */
+        config: copyJson((node.process_builder ?? {}) as JsonRecord),
+        artifact_dir: artifactDir,
+      });
+      node.planned_invocations.push(invocationId);
+    }
+
+    if (resolution.resolution === 'build_via_lifecyclemodel_automated_builder') {
+      const invocationId = `${node.node_id}:lifecyclemodel-builder`;
+      const artifactDir = path.resolve(
+        node.submodel_builder?.out_dir ??
+          path.join(outDir, 'downstream', safeSlug(node.node_id), 'lifecyclemodel-builder'),
+      );
+      invocations.push({
+        invocation_id: invocationId,
+        node_id: node.node_id,
+        kind: 'lifecyclemodel_builder',
+        /* c8 ignore next -- build_via_lifecyclemodel_automated_builder always has submodel_builder config */
+        config: copyJson((node.submodel_builder ?? {}) as JsonRecord),
+        artifact_dir: artifactDir,
+      });
+      node.planned_invocations.push(invocationId);
+    }
+
+    if (node.resolution && shouldRunProjector(node, node.resolution)) {
+      const invocationId = `${node.node_id}:projector`;
+      const dependsOnInvocationId =
+        node.resolution === 'build_via_lifecyclemodel_automated_builder'
+          ? `${node.node_id}:lifecyclemodel-builder`
+          : undefined;
+      const artifactDir = path.resolve(
+        node.projector?.out_dir ??
+          path.join(outDir, 'downstream', safeSlug(node.node_id), 'projector'),
+      );
+      invocations.push({
+        invocation_id: invocationId,
+        node_id: node.node_id,
+        kind: 'projector',
+        /* c8 ignore next -- projector invocations are only scheduled when projector config exists */
+        config: copyJson((node.projector ?? {}) as JsonRecord),
+        artifact_dir: artifactDir,
+        depends_on_invocation_id: dependsOnInvocationId,
+      });
+      node.planned_invocations.push(invocationId);
+    }
+  });
+
+  return {
+    skill: 'lifecyclemodel-recursive-orchestrator',
+    request_id:
+      nonEmptyString(request.request_id) ??
+      `run-${nowIso(now).replace(/[-:.]/gu, '').replace(/Z$/u, 'Z')}`,
+    created_at: nowIso(now),
+    request_file: requestPath,
+    goal,
+    root,
+    orchestration,
+    candidate_sources: candidateSources,
+    publish: {
+      /* c8 ignore next -- validateRequestShape guarantees a supported intent before buildPlan runs */
+      intent: firstNonEmpty(publish.intent, 'dry_run') ?? 'dry_run',
+      prepare_lifecyclemodel_payload: publish.prepare_lifecyclemodel_payload !== false,
+      prepare_resulting_process_payload: publish.prepare_resulting_process_payload !== false,
+      prepare_relation_payload: publish.prepare_relation_payload !== false,
+    },
+    notes: ensureList(request.notes)
+      .map((entry) => nonEmptyString(entry))
+      .filter((entry): entry is string => Boolean(entry)),
+    nodes: ordered,
+    edges,
+    invocations,
+    planner_summary: {
+      status: 'planned',
+      message: 'Request validated, nodes normalized, and downstream invocations scheduled.',
+    },
+    warnings,
+    unresolved,
+    boundaries,
+    artifacts: {
+      root: outDir,
+      request_normalized: path.join(outDir, 'request.normalized.json'),
+      assembly_plan: path.join(outDir, 'assembly-plan.json'),
+      graph_manifest: path.join(outDir, 'graph-manifest.json'),
+      lineage_manifest: path.join(outDir, 'lineage-manifest.json'),
+      boundary_report: path.join(outDir, 'boundary-report.json'),
+      invocations_dir: path.join(outDir, 'invocations'),
+      publish_bundle: path.join(outDir, 'publish-bundle.json'),
+      publish_summary: path.join(outDir, 'publish-summary.json'),
+    },
+    summary: {
+      node_count: ordered.length,
+      edge_count: edges.length,
+      invocation_count: invocations.length,
+      unresolved_count: unresolved.length,
+    },
+  };
+}
+
+function executionStatusByNode(
+  plan: AssemblyPlan,
+  executionResults: InvocationExecutionResult[],
+): Record<string, string> {
+  const byNode = new Map<string, InvocationExecutionResult[]>();
+  executionResults.forEach((result) => {
+    const list = byNode.get(result.node_id) ?? [];
+    list.push(result);
+    byNode.set(result.node_id, list);
+  });
+
+  const statuses: Record<string, string> = {};
+  plan.nodes.forEach((node) => {
+    const nodeResults = byNode.get(node.node_id) ?? [];
+    if (node.resolution === 'unresolved') {
+      statuses[node.node_id] = 'unresolved';
+      return;
+    }
+    if (node.resolution === 'cutoff') {
+      statuses[node.node_id] = 'cutoff';
+      return;
+    }
+    if (node.resolution?.startsWith('reused_')) {
+      statuses[node.node_id] = 'reused';
+      return;
+    }
+    if (nodeResults.length === 0) {
+      statuses[node.node_id] = 'planned';
+      return;
+    }
+    if (nodeResults.some((result) => result.status === 'failed')) {
+      statuses[node.node_id] = 'failed';
+      return;
+    }
+    if (nodeResults.some((result) => result.status.startsWith('skipped'))) {
+      statuses[node.node_id] = 'blocked';
+      return;
+    }
+    if (nodeResults.every((result) => result.status === 'success')) {
+      statuses[node.node_id] = 'completed';
+      return;
+    }
+
+    statuses[node.node_id] = 'incomplete';
+  });
+
+  return statuses;
+}
+
+function collectResultingProcessRelations(
+  executionResults: InvocationExecutionResult[],
+): JsonRecord[] {
+  const relations: JsonRecord[] = [];
+
+  executionResults.forEach((result) => {
+    const bundlePath = nonEmptyString(result.artifacts?.projection_bundle);
+    if (!bundlePath || !existsSync(bundlePath)) {
+      return;
+    }
+
+    const bundle = readJsonArtifact(bundlePath);
+    if (!isRecord(bundle)) {
+      return;
+    }
+
+    ensureList(bundle.relations).forEach((relation) => {
+      if (!isRecord(relation)) {
+        return;
+      }
+
+      relations.push({
+        ...copyJson(relation),
+        node_id: result.node_id,
+      });
+    });
+  });
+
+  return relations;
+}
+
+function buildGraphManifest(
+  plan: AssemblyPlan,
+  executionResults: InvocationExecutionResult[],
+): GraphManifest {
+  const nodeStatuses = executionStatusByNode(plan, executionResults);
+  return {
+    root: {
+      request_id: plan.request_id,
+      goal: copyJson(plan.goal),
+      mode: plan.orchestration.mode,
+      max_depth: plan.orchestration.max_depth,
+    },
+    nodes: plan.nodes.map((node) => ({
+      node_id: node.node_id,
+      label: node.label,
+      kind: node.kind,
+      resolution: node.resolution,
+      /* c8 ignore next -- executionStatusByNode always materializes every plan node */
+      execution_status: nodeStatuses[node.node_id] ?? 'planned',
+      selected_candidate: copyJson(node.selected_candidate ?? null),
+      depends_on: copyJson(node.depends_on),
+      boundary_reason: node.boundary_reason ?? null,
+    })),
+    edges: copyJson(plan.edges),
+    boundaries: copyJson(plan.boundaries),
+    unresolved: copyJson(plan.unresolved),
+    stats: {
+      node_count: plan.nodes.length,
+      edge_count: plan.edges.length,
+      invocation_count: plan.invocations.length,
+      unresolved_count: plan.unresolved.length,
+      completed_invocation_count: executionResults.filter((result) => result.status === 'success')
+        .length,
+    },
+  };
+}
+
+function buildLineageManifest(
+  plan: AssemblyPlan,
+  executionResults: InvocationExecutionResult[],
+): LineageManifest {
+  const executionByInvocation = new Map(
+    executionResults.map((result) => [result.invocation_id, result]),
+  );
+  const nodeStatuses = executionStatusByNode(plan, executionResults);
+
+  const publishedDependencies = plan.nodes
+    .filter((node) => isRecord(node.selected_candidate))
+    .map((node) => ({
+      node_id: node.node_id,
+      dependency_type: node.resolution,
+      candidate_id: node.selected_candidate?.id ?? null,
+      candidate_version: nonEmptyString(node.selected_candidate?.version) ?? null,
+    }));
+
+  return {
+    root_request: {
+      request_id: plan.request_id,
+      goal: copyJson(plan.goal),
+      root: copyJson(plan.root),
+      orchestration: copyJson(plan.orchestration),
+      publish: copyJson(plan.publish),
+    },
+    builder_invocations: plan.invocations.map((invocation) => {
+      const result = executionByInvocation.get(invocation.invocation_id);
+      return {
+        invocation_id: invocation.invocation_id,
+        node_id: invocation.node_id,
+        kind: invocation.kind,
+        artifact_dir: invocation.artifact_dir,
+        status: result?.status ?? 'planned',
+        exit_code: result?.exit_code ?? null,
+        result_file: result?.result_file ?? null,
+      };
+    }),
+    node_resolution_log: plan.nodes.map((node) => ({
+      node_id: node.node_id,
+      label: node.label,
+      resolution: node.resolution,
+      reason: node.resolution_reason,
+      selected_candidate: copyJson(node.selected_candidate ?? null),
+      /* c8 ignore next -- executionStatusByNode always materializes every plan node */
+      execution_status: nodeStatuses[node.node_id] ?? 'planned',
+    })),
+    published_dependencies: publishedDependencies,
+    resulting_process_relations: collectResultingProcessRelations(executionResults),
+    unresolved_history: copyJson(plan.unresolved),
+  };
+}
+
+function buildBoundaryReport(
+  plan: AssemblyPlan,
+  executionResults: InvocationExecutionResult[],
+): JsonRecord {
+  return {
+    request_id: plan.request_id,
+    generated_at: nowIso(),
+    boundaries: copyJson(plan.boundaries),
+    unresolved: copyJson(plan.unresolved),
+    execution_summary: {
+      successful_invocations: executionResults.filter((result) => result.status === 'success')
+        .length,
+      failed_invocations: executionResults.filter((result) => result.status === 'failed').length,
+      blocked_invocations: executionResults.filter((result) => result.status.startsWith('skipped'))
+        .length,
+    },
+  };
+}
+
+function writePlanArtifacts(
+  normalizedRequest: JsonRecord,
+  plan: AssemblyPlan,
+  graphManifest: GraphManifest,
+  lineageManifest: LineageManifest,
+  boundaryReport: JsonRecord,
+): void {
+  writeJsonArtifact(plan.artifacts.request_normalized, normalizedRequest);
+  writeJsonArtifact(plan.artifacts.assembly_plan, plan);
+  writeJsonArtifact(plan.artifacts.graph_manifest, graphManifest);
+  writeJsonArtifact(plan.artifacts.lineage_manifest, lineageManifest);
+  writeJsonArtifact(plan.artifacts.boundary_report, boundaryReport);
+}
+
+function requireFile(filePath: string, label: string): void {
+  if (!existsSync(filePath)) {
+    throw new CliError(`Missing ${label}: ${filePath}`, {
+      code: 'LIFECYCLEMODEL_ORCHESTRATE_MISSING_FILE',
+      exitCode: 2,
+      details: { filePath, label },
+    });
+  }
+}
+
+function writeRequestFile(filePath: string, payload: unknown): string {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return filePath;
+}
+
+function parseInlineJson(value: unknown, label: string): JsonRecord {
+  if (isRecord(value)) {
+    return copyJson(value);
+  }
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      if (!isRecord(parsed)) {
+        throw new Error('parsed value is not an object');
+      }
+      return parsed;
+    } catch (error) {
+      throw new CliError(`Invalid ${label} JSON string.`, {
+        code: 'LIFECYCLEMODEL_ORCHESTRATE_INVALID_REQUEST',
+        exitCode: 2,
+        details: { value, message: String(error) },
+      });
+    }
+  }
+
+  throw new CliError(`${label} must be a JSON object or JSON string.`, {
+    code: 'LIFECYCLEMODEL_ORCHESTRATE_INVALID_REQUEST',
+    exitCode: 2,
+    details: { value },
+  });
+}
+
+function buildProcessBuilderArtifacts(report: ProcessAutoBuildReport): JsonRecord {
+  return {
+    run_id: report.run_id,
+    run_root: report.run_root,
+    state_file: report.files.state,
+    exports_dir: path.join(report.run_root, 'exports', 'processes'),
+    report: report.files.report,
+  };
+}
+
+function buildLifecyclemodelBuilderArtifacts(report: LifecyclemodelAutoBuildReport): JsonRecord {
+  return {
+    run_root: report.run_root,
+    run_id: report.run_id,
+    run_plan: report.files.run_plan,
+    resolved_manifest: report.files.resolved_manifest,
+    produced_model_files: report.local_build_reports.map((entry) => entry.model_file),
+    process_catalog_files: report.local_build_reports.map((entry) => entry.process_catalog_file),
+    source_run_dirs: report.local_build_reports.map((entry) => entry.run_dir),
+    report_files: report.local_build_reports.map((entry) => entry.summary_file),
+    report: report.files.report,
+  };
+}
+
+function buildProjectorArtifacts(report: LifecyclemodelResultingProcessReport): JsonRecord {
+  return {
+    out_dir: report.out_dir,
+    projection_bundle: report.files.process_projection_bundle,
+    projection_report: report.files.projection_report,
+    request_normalized: report.files.normalized_request,
+  };
+}
+
+async function executeProcessBuilderInvocation(
+  invocation: PlanInvocation,
+  plan: AssemblyPlan,
+  resultFile: string,
+  now: Date,
+): Promise<InvocationExecutionResult> {
+  const config = invocation.config;
+  if (nonEmptyString(config.python_bin)) {
+    throw new CliError(
+      `Invocation ${invocation.invocation_id} still requests process_builder.python_bin, which is removed from the CLI-only path.`,
+      {
+        code: 'LIFECYCLEMODEL_ORCHESTRATE_LEGACY_CONFIG',
+        exitCode: 2,
+      },
+    );
+  }
+  if (config.mode === 'langgraph') {
+    throw new CliError(
+      `Invocation ${invocation.invocation_id} still requests process_builder.mode=langgraph, which is removed from the CLI-only path.`,
+      {
+        code: 'LIFECYCLEMODEL_ORCHESTRATE_LEGACY_CONFIG',
+        exitCode: 2,
+      },
+    );
+  }
+
+  const requestsDir = path.join(plan.artifacts.invocations_dir, 'requests');
+  const slug = safeSlug(invocation.invocation_id);
+  let flowFile = nonEmptyString(config.flow_file);
+  if (!flowFile) {
+    const flowPayload = parseInlineJson(config.flow_json, `${invocation.invocation_id} flow_json`);
+    flowFile = writeRequestFile(path.join(requestsDir, `${slug}.flow.json`), flowPayload);
+  }
+
+  const request = {
+    flow_file: flowFile,
+    operation: 'produce',
+  };
+  const requestFile = writeRequestFile(
+    path.join(requestsDir, `${slug}.process-auto-build.request.json`),
+    request,
+  );
+  const runId =
+    nonEmptyString(config.run_id) ?? `${safeSlug(plan.request_id)}-${safeSlug(invocation.node_id)}`;
+  const report = await runProcessAutoBuild({
+    inputPath: requestFile,
+    inputValue: request,
+    outDir: invocation.artifact_dir,
+    now,
+    requestIdOverride: `${plan.request_id}:${invocation.node_id}`,
+    runIdOverride: runId,
+  });
+
+  const result: InvocationExecutionResult = {
+    invocation_id: invocation.invocation_id,
+    node_id: invocation.node_id,
+    kind: invocation.kind,
+    status: 'success',
+    exit_code: 0,
+    result_file: resultFile,
+    planned_artifacts: {
+      run_id: runId,
+      run_root: report.run_root,
+    },
+    artifacts: buildProcessBuilderArtifacts(report),
+  };
+  writeJsonArtifact(resultFile, result);
+  return result;
+}
+
+async function executeLifecyclemodelBuilderInvocation(
+  invocation: PlanInvocation,
+  resultFile: string,
+  now: Date,
+): Promise<InvocationExecutionResult> {
+  const config = invocation.config;
+  const manifest = nonEmptyString(config.manifest);
+  if (!manifest) {
+    throw new CliError(
+      `Invocation ${invocation.invocation_id} is missing submodel_builder.manifest.`,
+      {
+        code: 'LIFECYCLEMODEL_ORCHESTRATE_INVALID_REQUEST',
+        exitCode: 2,
+      },
+    );
+  }
+  requireFile(manifest, 'lifecyclemodel builder manifest');
+
+  if (config.dry_run === true) {
+    const result: InvocationExecutionResult = {
+      invocation_id: invocation.invocation_id,
+      node_id: invocation.node_id,
+      kind: invocation.kind,
+      status: 'success',
+      exit_code: 0,
+      result_file: resultFile,
+      dry_run: true,
+      planned_artifacts: {
+        out_dir: invocation.artifact_dir,
+        manifest,
+      },
+      artifacts: {
+        out_dir: invocation.artifact_dir,
+        run_plan: null,
+        resolved_manifest: null,
+        produced_model_files: [],
+        process_catalog_files: [],
+        report_files: [],
+      },
+    };
+    writeJsonArtifact(resultFile, result);
+    return result;
+  }
+
+  const report = await runLifecyclemodelAutoBuild({
+    inputPath: manifest,
+    outDir: invocation.artifact_dir,
+    now,
+  });
+  const result: InvocationExecutionResult = {
+    invocation_id: invocation.invocation_id,
+    node_id: invocation.node_id,
+    kind: invocation.kind,
+    status: 'success',
+    exit_code: 0,
+    result_file: resultFile,
+    planned_artifacts: {
+      out_dir: invocation.artifact_dir,
+      manifest,
+    },
+    artifacts: buildLifecyclemodelBuilderArtifacts(report),
+  };
+  writeJsonArtifact(resultFile, result);
+  return result;
+}
+
+function inferProjectorModelFile(
+  invocation: PlanInvocation,
+  executionMap: Map<string, InvocationExecutionResult>,
+): string | null {
+  const explicit = nonEmptyString(invocation.config.model_file);
+  if (explicit) {
+    return explicit;
+  }
+
+  const dependencyId = nonEmptyString(invocation.depends_on_invocation_id);
+  if (!dependencyId) {
+    return null;
+  }
+  const dependency = executionMap.get(dependencyId);
+  const modelFiles = ensureList(dependency?.artifacts?.produced_model_files)
+    .map((entry) => nonEmptyString(entry))
+    .filter((entry): entry is string => Boolean(entry));
+  return modelFiles[0] ?? null;
+}
+
+function buildProjectorRequest(
+  invocation: PlanInvocation,
+  modelFile: string,
+  plan: AssemblyPlan,
+  processCatalogPath: string | null,
+  sourceRunDirs: string[],
+): JsonRecord {
+  return {
+    source_model: {
+      json_ordered_path: modelFile,
+    },
+    projection: {
+      mode: invocation.config.projection_role === 'all' ? 'all-subproducts' : 'primary-only',
+      metadata_overrides: {
+        projection_source: 'lifecyclemodel_orchestrate',
+      },
+      attach_graph_snapshot: false,
+    },
+    process_sources: {
+      ...(processCatalogPath ? { process_catalog_path: processCatalogPath } : {}),
+      ...(sourceRunDirs.length > 0 ? { run_dirs: sourceRunDirs } : {}),
+      allow_remote_lookup: false,
+    },
+    publish: {
+      /* c8 ignore next -- buildPlan normalizes intent before projector requests are constructed */
+      intent: firstNonEmpty(plan.publish.intent, 'prepare_only') ?? 'prepare_only',
+      prepare_process_payloads: plan.publish.prepare_resulting_process_payload !== false,
+      prepare_relation_payloads: plan.publish.prepare_relation_payload !== false,
+    },
+  };
+}
+
+async function executeProjectorInvocation(
+  invocation: PlanInvocation,
+  plan: AssemblyPlan,
+  executionMap: Map<string, InvocationExecutionResult>,
+  resultFile: string,
+  now: Date,
+  env: NodeJS.ProcessEnv,
+  fetchImpl: FetchLike | undefined,
+): Promise<InvocationExecutionResult> {
+  const requestPath = nonEmptyString(invocation.config.request);
+  let projectorRequestPath = requestPath;
+  if (!projectorRequestPath) {
+    const modelFile = inferProjectorModelFile(invocation, executionMap);
+    if (!modelFile) {
+      throw new CliError(
+        `Invocation ${invocation.invocation_id} requires projector.request or a prior lifecyclemodel build result.`,
+        {
+          code: 'LIFECYCLEMODEL_ORCHESTRATE_PROJECTOR_REQUEST_REQUIRED',
+          exitCode: 2,
+        },
+      );
+    }
+    /* c8 ignore start -- optional dependency artifacts are purely defensive here */
+    const dependency = nonEmptyString(invocation.depends_on_invocation_id)
+      ? executionMap.get(String(invocation.depends_on_invocation_id))
+      : undefined;
+    const processCatalogPath =
+      ensureList(dependency?.artifacts?.process_catalog_files)
+        .map((entry) => nonEmptyString(entry))
+        .filter((entry): entry is string => Boolean(entry))[0] ?? null;
+    /* c8 ignore stop */
+    const sourceRunDirs = ensureList(dependency?.artifacts?.source_run_dirs)
+      .map((entry) => nonEmptyString(entry))
+      .filter((entry): entry is string => Boolean(entry));
+    projectorRequestPath = writeRequestFile(
+      path.join(
+        plan.artifacts.invocations_dir,
+        'requests',
+        `${safeSlug(invocation.invocation_id)}.projector.request.json`,
+      ),
+      buildProjectorRequest(invocation, modelFile, plan, processCatalogPath, sourceRunDirs),
+    );
+  } else {
+    requireFile(projectorRequestPath, 'projector request');
+  }
+
+  const report = await runLifecyclemodelBuildResultingProcess({
+    inputPath: projectorRequestPath,
+    outDir: invocation.artifact_dir,
+    now,
+    env,
+    fetchImpl,
+  });
+  const result: InvocationExecutionResult = {
+    invocation_id: invocation.invocation_id,
+    node_id: invocation.node_id,
+    kind: invocation.kind,
+    status: 'success',
+    exit_code: 0,
+    result_file: resultFile,
+    planned_artifacts: {
+      out_dir: invocation.artifact_dir,
+      request: projectorRequestPath,
+    },
+    artifacts: buildProjectorArtifacts(report),
+  };
+  writeJsonArtifact(resultFile, result);
+  return result;
+}
+
+async function executePlan(
+  plan: AssemblyPlan,
+  now: Date,
+  env: NodeJS.ProcessEnv,
+  fetchImpl: FetchLike | undefined,
+): Promise<InvocationExecutionResult[]> {
+  mkdirSync(plan.artifacts.invocations_dir, { recursive: true });
+  const results: InvocationExecutionResult[] = [];
+  const executionMap = new Map<string, InvocationExecutionResult>();
+  const failFast = plan.orchestration.fail_fast !== false;
+  let stopRemaining = false;
+
+  for (const invocation of plan.invocations) {
+    const resultFile = path.join(
+      plan.artifacts.invocations_dir,
+      `${safeSlug(invocation.invocation_id)}.json`,
+    );
+    if (stopRemaining) {
+      const skipped: InvocationExecutionResult = {
+        invocation_id: invocation.invocation_id,
+        node_id: invocation.node_id,
+        kind: invocation.kind,
+        status: 'skipped_due_to_fail_fast',
+        exit_code: null,
+        result_file: resultFile,
+      };
+      writeJsonArtifact(resultFile, skipped);
+      results.push(skipped);
+      executionMap.set(invocation.invocation_id, skipped);
+      continue;
+    }
+
+    const dependencyId = nonEmptyString(invocation.depends_on_invocation_id);
+    if (dependencyId) {
+      const dependency = executionMap.get(dependencyId);
+      if (dependency && dependency.status !== 'success') {
+        const blocked: InvocationExecutionResult = {
+          invocation_id: invocation.invocation_id,
+          node_id: invocation.node_id,
+          kind: invocation.kind,
+          status: `skipped_due_to_dependency_${dependency.status}` as InvocationStatus,
+          exit_code: null,
+          result_file: resultFile,
+        };
+        writeJsonArtifact(resultFile, blocked);
+        results.push(blocked);
+        executionMap.set(invocation.invocation_id, blocked);
+        continue;
+      }
+    }
+
+    try {
+      let result: InvocationExecutionResult;
+      if (invocation.kind === 'process_builder') {
+        result = await executeProcessBuilderInvocation(invocation, plan, resultFile, now);
+      } else if (invocation.kind === 'lifecyclemodel_builder') {
+        result = await executeLifecyclemodelBuilderInvocation(invocation, resultFile, now);
+      } else {
+        result = await executeProjectorInvocation(
+          invocation,
+          plan,
+          executionMap,
+          resultFile,
+          now,
+          env,
+          fetchImpl,
+        );
+      }
+
+      results.push(result);
+      executionMap.set(invocation.invocation_id, result);
+    } catch (error) {
+      const failed: InvocationExecutionResult = {
+        invocation_id: invocation.invocation_id,
+        node_id: invocation.node_id,
+        kind: invocation.kind,
+        status: 'failed',
+        /* c8 ignore next -- current invocation helpers only throw CliError or structured failures */
+        exit_code: error instanceof CliError ? error.exitCode : 1,
+        result_file: resultFile,
+        /* c8 ignore next -- current invocation helpers only throw Error-like objects */
+        error: error instanceof Error ? error.message : String(error),
+      };
+      writeJsonArtifact(resultFile, failed);
+      results.push(failed);
+      executionMap.set(invocation.invocation_id, failed);
+      if (failFast) {
+        stopRemaining = true;
+      }
+    }
+  }
+
+  plan.execution_summary = {
+    executed_at: nowIso(now),
+    successful_invocations: results.filter((result) => result.status === 'success').length,
+    failed_invocations: results.filter((result) => result.status === 'failed').length,
+    blocked_invocations: results.filter((result) => result.status.startsWith('skipped')).length,
+    status: results.some((result) => result.status === 'failed') ? 'failed' : 'completed',
+  };
+  plan.planner_summary = {
+    status: 'executed',
+    message: 'Scheduled downstream builders were executed and invocation artifacts were recorded.',
+  };
+  plan.invocations.forEach((invocation) => {
+    const result = executionMap.get(invocation.invocation_id);
+    /* c8 ignore start -- executionMap is populated for every planned invocation during executePlan */
+    if (!result) {
+      return;
+    }
+    /* c8 ignore stop */
+    invocation.last_status = result.status;
+    invocation.last_exit_code = result.exit_code;
+    invocation.last_result_file = result.result_file;
+    invocation.artifacts = result.artifacts;
+  });
+
+  return results;
+}
+
+function loadInvocationResults(invocationsDir: string): InvocationExecutionResult[] {
+  if (!existsSync(invocationsDir)) {
+    return [];
+  }
+
+  return readdirSync(invocationsDir)
+    .filter((entry) => entry.endsWith('.json'))
+    .sort()
+    .map((entry) => readJsonArtifact(path.join(invocationsDir, entry)))
+    .filter((entry): entry is InvocationExecutionResult => isRecord(entry))
+    .map((entry) => entry as InvocationExecutionResult);
+}
+
+function collectPublishBundle(
+  runDir: string,
+  plan: AssemblyPlan,
+  graphManifest: GraphManifest,
+  lineageManifest: LineageManifest,
+  executionResults: InvocationExecutionResult[],
+  publishLifecyclemodels: boolean,
+  publishResultingProcessRelations: boolean,
+): JsonRecord {
+  const lifecyclemodels: JsonRecord[] = [];
+  const projectedProcesses: JsonRecord[] = [];
+  const relations: JsonRecord[] = [];
+  const processBuildRuns: JsonRecord[] = [];
+
+  executionResults.forEach((result) => {
+    if (result.kind === 'lifecyclemodel_builder' && publishLifecyclemodels) {
+      ensureList(result.artifacts?.produced_model_files).forEach((filePath) => {
+        const resolved = nonEmptyString(filePath);
+        if (!resolved || !existsSync(resolved)) {
+          return;
+        }
+        lifecyclemodels.push({
+          node_id: result.node_id,
+          file: resolved,
+          json_ordered: readJsonArtifact(resolved),
+        });
+      });
+    }
+
+    if (result.kind === 'projector' && publishResultingProcessRelations) {
+      const bundlePath = nonEmptyString(result.artifacts?.projection_bundle);
+      if (bundlePath && existsSync(bundlePath)) {
+        const bundle = readJsonArtifact(bundlePath);
+        if (isRecord(bundle)) {
+          ensureList(bundle.projected_processes).forEach((payload) => {
+            if (!isRecord(payload)) {
+              return;
+            }
+            projectedProcesses.push({
+              ...copyJson(payload),
+              node_id: result.node_id,
+            });
+          });
+          ensureList(bundle.relations).forEach((payload) => {
+            if (!isRecord(payload)) {
+              return;
+            }
+            relations.push({
+              ...copyJson(payload),
+              node_id: result.node_id,
+            });
+          });
+        }
+      }
+    }
+
+    if (result.kind === 'process_builder') {
+      processBuildRuns.push({
+        node_id: result.node_id,
+        run_id: nonEmptyString(result.artifacts?.run_id),
+        run_root: nonEmptyString(result.artifacts?.run_root),
+        exports_dir: nonEmptyString(result.artifacts?.exports_dir),
+      });
+    }
+  });
+
+  return {
+    generated_at: nowIso(),
+    run_dir: runDir,
+    request_id: plan.request_id,
+    status: 'prepared_local_publish_bundle',
+    include_lifecyclemodels: publishLifecyclemodels,
+    include_resulting_process_relations: publishResultingProcessRelations,
+    graph_manifest: copyJson(graphManifest),
+    lineage_manifest: copyJson(lineageManifest),
+    lifecyclemodels,
+    projected_processes: projectedProcesses,
+    resulting_process_relations: relations,
+    process_build_runs: processBuildRuns,
+  };
+}
+
+function normalizeRequestForArtifacts(plan: AssemblyPlan): JsonRecord {
+  return {
+    request_id: plan.request_id,
+    goal: copyJson(plan.goal),
+    root: copyJson(plan.root),
+    orchestration: copyJson(plan.orchestration),
+    candidate_sources: copyJson(plan.candidate_sources),
+    publish: copyJson(plan.publish),
+    nodes: copyJson(plan.nodes),
+    edges: copyJson(plan.edges),
+    notes: copyJson(plan.notes),
+  };
+}
+
+function requireActionInputPath(options: RunLifecyclemodelOrchestrateOptions): string {
+  const inputPath = nonEmptyString(options.inputPath);
+  if (!inputPath) {
+    throw new CliError('Missing required --input for lifecyclemodel orchestrate plan/execute.', {
+      code: 'LIFECYCLEMODEL_ORCHESTRATE_INPUT_REQUIRED',
+      exitCode: 2,
+    });
+  }
+  return path.resolve(inputPath);
+}
+
+function requireActionOutDir(options: RunLifecyclemodelOrchestrateOptions): string {
+  const outDir = nonEmptyString(options.outDir);
+  if (!outDir) {
+    throw new CliError('Missing required --out-dir for lifecyclemodel orchestrate plan/execute.', {
+      code: 'LIFECYCLEMODEL_ORCHESTRATE_OUT_DIR_REQUIRED',
+      exitCode: 2,
+    });
+  }
+  return path.resolve(outDir);
+}
+
+function requirePublishRunDir(options: RunLifecyclemodelOrchestrateOptions): string {
+  const runDir = nonEmptyString(options.runDir);
+  if (!runDir) {
+    throw new CliError('Missing required --run-dir for lifecyclemodel orchestrate publish.', {
+      code: 'LIFECYCLEMODEL_ORCHESTRATE_RUN_DIR_REQUIRED',
+      exitCode: 2,
+    });
+  }
+  return path.resolve(runDir);
+}
+
+export async function runLifecyclemodelOrchestrate(
+  options: RunLifecyclemodelOrchestrateOptions,
+): Promise<LifecyclemodelOrchestrateReport> {
+  const now = options.now ?? new Date();
+  if (options.action === 'publish') {
+    const runDir = requirePublishRunDir(options);
+    const assemblyPlanPath = path.join(runDir, 'assembly-plan.json');
+    const graphManifestPath = path.join(runDir, 'graph-manifest.json');
+    const lineageManifestPath = path.join(runDir, 'lineage-manifest.json');
+    requireFile(assemblyPlanPath, 'assembly plan');
+    requireFile(graphManifestPath, 'graph manifest');
+    requireFile(lineageManifestPath, 'lineage manifest');
+    const plan = readJsonArtifact(assemblyPlanPath) as AssemblyPlan;
+    const graphManifest = readJsonArtifact(graphManifestPath) as GraphManifest;
+    const lineageManifest = readJsonArtifact(lineageManifestPath) as LineageManifest;
+    const publishLifecyclemodels =
+      options.publishLifecyclemodels || plan.publish.prepare_lifecyclemodel_payload !== false;
+    const publishResultingProcessRelations =
+      options.publishResultingProcessRelations ||
+      plan.publish.prepare_resulting_process_payload !== false ||
+      plan.publish.prepare_relation_payload !== false;
+    const executionResults = loadInvocationResults(path.join(runDir, 'invocations'));
+    const publishBundle = collectPublishBundle(
+      runDir,
+      plan,
+      graphManifest,
+      lineageManifest,
+      executionResults,
+      publishLifecyclemodels,
+      publishResultingProcessRelations,
+    );
+    const publishBundlePath = writeJsonArtifact(
+      path.join(runDir, 'publish-bundle.json'),
+      publishBundle,
+    );
+    const publishSummaryPath = writeJsonArtifact(path.join(runDir, 'publish-summary.json'), {
+      schema_version: 1,
+      generated_at_utc: nowIso(now),
+      action: 'publish',
+      status: 'prepared_local_publish_bundle',
+      request_id: plan.request_id,
+      run_dir: runDir,
+      lifecyclemodel_count: ensureList(publishBundle.lifecyclemodels).length,
+      projected_process_count: ensureList(publishBundle.projected_processes).length,
+      relation_count: ensureList(publishBundle.resulting_process_relations).length,
+      process_build_run_count: ensureList(publishBundle.process_build_runs).length,
+    });
+
+    return {
+      schema_version: 1,
+      generated_at_utc: nowIso(now),
+      action: 'publish',
+      status: 'prepared_local_publish_bundle',
+      request_id: plan.request_id,
+      run_dir: runDir,
+      counts: {
+        lifecyclemodels: ensureList(publishBundle.lifecyclemodels).length,
+        projected_processes: ensureList(publishBundle.projected_processes).length,
+        resulting_process_relations: ensureList(publishBundle.resulting_process_relations).length,
+        process_build_runs: ensureList(publishBundle.process_build_runs).length,
+      },
+      files: {
+        assembly_plan: assemblyPlanPath,
+        graph_manifest: graphManifestPath,
+        lineage_manifest: lineageManifestPath,
+        publish_bundle: publishBundlePath,
+        publish_summary: publishSummaryPath,
+      },
+    };
+  }
+
+  const inputPath = requireActionInputPath(options);
+  const outDir = requireActionOutDir(options);
+  const request = readJsonInput(inputPath);
+  const requestObject = requireObject(request, 'request');
+  if (options.allowProcessBuild === true) {
+    (requestObject.orchestration as JsonRecord).allow_process_build = true;
+  }
+  if (options.allowSubmodelBuild === true) {
+    (requestObject.orchestration as JsonRecord).allow_submodel_build = true;
+  }
+  const plan = buildPlan(requestObject, inputPath, outDir, now);
+  const normalizedRequest = normalizeRequestForArtifacts(plan);
+  const initialGraphManifest = buildGraphManifest(plan, []);
+  const initialLineageManifest = buildLineageManifest(plan, []);
+  const initialBoundaryReport = buildBoundaryReport(plan, []);
+  writePlanArtifacts(
+    normalizedRequest,
+    plan,
+    initialGraphManifest,
+    initialLineageManifest,
+    initialBoundaryReport,
+  );
+
+  if (options.action === 'plan') {
+    return {
+      schema_version: 1,
+      generated_at_utc: nowIso(now),
+      action: 'plan',
+      status: 'planned',
+      request_id: plan.request_id,
+      out_dir: outDir,
+      counts: {
+        nodes: plan.summary.node_count,
+        edges: plan.summary.edge_count,
+        invocations: plan.summary.invocation_count,
+        unresolved: plan.summary.unresolved_count,
+      },
+      files: {
+        request_normalized: plan.artifacts.request_normalized,
+        assembly_plan: plan.artifacts.assembly_plan,
+        graph_manifest: plan.artifacts.graph_manifest,
+        lineage_manifest: plan.artifacts.lineage_manifest,
+        boundary_report: plan.artifacts.boundary_report,
+      },
+      warnings: copyJson(plan.warnings),
+    };
+  }
+
+  const executionResults = await executePlan(
+    plan,
+    now,
+    options.env ?? process.env,
+    options.fetchImpl,
+  );
+  const graphManifest = buildGraphManifest(plan, executionResults);
+  const lineageManifest = buildLineageManifest(plan, executionResults);
+  const boundaryReport = buildBoundaryReport(plan, executionResults);
+  writePlanArtifacts(normalizedRequest, plan, graphManifest, lineageManifest, boundaryReport);
+
+  return {
+    schema_version: 1,
+    generated_at_utc: nowIso(now),
+    action: 'execute',
+    /* c8 ignore next -- executePlan always materializes execution_summary before returning */
+    status: plan.execution_summary?.status ?? 'completed',
+    request_id: plan.request_id,
+    out_dir: outDir,
+    execution: {
+      /* c8 ignore next -- executePlan always materializes execution_summary before returning */
+      successful_invocations: plan.execution_summary?.successful_invocations ?? 0,
+      /* c8 ignore next -- executePlan always materializes execution_summary before returning */
+      failed_invocations: plan.execution_summary?.failed_invocations ?? 0,
+      /* c8 ignore next -- executePlan always materializes execution_summary before returning */
+      blocked_invocations: plan.execution_summary?.blocked_invocations ?? 0,
+    },
+    files: {
+      request_normalized: plan.artifacts.request_normalized,
+      assembly_plan: plan.artifacts.assembly_plan,
+      graph_manifest: plan.artifacts.graph_manifest,
+      lineage_manifest: plan.artifacts.lineage_manifest,
+      boundary_report: plan.artifacts.boundary_report,
+      invocations_dir: plan.artifacts.invocations_dir,
+    },
+    warnings: copyJson(plan.warnings),
+  };
+}
+
+export const __testInternals = {
+  requireObject,
+  requireEnum,
+  requireBoolean,
+  requireInteger,
+  resolveInputPath,
+  defaultCandidateSources,
+  normalizeCandidate,
+  normalizeCandidateList,
+  normalizeRequestedAction,
+  normalizeDependsOn,
+  normalizeProcessBuilderConfig,
+  normalizeSubmodelBuilderConfig,
+  normalizeProjectorConfig,
+  normalizeNode,
+  deriveRootNode,
+  buildEdges,
+  topoSortNodes,
+  selectResolution,
+  shouldRunProjector,
+  validateRequestShape,
+  buildPlan,
+  executionStatusByNode,
+  buildGraphManifest,
+  buildLineageManifest,
+  buildBoundaryReport,
+  requireFile,
+  parseInlineJson,
+  inferProjectorModelFile,
+  executeProcessBuilderInvocation,
+  executeLifecyclemodelBuilderInvocation,
+  executeProjectorInvocation,
+  executePlan,
+  collectPublishBundle,
+  normalizeRequestForArtifacts,
+  loadInvocationResults,
+  buildProjectorRequest,
+};

--- a/src/lib/lifecyclemodel-publish-build.ts
+++ b/src/lib/lifecyclemodel-publish-build.ts
@@ -1,0 +1,442 @@
+import { existsSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { readJsonArtifact, writeJsonArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+import { normalizePublishRequest } from './publish.js';
+
+type JsonObject = Record<string, unknown>;
+
+type LifecyclemodelPublishValidationSummary = {
+  available: boolean;
+  ok: boolean | null;
+  report: string | null;
+};
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized || null;
+}
+
+function copyJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function readRequiredJsonObject(
+  filePath: string,
+  missingCode: string,
+  invalidCode: string,
+  label: string,
+): JsonObject {
+  if (!existsSync(filePath)) {
+    throw new CliError(`Required lifecyclemodel ${label} artifact not found: ${filePath}`, {
+      code: missingCode,
+      exitCode: 2,
+      details: { filePath, label },
+    });
+  }
+
+  const value = readJsonArtifact(filePath);
+  if (!isRecord(value)) {
+    throw new CliError(`Expected lifecyclemodel ${label} artifact JSON object: ${filePath}`, {
+      code: invalidCode,
+      exitCode: 2,
+      details: { filePath, label },
+    });
+  }
+
+  return value;
+}
+
+export type LifecyclemodelPublishBuildLayout = {
+  runId: string;
+  runRoot: string;
+  modelsDir: string;
+  reportsDir: string;
+  manifestsDir: string;
+  publishStageDir: string;
+  runManifestPath: string;
+  invocationIndexPath: string;
+  validationReportPath: string;
+  publishBundlePath: string;
+  publishRequestPath: string;
+  publishIntentPath: string;
+  reportPath: string;
+};
+
+export type LifecyclemodelPublishBuildReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: 'prepared_local_lifecyclemodel_publish_bundle';
+  run_id: string;
+  run_root: string;
+  counts: {
+    lifecyclemodels: number;
+  };
+  publish_defaults: {
+    commit: boolean;
+    publish_lifecyclemodels: boolean;
+    publish_processes: boolean;
+    publish_sources: boolean;
+    publish_relations: boolean;
+    publish_process_build_runs: boolean;
+    relation_mode: 'local_manifest_only';
+  };
+  validation: LifecyclemodelPublishValidationSummary;
+  files: {
+    run_manifest: string;
+    invocation_index: string;
+    publish_bundle: string;
+    publish_request: string;
+    publish_intent: string;
+    report: string;
+  };
+  next_actions: string[];
+};
+
+export type RunLifecyclemodelPublishBuildOptions = {
+  runDir: string;
+  now?: Date;
+  cwd?: string;
+};
+
+function buildLayout(runRoot: string): LifecyclemodelPublishBuildLayout {
+  const runId = path.basename(runRoot);
+  return {
+    runId,
+    runRoot,
+    modelsDir: path.join(runRoot, 'models'),
+    reportsDir: path.join(runRoot, 'reports'),
+    manifestsDir: path.join(runRoot, 'manifests'),
+    publishStageDir: path.join(runRoot, 'stage_outputs', '10_publish'),
+    runManifestPath: path.join(runRoot, 'manifests', 'run-manifest.json'),
+    invocationIndexPath: path.join(runRoot, 'manifests', 'invocation-index.json'),
+    validationReportPath: path.join(
+      runRoot,
+      'reports',
+      'lifecyclemodel-validate-build-report.json',
+    ),
+    publishBundlePath: path.join(runRoot, 'stage_outputs', '10_publish', 'publish-bundle.json'),
+    publishRequestPath: path.join(runRoot, 'stage_outputs', '10_publish', 'publish-request.json'),
+    publishIntentPath: path.join(runRoot, 'stage_outputs', '10_publish', 'publish-intent.json'),
+    reportPath: path.join(runRoot, 'reports', 'lifecyclemodel-publish-build-report.json'),
+  };
+}
+
+function resolveLayout(
+  options: RunLifecyclemodelPublishBuildOptions,
+): LifecyclemodelPublishBuildLayout {
+  const runDir = nonEmptyString(options.runDir);
+  if (!runDir) {
+    throw new CliError('Missing required --run-dir for lifecyclemodel publish-build.', {
+      code: 'LIFECYCLEMODEL_PUBLISH_RUN_DIR_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  return buildLayout(path.resolve(runDir));
+}
+
+function ensureRunRootExists(layout: LifecyclemodelPublishBuildLayout): void {
+  if (!existsSync(layout.runRoot)) {
+    throw new CliError(`lifecyclemodel publish-build run root not found: ${layout.runRoot}`, {
+      code: 'LIFECYCLEMODEL_PUBLISH_RUN_NOT_FOUND',
+      exitCode: 2,
+    });
+  }
+}
+
+function readRequiredRunManifest(layout: LifecyclemodelPublishBuildLayout): JsonObject {
+  const manifest = readRequiredJsonObject(
+    layout.runManifestPath,
+    'LIFECYCLEMODEL_PUBLISH_RUN_MANIFEST_MISSING',
+    'LIFECYCLEMODEL_PUBLISH_RUN_MANIFEST_INVALID',
+    'run-manifest',
+  );
+
+  const manifestRunId = nonEmptyString(manifest.runId);
+  if (manifestRunId && manifestRunId !== layout.runId) {
+    throw new CliError(
+      `lifecyclemodel publish-build run manifest runId mismatch: ${layout.runManifestPath}`,
+      {
+        code: 'LIFECYCLEMODEL_PUBLISH_RUN_MANIFEST_MISMATCH',
+        exitCode: 2,
+        details: {
+          expected: layout.runId,
+          actual: manifestRunId,
+        },
+      },
+    );
+  }
+
+  return manifest;
+}
+
+function readInvocationIndex(layout: LifecyclemodelPublishBuildLayout): JsonObject {
+  if (!existsSync(layout.invocationIndexPath)) {
+    return {
+      schema_version: 1,
+      invocations: [],
+    };
+  }
+
+  const value = readJsonArtifact(layout.invocationIndexPath);
+  if (!isRecord(value)) {
+    throw new CliError(
+      `Expected lifecyclemodel publish invocation index JSON object: ${layout.invocationIndexPath}`,
+      {
+        code: 'LIFECYCLEMODEL_PUBLISH_INVOCATION_INDEX_INVALID',
+        exitCode: 2,
+      },
+    );
+  }
+
+  if (value.invocations === undefined) {
+    return {
+      schema_version: 1,
+      invocations: [],
+    };
+  }
+
+  if (!Array.isArray(value.invocations)) {
+    throw new CliError(
+      `Expected lifecyclemodel publish invocation index to contain an invocations array: ${layout.invocationIndexPath}`,
+      {
+        code: 'LIFECYCLEMODEL_PUBLISH_INVOCATION_INDEX_INVALID',
+        exitCode: 2,
+      },
+    );
+  }
+
+  return value;
+}
+
+function collectLifecyclemodelPayloads(layout: LifecyclemodelPublishBuildLayout): JsonObject[] {
+  const runNames = existsSync(layout.modelsDir) ? readdirSync(layout.modelsDir).sort() : [];
+  const payloads = runNames.flatMap((runName) => {
+    const lifecyclemodelsDir = path.join(
+      layout.modelsDir,
+      runName,
+      'tidas_bundle',
+      'lifecyclemodels',
+    );
+    if (!existsSync(lifecyclemodelsDir)) {
+      return [];
+    }
+
+    return readdirSync(lifecyclemodelsDir)
+      .filter((entry) => entry.endsWith('.json'))
+      .sort()
+      .map((entry) => {
+        const filePath = path.join(lifecyclemodelsDir, entry);
+        const value = readJsonArtifact(filePath);
+        if (!isRecord(value)) {
+          throw new CliError(`Expected lifecyclemodel publish payload JSON object: ${filePath}`, {
+            code: 'LIFECYCLEMODEL_PUBLISH_MODEL_INVALID',
+            exitCode: 2,
+          });
+        }
+        return value;
+      });
+  });
+
+  if (payloads.length === 0) {
+    throw new CliError(
+      `lifecyclemodel publish-build run does not contain any lifecyclemodel payloads: ${layout.modelsDir}`,
+      {
+        code: 'LIFECYCLEMODEL_PUBLISH_MODELS_NOT_FOUND',
+        exitCode: 2,
+      },
+    );
+  }
+
+  return payloads;
+}
+
+function readValidationSummary(
+  layout: LifecyclemodelPublishBuildLayout,
+): LifecyclemodelPublishValidationSummary {
+  if (!existsSync(layout.validationReportPath)) {
+    return {
+      available: false,
+      ok: null,
+      report: null,
+    };
+  }
+
+  const value = readJsonArtifact(layout.validationReportPath);
+  if (!isRecord(value)) {
+    throw new CliError(
+      `Expected lifecyclemodel validate-build report JSON object: ${layout.validationReportPath}`,
+      {
+        code: 'LIFECYCLEMODEL_PUBLISH_VALIDATION_REPORT_INVALID',
+        exitCode: 2,
+      },
+    );
+  }
+
+  return {
+    available: true,
+    ok: typeof value.ok === 'boolean' ? value.ok : false,
+    report: layout.validationReportPath,
+  };
+}
+
+function buildPublishRequest(): JsonObject {
+  return {
+    inputs: {
+      bundle_paths: ['./publish-bundle.json'],
+    },
+    publish: {
+      commit: false,
+      publish_lifecyclemodels: true,
+      publish_processes: false,
+      publish_sources: false,
+      publish_relations: false,
+      publish_process_build_runs: false,
+      relation_mode: 'local_manifest_only',
+    },
+    out_dir: './publish-run',
+  };
+}
+
+function buildPublishIntent(
+  layout: LifecyclemodelPublishBuildLayout,
+  lifecyclemodelCount: number,
+): JsonObject {
+  return {
+    ok: true,
+    command: 'publish run',
+    input_path: layout.publishRequestPath,
+    run_id: layout.runId,
+    run_root: layout.runRoot,
+    status: 'prepared_local_lifecyclemodel_publish_bundle',
+    lifecyclemodel_count: lifecyclemodelCount,
+  };
+}
+
+function buildInvocationIndex(
+  layout: LifecyclemodelPublishBuildLayout,
+  invocationIndex: JsonObject,
+  options: RunLifecyclemodelPublishBuildOptions,
+  now: Date,
+): JsonObject {
+  const priorInvocations = Array.isArray(invocationIndex.invocations)
+    ? [...invocationIndex.invocations]
+    : [];
+
+  return {
+    ...invocationIndex,
+    schema_version:
+      typeof invocationIndex.schema_version === 'number' ? invocationIndex.schema_version : 1,
+    invocations: [
+      ...priorInvocations,
+      {
+        command: ['lifecyclemodel', 'publish-build', '--run-dir', options.runDir],
+        cwd: options.cwd ?? process.cwd(),
+        created_at: now.toISOString(),
+        run_id: layout.runId,
+        run_root: layout.runRoot,
+        report_path: layout.reportPath,
+        publish_request_path: layout.publishRequestPath,
+      },
+    ],
+  };
+}
+
+function buildNextActions(layout: LifecyclemodelPublishBuildLayout): string[] {
+  return [
+    `inspect: ${layout.publishBundlePath}`,
+    `inspect: ${layout.publishRequestPath}`,
+    `run: tiangong publish run --input ${layout.publishRequestPath}`,
+  ];
+}
+
+export async function runLifecyclemodelPublishBuild(
+  options: RunLifecyclemodelPublishBuildOptions,
+): Promise<LifecyclemodelPublishBuildReport> {
+  const now = options.now ?? new Date();
+  const layout = resolveLayout(options);
+  ensureRunRootExists(layout);
+  const runManifest = readRequiredRunManifest(layout);
+  const invocationIndex = readInvocationIndex(layout);
+  const lifecyclemodels = collectLifecyclemodelPayloads(layout);
+  const validation = readValidationSummary(layout);
+  const publishRequest = buildPublishRequest();
+  const normalizedPublishRequest = normalizePublishRequest(publishRequest, {
+    requestPath: layout.publishRequestPath,
+    now,
+  });
+  const publishBundle = {
+    generated_at_utc: now.toISOString(),
+    run_id: layout.runId,
+    run_root: layout.runRoot,
+    status: 'prepared_local_lifecyclemodel_publish_bundle' as const,
+    source_run: {
+      run_manifest: copyJson(runManifest),
+    },
+    validation: copyJson(validation),
+    lifecyclemodels: copyJson(lifecyclemodels),
+    relations: [],
+  };
+  const publishIntent = buildPublishIntent(layout, lifecyclemodels.length);
+  const report: LifecyclemodelPublishBuildReport = {
+    schema_version: 1,
+    generated_at_utc: now.toISOString(),
+    status: 'prepared_local_lifecyclemodel_publish_bundle',
+    run_id: layout.runId,
+    run_root: layout.runRoot,
+    counts: {
+      lifecyclemodels: lifecyclemodels.length,
+    },
+    publish_defaults: {
+      commit: normalizedPublishRequest.publish.commit,
+      publish_lifecyclemodels: normalizedPublishRequest.publish.publish_lifecyclemodels,
+      publish_processes: normalizedPublishRequest.publish.publish_processes,
+      publish_sources: normalizedPublishRequest.publish.publish_sources,
+      publish_relations: normalizedPublishRequest.publish.publish_relations,
+      publish_process_build_runs: normalizedPublishRequest.publish.publish_process_build_runs,
+      relation_mode: normalizedPublishRequest.publish.relation_mode,
+    },
+    validation,
+    files: {
+      run_manifest: layout.runManifestPath,
+      invocation_index: layout.invocationIndexPath,
+      publish_bundle: layout.publishBundlePath,
+      publish_request: layout.publishRequestPath,
+      publish_intent: layout.publishIntentPath,
+      report: layout.reportPath,
+    },
+    next_actions: buildNextActions(layout),
+  };
+
+  writeJsonArtifact(
+    layout.invocationIndexPath,
+    buildInvocationIndex(layout, invocationIndex, options, now),
+  );
+  writeJsonArtifact(layout.publishBundlePath, publishBundle);
+  writeJsonArtifact(layout.publishRequestPath, publishRequest);
+  writeJsonArtifact(layout.publishIntentPath, publishIntent);
+  writeJsonArtifact(layout.reportPath, report);
+
+  return report;
+}
+
+export const __testInternals = {
+  buildLayout,
+  resolveLayout,
+  readInvocationIndex,
+  collectLifecyclemodelPayloads,
+  readValidationSummary,
+  buildPublishRequest,
+  buildPublishIntent,
+  buildInvocationIndex,
+  buildNextActions,
+};

--- a/src/lib/lifecyclemodel-validate-build.ts
+++ b/src/lib/lifecyclemodel-validate-build.ts
@@ -1,0 +1,383 @@
+import { existsSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { readJsonArtifact, writeJsonArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+import {
+  runValidation,
+  type RunValidationOptions,
+  type ValidationRunReport,
+} from './validation.js';
+
+type JsonObject = Record<string, unknown>;
+
+type ModelBundleEntry = {
+  runName: string;
+  inputDir: string;
+  modelFiles: string[];
+};
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized || null;
+}
+
+function readRequiredJsonObject(
+  filePath: string,
+  missingCode: string,
+  invalidCode: string,
+  label: string,
+): JsonObject {
+  if (!existsSync(filePath)) {
+    throw new CliError(`Required lifecyclemodel ${label} artifact not found: ${filePath}`, {
+      code: missingCode,
+      exitCode: 2,
+      details: { filePath, label },
+    });
+  }
+
+  const value = readJsonArtifact(filePath);
+  if (!isRecord(value)) {
+    throw new CliError(`Expected lifecyclemodel ${label} artifact JSON object: ${filePath}`, {
+      code: invalidCode,
+      exitCode: 2,
+      details: { filePath, label },
+    });
+  }
+
+  return value;
+}
+
+export type LifecyclemodelValidateBuildLayout = {
+  runId: string;
+  runRoot: string;
+  modelsDir: string;
+  reportsDir: string;
+  modelReportsDir: string;
+  manifestsDir: string;
+  runManifestPath: string;
+  invocationIndexPath: string;
+  autoBuildReportPath: string;
+  reportPath: string;
+};
+
+export type LifecyclemodelValidateBuildModelReport = {
+  run_name: string;
+  input_dir: string;
+  model_files: string[];
+  report_file: string;
+  validation: ValidationRunReport;
+};
+
+export type LifecyclemodelValidateBuildReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: 'completed_lifecyclemodel_validate_build';
+  run_id: string;
+  run_root: string;
+  ok: boolean;
+  engine: string;
+  counts: {
+    models: number;
+    ok: number;
+    failed: number;
+  };
+  files: {
+    run_manifest: string;
+    invocation_index: string;
+    auto_build_report: string | null;
+    report: string;
+    model_reports_dir: string;
+  };
+  model_reports: LifecyclemodelValidateBuildModelReport[];
+  next_actions: string[];
+};
+
+export type RunLifecyclemodelValidateBuildOptions = {
+  runDir: string;
+  engine?: string;
+  now?: Date;
+  cwd?: string;
+};
+
+export type LifecyclemodelValidateBuildDeps = {
+  runValidationImpl?: (options: RunValidationOptions) => Promise<ValidationRunReport>;
+};
+
+function buildLayout(runRoot: string): LifecyclemodelValidateBuildLayout {
+  const runId = path.basename(runRoot);
+  return {
+    runId,
+    runRoot,
+    modelsDir: path.join(runRoot, 'models'),
+    reportsDir: path.join(runRoot, 'reports'),
+    modelReportsDir: path.join(runRoot, 'reports', 'model-validations'),
+    manifestsDir: path.join(runRoot, 'manifests'),
+    runManifestPath: path.join(runRoot, 'manifests', 'run-manifest.json'),
+    invocationIndexPath: path.join(runRoot, 'manifests', 'invocation-index.json'),
+    autoBuildReportPath: path.join(runRoot, 'reports', 'lifecyclemodel-auto-build-report.json'),
+    reportPath: path.join(runRoot, 'reports', 'lifecyclemodel-validate-build-report.json'),
+  };
+}
+
+function resolveLayout(
+  options: RunLifecyclemodelValidateBuildOptions,
+): LifecyclemodelValidateBuildLayout {
+  const runDir = nonEmptyString(options.runDir);
+  if (!runDir) {
+    throw new CliError('Missing required --run-dir for lifecyclemodel validate-build.', {
+      code: 'LIFECYCLEMODEL_VALIDATE_RUN_DIR_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  return buildLayout(path.resolve(runDir));
+}
+
+function ensureRunRootExists(layout: LifecyclemodelValidateBuildLayout): void {
+  if (!existsSync(layout.runRoot)) {
+    throw new CliError(`lifecyclemodel validate-build run root not found: ${layout.runRoot}`, {
+      code: 'LIFECYCLEMODEL_VALIDATE_RUN_NOT_FOUND',
+      exitCode: 2,
+    });
+  }
+}
+
+function readRequiredRunManifest(layout: LifecyclemodelValidateBuildLayout): JsonObject {
+  const manifest = readRequiredJsonObject(
+    layout.runManifestPath,
+    'LIFECYCLEMODEL_VALIDATE_RUN_MANIFEST_MISSING',
+    'LIFECYCLEMODEL_VALIDATE_RUN_MANIFEST_INVALID',
+    'run-manifest',
+  );
+
+  const manifestRunId = nonEmptyString(manifest.runId);
+  if (manifestRunId && manifestRunId !== layout.runId) {
+    throw new CliError(
+      `lifecyclemodel validate-build run manifest runId mismatch: ${layout.runManifestPath}`,
+      {
+        code: 'LIFECYCLEMODEL_VALIDATE_RUN_MANIFEST_MISMATCH',
+        exitCode: 2,
+        details: {
+          expected: layout.runId,
+          actual: manifestRunId,
+        },
+      },
+    );
+  }
+
+  return manifest;
+}
+
+function readInvocationIndex(layout: LifecyclemodelValidateBuildLayout): JsonObject {
+  if (!existsSync(layout.invocationIndexPath)) {
+    return {
+      schema_version: 1,
+      invocations: [],
+    };
+  }
+
+  const value = readJsonArtifact(layout.invocationIndexPath);
+  if (!isRecord(value)) {
+    throw new CliError(
+      `Expected lifecyclemodel validate invocation index JSON object: ${layout.invocationIndexPath}`,
+      {
+        code: 'LIFECYCLEMODEL_VALIDATE_INVOCATION_INDEX_INVALID',
+        exitCode: 2,
+      },
+    );
+  }
+
+  if (value.invocations === undefined) {
+    return {
+      schema_version: 1,
+      invocations: [],
+    };
+  }
+
+  if (!Array.isArray(value.invocations)) {
+    throw new CliError(
+      `Expected lifecyclemodel validate invocation index to contain an invocations array: ${layout.invocationIndexPath}`,
+      {
+        code: 'LIFECYCLEMODEL_VALIDATE_INVOCATION_INDEX_INVALID',
+        exitCode: 2,
+      },
+    );
+  }
+
+  return value;
+}
+
+function discoverModelEntries(layout: LifecyclemodelValidateBuildLayout): ModelBundleEntry[] {
+  const runNames = existsSync(layout.modelsDir) ? readdirSync(layout.modelsDir).sort() : [];
+  const entries = runNames.flatMap((runName) => {
+    const inputDir = path.join(layout.modelsDir, runName, 'tidas_bundle');
+    const lifecyclemodelsDir = path.join(inputDir, 'lifecyclemodels');
+    if (!existsSync(lifecyclemodelsDir)) {
+      return [];
+    }
+
+    const modelFiles = readdirSync(lifecyclemodelsDir)
+      .filter((entry) => entry.endsWith('.json'))
+      .sort()
+      .map((entry) => path.join(lifecyclemodelsDir, entry));
+
+    if (modelFiles.length === 0) {
+      throw new CliError(
+        `lifecyclemodel validate-build found a bundle without lifecyclemodel JSON files: ${lifecyclemodelsDir}`,
+        {
+          code: 'LIFECYCLEMODEL_VALIDATE_MODELS_EMPTY',
+          exitCode: 2,
+        },
+      );
+    }
+
+    return [{ runName, inputDir, modelFiles }];
+  });
+
+  if (entries.length === 0) {
+    throw new CliError(
+      `lifecyclemodel validate-build run does not contain any model bundles: ${layout.modelsDir}`,
+      {
+        code: 'LIFECYCLEMODEL_VALIDATE_MODELS_NOT_FOUND',
+        exitCode: 2,
+      },
+    );
+  }
+
+  return entries;
+}
+
+function buildInvocationIndex(
+  layout: LifecyclemodelValidateBuildLayout,
+  invocationIndex: JsonObject,
+  options: RunLifecyclemodelValidateBuildOptions,
+  now: Date,
+): JsonObject {
+  const priorInvocations = Array.isArray(invocationIndex.invocations)
+    ? [...invocationIndex.invocations]
+    : [];
+  const command = ['lifecyclemodel', 'validate-build', '--run-dir', options.runDir];
+  if (options.engine) {
+    command.push('--engine', options.engine);
+  }
+
+  return {
+    ...invocationIndex,
+    schema_version:
+      typeof invocationIndex.schema_version === 'number' ? invocationIndex.schema_version : 1,
+    invocations: [
+      ...priorInvocations,
+      {
+        command,
+        cwd: options.cwd ?? process.cwd(),
+        created_at: now.toISOString(),
+        run_id: layout.runId,
+        run_root: layout.runRoot,
+        report_path: layout.reportPath,
+        model_reports_dir: layout.modelReportsDir,
+      },
+    ],
+  };
+}
+
+function buildNextActions(layout: LifecyclemodelValidateBuildLayout): string[] {
+  return [
+    `inspect: ${layout.reportPath}`,
+    `inspect: ${layout.modelReportsDir}`,
+    `run: tiangong lifecyclemodel publish-build --run-dir ${layout.runRoot}`,
+  ];
+}
+
+function resolveValidationImpl(
+  deps: LifecyclemodelValidateBuildDeps,
+): (options: RunValidationOptions) => Promise<ValidationRunReport> {
+  return deps.runValidationImpl ?? runValidation;
+}
+
+function resolveReportEngine(
+  modelReports: LifecyclemodelValidateBuildModelReport[],
+  requestedEngine?: string,
+): string {
+  return modelReports[0]?.validation.mode ?? requestedEngine ?? 'auto';
+}
+
+export async function runLifecyclemodelValidateBuild(
+  options: RunLifecyclemodelValidateBuildOptions,
+  deps: LifecyclemodelValidateBuildDeps = {},
+): Promise<LifecyclemodelValidateBuildReport> {
+  const now = options.now ?? new Date();
+  const layout = resolveLayout(options);
+  ensureRunRootExists(layout);
+  readRequiredRunManifest(layout);
+  const invocationIndex = readInvocationIndex(layout);
+  const validationImpl = resolveValidationImpl(deps);
+  const modelEntries = discoverModelEntries(layout);
+
+  const modelReports: LifecyclemodelValidateBuildModelReport[] = [];
+  for (const entry of modelEntries) {
+    const reportFile = path.join(layout.modelReportsDir, `${entry.runName}.json`);
+    const validation = await validationImpl({
+      inputDir: entry.inputDir,
+      engine: options.engine,
+      reportFile,
+    });
+    modelReports.push({
+      run_name: entry.runName,
+      input_dir: entry.inputDir,
+      model_files: entry.modelFiles,
+      report_file: reportFile,
+      validation,
+    });
+  }
+
+  const okCount = modelReports.filter((entry) => entry.validation.ok).length;
+  const report: LifecyclemodelValidateBuildReport = {
+    schema_version: 1,
+    generated_at_utc: now.toISOString(),
+    status: 'completed_lifecyclemodel_validate_build',
+    run_id: layout.runId,
+    run_root: layout.runRoot,
+    ok: okCount === modelReports.length,
+    engine: resolveReportEngine(modelReports, options.engine),
+    counts: {
+      models: modelReports.length,
+      ok: okCount,
+      failed: modelReports.length - okCount,
+    },
+    files: {
+      run_manifest: layout.runManifestPath,
+      invocation_index: layout.invocationIndexPath,
+      auto_build_report: existsSync(layout.autoBuildReportPath) ? layout.autoBuildReportPath : null,
+      report: layout.reportPath,
+      model_reports_dir: layout.modelReportsDir,
+    },
+    model_reports: modelReports,
+    next_actions: buildNextActions(layout),
+  };
+
+  writeJsonArtifact(
+    layout.invocationIndexPath,
+    buildInvocationIndex(layout, invocationIndex, options, now),
+  );
+  writeJsonArtifact(layout.reportPath, report);
+  return report;
+}
+
+export const __testInternals = {
+  buildLayout,
+  resolveLayout,
+  readInvocationIndex,
+  discoverModelEntries,
+  buildInvocationIndex,
+  buildNextActions,
+  resolveValidationImpl,
+  resolveReportEngine,
+};

--- a/src/lib/publish.ts
+++ b/src/lib/publish.ts
@@ -1,8 +1,15 @@
 import path from 'node:path';
 import { CliError } from './errors.js';
 import { writeJsonArtifact } from './artifacts.js';
+import type { FetchLike } from './http.js';
 import { readJsonInput } from './io.js';
 import { buildRunId, resolveRunLayout } from './run.js';
+import {
+  hasSupabaseRestRuntime,
+  syncSupabaseJsonOrderedRecord,
+  type SupabaseJsonOrderedTable,
+  type SupabaseJsonOrderedWriteMode,
+} from './supabase-json-ordered-write.js';
 
 type JsonObject = Record<string, unknown>;
 
@@ -271,6 +278,9 @@ export type RunPublishOptions = {
   outDir?: string | null;
   commit?: boolean | null;
   executors?: PublishExecutors;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: FetchLike;
+  timeoutMs?: number;
   now?: Date;
 };
 
@@ -297,8 +307,26 @@ type PublishRequestOptions = {
 };
 
 function extract_lifecyclemodel_identity(payload: JsonObject): [string, string] {
-  const datasetId = first_non_empty(payload['@id'], payload.id);
-  const version = first_non_empty(payload['@version'], payload.version, DEFAULT_DATASET_VERSION)!;
+  const root = isRecord(payload.lifeCycleModelDataSet) ? payload.lifeCycleModelDataSet : payload;
+  const lifeCycleModelInformation = isRecord(root.lifeCycleModelInformation)
+    ? root.lifeCycleModelInformation
+    : {};
+  const dataSetInformation = isRecord(lifeCycleModelInformation.dataSetInformation)
+    ? lifeCycleModelInformation.dataSetInformation
+    : {};
+  const administrativeInformation = isRecord(root.administrativeInformation)
+    ? root.administrativeInformation
+    : {};
+  const publicationAndOwnership = isRecord(administrativeInformation.publicationAndOwnership)
+    ? administrativeInformation.publicationAndOwnership
+    : {};
+  const datasetId = first_non_empty(payload['@id'], payload.id, dataSetInformation['common:UUID']);
+  const version = first_non_empty(
+    payload['@version'],
+    payload.version,
+    publicationAndOwnership['common:dataSetVersion'],
+    DEFAULT_DATASET_VERSION,
+  )!;
   if (!datasetId) {
     throw new CliError('Lifecycle model payload missing @id/id.', {
       code: 'PUBLISH_LIFECYCLEMODEL_ID_MISSING',
@@ -747,6 +775,67 @@ function build_relation_manifest(
   };
 }
 
+function table_write_mode_for_publish(): SupabaseJsonOrderedWriteMode {
+  return 'upsert_current_version';
+}
+
+function build_default_dataset_executor(options: {
+  table: SupabaseJsonOrderedTable;
+  env: NodeJS.ProcessEnv;
+  fetchImpl: FetchLike;
+  timeoutMs?: number;
+}) {
+  return async (args: DatasetPublishExecutorArgs): Promise<unknown> =>
+    syncSupabaseJsonOrderedRecord({
+      table: options.table,
+      id: args.id,
+      version: args.version,
+      payload: args.payload,
+      writeMode: table_write_mode_for_publish(),
+      env: options.env,
+      fetchImpl: options.fetchImpl,
+      timeoutMs: options.timeoutMs,
+    });
+}
+
+function resolve_dataset_executors(options: RunPublishOptions): PublishExecutors {
+  const explicit = options.executors ?? {};
+  const env = options.env;
+  const fetchImpl = options.fetchImpl;
+
+  if (!env || !fetchImpl || !hasSupabaseRestRuntime(env)) {
+    return explicit;
+  }
+
+  return {
+    lifecyclemodels:
+      explicit.lifecyclemodels ??
+      build_default_dataset_executor({
+        table: 'lifecyclemodels',
+        env,
+        fetchImpl,
+        timeoutMs: options.timeoutMs,
+      }),
+    processes:
+      explicit.processes ??
+      build_default_dataset_executor({
+        table: 'processes',
+        env,
+        fetchImpl,
+        timeoutMs: options.timeoutMs,
+      }),
+    sources:
+      explicit.sources ??
+      build_default_dataset_executor({
+        table: 'sources',
+        env,
+        fetchImpl,
+        timeoutMs: options.timeoutMs,
+      }),
+    process_build_runs: explicit.process_build_runs,
+  };
+}
+
 export async function runPublish(options: RunPublishOptions): Promise<PublishReport> {
   const requestPath = path.resolve(options.inputPath);
   const requestDir = path.dirname(requestPath);
@@ -760,6 +849,7 @@ export async function runPublish(options: RunPublishOptions): Promise<PublishRep
   const collected = collectPublishInputs(normalized, requestDir);
   const now = options.now ?? new Date();
   const outDir = normalized.out_dir;
+  const executors = resolve_dataset_executors(options);
 
   const files = {
     normalized_request: path.join(outDir, 'normalized-request.json'),
@@ -774,28 +864,28 @@ export async function runPublish(options: RunPublishOptions): Promise<PublishRep
   const lifecyclemodels = normalized.publish.publish_lifecyclemodels
     ? await publish_lifecyclemodels(collected.lifecyclemodels, {
         commit: normalized.publish.commit,
-        executor: options.executors?.lifecyclemodels,
+        executor: executors.lifecyclemodels,
         publish: normalized.publish,
       })
     : [];
   const processes = normalized.publish.publish_processes
     ? await publish_processes(collected.processes, {
         commit: normalized.publish.commit,
-        executor: options.executors?.processes,
+        executor: executors.processes,
         publish: normalized.publish,
       })
     : [];
   const sources = normalized.publish.publish_sources
     ? await publish_sources(collected.sources, {
         commit: normalized.publish.commit,
-        executor: options.executors?.sources,
+        executor: executors.sources,
         publish: normalized.publish,
       })
     : [];
   const processBuildRuns = normalized.publish.publish_process_build_runs
     ? await publish_process_build_runs(collected.process_build_runs, {
         commit: normalized.publish.commit,
-        executor: options.executors?.process_build_runs,
+        executor: executors.process_build_runs,
         publish: normalized.publish,
       })
     : [];

--- a/src/lib/supabase-json-ordered-write.ts
+++ b/src/lib/supabase-json-ordered-write.ts
@@ -1,0 +1,358 @@
+import { CliError } from './errors.js';
+import type { FetchLike, ResponseLike } from './http.js';
+import { deriveSupabaseRestBaseUrl, requireSupabaseRestRuntime } from './supabase-rest.js';
+
+type JsonObject = Record<string, unknown>;
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export type SupabaseJsonOrderedTable = 'lifecyclemodels' | 'processes' | 'sources';
+export type SupabaseJsonOrderedWriteMode = 'upsert_current_version' | 'append_only_insert';
+export type SupabaseJsonOrderedWriteOperation =
+  | 'insert'
+  | 'update_existing'
+  | 'update_after_insert_error'
+  | 'skipped_existing';
+
+export type SupabaseJsonOrderedWriteResult = {
+  status: 'success';
+  operation: SupabaseJsonOrderedWriteOperation;
+};
+
+type VisibleRow = {
+  id: string;
+  version: string;
+  state_code: number | null;
+};
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function trimToken(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function buildHeaders(apiKey: string): Record<string, string> {
+  return {
+    Accept: 'application/json',
+    Authorization: `Bearer ${apiKey}`,
+    apikey: apiKey,
+  };
+}
+
+function buildSelectUrl(
+  restBaseUrl: string,
+  table: SupabaseJsonOrderedTable,
+  id: string,
+  version: string,
+): string {
+  const url = new URL(`${restBaseUrl.replace(/\/+$/u, '')}/${table}`);
+  url.searchParams.set('select', 'id,version,state_code');
+  url.searchParams.set('id', `eq.${id}`);
+  url.searchParams.set('version', `eq.${version}`);
+  return url.toString();
+}
+
+function buildUpdateUrl(
+  restBaseUrl: string,
+  table: SupabaseJsonOrderedTable,
+  id: string,
+  version: string,
+): string {
+  const url = new URL(`${restBaseUrl.replace(/\/+$/u, '')}/${table}`);
+  url.searchParams.set('id', `eq.${id}`);
+  url.searchParams.set('version', `eq.${version}`);
+  return url.toString();
+}
+
+async function parseResponse(response: ResponseLike, url: string): Promise<unknown> {
+  const rawText = await response.text();
+  const contentType = response.headers.get('content-type') ?? '';
+
+  if (!response.ok) {
+    throw new CliError(`HTTP ${response.status} returned from ${url}`, {
+      code: 'REMOTE_REQUEST_FAILED',
+      exitCode: 1,
+      details: rawText,
+    });
+  }
+
+  if (!rawText) {
+    return null;
+  }
+
+  if (contentType.includes('application/json')) {
+    try {
+      return JSON.parse(rawText);
+    } catch (error) {
+      throw new CliError(`Remote response was not valid JSON for ${url}`, {
+        code: 'REMOTE_INVALID_JSON',
+        exitCode: 1,
+        details: String(error),
+      });
+    }
+  }
+
+  return rawText;
+}
+
+async function requestJson(options: {
+  method: 'GET' | 'POST' | 'PATCH';
+  url: string;
+  headers: Record<string, string>;
+  body?: unknown;
+  timeoutMs: number;
+  fetchImpl: FetchLike;
+}): Promise<unknown> {
+  const response = await options.fetchImpl(options.url, {
+    method: options.method,
+    headers: options.headers,
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+    signal: AbortSignal.timeout(options.timeoutMs),
+  });
+  return parseResponse(response, options.url);
+}
+
+function parseVisibleRows(payload: unknown, url: string): VisibleRow[] {
+  if (!Array.isArray(payload)) {
+    throw new CliError(`Supabase REST response was not a JSON array for ${url}`, {
+      code: 'SUPABASE_REST_RESPONSE_INVALID',
+      exitCode: 1,
+      details: payload,
+    });
+  }
+
+  return payload.map((item, index) => {
+    if (!isRecord(item)) {
+      throw new CliError(`Supabase REST row ${index} was not a JSON object for ${url}`, {
+        code: 'SUPABASE_REST_RESPONSE_INVALID',
+        exitCode: 1,
+        details: item,
+      });
+    }
+
+    return {
+      id: trimToken(item.id),
+      version: trimToken(item.version),
+      state_code: typeof item.state_code === 'number' ? item.state_code : null,
+    };
+  });
+}
+
+async function exactVisibleRows(options: {
+  restBaseUrl: string;
+  table: SupabaseJsonOrderedTable;
+  apiKey: string;
+  id: string;
+  version: string;
+  timeoutMs: number;
+  fetchImpl: FetchLike;
+}): Promise<VisibleRow[]> {
+  const url = buildSelectUrl(options.restBaseUrl, options.table, options.id, options.version);
+  const payload = await requestJson({
+    method: 'GET',
+    url,
+    headers: buildHeaders(options.apiKey),
+    timeoutMs: options.timeoutMs,
+    fetchImpl: options.fetchImpl,
+  });
+  return parseVisibleRows(payload, url);
+}
+
+async function insertJsonOrderedRow(options: {
+  restBaseUrl: string;
+  table: SupabaseJsonOrderedTable;
+  apiKey: string;
+  id: string;
+  payload: JsonObject;
+  timeoutMs: number;
+  fetchImpl: FetchLike;
+  extraData?: JsonObject;
+}): Promise<void> {
+  await requestJson({
+    method: 'POST',
+    url: `${options.restBaseUrl.replace(/\/+$/u, '')}/${options.table}`,
+    headers: {
+      ...buildHeaders(options.apiKey),
+      'Content-Type': 'application/json',
+      Prefer: 'return=representation',
+    },
+    body: {
+      id: options.id,
+      json_ordered: options.payload,
+      ...(options.extraData ?? {}),
+    },
+    timeoutMs: options.timeoutMs,
+    fetchImpl: options.fetchImpl,
+  });
+}
+
+async function updateJsonOrderedRow(options: {
+  restBaseUrl: string;
+  table: SupabaseJsonOrderedTable;
+  apiKey: string;
+  id: string;
+  version: string;
+  payload: JsonObject;
+  timeoutMs: number;
+  fetchImpl: FetchLike;
+  extraData?: JsonObject;
+}): Promise<void> {
+  await requestJson({
+    method: 'PATCH',
+    url: buildUpdateUrl(options.restBaseUrl, options.table, options.id, options.version),
+    headers: {
+      ...buildHeaders(options.apiKey),
+      'Content-Type': 'application/json',
+      Prefer: 'return=representation',
+    },
+    body: {
+      json_ordered: options.payload,
+      ...(options.extraData ?? {}),
+    },
+    timeoutMs: options.timeoutMs,
+    fetchImpl: options.fetchImpl,
+  });
+}
+
+function requireNonEmptyToken(value: string, label: string, code: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new CliError(`Missing required ${label}.`, {
+      code,
+      exitCode: 2,
+    });
+  }
+  return normalized;
+}
+
+export function hasSupabaseRestRuntime(env: NodeJS.ProcessEnv | undefined): boolean {
+  if (!env) {
+    return false;
+  }
+
+  return Boolean(trimToken(env.TIANGONG_LCA_API_BASE_URL) && trimToken(env.TIANGONG_LCA_API_KEY));
+}
+
+export async function syncSupabaseJsonOrderedRecord(options: {
+  table: SupabaseJsonOrderedTable;
+  id: string;
+  version: string;
+  payload: JsonObject;
+  writeMode: SupabaseJsonOrderedWriteMode;
+  env: NodeJS.ProcessEnv;
+  fetchImpl: FetchLike;
+  timeoutMs?: number;
+  extraData?: JsonObject;
+}): Promise<SupabaseJsonOrderedWriteResult> {
+  const id = requireNonEmptyToken(options.id, 'dataset id', 'SUPABASE_JSON_ORDERED_ID_REQUIRED');
+  const version = requireNonEmptyToken(
+    options.version,
+    'dataset version',
+    'SUPABASE_JSON_ORDERED_VERSION_REQUIRED',
+  );
+  const runtime = requireSupabaseRestRuntime(options.env);
+  const restBaseUrl = deriveSupabaseRestBaseUrl(runtime.apiBaseUrl);
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const visibleBefore = await exactVisibleRows({
+    restBaseUrl,
+    table: options.table,
+    apiKey: runtime.apiKey,
+    id,
+    version,
+    timeoutMs,
+    fetchImpl: options.fetchImpl,
+  });
+
+  if (options.writeMode === 'append_only_insert' && visibleBefore.length > 0) {
+    return {
+      status: 'success',
+      operation: 'skipped_existing',
+    };
+  }
+
+  if (visibleBefore.length > 0) {
+    await updateJsonOrderedRow({
+      restBaseUrl,
+      table: options.table,
+      apiKey: runtime.apiKey,
+      id,
+      version,
+      payload: options.payload,
+      timeoutMs,
+      fetchImpl: options.fetchImpl,
+      extraData: options.extraData,
+    });
+    return {
+      status: 'success',
+      operation: 'update_existing',
+    };
+  }
+
+  try {
+    await insertJsonOrderedRow({
+      restBaseUrl,
+      table: options.table,
+      apiKey: runtime.apiKey,
+      id,
+      payload: options.payload,
+      timeoutMs,
+      fetchImpl: options.fetchImpl,
+      extraData: options.extraData,
+    });
+    return {
+      status: 'success',
+      operation: 'insert',
+    };
+  } catch (error) {
+    const visibleAfter = await exactVisibleRows({
+      restBaseUrl,
+      table: options.table,
+      apiKey: runtime.apiKey,
+      id,
+      version,
+      timeoutMs,
+      fetchImpl: options.fetchImpl,
+    });
+
+    if (visibleAfter.length === 0) {
+      throw error;
+    }
+
+    if (options.writeMode === 'append_only_insert') {
+      return {
+        status: 'success',
+        operation: 'skipped_existing',
+      };
+    }
+
+    await updateJsonOrderedRow({
+      restBaseUrl,
+      table: options.table,
+      apiKey: runtime.apiKey,
+      id,
+      version,
+      payload: options.payload,
+      timeoutMs,
+      fetchImpl: options.fetchImpl,
+      extraData: options.extraData,
+    });
+    return {
+      status: 'success',
+      operation: 'update_after_insert_error',
+    };
+  }
+}
+
+export const __testInternals = {
+  buildHeaders,
+  buildSelectUrl,
+  buildUpdateUrl,
+  parseVisibleRows,
+  exactVisibleRows,
+  insertJsonOrderedRow,
+  updateJsonOrderedRow,
+  requireNonEmptyToken,
+};

--- a/test/cli-flow-build-alias-map.test.ts
+++ b/test/cli-flow-build-alias-map.test.ts
@@ -1,0 +1,131 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { executeCli } from '../src/cli.js';
+import type { DotEnvLoadResult } from '../src/lib/dotenv.js';
+import type { FetchLike } from '../src/lib/http.js';
+import type { RunFlowBuildAliasMapOptions } from '../src/lib/flow-build-alias-map.js';
+
+const dotEnvStatus: DotEnvLoadResult = {
+  loaded: false,
+  path: '/tmp/.env',
+  count: 0,
+};
+
+const makeDeps = () => ({
+  env: {
+    TIANGONG_LCA_API_BASE_URL: 'https://example.com/functions/v1',
+    TIANGONG_LCA_API_KEY: 'secret-token',
+    TIANGONG_LCA_REGION: 'us-east-1',
+  } as NodeJS.ProcessEnv,
+  dotEnvStatus,
+  fetchImpl: (async () => ({
+    ok: true,
+    status: 200,
+    headers: {
+      get: () => 'application/json',
+    },
+    text: async () => JSON.stringify({ ok: true }),
+  })) as FetchLike,
+});
+
+test('executeCli returns help for flow build-alias-map', async () => {
+  const flowHelp = await executeCli(['flow', '--help'], makeDeps());
+  assert.equal(flowHelp.exitCode, 0);
+  assert.match(flowHelp.stdout, /build-alias-map/u);
+
+  const buildAliasHelp = await executeCli(['flow', 'build-alias-map', '--help'], makeDeps());
+  assert.equal(buildAliasHelp.exitCode, 0);
+  assert.match(
+    buildAliasHelp.stdout,
+    /tiangong flow build-alias-map --old-flow-file <file> --new-flow-file <file> --out-dir <dir>/u,
+  );
+  assert.match(buildAliasHelp.stdout, /--seed-alias-map/u);
+});
+
+test('executeCli dispatches flow build-alias-map to the implemented CLI module', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-build-alias-map-dispatch-'));
+  const oldFlowFileA = path.join(dir, 'old-a.jsonl');
+  const oldFlowFileB = path.join(dir, 'old-b.json');
+  const newFlowFile = path.join(dir, 'new.jsonl');
+  const seedAliasMapFile = path.join(dir, 'seed-alias-map.json');
+
+  writeFileSync(oldFlowFileA, '[]\n', 'utf8');
+  writeFileSync(oldFlowFileB, '[]\n', 'utf8');
+  writeFileSync(newFlowFile, '[]\n', 'utf8');
+  writeFileSync(seedAliasMapFile, '{}\n', 'utf8');
+
+  try {
+    let observedOptions: RunFlowBuildAliasMapOptions | undefined;
+    const result = await executeCli(
+      [
+        'flow',
+        'build-alias-map',
+        '--old-flow-file',
+        oldFlowFileA,
+        '--old-flow-file',
+        oldFlowFileB,
+        '--new-flow-file',
+        newFlowFile,
+        '--seed-alias-map',
+        seedAliasMapFile,
+        '--out-dir',
+        path.join(dir, 'alias-map'),
+        '--json',
+      ],
+      {
+        ...makeDeps(),
+        runFlowBuildAliasMapImpl: async (options) => {
+          observedOptions = options;
+          return {
+            schema_version: 1,
+            generated_at_utc: '2026-03-30T23:15:00.000Z',
+            status: 'completed_local_flow_build_alias_map',
+            old_flow_files: [oldFlowFileA, oldFlowFileB],
+            new_flow_files: [newFlowFile],
+            seed_alias_map_file: seedAliasMapFile,
+            out_dir: path.join(dir, 'alias-map'),
+            summary: {
+              old_flow_count: 2,
+              new_flow_count: 1,
+              alias_entries_versioned: 1,
+              alias_entries_uuid_only: 0,
+              manual_review_count: 0,
+              decision_counts: {
+                alias_map_entry: 1,
+              },
+            },
+            files: {
+              out_dir: path.join(dir, 'alias-map'),
+              alias_plan: path.join(dir, 'alias-map', 'alias-plan.json'),
+              alias_plan_jsonl: path.join(dir, 'alias-map', 'alias-plan.jsonl'),
+              flow_alias_map: path.join(dir, 'alias-map', 'flow-alias-map.json'),
+              manual_review_queue: path.join(dir, 'alias-map', 'manual-review-queue.jsonl'),
+              summary: path.join(dir, 'alias-map', 'alias-summary.json'),
+            },
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(JSON.parse(result.stdout).status, 'completed_local_flow_build_alias_map');
+    assert.deepEqual(observedOptions, {
+      oldFlowFiles: [oldFlowFileA, oldFlowFileB],
+      newFlowFiles: [newFlowFile],
+      seedAliasMapFile,
+      outDir: path.join(dir, 'alias-map'),
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli returns parsing errors for invalid flow build-alias-map flags', async () => {
+  const invalidArgsResult = await executeCli(['flow', 'build-alias-map', '--bad-flag'], makeDeps());
+
+  assert.equal(invalidArgsResult.exitCode, 2);
+  assert.match(invalidArgsResult.stderr, /INVALID_ARGS/u);
+});

--- a/test/cli-flow-process-flow-repairs.test.ts
+++ b/test/cli-flow-process-flow-repairs.test.ts
@@ -1,0 +1,387 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { executeCli } from '../src/cli.js';
+import type { DotEnvLoadResult } from '../src/lib/dotenv.js';
+import type { FetchLike } from '../src/lib/http.js';
+import type {
+  RunFlowApplyProcessFlowRepairsOptions,
+  RunFlowPlanProcessFlowRepairsOptions,
+  RunFlowScanProcessFlowRefsOptions,
+} from '../src/lib/flow-regen-product.js';
+
+const dotEnvStatus: DotEnvLoadResult = {
+  loaded: false,
+  path: '/tmp/.env',
+  count: 0,
+};
+
+const makeDeps = () => ({
+  env: {
+    TIANGONG_LCA_API_BASE_URL: 'https://example.com/functions/v1',
+    TIANGONG_LCA_API_KEY: 'secret-token',
+    TIANGONG_LCA_REGION: 'us-east-1',
+  } as NodeJS.ProcessEnv,
+  dotEnvStatus,
+  fetchImpl: (async () => ({
+    ok: true,
+    status: 200,
+    headers: {
+      get: () => 'application/json',
+    },
+    text: async () => JSON.stringify({ ok: true }),
+  })) as FetchLike,
+});
+
+test('executeCli returns help for the flow process-ref scan and repair subcommands', async () => {
+  const flowHelp = await executeCli(['flow', '--help'], makeDeps());
+  assert.equal(flowHelp.exitCode, 0);
+  assert.match(flowHelp.stdout, /scan-process-flow-refs/u);
+  assert.match(flowHelp.stdout, /plan-process-flow-repairs/u);
+  assert.match(flowHelp.stdout, /apply-process-flow-repairs/u);
+
+  const scanHelp = await executeCli(['flow', 'scan-process-flow-refs', '--help'], makeDeps());
+  assert.equal(scanHelp.exitCode, 0);
+  assert.match(
+    scanHelp.stdout,
+    /tiangong flow scan-process-flow-refs --processes-file <file> --scope-flow-file <file> --out-dir <dir>/u,
+  );
+  assert.match(scanHelp.stdout, /--catalog-flow-file/u);
+
+  const planHelp = await executeCli(['flow', 'plan-process-flow-repairs', '--help'], makeDeps());
+  assert.equal(planHelp.exitCode, 0);
+  assert.match(
+    planHelp.stdout,
+    /tiangong flow plan-process-flow-repairs --processes-file <file> --scope-flow-file <file> --out-dir <dir>/u,
+  );
+  assert.match(planHelp.stdout, /--scan-findings/u);
+
+  const applyHelp = await executeCli(['flow', 'apply-process-flow-repairs', '--help'], makeDeps());
+  assert.equal(applyHelp.exitCode, 0);
+  assert.match(
+    applyHelp.stdout,
+    /tiangong flow apply-process-flow-repairs --processes-file <file> --scope-flow-file <file> --out-dir <dir>/u,
+  );
+  assert.match(applyHelp.stdout, /--process-pool-file/u);
+});
+
+test('executeCli dispatches flow scan-process-flow-refs to the implemented CLI module', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-scan-process-refs-dispatch-'));
+  const processesFile = path.join(dir, 'processes.jsonl');
+  const scopeFlowFile = path.join(dir, 'scope-flows.jsonl');
+  const catalogFlowFile = path.join(dir, 'catalog-flows.jsonl');
+  const aliasMapFile = path.join(dir, 'alias-map.json');
+
+  writeFileSync(processesFile, '[]\n', 'utf8');
+  writeFileSync(scopeFlowFile, '[]\n', 'utf8');
+  writeFileSync(catalogFlowFile, '[]\n', 'utf8');
+  writeFileSync(aliasMapFile, '{}\n', 'utf8');
+
+  try {
+    let observedOptions: RunFlowScanProcessFlowRefsOptions | undefined;
+    const result = await executeCli(
+      [
+        'flow',
+        'scan-process-flow-refs',
+        '--processes-file',
+        processesFile,
+        '--scope-flow-file',
+        scopeFlowFile,
+        '--catalog-flow-file',
+        catalogFlowFile,
+        '--alias-map',
+        aliasMapFile,
+        '--exclude-emergy',
+        '--out-dir',
+        path.join(dir, 'scan'),
+        '--json',
+      ],
+      {
+        ...makeDeps(),
+        runFlowScanProcessFlowRefsImpl: async (options) => {
+          observedOptions = options;
+          return {
+            schema_version: 1,
+            generated_at_utc: '2026-03-30T22:00:00.000Z',
+            status: 'completed_local_flow_scan_process_flow_refs',
+            processes_file: processesFile,
+            scope_flow_files: [scopeFlowFile],
+            catalog_flow_files: [catalogFlowFile],
+            alias_map_file: aliasMapFile,
+            exclude_emergy: true,
+            out_dir: path.join(dir, 'scan'),
+            summary: {
+              process_count_before_emergy_exclusion: 2,
+              process_count: 1,
+              emergy_excluded_process_count: 1,
+              exchange_count: 1,
+              issue_counts: { exists_in_target: 1 },
+              processes_with_issues: 0,
+            },
+            files: {
+              out_dir: path.join(dir, 'scan'),
+              emergy_excluded_processes: path.join(dir, 'scan', 'emergy-excluded-processes.json'),
+              summary: path.join(dir, 'scan', 'scan-summary.json'),
+              findings: path.join(dir, 'scan', 'scan-findings.json'),
+              findings_jsonl: path.join(dir, 'scan', 'scan-findings.jsonl'),
+            },
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(JSON.parse(result.stdout).status, 'completed_local_flow_scan_process_flow_refs');
+    assert.deepEqual(observedOptions, {
+      processesFile,
+      scopeFlowFiles: [scopeFlowFile],
+      catalogFlowFiles: [catalogFlowFile],
+      aliasMapFile,
+      excludeEmergy: true,
+      outDir: path.join(dir, 'scan'),
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli dispatches flow plan-process-flow-repairs to the implemented CLI module', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-plan-process-repairs-dispatch-'));
+  const processesFile = path.join(dir, 'processes.jsonl');
+  const scopeFlowFile = path.join(dir, 'scope-flows.jsonl');
+  const aliasMapFile = path.join(dir, 'alias-map.json');
+  const scanFindingsFile = path.join(dir, 'scan-findings.json');
+
+  writeFileSync(processesFile, '[]\n', 'utf8');
+  writeFileSync(scopeFlowFile, '[]\n', 'utf8');
+  writeFileSync(aliasMapFile, '{}\n', 'utf8');
+  writeFileSync(scanFindingsFile, '[]\n', 'utf8');
+
+  try {
+    let observedOptions: RunFlowPlanProcessFlowRepairsOptions | undefined;
+    const result = await executeCli(
+      [
+        'flow',
+        'plan-process-flow-repairs',
+        '--processes-file',
+        processesFile,
+        '--scope-flow-file',
+        scopeFlowFile,
+        '--alias-map',
+        aliasMapFile,
+        '--scan-findings',
+        scanFindingsFile,
+        '--auto-patch-policy',
+        'alias-or-unique-name',
+        '--out-dir',
+        path.join(dir, 'repair-plan'),
+        '--json',
+      ],
+      {
+        ...makeDeps(),
+        runFlowPlanProcessFlowRepairsImpl: async (options) => {
+          observedOptions = options;
+          return {
+            schema_version: 1,
+            generated_at_utc: '2026-03-30T22:10:00.000Z',
+            status: 'completed_local_flow_plan_process_flow_repairs',
+            processes_file: processesFile,
+            scope_flow_files: [scopeFlowFile],
+            alias_map_file: aliasMapFile,
+            scan_findings_file: scanFindingsFile,
+            auto_patch_policy: 'alias-or-unique-name',
+            out_dir: path.join(dir, 'repair-plan'),
+            summary: {
+              auto_patch_policy: 'alias-or-unique-name',
+              process_count: 1,
+              repair_item_count: 1,
+              decision_counts: { auto_patch: 1 },
+              patched_process_count: 0,
+            },
+            files: {
+              out_dir: path.join(dir, 'repair-plan'),
+              plan: path.join(dir, 'repair-plan', 'repair-plan.json'),
+              plan_jsonl: path.join(dir, 'repair-plan', 'repair-plan.jsonl'),
+              manual_review_queue: path.join(dir, 'repair-plan', 'manual-review-queue.jsonl'),
+              summary: path.join(dir, 'repair-plan', 'repair-summary.json'),
+            },
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(
+      JSON.parse(result.stdout).status,
+      'completed_local_flow_plan_process_flow_repairs',
+    );
+    assert.deepEqual(observedOptions, {
+      processesFile,
+      scopeFlowFiles: [scopeFlowFile],
+      aliasMapFile,
+      scanFindingsFile,
+      autoPatchPolicy: 'alias-or-unique-name',
+      outDir: path.join(dir, 'repair-plan'),
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli dispatches flow apply-process-flow-repairs to the implemented CLI module', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-apply-process-repairs-dispatch-'));
+  const processesFile = path.join(dir, 'processes.jsonl');
+  const scopeFlowFile = path.join(dir, 'scope-flows.jsonl');
+  const aliasMapFile = path.join(dir, 'alias-map.json');
+  const scanFindingsFile = path.join(dir, 'scan-findings.json');
+  const processPoolFile = path.join(dir, 'process-pool.jsonl');
+
+  writeFileSync(processesFile, '[]\n', 'utf8');
+  writeFileSync(scopeFlowFile, '[]\n', 'utf8');
+  writeFileSync(aliasMapFile, '{}\n', 'utf8');
+  writeFileSync(scanFindingsFile, '[]\n', 'utf8');
+  writeFileSync(processPoolFile, '[]\n', 'utf8');
+
+  try {
+    let observedOptions: RunFlowApplyProcessFlowRepairsOptions | undefined;
+    const result = await executeCli(
+      [
+        'flow',
+        'apply-process-flow-repairs',
+        '--processes-file',
+        processesFile,
+        '--scope-flow-file',
+        scopeFlowFile,
+        '--alias-map',
+        aliasMapFile,
+        '--scan-findings',
+        scanFindingsFile,
+        '--process-pool-file',
+        processPoolFile,
+        '--out-dir',
+        path.join(dir, 'repair-apply'),
+        '--json',
+      ],
+      {
+        ...makeDeps(),
+        runFlowApplyProcessFlowRepairsImpl: async (options) => {
+          observedOptions = options;
+          return {
+            schema_version: 1,
+            generated_at_utc: '2026-03-30T22:20:00.000Z',
+            status: 'completed_local_flow_apply_process_flow_repairs',
+            processes_file: processesFile,
+            scope_flow_files: [scopeFlowFile],
+            alias_map_file: aliasMapFile,
+            scan_findings_file: scanFindingsFile,
+            auto_patch_policy: 'alias-only',
+            process_pool_file: processPoolFile,
+            out_dir: path.join(dir, 'repair-apply'),
+            summary: {
+              auto_patch_policy: 'alias-only',
+              process_count: 1,
+              repair_item_count: 1,
+              decision_counts: { auto_patch: 1 },
+              patched_process_count: 1,
+              process_pool_sync: {
+                pool_file: processPoolFile,
+                pool_pre_count: 0,
+                incoming_count: 1,
+                pool_post_count: 1,
+                inserted: 1,
+                updated: 0,
+                unchanged: 0,
+                skipped_invalid: 0,
+              },
+            },
+            files: {
+              out_dir: path.join(dir, 'repair-apply'),
+              plan: path.join(dir, 'repair-apply', 'repair-plan.json'),
+              plan_jsonl: path.join(dir, 'repair-apply', 'repair-plan.jsonl'),
+              manual_review_queue: path.join(dir, 'repair-apply', 'manual-review-queue.jsonl'),
+              summary: path.join(dir, 'repair-apply', 'repair-summary.json'),
+              patched_processes: path.join(dir, 'repair-apply', 'patched-processes.json'),
+              patch_root: path.join(dir, 'repair-apply', 'process-patches'),
+            },
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(
+      JSON.parse(result.stdout).status,
+      'completed_local_flow_apply_process_flow_repairs',
+    );
+    assert.deepEqual(observedOptions, {
+      processesFile,
+      scopeFlowFiles: [scopeFlowFile],
+      aliasMapFile,
+      scanFindingsFile,
+      autoPatchPolicy: 'alias-only',
+      processPoolFile,
+      outDir: path.join(dir, 'repair-apply'),
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli returns parsing errors for invalid flow scan and process-flow repair flags', async () => {
+  const invalidScanArgsResult = await executeCli(
+    ['flow', 'scan-process-flow-refs', '--bad-flag'],
+    makeDeps(),
+  );
+  assert.equal(invalidScanArgsResult.exitCode, 2);
+  assert.match(invalidScanArgsResult.stderr, /INVALID_ARGS/u);
+
+  const invalidPlanArgsResult = await executeCli(
+    ['flow', 'plan-process-flow-repairs', '--bad-flag'],
+    makeDeps(),
+  );
+  assert.equal(invalidPlanArgsResult.exitCode, 2);
+  assert.match(invalidPlanArgsResult.stderr, /INVALID_ARGS/u);
+
+  const invalidPlanPolicyResult = await executeCli(
+    ['flow', 'plan-process-flow-repairs', '--auto-patch-policy', 'bad-policy'],
+    makeDeps(),
+  );
+  assert.equal(invalidPlanPolicyResult.exitCode, 2);
+  assert.match(
+    invalidPlanPolicyResult.stderr,
+    /INVALID_FLOW_PLAN_PROCESS_FLOW_REPAIRS_AUTO_PATCH_POLICY/u,
+  );
+
+  const invalidApplyArgsResult = await executeCli(
+    ['flow', 'apply-process-flow-repairs', '--bad-flag'],
+    makeDeps(),
+  );
+  assert.equal(invalidApplyArgsResult.exitCode, 2);
+  assert.match(invalidApplyArgsResult.stderr, /INVALID_ARGS/u);
+
+  const invalidApplyPolicyResult = await executeCli(
+    ['flow', 'apply-process-flow-repairs', '--auto-patch-policy', 'bad-policy'],
+    makeDeps(),
+  );
+  assert.equal(invalidApplyPolicyResult.exitCode, 2);
+  assert.match(
+    invalidApplyPolicyResult.stderr,
+    /INVALID_FLOW_APPLY_PROCESS_FLOW_REPAIRS_AUTO_PATCH_POLICY/u,
+  );
+});
+
+test('executeCli validates missing required scan and process-flow repair inputs', async () => {
+  const scanResult = await executeCli(['flow', 'scan-process-flow-refs'], makeDeps());
+  assert.equal(scanResult.exitCode, 2);
+  assert.match(scanResult.stderr, /FLOW_SCAN_PROCESS_FLOW_REFS_PROCESSES_FILE_REQUIRED/u);
+
+  const planResult = await executeCli(['flow', 'plan-process-flow-repairs'], makeDeps());
+  assert.equal(planResult.exitCode, 2);
+  assert.match(planResult.stderr, /FLOW_PLAN_PROCESS_FLOW_REPAIRS_PROCESSES_FILE_REQUIRED/u);
+
+  const applyResult = await executeCli(['flow', 'apply-process-flow-repairs'], makeDeps());
+  assert.equal(applyResult.exitCode, 2);
+  assert.match(applyResult.stderr, /FLOW_APPLY_PROCESS_FLOW_REPAIRS_PROCESSES_FILE_REQUIRED/u);
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -6,8 +6,12 @@ import path from 'node:path';
 import { executeCli } from '../src/cli.js';
 import type { DotEnvLoadResult } from '../src/lib/dotenv.js';
 import type { FetchLike } from '../src/lib/http.js';
+import type { RunFlowReviewedPublishDataOptions } from '../src/lib/flow-publish-reviewed-data.js';
 import type { RunFlowPublishVersionOptions } from '../src/lib/flow-publish-version.js';
-import type { RunFlowRegenProductOptions } from '../src/lib/flow-regen-product.js';
+import type {
+  RunFlowRegenProductOptions,
+  RunFlowValidateProcessesOptions,
+} from '../src/lib/flow-regen-product.js';
 import type { RunFlowRemediateOptions } from '../src/lib/flow-remediate.js';
 import type { RunFlowReviewOptions } from '../src/lib/review-flow.js';
 
@@ -43,7 +47,8 @@ test('executeCli prints main help when no command is given', async () => {
   assert.match(result.stdout, /Planned Surface \(not implemented yet\):/u);
   assert.match(result.stdout, /process\s+get \| auto-build/u);
   assert.match(result.stdout, /process\s+auto-build/u);
-  assert.match(result.stdout, /lifecyclemodel build-resulting-process/u);
+  assert.match(result.stdout, /lifecyclemodel auto-build/u);
+  assert.match(result.stdout, /lifecyclemodel auto-build \| validate-build \| publish-build/u);
   assert.match(result.stdout, /publish-resulting-process/u);
   assert.match(result.stdout, /review\s+process/u);
   assert.match(result.stdout, /exit with code 2/u);
@@ -147,7 +152,10 @@ test('executeCli returns help for publish and validation namespaces', async () =
   assert.match(flowHelp.stdout, /list/u);
   assert.match(flowHelp.stdout, /remediate/u);
   assert.match(flowHelp.stdout, /publish-version/u);
+  assert.match(flowHelp.stdout, /publish-reviewed-data/u);
+  assert.match(flowHelp.stdout, /build-alias-map/u);
   assert.match(flowHelp.stdout, /regen-product/u);
+  assert.match(flowHelp.stdout, /validate-processes/u);
 });
 
 test('executeCli returns help for publish and validation subcommands', async () => {
@@ -193,6 +201,18 @@ test('executeCli returns help for publish and validation subcommands', async () 
   assert.match(flowPublishHelp.stdout, /--commit/u);
   assert.match(flowPublishHelp.stdout, /TIANGONG_LCA_API_BASE_URL/u);
 
+  const flowPublishReviewedHelp = await executeCli(
+    ['flow', 'publish-reviewed-data', '--help'],
+    makeDeps(),
+  );
+  assert.equal(flowPublishReviewedHelp.exitCode, 0);
+  assert.match(
+    flowPublishReviewedHelp.stdout,
+    /tiangong flow publish-reviewed-data --out-dir <dir> \[--flow-rows-file <file>\] \[--process-rows-file <file>\]/u,
+  );
+  assert.match(flowPublishReviewedHelp.stdout, /--flow-publish-policy/u);
+  assert.match(flowPublishReviewedHelp.stdout, /--process-publish-policy/u);
+
   const flowGetHelp = await executeCli(['flow', 'get', '--help'], makeDeps());
   assert.equal(flowGetHelp.exitCode, 0);
   assert.match(flowGetHelp.stdout, /tiangong flow get --id <flow-id>/u);
@@ -216,6 +236,15 @@ test('executeCli returns help for publish and validation subcommands', async () 
   assert.match(flowRegenHelp.stdout, /--auto-patch-policy/u);
   assert.match(flowRegenHelp.stdout, /repair-apply\/ \(only with --apply\)/u);
   assert.doesNotMatch(flowRegenHelp.stdout, /Planned contract:/u);
+
+  const flowValidateHelp = await executeCli(['flow', 'validate-processes', '--help'], makeDeps());
+  assert.equal(flowValidateHelp.exitCode, 0);
+  assert.match(
+    flowValidateHelp.stdout,
+    /tiangong flow validate-processes --original-processes-file <file> --patched-processes-file <file> --scope-flow-file <file> --out-dir <dir>/u,
+  );
+  assert.match(flowValidateHelp.stdout, /--tidas-mode/u);
+  assert.match(flowValidateHelp.stdout, /validation-failures\.jsonl/u);
 });
 
 test('executeCli returns group help for search and admin namespaces', async () => {
@@ -232,8 +261,22 @@ test('executeCli returns help for the lifecyclemodel namespace and implemented s
   const lifecyclemodelHelp = await executeCli(['lifecyclemodel'], makeDeps());
   assert.equal(lifecyclemodelHelp.exitCode, 0);
   assert.match(lifecyclemodelHelp.stdout, /tiangong lifecyclemodel <subcommand>/u);
+  assert.match(lifecyclemodelHelp.stdout, /auto-build/u);
+  assert.match(lifecyclemodelHelp.stdout, /validate-build/u);
+  assert.match(lifecyclemodelHelp.stdout, /publish-build/u);
   assert.match(lifecyclemodelHelp.stdout, /build-resulting-process/u);
   assert.match(lifecyclemodelHelp.stdout, /publish-resulting-process/u);
+  assert.match(lifecyclemodelHelp.stdout, /orchestrate/u);
+
+  const autoBuildHelp = await executeCli(['lifecyclemodel', 'auto-build', '--help'], makeDeps());
+  assert.equal(autoBuildHelp.exitCode, 0);
+  assert.match(autoBuildHelp.stdout, /tiangong lifecyclemodel auto-build --input <file>/u);
+  assert.match(autoBuildHelp.stdout, /"local_runs": \["\/abs\/path\/to\/process-build-run"\]/u);
+  assert.match(
+    autoBuildHelp.stdout,
+    /leaves follow-up validation and publish handoff to the companion validate-build and publish-build commands/u,
+  );
+  assert.doesNotMatch(autoBuildHelp.stdout, /Planned command/u);
 
   const buildHelp = await executeCli(
     ['lifecyclemodel', 'build-resulting-process', '--help'],
@@ -256,6 +299,458 @@ test('executeCli returns help for the lifecyclemodel namespace and implemented s
   );
   assert.match(publishHelp.stdout, /--publish-processes/u);
   assert.doesNotMatch(publishHelp.stdout, /Planned command/u);
+
+  const validateBuildHelp = await executeCli(
+    ['lifecyclemodel', 'validate-build', '--help'],
+    makeDeps(),
+  );
+  assert.equal(validateBuildHelp.exitCode, 0);
+  assert.match(validateBuildHelp.stdout, /tiangong lifecyclemodel validate-build --run-dir <dir>/u);
+  assert.match(validateBuildHelp.stdout, /--engine <mode>/u);
+  assert.doesNotMatch(validateBuildHelp.stdout, /Planned command/u);
+
+  const lifecyclemodelPublishBuildHelp = await executeCli(
+    ['lifecyclemodel', 'publish-build', '--help'],
+    makeDeps(),
+  );
+  assert.equal(lifecyclemodelPublishBuildHelp.exitCode, 0);
+  assert.match(
+    lifecyclemodelPublishBuildHelp.stdout,
+    /tiangong lifecyclemodel publish-build --run-dir <dir>/u,
+  );
+  assert.match(lifecyclemodelPublishBuildHelp.stdout, /publish-bundle\.json/u);
+  assert.doesNotMatch(lifecyclemodelPublishBuildHelp.stdout, /Planned command/u);
+
+  const lifecyclemodelOrchestrateHelp = await executeCli(
+    ['lifecyclemodel', 'orchestrate', '--help'],
+    makeDeps(),
+  );
+  assert.equal(lifecyclemodelOrchestrateHelp.exitCode, 0);
+  assert.match(
+    lifecyclemodelOrchestrateHelp.stdout,
+    /tiangong lifecyclemodel orchestrate <plan\|execute\|publish>/u,
+  );
+  assert.match(lifecyclemodelOrchestrateHelp.stdout, /--allow-process-build/u);
+  assert.match(lifecyclemodelOrchestrateHelp.stdout, /--publish-resulting-process-relations/u);
+  assert.doesNotMatch(lifecyclemodelOrchestrateHelp.stdout, /Planned command/u);
+});
+
+test('executeCli executes lifecyclemodel auto-build with injected implementation', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-auto-build-cli-'));
+  const inputPath = path.join(dir, 'request.json');
+  writeFileSync(inputPath, '{"local_runs":["./run-1"]}', 'utf8');
+
+  try {
+    const result = await executeCli(
+      ['lifecyclemodel', 'auto-build', '--json', '--input', inputPath, '--out-dir', './run-root'],
+      {
+        ...makeDeps(),
+        runLifecyclemodelAutoBuildImpl: async (options) => {
+          assert.equal(options.inputPath, inputPath);
+          assert.equal(options.outDir, './run-root');
+          assert.equal(options.cwd, process.cwd());
+          return {
+            schema_version: 1,
+            generated_at_utc: '2026-03-30T00:00:00.000Z',
+            status: 'completed_local_lifecyclemodel_auto_build_run',
+            request_path: inputPath,
+            run_id: 'lifecyclemodel_auto_build_demo_build_20260330T000000Z_id123456',
+            run_root: path.join(dir, 'run-root'),
+            local_run_count: 1,
+            built_model_count: 1,
+            files: {
+              request_snapshot: path.join(
+                dir,
+                'run-root',
+                'request',
+                'lifecyclemodel-auto-build.request.json',
+              ),
+              normalized_request: path.join(dir, 'run-root', 'request', 'request.normalized.json'),
+              run_plan: path.join(dir, 'run-root', 'run-plan.json'),
+              resolved_manifest: path.join(dir, 'run-root', 'resolved-manifest.json'),
+              selection_brief: path.join(dir, 'run-root', 'selection', 'selection-brief.md'),
+              reference_model_summary: path.join(
+                dir,
+                'run-root',
+                'discovery',
+                'reference-model-summary.json',
+              ),
+              invocation_index: path.join(dir, 'run-root', 'manifests', 'invocation-index.json'),
+              run_manifest: path.join(dir, 'run-root', 'manifests', 'run-manifest.json'),
+              report: path.join(
+                dir,
+                'run-root',
+                'reports',
+                'lifecyclemodel-auto-build-report.json',
+              ),
+            },
+            local_build_reports: [
+              {
+                run_dir: path.join(dir, 'run-1'),
+                run_name: 'run-1',
+                model_file: path.join(
+                  dir,
+                  'run-root',
+                  'models',
+                  'run-1',
+                  'tidas_bundle',
+                  'lifecyclemodels',
+                  'lm.json',
+                ),
+                summary_file: path.join(dir, 'run-root', 'models', 'run-1', 'summary.json'),
+                connections_file: path.join(dir, 'run-root', 'models', 'run-1', 'connections.json'),
+                process_catalog_file: path.join(
+                  dir,
+                  'run-root',
+                  'models',
+                  'run-1',
+                  'process-catalog.json',
+                ),
+                summary: {
+                  model_uuid: 'lm-demo',
+                },
+              },
+            ],
+            next_actions: ['inspect: run-plan'],
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /"status":"completed_local_lifecyclemodel_auto_build_run"/u);
+    assert.match(result.stdout, /"run_plan"/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli executes lifecyclemodel orchestrate with injected implementation', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-orchestrate-cli-'));
+  const inputPath = path.join(dir, 'request.json');
+  writeFileSync(
+    inputPath,
+    '{"goal":{"name":"Demo"},"root":{"kind":"lifecyclemodel","lifecyclemodel":{"id":"lm-demo"}},"orchestration":{"mode":"collapsed","max_depth":1,"reuse_resulting_process_first":true,"allow_process_build":true,"allow_submodel_build":true,"pin_child_versions":true,"stop_at_elementary_flow":false},"publish":{"intent":"prepare_only"}}',
+    'utf8',
+  );
+
+  try {
+    const result = await executeCli(
+      [
+        'lifecyclemodel',
+        'orchestrate',
+        'plan',
+        '--json',
+        '--input',
+        inputPath,
+        '--out-dir',
+        './run-root',
+      ],
+      {
+        ...makeDeps(),
+        runLifecyclemodelOrchestrateImpl: async (options) => {
+          assert.equal(options.action, 'plan');
+          assert.equal(options.inputPath, inputPath);
+          assert.equal(options.outDir, './run-root');
+          assert.equal(options.runDir, '');
+          assert.equal(options.allowProcessBuild, false);
+          assert.equal(options.publishLifecyclemodels, false);
+          return {
+            schema_version: 1,
+            generated_at_utc: '2026-03-30T00:00:00.000Z',
+            action: 'plan',
+            status: 'planned',
+            request_id: 'demo-run',
+            out_dir: path.join(dir, 'run-root'),
+            counts: {
+              nodes: 1,
+              edges: 0,
+              invocations: 1,
+              unresolved: 0,
+            },
+            files: {
+              request_normalized: path.join(dir, 'run-root', 'request.normalized.json'),
+              assembly_plan: path.join(dir, 'run-root', 'assembly-plan.json'),
+              graph_manifest: path.join(dir, 'run-root', 'graph-manifest.json'),
+              lineage_manifest: path.join(dir, 'run-root', 'lineage-manifest.json'),
+              boundary_report: path.join(dir, 'run-root', 'boundary-report.json'),
+            },
+            warnings: [],
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /"action":"plan"/u);
+    assert.match(result.stdout, /"assembly_plan"/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli maps lifecyclemodel orchestrate execute failures to exit code 1', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-orchestrate-fail-cli-'));
+  const inputPath = path.join(dir, 'request.json');
+  writeFileSync(
+    inputPath,
+    '{"goal":{"name":"Demo"},"root":{"kind":"lifecyclemodel","lifecyclemodel":{"id":"lm-demo"}},"orchestration":{"mode":"collapsed","max_depth":1,"reuse_resulting_process_first":true,"allow_process_build":true,"allow_submodel_build":true,"pin_child_versions":true,"stop_at_elementary_flow":false},"publish":{"intent":"prepare_only"}}',
+    'utf8',
+  );
+
+  try {
+    const result = await executeCli(
+      [
+        'lifecyclemodel',
+        'orchestrate',
+        'execute',
+        '--json',
+        '--input',
+        inputPath,
+        '--out-dir',
+        './run-root',
+      ],
+      {
+        ...makeDeps(),
+        runLifecyclemodelOrchestrateImpl: async () => ({
+          schema_version: 1,
+          generated_at_utc: '2026-03-30T00:00:00.000Z',
+          action: 'execute',
+          status: 'failed',
+          request_id: 'demo-run',
+          out_dir: path.join(dir, 'run-root'),
+          execution: {
+            successful_invocations: 1,
+            failed_invocations: 1,
+            blocked_invocations: 0,
+          },
+          files: {
+            request_normalized: path.join(dir, 'run-root', 'request.normalized.json'),
+            assembly_plan: path.join(dir, 'run-root', 'assembly-plan.json'),
+            graph_manifest: path.join(dir, 'run-root', 'graph-manifest.json'),
+            lineage_manifest: path.join(dir, 'run-root', 'lineage-manifest.json'),
+            boundary_report: path.join(dir, 'run-root', 'boundary-report.json'),
+            invocations_dir: path.join(dir, 'run-root', 'invocations'),
+          },
+          warnings: [],
+        }),
+      },
+    );
+
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stdout, /"status":"failed"/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli accepts lifecyclemodel orchestrate request alias and explicit run-dir flags', async () => {
+  const result = await executeCli(
+    [
+      'lifecyclemodel',
+      'orchestrate',
+      'publish',
+      '--json',
+      '--request',
+      './request-alias.json',
+      '--run-dir',
+      './run-root',
+    ],
+    {
+      ...makeDeps(),
+      runLifecyclemodelOrchestrateImpl: async (options) => {
+        assert.equal(options.action, 'publish');
+        assert.equal(options.inputPath, './request-alias.json');
+        assert.equal(options.runDir, './run-root');
+        return {
+          schema_version: 1,
+          generated_at_utc: '2026-03-31T00:00:00.000Z',
+          action: 'publish',
+          status: 'prepared_local_publish_bundle',
+          request_id: 'demo-run',
+          run_dir: './run-root',
+          counts: {
+            lifecyclemodels: 0,
+            projected_processes: 0,
+            resulting_process_relations: 0,
+            process_build_runs: 0,
+          },
+          files: {
+            assembly_plan: './run-root/assembly-plan.json',
+            graph_manifest: './run-root/graph-manifest.json',
+            lineage_manifest: './run-root/lineage-manifest.json',
+            publish_bundle: './run-root/publish-bundle.json',
+            publish_summary: './run-root/publish-summary.json',
+          },
+        };
+      },
+    },
+  );
+
+  assert.equal(result.exitCode, 0);
+  assert.match(result.stdout, /"action":"publish"/u);
+  assert.match(result.stdout, /"publish_bundle"/u);
+});
+
+test('executeCli executes lifecyclemodel validate-build with injected implementation', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-validate-build-cli-'));
+  const runDir = path.join(dir, 'lm-run');
+
+  try {
+    const result = await executeCli(
+      ['lifecyclemodel', 'validate-build', '--json', '--run-dir', runDir, '--engine', 'all'],
+      {
+        ...makeDeps(),
+        runLifecyclemodelValidateBuildImpl: async (options) => {
+          assert.equal(options.runDir, runDir);
+          assert.equal(options.engine, 'all');
+          return {
+            schema_version: 1,
+            generated_at_utc: '2026-03-30T00:00:00.000Z',
+            status: 'completed_lifecyclemodel_validate_build',
+            run_id: 'lm-run',
+            run_root: runDir,
+            ok: false,
+            engine: 'all',
+            counts: {
+              models: 1,
+              ok: 0,
+              failed: 1,
+            },
+            files: {
+              run_manifest: path.join(runDir, 'manifests', 'run-manifest.json'),
+              invocation_index: path.join(runDir, 'manifests', 'invocation-index.json'),
+              auto_build_report: path.join(
+                runDir,
+                'reports',
+                'lifecyclemodel-auto-build-report.json',
+              ),
+              report: path.join(runDir, 'reports', 'lifecyclemodel-validate-build-report.json'),
+              model_reports_dir: path.join(runDir, 'reports', 'model-validations'),
+            },
+            model_reports: [],
+            next_actions: [],
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stdout, /"status":"completed_lifecyclemodel_validate_build"/u);
+    assert.match(result.stdout, /"ok":false/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli returns exit code 0 when lifecyclemodel validate-build reports ok', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-validate-build-cli-ok-'));
+  const runDir = path.join(dir, 'lm-run-ok');
+
+  try {
+    const result = await executeCli(['lifecyclemodel', 'validate-build', '--run-dir', runDir], {
+      ...makeDeps(),
+      runLifecyclemodelValidateBuildImpl: async () => ({
+        schema_version: 1,
+        generated_at_utc: '2026-03-30T00:00:00.000Z',
+        status: 'completed_lifecyclemodel_validate_build',
+        run_id: 'lm-run-ok',
+        run_root: runDir,
+        ok: true,
+        engine: 'auto',
+        counts: {
+          models: 1,
+          ok: 1,
+          failed: 0,
+        },
+        files: {
+          run_manifest: path.join(runDir, 'manifests', 'run-manifest.json'),
+          invocation_index: path.join(runDir, 'manifests', 'invocation-index.json'),
+          auto_build_report: null,
+          report: path.join(runDir, 'reports', 'lifecyclemodel-validate-build-report.json'),
+          model_reports_dir: path.join(runDir, 'reports', 'model-validations'),
+        },
+        model_reports: [],
+        next_actions: [],
+      }),
+    });
+
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /"ok": true/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli executes lifecyclemodel publish-build with injected implementation', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-publish-build-cli-'));
+  const runDir = path.join(dir, 'lm-run');
+
+  try {
+    const result = await executeCli(
+      ['lifecyclemodel', 'publish-build', '--json', '--run-dir', runDir],
+      {
+        ...makeDeps(),
+        runLifecyclemodelPublishBuildImpl: async (options) => {
+          assert.equal(options.runDir, runDir);
+          return {
+            schema_version: 1,
+            generated_at_utc: '2026-03-30T00:00:00.000Z',
+            status: 'prepared_local_lifecyclemodel_publish_bundle',
+            run_id: 'lm-run',
+            run_root: runDir,
+            counts: {
+              lifecyclemodels: 1,
+            },
+            publish_defaults: {
+              commit: false,
+              publish_lifecyclemodels: true,
+              publish_processes: false,
+              publish_sources: false,
+              publish_relations: false,
+              publish_process_build_runs: false,
+              relation_mode: 'local_manifest_only',
+            },
+            validation: {
+              available: false,
+              ok: null,
+              report: null,
+            },
+            files: {
+              run_manifest: path.join(runDir, 'manifests', 'run-manifest.json'),
+              invocation_index: path.join(runDir, 'manifests', 'invocation-index.json'),
+              publish_bundle: path.join(
+                runDir,
+                'stage_outputs',
+                '10_publish',
+                'publish-bundle.json',
+              ),
+              publish_request: path.join(
+                runDir,
+                'stage_outputs',
+                '10_publish',
+                'publish-request.json',
+              ),
+              publish_intent: path.join(
+                runDir,
+                'stage_outputs',
+                '10_publish',
+                'publish-intent.json',
+              ),
+              report: path.join(runDir, 'reports', 'lifecyclemodel-publish-build-report.json'),
+            },
+            next_actions: [],
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /"status":"prepared_local_lifecyclemodel_publish_bundle"/u);
+    assert.match(result.stdout, /"lifecyclemodels":1/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test('executeCli returns help for the process namespace and implemented subcommands', async () => {
@@ -1439,7 +1934,7 @@ test('executeCli returns parsing errors for invalid publish and validation flags
   assert.match(reviewResult.stderr, /INVALID_LLM_MAX_PROCESSES/u);
 });
 
-test('executeCli returns parsing errors for invalid lifecyclemodel build, process get/build, resume, publish-build, and batch-build flags', async () => {
+test('executeCli returns parsing errors for invalid lifecyclemodel, process, and publish-build flags', async () => {
   const result = await executeCli(
     ['lifecyclemodel', 'build-resulting-process', '--bad-flag'],
     makeDeps(),
@@ -1448,6 +1943,22 @@ test('executeCli returns parsing errors for invalid lifecyclemodel build, proces
   assert.equal(result.stdout, '');
   assert.match(result.stderr, /INVALID_ARGS/u);
 
+  const validateBuildResult = await executeCli(
+    ['lifecyclemodel', 'validate-build', '--bad-flag'],
+    makeDeps(),
+  );
+  assert.equal(validateBuildResult.exitCode, 2);
+  assert.equal(validateBuildResult.stdout, '');
+  assert.match(validateBuildResult.stderr, /INVALID_ARGS/u);
+
+  const lifecyclemodelPublishBuildResult = await executeCli(
+    ['lifecyclemodel', 'publish-build', '--bad-flag'],
+    makeDeps(),
+  );
+  assert.equal(lifecyclemodelPublishBuildResult.exitCode, 2);
+  assert.equal(lifecyclemodelPublishBuildResult.stdout, '');
+  assert.match(lifecyclemodelPublishBuildResult.stderr, /INVALID_ARGS/u);
+
   const publishResult = await executeCli(
     ['lifecyclemodel', 'publish-resulting-process', '--bad-flag'],
     makeDeps(),
@@ -1455,6 +1966,22 @@ test('executeCli returns parsing errors for invalid lifecyclemodel build, proces
   assert.equal(publishResult.exitCode, 2);
   assert.equal(publishResult.stdout, '');
   assert.match(publishResult.stderr, /INVALID_ARGS/u);
+
+  const orchestrateResult = await executeCli(
+    ['lifecyclemodel', 'orchestrate', '--bad-flag'],
+    makeDeps(),
+  );
+  assert.equal(orchestrateResult.exitCode, 2);
+  assert.equal(orchestrateResult.stdout, '');
+  assert.match(orchestrateResult.stderr, /INVALID_ARGS/u);
+
+  const invalidOrchestrateActionResult = await executeCli(
+    ['lifecyclemodel', 'orchestrate', 'bad-action'],
+    makeDeps(),
+  );
+  assert.equal(invalidOrchestrateActionResult.exitCode, 2);
+  assert.equal(invalidOrchestrateActionResult.stdout, '');
+  assert.match(invalidOrchestrateActionResult.stderr, /INVALID_ARGS/u);
 
   const processGetResult = await executeCli(['process', 'get', '--bad-flag'], makeDeps());
   assert.equal(processGetResult.exitCode, 2);
@@ -1745,13 +2272,6 @@ test('executeCli validates missing required flow regen-product inputs once the c
   assert.match(result.stderr, /FLOW_REGEN_PROCESSES_FILE_REQUIRED/u);
 });
 
-test('executeCli returns planned command message for lifecyclemodel subcommands after help is introduced', async () => {
-  const result = await executeCli(['lifecyclemodel', 'auto-build'], makeDeps());
-  assert.equal(result.exitCode, 2);
-  assert.equal(result.stdout, '');
-  assert.match(result.stderr, /Command 'lifecyclemodel auto-build'/u);
-});
-
 test('executeCli returns planned command message and dedicated help for review lifecyclemodel', async () => {
   const lifecyclemodelResult = await executeCli(['review', 'lifecyclemodel'], makeDeps());
   assert.equal(lifecyclemodelResult.exitCode, 2);
@@ -2030,6 +2550,384 @@ test('executeCli dispatches flow publish-version to the implemented CLI module',
     assert.equal(observedOptions?.maxWorkers, 8);
     assert.equal(observedOptions?.limit, 12);
     assert.equal(observedOptions?.targetUserId, 'user-123');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli dispatches flow publish-reviewed-data to the implemented CLI module', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-publish-reviewed-dispatch-'));
+  const flowRowsFile = path.join(dir, 'reviewed-flows.jsonl');
+  const processRowsFile = path.join(dir, 'reviewed-processes.jsonl');
+  writeFileSync(flowRowsFile, '[]\n', 'utf8');
+  writeFileSync(processRowsFile, '[]\n', 'utf8');
+
+  try {
+    let observedOptions: RunFlowReviewedPublishDataOptions | undefined;
+    const result = await executeCli(
+      [
+        'flow',
+        'publish-reviewed-data',
+        '--flow-rows-file',
+        flowRowsFile,
+        '--original-flow-rows-file',
+        path.join(dir, 'original-flows.jsonl'),
+        '--process-rows-file',
+        processRowsFile,
+        '--flow-publish-policy',
+        'upsert_current_version',
+        '--process-publish-policy',
+        'append_only_bump',
+        '--no-rewrite-process-flow-refs',
+        '--out-dir',
+        path.join(dir, 'publish-reviewed'),
+        '--max-workers',
+        '6',
+        '--target-user-id',
+        'user-456',
+        '--json',
+      ],
+      {
+        ...makeDeps(),
+        runFlowReviewedPublishDataImpl: async (options) => {
+          observedOptions = options;
+          return {
+            schema_version: 1,
+            generated_at_utc: '2026-03-30T16:30:00.000Z',
+            status: 'prepared_flow_publish_reviewed_data',
+            mode: 'dry_run',
+            flow_rows_file: flowRowsFile,
+            process_rows_file: processRowsFile,
+            original_flow_rows_file: path.join(dir, 'original-flows.jsonl'),
+            out_dir: path.join(dir, 'publish-reviewed'),
+            flow_publish_policy: 'upsert_current_version',
+            process_publish_policy: 'append_only_bump',
+            rewrite_process_flow_refs: false,
+            counts: {
+              input_flow_rows: 1,
+              input_process_rows: 1,
+              original_flow_rows: 1,
+              prepared_flow_rows: 1,
+              prepared_process_rows: 1,
+              skipped_unchanged_flow_rows: 0,
+              rewritten_process_flow_refs: 0,
+              flow_publish_reports: 1,
+              process_publish_reports: 1,
+              success_count: 0,
+              failure_count: 0,
+            },
+            max_workers: 6,
+            target_user_id_override: 'user-456',
+            files: {
+              prepared_flow_rows: path.join(dir, 'publish-reviewed', 'prepared-flow-rows.json'),
+              prepared_process_rows: path.join(
+                dir,
+                'publish-reviewed',
+                'prepared-process-rows.json',
+              ),
+              flow_version_map: path.join(dir, 'publish-reviewed', 'flow-version-map.json'),
+              skipped_unchanged_flow_rows: path.join(
+                dir,
+                'publish-reviewed',
+                'skipped-unchanged-flow-rows.json',
+              ),
+              process_ref_rewrite_evidence: path.join(
+                dir,
+                'publish-reviewed',
+                'process-flow-ref-rewrite-evidence.jsonl',
+              ),
+              success_list: path.join(
+                dir,
+                'publish-reviewed',
+                'flows_tidas_sdk_plus_classification_mcp_success_list.json',
+              ),
+              remote_failed: path.join(
+                dir,
+                'publish-reviewed',
+                'flows_tidas_sdk_plus_classification_remote_validation_failed.jsonl',
+              ),
+              flow_publish_version_report: path.join(
+                dir,
+                'publish-reviewed',
+                'flows_tidas_sdk_plus_classification_mcp_sync_report.json',
+              ),
+              report: path.join(dir, 'publish-reviewed', 'publish-report.json'),
+            },
+            flow_reports: [
+              {
+                entity_type: 'flow',
+                id: 'flow-1',
+                name: 'flow-1',
+                original_version: '01.00.001',
+                publish_version: '01.00.001',
+                publish_policy: 'upsert_current_version',
+                version_strategy: 'keep_current',
+                status: 'updated',
+                operation: 'update_existing',
+              },
+            ],
+            process_reports: [],
+            skipped_unchanged_flow_rows: [],
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stderr, '');
+    assert.equal(JSON.parse(result.stdout).status, 'prepared_flow_publish_reviewed_data');
+    assert.equal(observedOptions?.flowRowsFile, flowRowsFile);
+    assert.equal(observedOptions?.originalFlowRowsFile, path.join(dir, 'original-flows.jsonl'));
+    assert.equal(observedOptions?.processRowsFile, processRowsFile);
+    assert.equal(observedOptions?.outDir, path.join(dir, 'publish-reviewed'));
+    assert.equal(observedOptions?.flowPublishPolicy, 'upsert_current_version');
+    assert.equal(observedOptions?.processPublishPolicy, 'append_only_bump');
+    assert.equal(observedOptions?.rewriteProcessFlowRefs, false);
+    assert.equal(observedOptions?.commit, false);
+    assert.equal(observedOptions?.maxWorkers, 6);
+    assert.equal(observedOptions?.targetUserId, 'user-456');
+    assert.equal(
+      observedOptions?.env?.TIANGONG_LCA_API_BASE_URL,
+      'https://example.com/functions/v1',
+    );
+    assert.equal(observedOptions?.env?.TIANGONG_LCA_API_KEY, 'secret-token');
+    assert.equal(typeof observedOptions?.fetchImpl, 'function');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli maps flow publish-reviewed-data failures to exit code 1', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-publish-reviewed-failure-'));
+  const flowRowsFile = path.join(dir, 'reviewed-flows.jsonl');
+  writeFileSync(flowRowsFile, '[]\n', 'utf8');
+
+  try {
+    const result = await executeCli(
+      [
+        'flow',
+        'publish-reviewed-data',
+        '--flow-rows-file',
+        flowRowsFile,
+        '--out-dir',
+        path.join(dir, 'publish-reviewed'),
+        '--commit',
+        '--json',
+      ],
+      {
+        ...makeDeps(),
+        runFlowReviewedPublishDataImpl: async () => ({
+          schema_version: 1,
+          generated_at_utc: '2026-03-30T16:45:00.000Z',
+          status: 'completed_flow_publish_reviewed_data_with_failures',
+          mode: 'commit',
+          flow_rows_file: flowRowsFile,
+          process_rows_file: null,
+          original_flow_rows_file: null,
+          out_dir: path.join(dir, 'publish-reviewed'),
+          flow_publish_policy: 'append_only_bump',
+          process_publish_policy: 'append_only_bump',
+          rewrite_process_flow_refs: true,
+          counts: {
+            input_flow_rows: 1,
+            input_process_rows: 0,
+            original_flow_rows: 0,
+            prepared_flow_rows: 1,
+            prepared_process_rows: 0,
+            skipped_unchanged_flow_rows: 0,
+            rewritten_process_flow_refs: 0,
+            flow_publish_reports: 1,
+            process_publish_reports: 0,
+            success_count: 0,
+            failure_count: 1,
+          },
+          max_workers: 4,
+          target_user_id_override: null,
+          files: {
+            prepared_flow_rows: path.join(dir, 'publish-reviewed', 'prepared-flow-rows.json'),
+            prepared_process_rows: path.join(dir, 'publish-reviewed', 'prepared-process-rows.json'),
+            flow_version_map: path.join(dir, 'publish-reviewed', 'flow-version-map.json'),
+            skipped_unchanged_flow_rows: path.join(
+              dir,
+              'publish-reviewed',
+              'skipped-unchanged-flow-rows.json',
+            ),
+            process_ref_rewrite_evidence: path.join(
+              dir,
+              'publish-reviewed',
+              'process-flow-ref-rewrite-evidence.jsonl',
+            ),
+            success_list: path.join(
+              dir,
+              'publish-reviewed',
+              'flows_tidas_sdk_plus_classification_mcp_success_list.json',
+            ),
+            remote_failed: path.join(
+              dir,
+              'publish-reviewed',
+              'flows_tidas_sdk_plus_classification_remote_validation_failed.jsonl',
+            ),
+            flow_publish_version_report: path.join(
+              dir,
+              'publish-reviewed',
+              'flows_tidas_sdk_plus_classification_mcp_sync_report.json',
+            ),
+            report: path.join(dir, 'publish-reviewed', 'publish-report.json'),
+          },
+          flow_reports: [
+            {
+              entity_type: 'flow',
+              id: 'flow-1',
+              name: 'flow-1',
+              original_version: '01.00.001',
+              publish_version: '01.00.002',
+              publish_policy: 'append_only_bump',
+              version_strategy: 'bump',
+              status: 'failed',
+              error: [{ code: 'REMOTE_REQUEST_FAILED', message: 'duplicate version' }],
+            },
+          ],
+          process_reports: [],
+          skipped_unchanged_flow_rows: [],
+        }),
+      },
+    );
+
+    assert.equal(result.exitCode, 1);
+    assert.equal(result.stderr, '');
+    assert.equal(
+      JSON.parse(result.stdout).status,
+      'completed_flow_publish_reviewed_data_with_failures',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli dispatches flow validate-processes to the implemented CLI module', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-validate-processes-dispatch-'));
+  const originalProcessesFile = path.join(dir, 'before.jsonl');
+  const patchedProcessesFile = path.join(dir, 'after.jsonl');
+  const scopeFlowFile = path.join(dir, 'scope.jsonl');
+  writeFileSync(originalProcessesFile, '[]\n', 'utf8');
+  writeFileSync(patchedProcessesFile, '[]\n', 'utf8');
+  writeFileSync(scopeFlowFile, '[]\n', 'utf8');
+
+  try {
+    let observedOptions: RunFlowValidateProcessesOptions | undefined;
+    const result = await executeCli(
+      [
+        'flow',
+        'validate-processes',
+        '--original-processes-file',
+        originalProcessesFile,
+        '--patched-processes-file',
+        patchedProcessesFile,
+        '--scope-flow-file',
+        scopeFlowFile,
+        '--out-dir',
+        path.join(dir, 'validate'),
+        '--tidas-mode',
+        'required',
+        '--json',
+      ],
+      {
+        ...makeDeps(),
+        runFlowValidateProcessesImpl: async (options) => {
+          observedOptions = options;
+          return {
+            schema_version: 1,
+            generated_at_utc: '2026-03-30T19:00:00.000Z',
+            status: 'completed_local_flow_validate_processes',
+            original_processes_file: originalProcessesFile,
+            patched_processes_file: patchedProcessesFile,
+            scope_flow_files: [scopeFlowFile],
+            out_dir: path.join(dir, 'validate'),
+            tidas_mode: 'required',
+            summary: {
+              patched_process_count: 1,
+              passed: 1,
+              failed: 0,
+              tidas_validation: true,
+            },
+            files: {
+              out_dir: path.join(dir, 'validate'),
+              report: path.join(dir, 'validate', 'validation-report.json'),
+              failures: path.join(dir, 'validate', 'validation-failures.jsonl'),
+            },
+            results: [],
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stderr, '');
+    assert.equal(JSON.parse(result.stdout).status, 'completed_local_flow_validate_processes');
+    assert.equal(observedOptions?.originalProcessesFile, originalProcessesFile);
+    assert.equal(observedOptions?.patchedProcessesFile, patchedProcessesFile);
+    assert.deepEqual(observedOptions?.scopeFlowFiles, [scopeFlowFile]);
+    assert.equal(observedOptions?.tidasMode, 'required');
+    assert.equal(observedOptions?.outDir, path.join(dir, 'validate'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli maps flow validate-processes failures to exit code 1', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-validate-processes-failure-'));
+  const originalProcessesFile = path.join(dir, 'before.jsonl');
+  const patchedProcessesFile = path.join(dir, 'after.jsonl');
+  const scopeFlowFile = path.join(dir, 'scope.jsonl');
+  writeFileSync(originalProcessesFile, '[]\n', 'utf8');
+  writeFileSync(patchedProcessesFile, '[]\n', 'utf8');
+  writeFileSync(scopeFlowFile, '[]\n', 'utf8');
+
+  try {
+    const result = await executeCli(
+      [
+        'flow',
+        'validate-processes',
+        '--original-processes-file',
+        originalProcessesFile,
+        '--patched-processes-file',
+        patchedProcessesFile,
+        '--scope-flow-file',
+        scopeFlowFile,
+        '--out-dir',
+        path.join(dir, 'validate'),
+        '--json',
+      ],
+      {
+        ...makeDeps(),
+        runFlowValidateProcessesImpl: async () => ({
+          schema_version: 1,
+          generated_at_utc: '2026-03-30T19:05:00.000Z',
+          status: 'completed_local_flow_validate_processes',
+          original_processes_file: originalProcessesFile,
+          patched_processes_file: patchedProcessesFile,
+          scope_flow_files: [scopeFlowFile],
+          out_dir: path.join(dir, 'validate'),
+          tidas_mode: 'auto',
+          summary: {
+            patched_process_count: 1,
+            passed: 0,
+            failed: 1,
+            tidas_validation: false,
+          },
+          files: {
+            out_dir: path.join(dir, 'validate'),
+            report: path.join(dir, 'validate', 'validation-report.json'),
+            failures: path.join(dir, 'validate', 'validation-failures.jsonl'),
+          },
+          results: [],
+        }),
+      },
+    );
+
+    assert.equal(result.exitCode, 1);
+    assert.equal(result.stderr, '');
+    assert.equal(JSON.parse(result.stdout).summary.failed, 1);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -2353,7 +3251,7 @@ test('executeCli maps flow publish-version failure reports to exit code 1', asyn
   }
 });
 
-test('executeCli returns parsing errors for invalid flow get, list, remediate, publish-version, and regen-product flags', async () => {
+test('executeCli returns parsing errors for invalid flow get, list, remediate, publish-version, validate-processes, and regen-product flags', async () => {
   const invalidGetArgsResult = await executeCli(['flow', 'get', '--bad-flag'], makeDeps());
   assert.equal(invalidGetArgsResult.exitCode, 2);
   assert.match(invalidGetArgsResult.stderr, /INVALID_ARGS/u);
@@ -2423,12 +3321,67 @@ test('executeCli returns parsing errors for invalid flow get, list, remediate, p
   assert.equal(invalidLimitResult.exitCode, 2);
   assert.match(invalidLimitResult.stderr, /INVALID_FLOW_PUBLISH_VERSION_LIMIT/u);
 
+  const invalidReviewedArgsResult = await executeCli(
+    ['flow', 'publish-reviewed-data', '--bad-flag'],
+    makeDeps(),
+  );
+  assert.equal(invalidReviewedArgsResult.exitCode, 2);
+  assert.match(invalidReviewedArgsResult.stderr, /INVALID_ARGS/u);
+
+  const invalidReviewedModeResult = await executeCli(
+    ['flow', 'publish-reviewed-data', '--commit', '--dry-run'],
+    makeDeps(),
+  );
+  assert.equal(invalidReviewedModeResult.exitCode, 2);
+  assert.match(invalidReviewedModeResult.stderr, /FLOW_PUBLISH_REVIEWED_MODE_CONFLICT/u);
+
+  const invalidReviewedFlowPolicyResult = await executeCli(
+    ['flow', 'publish-reviewed-data', '--flow-publish-policy', 'bad-policy'],
+    makeDeps(),
+  );
+  assert.equal(invalidReviewedFlowPolicyResult.exitCode, 2);
+  assert.match(
+    invalidReviewedFlowPolicyResult.stderr,
+    /FLOW_PUBLISH_REVIEWED_FLOW_POLICY_INVALID/u,
+  );
+
+  const invalidReviewedProcessPolicyResult = await executeCli(
+    ['flow', 'publish-reviewed-data', '--process-publish-policy', 'bad-policy'],
+    makeDeps(),
+  );
+  assert.equal(invalidReviewedProcessPolicyResult.exitCode, 2);
+  assert.match(
+    invalidReviewedProcessPolicyResult.stderr,
+    /FLOW_PUBLISH_REVIEWED_PROCESS_POLICY_INVALID/u,
+  );
+
+  const invalidReviewedWorkersResult = await executeCli(
+    ['flow', 'publish-reviewed-data', '--max-workers', '0'],
+    makeDeps(),
+  );
+  assert.equal(invalidReviewedWorkersResult.exitCode, 2);
+  assert.match(invalidReviewedWorkersResult.stderr, /INVALID_FLOW_PUBLISH_REVIEWED_MAX_WORKERS/u);
+
   const invalidRegenArgsResult = await executeCli(
     ['flow', 'regen-product', '--bad-flag'],
     makeDeps(),
   );
   assert.equal(invalidRegenArgsResult.exitCode, 2);
   assert.match(invalidRegenArgsResult.stderr, /INVALID_ARGS/u);
+
+  const invalidValidateArgsResult = await executeCli(
+    ['flow', 'validate-processes', '--bad-flag'],
+    makeDeps(),
+  );
+  assert.equal(invalidValidateArgsResult.exitCode, 2);
+  assert.match(invalidValidateArgsResult.stderr, /INVALID_ARGS/u);
+
+  const invalidValidateTidasModeResult = await executeCli(
+    ['flow', 'validate-processes', '--tidas-mode', 'bad-mode'],
+    makeDeps(),
+  );
+  assert.equal(invalidValidateTidasModeResult.exitCode, 2);
+  assert.match(invalidValidateTidasModeResult.stderr, /INVALID_FLOW_VALIDATE_TIDAS_MODE/u);
 
   const invalidRegenPolicyResult = await executeCli(
     ['flow', 'regen-product', '--auto-patch-policy', 'bad-policy'],
@@ -2630,11 +3583,12 @@ test('executeCli returns planned command message for other unimplemented process
   assert.match(flowRegenHelp.stdout, /Apply deterministic patches and run local validation/u);
 });
 
-test('executeCli returns dedicated help for planned lifecyclemodel subcommands', async () => {
-  const result = await executeCli(['lifecyclemodel', 'auto-build', '--help'], makeDeps());
+test('executeCli returns dedicated help for implemented lifecyclemodel validate-build', async () => {
+  const result = await executeCli(['lifecyclemodel', 'validate-build', '--help'], makeDeps());
   assert.equal(result.exitCode, 0);
-  assert.match(result.stdout, /Planned contract:/u);
-  assert.match(result.stdout, /discover candidate processes/u);
+  assert.match(result.stdout, /model validation reports/u);
+  assert.match(result.stdout, /tidas_bundle/u);
+  assert.doesNotMatch(result.stdout, /Planned contract:/u);
   assert.equal(result.stderr, '');
 });
 

--- a/test/flow-build-alias-map.test.ts
+++ b/test/flow-build-alias-map.test.ts
@@ -1,0 +1,533 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { __testInternals, runFlowBuildAliasMap } from '../src/lib/flow-build-alias-map.js';
+import { CliError } from '../src/lib/errors.js';
+
+type JsonRecord = Record<string, unknown>;
+
+function lang(text: string, langCode = 'en'): JsonRecord {
+  return {
+    '@xml:lang': langCode,
+    '#text': text,
+  };
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function writeJsonl(filePath: string, rows: unknown[]): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(
+    filePath,
+    `${rows.map((row) => JSON.stringify(row)).join('\n')}${rows.length ? '\n' : ''}`,
+    'utf8',
+  );
+}
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, 'utf8')) as unknown;
+}
+
+function readJsonl(filePath: string): unknown[] {
+  return readFileSync(filePath, 'utf8')
+    .split(/\r?\n/gu)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as unknown);
+}
+
+function makeFlowRow(options: {
+  id: string;
+  version?: string;
+  name?: string;
+  flowType?: string;
+}): JsonRecord {
+  const version = options.version ?? '01.00.000';
+  const name = options.name ?? options.id;
+  const flowType = options.flowType ?? 'Product flow';
+
+  return {
+    id: options.id,
+    version,
+    json_ordered: {
+      flowDataSet: {
+        flowInformation: {
+          dataSetInformation: {
+            'common:UUID': options.id,
+            name: {
+              baseName: [lang(name)],
+            },
+            'common:shortDescription': [lang(`${name} short`)],
+          },
+        },
+        modellingAndValidation: {
+          LCIMethodAndAllocation: {
+            typeOfDataSet: flowType,
+          },
+        },
+        administrativeInformation: {
+          publicationAndOwnership: {
+            'common:dataSetVersion': version,
+          },
+        },
+      },
+    },
+  };
+}
+
+test('runFlowBuildAliasMap writes alias artifacts from deterministic and manual decisions', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-build-alias-map-'));
+  const oldFlowFile = path.join(dir, 'old-flows.json');
+  const newFlowFile = path.join(dir, 'new-flows.jsonl');
+  const seedAliasMapFile = path.join(dir, 'seed-alias-map.json');
+  const outDir = path.join(dir, 'alias-map');
+
+  writeJson(oldFlowFile, [
+    makeFlowRow({ id: 'present-flow', name: 'Present Flow' }),
+    makeFlowRow({ id: 'seed-old', name: 'Seeded Legacy Flow' }),
+    makeFlowRow({ id: 'sameuuid-flow', name: 'Same UUID Flow' }),
+    makeFlowRow({ id: 'old-name-type', name: 'Name Type Flow' }),
+    makeFlowRow({ id: 'old-shared', version: '01.00.000', name: 'Shared Flow' }),
+    makeFlowRow({ id: 'old-shared', version: '02.00.000', name: 'Shared Flow' }),
+    makeFlowRow({ id: 'multi-uuid', name: 'Multi UUID Flow' }),
+    makeFlowRow({ id: 'ambig-old', name: 'Ambiguous Flow' }),
+    makeFlowRow({ id: 'mismatch-old', name: 'Type Mismatch Flow' }),
+    makeFlowRow({ id: 'no-match', name: 'No Match Flow' }),
+  ]);
+  writeJsonl(newFlowFile, [
+    makeFlowRow({ id: 'present-flow', name: 'Present Flow' }),
+    makeFlowRow({ id: 'seed-target', name: 'Seed Target Flow' }),
+    makeFlowRow({ id: 'sameuuid-flow', version: '02.00.000', name: 'Same UUID Flow' }),
+    makeFlowRow({ id: 'new-name-type', name: 'Name Type Flow' }),
+    makeFlowRow({ id: 'new-shared-target', name: 'Shared Flow' }),
+    makeFlowRow({ id: 'multi-uuid', version: '02.00.000', name: 'Multi UUID Flow' }),
+    makeFlowRow({ id: 'multi-uuid', version: '03.00.000', name: 'Multi UUID Flow' }),
+    makeFlowRow({ id: 'ambig-target-1', name: 'Ambiguous Flow' }),
+    makeFlowRow({ id: 'ambig-target-2', name: 'Ambiguous Flow' }),
+    makeFlowRow({
+      id: 'type-mismatch-target',
+      name: 'Type Mismatch Flow',
+      flowType: 'Waste flow',
+    }),
+  ]);
+  writeJson(seedAliasMapFile, {
+    'seed-old@01.00.000': {
+      id: 'seed-target',
+      version: '01.00.000',
+    },
+  });
+
+  try {
+    const report = await runFlowBuildAliasMap(
+      {
+        oldFlowFiles: [oldFlowFile],
+        newFlowFiles: [newFlowFile],
+        seedAliasMapFile,
+        outDir,
+      },
+      {
+        now: () => new Date('2026-03-30T23:00:00.000Z'),
+      },
+    );
+
+    assert.equal(report.status, 'completed_local_flow_build_alias_map');
+    assert.equal(report.generated_at_utc, '2026-03-30T23:00:00.000Z');
+    assert.deepEqual(report.old_flow_files, [oldFlowFile]);
+    assert.deepEqual(report.new_flow_files, [newFlowFile]);
+    assert.equal(report.seed_alias_map_file, seedAliasMapFile);
+    assert.deepEqual(report.summary, {
+      old_flow_count: 10,
+      new_flow_count: 10,
+      alias_entries_versioned: 5,
+      alias_entries_uuid_only: 4,
+      manual_review_count: 4,
+      decision_counts: {
+        no_alias_needed: 1,
+        alias_map_entry: 5,
+        manual_review: 4,
+      },
+    });
+    assert.equal(existsSync(report.files.alias_plan), true);
+    assert.equal(existsSync(report.files.alias_plan_jsonl), true);
+    assert.equal(existsSync(report.files.flow_alias_map), true);
+    assert.equal(existsSync(report.files.manual_review_queue), true);
+    assert.equal(existsSync(report.files.summary), true);
+    assert.deepEqual(readJson(report.files.summary), report.summary);
+    assert.deepEqual(readJson(report.files.flow_alias_map), {
+      'seed-old@01.00.000': {
+        id: 'seed-target',
+        version: '01.00.000',
+        reason: 'seed_alias_map',
+      },
+      'seed-old': {
+        id: 'seed-target',
+        version: '01.00.000',
+        reason: 'all_versions_share_same_target',
+      },
+      'sameuuid-flow@01.00.000': {
+        id: 'sameuuid-flow',
+        version: '02.00.000',
+        reason: 'same_uuid_single_target_version',
+      },
+      'sameuuid-flow': {
+        id: 'sameuuid-flow',
+        version: '02.00.000',
+        reason: 'all_versions_share_same_target',
+      },
+      'old-name-type@01.00.000': {
+        id: 'new-name-type',
+        version: '01.00.000',
+        reason: 'unique_exact_name_and_type_match',
+      },
+      'old-name-type': {
+        id: 'new-name-type',
+        version: '01.00.000',
+        reason: 'all_versions_share_same_target',
+      },
+      'old-shared@01.00.000': {
+        id: 'new-shared-target',
+        version: '01.00.000',
+        reason: 'unique_exact_name_and_type_match',
+      },
+      'old-shared@02.00.000': {
+        id: 'new-shared-target',
+        version: '01.00.000',
+        reason: 'unique_exact_name_and_type_match',
+      },
+      'old-shared': {
+        id: 'new-shared-target',
+        version: '01.00.000',
+        reason: 'all_versions_share_same_target',
+      },
+    });
+    assert.equal((readJson(report.files.alias_plan) as unknown[]).length, 10);
+    assert.equal(readJsonl(report.files.manual_review_queue).length, 4);
+    assert.deepEqual(
+      readJsonl(report.files.manual_review_queue)
+        .map((item) => String((item as JsonRecord).reason))
+        .sort(),
+      [
+        'ambiguous_name_and_type_match',
+        'name_match_flow_type_mismatch',
+        'no_deterministic_match',
+        'same_uuid_multiple_target_versions',
+      ],
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runFlowBuildAliasMap supports omitted seed alias maps and emits uuid-only aliases only for stable targets', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-build-alias-map-no-seed-'));
+  const oldFlowFile = path.join(dir, 'old-flows.jsonl');
+  const newFlowFile = path.join(dir, 'new-flows.json');
+  const outDir = path.join(dir, 'alias-map');
+
+  writeJsonl(oldFlowFile, [
+    makeFlowRow({ id: 'legacy-stable', version: '01.00.000', name: 'Stable Flow' }),
+    makeFlowRow({ id: 'legacy-stable', version: '02.00.000', name: 'Stable Flow' }),
+    makeFlowRow({ id: 'legacy-divergent', version: '01.00.000', name: 'Divergent Flow A' }),
+    makeFlowRow({ id: 'legacy-divergent', version: '02.00.000', name: 'Divergent Flow B' }),
+  ]);
+  writeJson(newFlowFile, [
+    makeFlowRow({ id: 'stable-target', name: 'Stable Flow' }),
+    makeFlowRow({ id: 'divergent-target-a', name: 'Divergent Flow A' }),
+    makeFlowRow({ id: 'divergent-target-b', name: 'Divergent Flow B' }),
+  ]);
+
+  try {
+    const report = await runFlowBuildAliasMap({
+      oldFlowFiles: [oldFlowFile],
+      newFlowFiles: [newFlowFile],
+      outDir,
+    });
+
+    assert.equal(report.seed_alias_map_file, null);
+    assert.deepEqual(readJson(report.files.flow_alias_map), {
+      'legacy-stable@01.00.000': {
+        id: 'stable-target',
+        version: '01.00.000',
+        reason: 'unique_exact_name_and_type_match',
+      },
+      'legacy-stable@02.00.000': {
+        id: 'stable-target',
+        version: '01.00.000',
+        reason: 'unique_exact_name_and_type_match',
+      },
+      'legacy-stable': {
+        id: 'stable-target',
+        version: '01.00.000',
+        reason: 'all_versions_share_same_target',
+      },
+      'legacy-divergent@01.00.000': {
+        id: 'divergent-target-a',
+        version: '01.00.000',
+        reason: 'unique_exact_name_and_type_match',
+      },
+      'legacy-divergent@02.00.000': {
+        id: 'divergent-target-b',
+        version: '01.00.000',
+        reason: 'unique_exact_name_and_type_match',
+      },
+    });
+    assert.deepEqual(report.summary, {
+      old_flow_count: 4,
+      new_flow_count: 3,
+      alias_entries_versioned: 4,
+      alias_entries_uuid_only: 1,
+      manual_review_count: 0,
+      decision_counts: {
+        alias_map_entry: 4,
+      },
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('flow build alias helper guards reject missing paths and invalid JSON object inputs', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-build-alias-map-errors-'));
+  const invalidJsonFile = path.join(dir, 'invalid.json');
+  const invalidObjectFile = path.join(dir, 'array.json');
+
+  writeFileSync(invalidJsonFile, '{not-json', 'utf8');
+  writeJson(invalidObjectFile, []);
+
+  try {
+    assert.throws(
+      () => __testInternals.assertInputFile('', 'FLOW_REQUIRED', 'FLOW_MISSING'),
+      (error: unknown) =>
+        error instanceof CliError && error.code === 'FLOW_REQUIRED' && error.exitCode === 2,
+    );
+    assert.throws(
+      () =>
+        __testInternals.assertInputFile(
+          path.join(dir, 'missing.json'),
+          'FLOW_REQUIRED',
+          'FLOW_MISSING',
+        ),
+      (error: unknown) =>
+        error instanceof CliError && error.code === 'FLOW_MISSING' && error.exitCode === 2,
+    );
+    assert.throws(
+      () => __testInternals.assertInputFiles([], 'FLOW_FILES_REQUIRED', 'FLOW_FILE_MISSING'),
+      (error: unknown) =>
+        error instanceof CliError && error.code === 'FLOW_FILES_REQUIRED' && error.exitCode === 2,
+    );
+    assert.throws(
+      () => __testInternals.assertOutDir(''),
+      (error: unknown) =>
+        error instanceof CliError &&
+        error.code === 'FLOW_BUILD_ALIAS_MAP_OUT_DIR_REQUIRED' &&
+        error.exitCode === 2,
+    );
+    assert.throws(
+      () =>
+        __testInternals.readJsonObjectFile(
+          invalidJsonFile,
+          'FLOW_REQUIRED',
+          'FLOW_MISSING',
+          'FLOW_INVALID',
+        ),
+      (error: unknown) =>
+        error instanceof CliError &&
+        error.code === 'FLOW_INVALID' &&
+        error.exitCode === 2 &&
+        String(error.details).length > 0,
+    );
+    assert.throws(
+      () =>
+        __testInternals.readJsonObjectFile(
+          invalidObjectFile,
+          'FLOW_REQUIRED',
+          'FLOW_MISSING',
+          'FLOW_INVALID',
+        ),
+      (error: unknown) =>
+        error instanceof CliError && error.code === 'FLOW_INVALID' && error.exitCode === 2,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runFlowBuildAliasMap applies runtime defaults for omitted old/new file arrays before validation', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-build-alias-map-runtime-defaults-'));
+  const oldFlowFile = path.join(dir, 'old-flows.jsonl');
+  const newFlowFile = path.join(dir, 'new-flows.jsonl');
+
+  writeJsonl(oldFlowFile, []);
+  writeJsonl(newFlowFile, []);
+
+  try {
+    await assert.rejects(
+      () =>
+        runFlowBuildAliasMap({
+          oldFlowFiles: undefined as unknown as string[],
+          newFlowFiles: [newFlowFile],
+          outDir: path.join(dir, 'alias-map-old'),
+        }),
+      (error: unknown) =>
+        error instanceof CliError &&
+        error.code === 'FLOW_BUILD_ALIAS_MAP_OLD_FLOW_FILES_REQUIRED' &&
+        error.exitCode === 2,
+    );
+    await assert.rejects(
+      () =>
+        runFlowBuildAliasMap({
+          oldFlowFiles: [oldFlowFile],
+          newFlowFiles: undefined as unknown as string[],
+          outDir: path.join(dir, 'alias-map-new'),
+        }),
+      (error: unknown) =>
+        error instanceof CliError &&
+        error.code === 'FLOW_BUILD_ALIAS_MAP_NEW_FLOW_FILES_REQUIRED' &&
+        error.exitCode === 2,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('flow build alias helpers expose deterministic lookup, indexing, and planning behavior', () => {
+  const record = makeFlowRow({
+    id: 'helper-flow',
+    version: '02.00.000',
+    name: 'Helper Flow',
+    flowType: 'Waste flow',
+  });
+  const index = __testInternals.buildFlowIndex([record]);
+  const oldRecord = index.records[0];
+
+  assert.equal(index.byUuid['helper-flow'].length, 1);
+  assert.equal(index.byUuidVersion['helper-flow@02.00.000']?.name, 'Helper Flow');
+  assert.equal(index.byName['helper flow']?.length, 1);
+  assert.deepEqual(__testInternals.candidateRef(oldRecord), {
+    id: 'helper-flow',
+    version: '02.00.000',
+    name: 'Helper Flow',
+  });
+  assert.deepEqual(__testInternals.candidateRef(oldRecord, true), {
+    id: 'helper-flow',
+    version: '02.00.000',
+    name: 'Helper Flow',
+    flow_type: 'Waste flow',
+  });
+  assert.deepEqual(
+    __testInternals.aliasLookup(
+      {
+        'helper-flow@02.00.000': { id: 'target-a', version: '03.00.000' },
+        'helper-flow': { id: 'target-b', version: '04.00.000' },
+      },
+      'helper-flow',
+      '02.00.000',
+    ),
+    { id: 'target-a', version: '03.00.000' },
+  );
+  assert.deepEqual(
+    __testInternals.aliasLookup(
+      {
+        'helper-flow': { id: 'target-b', version: '04.00.000' },
+      },
+      'helper-flow',
+      null,
+    ),
+    { id: 'target-b', version: '04.00.000' },
+  );
+  assert.equal(__testInternals.aliasLookup({}, 'missing-flow', null), null);
+  assert.deepEqual(
+    __testInternals.buildDecisionCounts([
+      {
+        old_flow_id: 'a',
+        old_flow_version: '01.00.000',
+        old_flow_name: 'A',
+        old_flow_type: 'Product flow',
+        decision: 'manual_review',
+        reason: 'manual',
+      },
+      {
+        old_flow_id: 'b',
+        old_flow_version: '01.00.000',
+        old_flow_name: 'B',
+        old_flow_type: 'Product flow',
+        decision: 'manual_review',
+        reason: 'manual',
+      },
+      {
+        old_flow_id: 'c',
+        old_flow_version: '01.00.000',
+        old_flow_name: 'C',
+        old_flow_type: 'Product flow',
+        decision: 'alias_map_entry',
+        reason: 'alias',
+        target_flow_id: 'target-c',
+        target_flow_version: '01.00.000',
+      },
+    ]),
+    {
+      manual_review: 2,
+      alias_map_entry: 1,
+    },
+  );
+  assert.deepEqual(__testInternals.buildOutputFiles('/tmp/helper-out'), {
+    out_dir: '/tmp/helper-out',
+    alias_plan: '/tmp/helper-out/alias-plan.json',
+    alias_plan_jsonl: '/tmp/helper-out/alias-plan.jsonl',
+    flow_alias_map: '/tmp/helper-out/flow-alias-map.json',
+    manual_review_queue: '/tmp/helper-out/manual-review-queue.jsonl',
+    summary: '/tmp/helper-out/alias-summary.json',
+  });
+
+  const seededPlan = __testInternals.planAlias(
+    oldRecord,
+    __testInternals.buildFlowIndex([
+      makeFlowRow({
+        id: 'target-seeded',
+        version: '03.00.000',
+        name: 'Seeded Flow',
+        flowType: 'Waste flow',
+      }),
+    ]),
+    {
+      'helper-flow@02.00.000': {
+        id: 'target-seeded',
+        version: '03.00.000',
+      },
+    },
+  );
+  assert.equal(seededPlan.decision, 'alias_map_entry');
+  assert.equal(seededPlan.reason, 'seed_alias_map');
+
+  const fallbackPlan = __testInternals.planAlias(oldRecord, __testInternals.buildFlowIndex([]), {
+    'helper-flow@02.00.000': {
+      id: 'missing-target',
+      version: '09.00.000',
+    },
+  });
+  assert.equal(fallbackPlan.decision, 'manual_review');
+  assert.equal(fallbackPlan.reason, 'no_deterministic_match');
+
+  const legacyRecordWithoutVersion = {
+    id: 'legacy-helper',
+    version: '',
+    name: 'Legacy Helper',
+    flowType: 'Waste flow',
+    shortDescription: null,
+    row: {},
+  };
+  const incompleteSeedPlan = __testInternals.planAlias(
+    legacyRecordWithoutVersion,
+    __testInternals.buildFlowIndex([]),
+    {
+      'legacy-helper': {},
+    },
+  );
+  assert.equal(incompleteSeedPlan.decision, 'manual_review');
+  assert.equal(incompleteSeedPlan.reason, 'no_deterministic_match');
+});

--- a/test/flow-process-flow-repairs.test.ts
+++ b/test/flow-process-flow-repairs.test.ts
@@ -1,0 +1,504 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  runFlowApplyProcessFlowRepairs,
+  runFlowPlanProcessFlowRepairs,
+  runFlowScanProcessFlowRefs,
+} from '../src/lib/flow-regen-product.js';
+import { CliError } from '../src/lib/errors.js';
+
+type JsonRecord = Record<string, unknown>;
+
+function lang(text: string, langCode = 'en'): JsonRecord {
+  return {
+    '@xml:lang': langCode,
+    '#text': text,
+  };
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function writeJsonl(filePath: string, rows: unknown[]): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(
+    filePath,
+    `${rows.map((row) => JSON.stringify(row)).join('\n')}${rows.length ? '\n' : ''}`,
+    'utf8',
+  );
+}
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, 'utf8')) as unknown;
+}
+
+function makeFlowRow(options: { id: string; version?: string; name?: string }): JsonRecord {
+  const version = options.version ?? '01.00.000';
+  const name = options.name ?? options.id;
+
+  return {
+    id: options.id,
+    version,
+    json_ordered: {
+      flowDataSet: {
+        flowInformation: {
+          dataSetInformation: {
+            'common:UUID': options.id,
+            name: {
+              baseName: [lang(name)],
+            },
+            'common:shortDescription': [lang(`${name} short`)],
+          },
+        },
+        administrativeInformation: {
+          publicationAndOwnership: {
+            'common:dataSetVersion': version,
+          },
+        },
+      },
+    },
+  };
+}
+
+function makeExchange(options: {
+  internalId?: string;
+  flowId?: string;
+  flowVersion?: string;
+  flowText?: string;
+}): JsonRecord {
+  return {
+    '@dataSetInternalID': options.internalId ?? '1',
+    exchangeDirection: 'Output',
+    referenceToFlowDataSet: {
+      '@type': 'flow data set',
+      '@refObjectId': options.flowId ?? '',
+      '@version': options.flowVersion ?? '',
+      '@uri': '../flows/example.xml',
+      'common:shortDescription': [lang(options.flowText ?? 'Flow text')],
+    },
+  };
+}
+
+function makeProcessRow(options: {
+  id: string;
+  version?: string;
+  name?: string;
+  exchanges?: JsonRecord[];
+  functionalUnit?: unknown;
+}): JsonRecord {
+  const version = options.version ?? '01.00.000';
+  const exchanges = options.exchanges ?? [
+    makeExchange({ flowId: 'flow-1', flowVersion: version, flowText: 'Scope Flow' }),
+  ];
+
+  return {
+    id: options.id,
+    version,
+    json_ordered: {
+      processDataSet: {
+        processInformation: {
+          dataSetInformation: {
+            'common:UUID': options.id,
+            name: {
+              baseName: [lang(options.name ?? options.id)],
+            },
+          },
+          quantitativeReference: {
+            referenceToReferenceFlow: String(exchanges[0]?.['@dataSetInternalID'] ?? '1'),
+            functionalUnitOrOther: options.functionalUnit ?? [],
+          },
+        },
+        administrativeInformation: {
+          publicationAndOwnership: {
+            'common:dataSetVersion': version,
+          },
+        },
+        exchanges: {
+          exchange: exchanges,
+        },
+      },
+    },
+  };
+}
+
+test('runFlowScanProcessFlowRefs writes scan artifacts with explicit catalog and alias-map inputs', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-scan-process-refs-explicit-'));
+  const processesFile = path.join(dir, 'processes.jsonl');
+  const scopeFlowFile = path.join(dir, 'scope-flows.jsonl');
+  const catalogFlowFile = path.join(dir, 'catalog-flows.jsonl');
+  const aliasMapFile = path.join(dir, 'alias-map.json');
+  const outDir = path.join(dir, 'scan');
+
+  const validProcess = makeProcessRow({
+    id: 'proc-valid',
+    name: 'Valid process',
+  });
+  const emergyProcess = makeProcessRow({
+    id: 'proc-emergy',
+    name: 'Emergy process',
+    functionalUnit: [lang('Solar emergy basis')],
+  });
+
+  writeJsonl(processesFile, [validProcess, emergyProcess]);
+  writeJsonl(scopeFlowFile, [makeFlowRow({ id: 'flow-1', name: 'Scope Flow' })]);
+  writeJsonl(catalogFlowFile, [makeFlowRow({ id: 'flow-1', name: 'Scope Flow' })]);
+  writeJson(aliasMapFile, {});
+
+  try {
+    const report = await runFlowScanProcessFlowRefs(
+      {
+        processesFile,
+        scopeFlowFiles: [scopeFlowFile],
+        catalogFlowFiles: [catalogFlowFile],
+        aliasMapFile,
+        excludeEmergy: true,
+        outDir,
+      },
+      {
+        now: () => new Date('2026-03-30T20:00:00.000Z'),
+      },
+    );
+
+    assert.equal(report.status, 'completed_local_flow_scan_process_flow_refs');
+    assert.equal(report.generated_at_utc, '2026-03-30T20:00:00.000Z');
+    assert.deepEqual(report.scope_flow_files, [scopeFlowFile]);
+    assert.deepEqual(report.catalog_flow_files, [catalogFlowFile]);
+    assert.equal(report.alias_map_file, aliasMapFile);
+    assert.equal(report.exclude_emergy, true);
+    assert.deepEqual(report.summary, {
+      process_count_before_emergy_exclusion: 2,
+      process_count: 1,
+      emergy_excluded_process_count: 1,
+      exchange_count: 1,
+      issue_counts: {
+        exists_in_target: 1,
+      },
+      processes_with_issues: 0,
+    });
+    assert.equal(existsSync(report.files.summary), true);
+    assert.equal(existsSync(report.files.findings_jsonl), true);
+    assert.deepEqual(readJson(report.files.summary), report.summary);
+    assert.deepEqual(readJson(report.files.emergy_excluded_processes), [
+      {
+        entity_type: 'process',
+        process_id: 'proc-emergy',
+        process_version: '01.00.000',
+        process_name: 'Emergy process',
+        reference_flow_id: 'flow-1',
+        reference_flow_version: '01.00.000',
+        reference_exchange_internal_id: '1',
+        excluded: true,
+        reason: 'reference_flow_name_mentions_emergy',
+        signals: ['process_ref_text:Solar emergy basis'],
+      },
+    ]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runFlowScanProcessFlowRefs defaults catalog inputs to the scope files when omitted', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-scan-process-refs-default-'));
+  const processesFile = path.join(dir, 'processes.json');
+  const scopeFlowFile = path.join(dir, 'scope-flows.json');
+  const outDir = path.join(dir, 'scan');
+
+  writeJson(processesFile, [makeProcessRow({ id: 'proc-default' })]);
+  writeJson(scopeFlowFile, [makeFlowRow({ id: 'flow-1', name: 'Scope Flow' })]);
+
+  try {
+    const report = await runFlowScanProcessFlowRefs({
+      processesFile,
+      scopeFlowFiles: [scopeFlowFile],
+      outDir,
+    });
+
+    assert.equal(report.alias_map_file, null);
+    assert.deepEqual(report.catalog_flow_files, [scopeFlowFile]);
+    assert.equal(report.summary.process_count, 1);
+    assert.equal(report.summary.issue_counts.exists_in_target, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runFlowPlanProcessFlowRepairs writes repair plans from alias maps and optional scan findings', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-plan-process-repairs-'));
+  const processesFile = path.join(dir, 'processes.jsonl');
+  const scopeFlowFile = path.join(dir, 'scope-flows.jsonl');
+  const aliasMapFile = path.join(dir, 'alias-map.json');
+  const scanFindingsFile = path.join(dir, 'scan-findings.json');
+  const outDir = path.join(dir, 'repair-plan');
+
+  writeJsonl(processesFile, [
+    makeProcessRow({
+      id: 'proc-plan',
+      exchanges: [
+        makeExchange({
+          internalId: '1',
+          flowId: 'old-flow',
+          flowVersion: '01.00.000',
+          flowText: 'Target Flow',
+        }),
+      ],
+    }),
+  ]);
+  writeJsonl(scopeFlowFile, [makeFlowRow({ id: 'new-flow', name: 'Target Flow' })]);
+  writeJson(aliasMapFile, {
+    'old-flow@01.00.000': {
+      id: 'new-flow',
+      version: '01.00.000',
+    },
+  });
+  writeJson(scanFindingsFile, [
+    {
+      process_id: 'proc-plan',
+      process_version: '01.00.000',
+      exchange_internal_id: '1',
+      issue_type: 'missing_uuid',
+    },
+  ]);
+
+  try {
+    const report = await runFlowPlanProcessFlowRepairs(
+      {
+        processesFile,
+        scopeFlowFiles: [scopeFlowFile],
+        aliasMapFile,
+        scanFindingsFile,
+        autoPatchPolicy: 'alias-only',
+        outDir,
+      },
+      {
+        now: () => new Date('2026-03-30T20:30:00.000Z'),
+      },
+    );
+
+    assert.equal(report.status, 'completed_local_flow_plan_process_flow_repairs');
+    assert.equal(report.generated_at_utc, '2026-03-30T20:30:00.000Z');
+    assert.equal(report.alias_map_file, aliasMapFile);
+    assert.equal(report.scan_findings_file, scanFindingsFile);
+    assert.deepEqual(report.summary, {
+      auto_patch_policy: 'alias-only',
+      process_count: 1,
+      repair_item_count: 1,
+      decision_counts: {
+        auto_patch: 1,
+      },
+      patched_process_count: 0,
+    });
+
+    const repairPlan = readJson(report.files.plan) as JsonRecord[];
+    assert.equal(repairPlan.length, 1);
+    assert.equal(repairPlan[0]?.decision, 'auto_patch');
+    assert.equal(repairPlan[0]?.current_issue_type, 'missing_uuid');
+    assert.equal(repairPlan[0]?.target_flow_id, 'new-flow');
+    assert.equal(existsSync(report.files.manual_review_queue), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runFlowPlanProcessFlowRepairs defaults alias-map and scan-findings inputs when omitted', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-plan-process-repairs-defaults-'));
+  const processesFile = path.join(dir, 'processes.json');
+  const scopeFlowFile = path.join(dir, 'scope-flows.json');
+  const outDir = path.join(dir, 'repair-plan');
+
+  writeJson(processesFile, [
+    makeProcessRow({
+      id: 'proc-plan-default',
+      exchanges: [
+        makeExchange({
+          internalId: '1',
+          flowId: 'scope-flow',
+          flowVersion: '01.00.000',
+          flowText: 'Scope Flow',
+        }),
+      ],
+    }),
+  ]);
+  writeJson(scopeFlowFile, [makeFlowRow({ id: 'scope-flow', name: 'Scope Flow' })]);
+
+  try {
+    const report = await runFlowPlanProcessFlowRepairs({
+      processesFile,
+      scopeFlowFiles: [scopeFlowFile],
+      outDir,
+    });
+
+    assert.equal(report.alias_map_file, null);
+    assert.equal(report.scan_findings_file, null);
+    assert.deepEqual(report.summary, {
+      auto_patch_policy: 'alias-only',
+      process_count: 1,
+      repair_item_count: 1,
+      decision_counts: {
+        keep_as_is: 1,
+      },
+      patched_process_count: 0,
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runFlowApplyProcessFlowRepairs supports no-op and patched apply runs without scan-findings input', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-apply-process-repairs-'));
+  const scopeFlowFile = path.join(dir, 'scope-flows.jsonl');
+  const aliasMapFile = path.join(dir, 'alias-map.json');
+  const processPoolFile = path.join(dir, 'process-pool.jsonl');
+
+  writeJsonl(scopeFlowFile, [makeFlowRow({ id: 'scope-flow', name: 'Scope Flow' })]);
+  writeJson(aliasMapFile, {
+    'old-flow@01.00.000': {
+      id: 'scope-flow',
+      version: '01.00.000',
+    },
+  });
+
+  const noopProcessesFile = path.join(dir, 'noop-processes.json');
+  writeJson(noopProcessesFile, [
+    makeProcessRow({
+      id: 'proc-noop',
+      exchanges: [
+        makeExchange({
+          internalId: '1',
+          flowId: 'scope-flow',
+          flowVersion: '01.00.000',
+          flowText: 'Scope Flow',
+        }),
+      ],
+    }),
+  ]);
+
+  const patchProcessesFile = path.join(dir, 'patch-processes.jsonl');
+  writeJsonl(patchProcessesFile, [
+    makeProcessRow({
+      id: 'proc-patch',
+      exchanges: [
+        makeExchange({
+          internalId: '1',
+          flowId: 'old-flow',
+          flowVersion: '01.00.000',
+          flowText: 'Scope Flow',
+        }),
+      ],
+    }),
+  ]);
+  writeJsonl(processPoolFile, []);
+
+  try {
+    const noopReport = await runFlowApplyProcessFlowRepairs({
+      processesFile: noopProcessesFile,
+      scopeFlowFiles: [scopeFlowFile],
+      outDir: path.join(dir, 'repair-apply-noop'),
+    });
+
+    assert.equal(noopReport.process_pool_file, null);
+    assert.equal(noopReport.summary.patched_process_count, 0);
+    assert.equal(noopReport.summary.decision_counts.keep_as_is, 1);
+    assert.deepEqual(readJson(noopReport.files.patched_processes), []);
+
+    const patchedReport = await runFlowApplyProcessFlowRepairs(
+      {
+        processesFile: patchProcessesFile,
+        scopeFlowFiles: [scopeFlowFile],
+        aliasMapFile,
+        processPoolFile,
+        outDir: path.join(dir, 'repair-apply-patched'),
+      },
+      {
+        now: () => new Date('2026-03-30T21:00:00.000Z'),
+      },
+    );
+
+    assert.equal(patchedReport.status, 'completed_local_flow_apply_process_flow_repairs');
+    assert.equal(patchedReport.generated_at_utc, '2026-03-30T21:00:00.000Z');
+    assert.equal(patchedReport.process_pool_file, processPoolFile);
+    assert.equal(patchedReport.scan_findings_file, null);
+    assert.equal(patchedReport.summary.auto_patch_policy, 'alias-only');
+    assert.equal(patchedReport.summary.patched_process_count, 1);
+    assert.equal(
+      (patchedReport.summary.process_pool_sync as JsonRecord | undefined)?.pool_post_count,
+      1,
+    );
+    assert.equal(existsSync(patchedReport.files.patched_processes), true);
+    assert.equal(
+      existsSync(path.join(patchedReport.files.patch_root, 'proc-patch__01.00.000', 'diff.patch')),
+      true,
+    );
+
+    const patchedRows = readJson(patchedReport.files.patched_processes) as JsonRecord[];
+    const patchedRef = ((
+      (
+        (((patchedRows[0]?.json_ordered as JsonRecord).processDataSet as JsonRecord).exchanges ??
+          {}) as JsonRecord
+      ).exchange as JsonRecord[]
+    )[0]?.referenceToFlowDataSet ?? {}) as JsonRecord;
+    assert.equal(patchedRef['@refObjectId'], 'scope-flow');
+    assert.equal(patchedRef['@version'], '01.00.000');
+
+    const syncedPool = readFileSync(processPoolFile, 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as JsonRecord);
+    assert.equal(syncedPool.length, 1);
+    assert.equal(syncedPool[0]?.id, 'proc-patch');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('flow scan/plan/apply process-flow repair runners reject missing scope flow inputs', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-process-repairs-missing-scope-'));
+  const processesFile = path.join(dir, 'processes.jsonl');
+
+  writeJsonl(processesFile, []);
+
+  try {
+    await assert.rejects(
+      () =>
+        runFlowScanProcessFlowRefs({
+          processesFile,
+          scopeFlowFiles: undefined as unknown as string[],
+          outDir: path.join(dir, 'scan'),
+        }),
+      (error) =>
+        error instanceof CliError &&
+        error.code === 'FLOW_SCAN_PROCESS_FLOW_REFS_SCOPE_FLOW_FILES_REQUIRED',
+    );
+
+    await assert.rejects(
+      () =>
+        runFlowPlanProcessFlowRepairs({
+          processesFile,
+          scopeFlowFiles: undefined as unknown as string[],
+          outDir: path.join(dir, 'repair-plan'),
+        }),
+      (error) =>
+        error instanceof CliError &&
+        error.code === 'FLOW_PLAN_PROCESS_FLOW_REPAIRS_SCOPE_FLOW_FILES_REQUIRED',
+    );
+
+    await assert.rejects(
+      () =>
+        runFlowApplyProcessFlowRepairs({
+          processesFile,
+          scopeFlowFiles: undefined as unknown as string[],
+          outDir: path.join(dir, 'repair-apply'),
+        }),
+      (error) =>
+        error instanceof CliError &&
+        error.code === 'FLOW_APPLY_PROCESS_FLOW_REPAIRS_SCOPE_FLOW_FILES_REQUIRED',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/flow-publish-reviewed-data.test.ts
+++ b/test/flow-publish-reviewed-data.test.ts
@@ -1,0 +1,1817 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { CliError } from '../src/lib/errors.js';
+import type { FlowPublishVersionReport } from '../src/lib/flow-publish-version.js';
+import {
+  __testInternals,
+  runFlowReviewedPublishData,
+} from '../src/lib/flow-publish-reviewed-data.js';
+
+type JsonRecord = Record<string, unknown>;
+
+function writeJson(filePath: string, value: unknown): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function writeJsonl(filePath: string, rows: unknown[]): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(
+    filePath,
+    `${rows.map((row) => JSON.stringify(row)).join('\n')}${rows.length ? '\n' : ''}`,
+    'utf8',
+  );
+}
+
+function makeFlowRow(options: {
+  id: string;
+  version?: string;
+  envelope?: 'json_ordered' | 'root';
+  extraPayload?: JsonRecord;
+}): JsonRecord {
+  const payload: JsonRecord = {
+    flowDataSet: {
+      flowInformation: {
+        dataSetInformation: {
+          'common:UUID': options.id,
+          name: {
+            baseName: {
+              '@xml:lang': 'en',
+              '#text': `${options.id} name`,
+            },
+          },
+        },
+      },
+      administrativeInformation: {
+        publicationAndOwnership: {
+          'common:dataSetVersion': options.version ?? '01.00.001',
+        },
+      },
+      ...options.extraPayload,
+    },
+  };
+
+  if (options.envelope === 'root') {
+    return payload;
+  }
+
+  return {
+    id: options.id,
+    version: options.version ?? '01.00.001',
+    json_ordered: payload,
+  };
+}
+
+function lang(text: string, langCode = 'en'): JsonRecord {
+  return {
+    '@xml:lang': langCode,
+    '#text': text,
+  };
+}
+
+function makeExchange(options: {
+  internalId?: string;
+  flowId?: string;
+  flowVersion?: string;
+  flowText?: string;
+  shortDescriptionShape?: 'array' | 'object';
+}): JsonRecord {
+  const shortDescription = lang(options.flowText ?? 'Flow text');
+
+  return {
+    '@dataSetInternalID': options.internalId ?? '1',
+    exchangeDirection: 'Output',
+    referenceToFlowDataSet: {
+      '@type': 'flow data set',
+      '@refObjectId': options.flowId ?? '',
+      '@version': options.flowVersion ?? '',
+      '@uri': '../flows/example.xml',
+      'common:shortDescription':
+        options.shortDescriptionShape === 'object' ? shortDescription : [shortDescription],
+    },
+  };
+}
+
+function makeProcessRow(options: {
+  id: string;
+  version?: string;
+  name?: string;
+  envelope?: 'json_ordered' | 'root';
+  exchanges?: JsonRecord[];
+}): JsonRecord {
+  const version = options.version ?? '01.00.000';
+  const exchanges = options.exchanges ?? [
+    makeExchange({ flowId: 'flow-1', flowVersion: version, flowText: 'Scope Flow' }),
+  ];
+  const payload: JsonRecord = {
+    processDataSet: {
+      processInformation: {
+        dataSetInformation: {
+          'common:UUID': options.id,
+          name: {
+            baseName: [lang(options.name ?? `${options.id} name`)],
+          },
+        },
+        quantitativeReference: {
+          referenceToReferenceFlow: String(exchanges[0]?.['@dataSetInternalID'] ?? '1'),
+          functionalUnitOrOther: [],
+        },
+      },
+      administrativeInformation: {
+        publicationAndOwnership: {
+          'common:dataSetVersion': version,
+        },
+      },
+      exchanges: {
+        exchange: exchanges,
+      },
+    },
+  };
+
+  if (options.envelope === 'root') {
+    return payload;
+  }
+
+  return {
+    id: options.id,
+    version,
+    json_ordered: payload,
+  };
+}
+
+test('runFlowReviewedPublishData writes flow-only dry-run artifacts and skips unchanged original rows', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-publish-reviewed-dry-run-'));
+  const flowRowsFile = path.join(dir, 'reviewed-flows.json');
+  const originalFlowRowsFile = path.join(dir, 'original-flows.json');
+  const outDir = path.join(dir, 'publish-reviewed');
+
+  writeJson(flowRowsFile, [
+    makeFlowRow({ id: 'flow-unchanged', version: '01.00.001' }),
+    makeFlowRow({
+      id: 'flow-changed',
+      version: '01.00.005',
+      envelope: 'root',
+      extraPayload: {
+        modellingAndValidation: {
+          LCIMethodAndAllocation: {
+            typeOfDataSet: 'product flow',
+          },
+        },
+      },
+    }),
+  ]);
+  writeJson(originalFlowRowsFile, [makeFlowRow({ id: 'flow-unchanged', version: '01.00.001' })]);
+
+  try {
+    const report = await runFlowReviewedPublishData({
+      flowRowsFile,
+      originalFlowRowsFile,
+      outDir,
+      flowPublishPolicy: 'append_only_bump',
+      now: new Date('2026-03-30T15:00:00.000Z'),
+    });
+
+    assert.deepEqual(report, {
+      schema_version: 1,
+      generated_at_utc: '2026-03-30T15:00:00.000Z',
+      status: 'prepared_flow_publish_reviewed_data',
+      mode: 'dry_run',
+      flow_rows_file: flowRowsFile,
+      process_rows_file: null,
+      original_flow_rows_file: originalFlowRowsFile,
+      out_dir: outDir,
+      flow_publish_policy: 'append_only_bump',
+      process_publish_policy: 'append_only_bump',
+      rewrite_process_flow_refs: true,
+      counts: {
+        input_flow_rows: 2,
+        input_process_rows: 0,
+        original_flow_rows: 1,
+        prepared_flow_rows: 1,
+        prepared_process_rows: 0,
+        skipped_unchanged_flow_rows: 1,
+        rewritten_process_flow_refs: 0,
+        flow_publish_reports: 1,
+        process_publish_reports: 0,
+        success_count: 0,
+        failure_count: 0,
+      },
+      max_workers: 4,
+      target_user_id_override: null,
+      files: {
+        prepared_flow_rows: path.join(outDir, 'prepared-flow-rows.json'),
+        prepared_process_rows: path.join(outDir, 'prepared-process-rows.json'),
+        flow_version_map: path.join(outDir, 'flow-version-map.json'),
+        skipped_unchanged_flow_rows: path.join(outDir, 'skipped-unchanged-flow-rows.json'),
+        process_ref_rewrite_evidence: path.join(outDir, 'process-flow-ref-rewrite-evidence.jsonl'),
+        success_list: path.join(
+          outDir,
+          'flows_tidas_sdk_plus_classification_mcp_success_list.json',
+        ),
+        remote_failed: path.join(
+          outDir,
+          'flows_tidas_sdk_plus_classification_remote_validation_failed.jsonl',
+        ),
+        flow_publish_version_report: path.join(
+          outDir,
+          'flows_tidas_sdk_plus_classification_mcp_sync_report.json',
+        ),
+        report: path.join(outDir, 'publish-report.json'),
+      },
+      flow_reports: [
+        {
+          entity_type: 'flow',
+          id: 'flow-changed',
+          name: 'flow-changed name',
+          original_version: '01.00.005',
+          publish_version: '01.00.006',
+          publish_policy: 'append_only_bump',
+          version_strategy: 'bump',
+          status: 'prepared',
+        },
+      ],
+      process_reports: [],
+      skipped_unchanged_flow_rows: [
+        {
+          entity_type: 'flow',
+          entity_id: 'flow-unchanged',
+          entity_name: 'flow-unchanged name',
+          version: '01.00.001',
+          reason: 'unchanged_vs_original_rows_file',
+        },
+      ],
+    });
+
+    const preparedRows = JSON.parse(
+      readFileSync(report.files.prepared_flow_rows, 'utf8'),
+    ) as JsonRecord[];
+    assert.equal(preparedRows.length, 1);
+    assert.equal((preparedRows[0] as JsonRecord).version, '01.00.006');
+    assert.equal(
+      (
+        (
+          ((preparedRows[0] as JsonRecord).flowDataSet as JsonRecord)
+            .administrativeInformation as JsonRecord
+        ).publicationAndOwnership as JsonRecord
+      )['common:dataSetVersion'],
+      '01.00.006',
+    );
+
+    const flowVersionMap = JSON.parse(
+      readFileSync(report.files.flow_version_map, 'utf8'),
+    ) as JsonRecord;
+    assert.deepEqual(flowVersionMap, {
+      'flow-changed@01.00.005': {
+        id: 'flow-changed',
+        source_version: '01.00.005',
+        target_version: '01.00.006',
+      },
+    });
+
+    assert.deepEqual(JSON.parse(readFileSync(report.files.prepared_process_rows, 'utf8')), []);
+    assert.equal(readFileSync(report.files.process_ref_rewrite_evidence, 'utf8'), '');
+    assert.deepEqual(JSON.parse(readFileSync(report.files.success_list, 'utf8')), []);
+    assert.equal(readFileSync(report.files.remote_failed, 'utf8'), '');
+
+    const compatReport = JSON.parse(
+      readFileSync(report.files.flow_publish_version_report, 'utf8'),
+    ) as JsonRecord;
+    assert.equal(compatReport.status, 'prepared_flow_publish_version');
+    assert.equal(((compatReport.counts as JsonRecord).total_rows as number) ?? -1, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runFlowReviewedPublishData delegates commit publish to flow publish-version and maps results back into publish-report', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-publish-reviewed-commit-'));
+  const flowRowsFile = path.join(dir, 'reviewed-flows.jsonl');
+  const outDir = path.join(dir, 'publish-reviewed');
+
+  writeJsonl(flowRowsFile, [
+    makeFlowRow({ id: 'flow-1', version: '01.00.001' }),
+    makeFlowRow({ id: 'flow-2', version: '01.00.002' }),
+  ]);
+
+  try {
+    let observedInputFile = '';
+    let observedMaxWorkers = 0;
+    let observedTargetUserId: string | null = null;
+
+    const report = await runFlowReviewedPublishData({
+      flowRowsFile,
+      outDir,
+      flowPublishPolicy: 'append_only_bump',
+      commit: true,
+      maxWorkers: 7,
+      targetUserId: 'user-override',
+      now: new Date('2026-03-30T16:00:00.000Z'),
+      runFlowPublishVersionImpl: async (options) => {
+        observedInputFile = options.inputFile;
+        observedMaxWorkers = options.maxWorkers ?? 0;
+        observedTargetUserId = options.targetUserId ?? null;
+
+        const preparedRows = JSON.parse(readFileSync(options.inputFile, 'utf8')) as JsonRecord[];
+        assert.deepEqual(
+          preparedRows.map((row) => row.version),
+          ['01.00.002', '01.00.003'],
+        );
+
+        writeJson(
+          path.join(options.outDir, 'flows_tidas_sdk_plus_classification_mcp_success_list.json'),
+          [{ id: 'flow-1', version: '01.00.002', operation: 'insert' }],
+        );
+        writeJsonl(
+          path.join(
+            options.outDir,
+            'flows_tidas_sdk_plus_classification_remote_validation_failed.jsonl',
+          ),
+          [
+            {
+              id: 'flow-2',
+              json_ordered: makeFlowRow({
+                id: 'flow-2',
+                version: '01.00.003',
+                envelope: 'root',
+              }),
+              reason: [
+                {
+                  validator: 'remote_rest',
+                  stage: 'insert',
+                  path: '',
+                  message: 'duplicate version',
+                  code: 'REMOTE_REQUEST_FAILED',
+                },
+              ],
+            },
+          ],
+        );
+
+        const compatReport: FlowPublishVersionReport = {
+          schema_version: 1,
+          generated_at_utc: '2026-03-30T16:00:00.000Z',
+          status: 'completed_flow_publish_version_with_failures',
+          mode: 'commit',
+          input_file: options.inputFile,
+          out_dir: options.outDir,
+          counts: {
+            total_rows: 2,
+            success_count: 1,
+            failure_count: 1,
+          },
+          operation_counts: {
+            insert: 1,
+          },
+          max_workers: 7,
+          limit: null,
+          target_user_id_override: 'user-override',
+          files: {
+            success_list: path.join(
+              options.outDir,
+              'flows_tidas_sdk_plus_classification_mcp_success_list.json',
+            ),
+            remote_failed: path.join(
+              options.outDir,
+              'flows_tidas_sdk_plus_classification_remote_validation_failed.jsonl',
+            ),
+            report: path.join(
+              options.outDir,
+              'flows_tidas_sdk_plus_classification_mcp_sync_report.json',
+            ),
+          },
+        };
+        writeJson(compatReport.files.report, compatReport);
+        return compatReport;
+      },
+    });
+
+    assert.equal(observedInputFile, path.join(outDir, 'prepared-flow-rows.json'));
+    assert.equal(observedMaxWorkers, 7);
+    assert.equal(observedTargetUserId, 'user-override');
+    assert.equal(report.status, 'completed_flow_publish_reviewed_data_with_failures');
+    assert.deepEqual(report.counts, {
+      input_flow_rows: 2,
+      input_process_rows: 0,
+      original_flow_rows: 0,
+      prepared_flow_rows: 2,
+      prepared_process_rows: 0,
+      skipped_unchanged_flow_rows: 0,
+      rewritten_process_flow_refs: 0,
+      flow_publish_reports: 2,
+      process_publish_reports: 0,
+      success_count: 1,
+      failure_count: 1,
+    });
+    assert.equal(report.process_rows_file, null);
+    assert.equal(report.process_publish_policy, 'append_only_bump');
+    assert.equal(report.rewrite_process_flow_refs, true);
+    assert.deepEqual(report.flow_reports, [
+      {
+        entity_type: 'flow',
+        id: 'flow-1',
+        name: 'flow-1 name',
+        original_version: '01.00.001',
+        publish_version: '01.00.002',
+        publish_policy: 'append_only_bump',
+        version_strategy: 'bump',
+        status: 'inserted',
+        operation: 'insert',
+      },
+      {
+        entity_type: 'flow',
+        id: 'flow-2',
+        name: 'flow-2 name',
+        original_version: '01.00.002',
+        publish_version: '01.00.003',
+        publish_policy: 'append_only_bump',
+        version_strategy: 'bump',
+        status: 'failed',
+        error: [
+          {
+            validator: 'remote_rest',
+            stage: 'insert',
+            path: '',
+            message: 'duplicate version',
+            code: 'REMOTE_REQUEST_FAILED',
+          },
+        ],
+      },
+    ]);
+
+    const publishReport = JSON.parse(readFileSync(report.files.report, 'utf8')) as JsonRecord;
+    assert.equal(publishReport.status, 'completed_flow_publish_reviewed_data_with_failures');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('flow publish reviewed data process helpers unwrap root payloads and map update/failure commit outcomes', async () => {
+  const rootProcessRow = makeProcessRow({
+    id: 'proc-root-payload',
+    version: '01.00.030',
+    envelope: 'root',
+  });
+  const directProcessPayloadRow = (
+    makeProcessRow({
+      id: 'proc-direct-payload',
+      version: '01.00.031',
+    }).json_ordered as JsonRecord
+  ).processDataSet as JsonRecord;
+  assert.deepEqual(__testInternals.process_publish_payload_from_row(rootProcessRow), {
+    processDataSet: rootProcessRow.processDataSet,
+  });
+  assert.deepEqual(__testInternals.process_publish_payload_from_row(directProcessPayloadRow), {
+    processDataSet: directProcessPayloadRow,
+  });
+
+  assert.deepEqual(
+    __testInternals.build_process_commit_success_report(
+      {
+        entity_type: 'process',
+        entity_id: 'proc-updated',
+        entity_name: 'proc updated',
+        original_version: '01.00.001',
+        publish_version: '01.00.001',
+        version_strategy: 'keep_current',
+        publish_policy: 'upsert_current_version',
+        row: {},
+      },
+      'update_existing',
+    ),
+    {
+      entity_type: 'process',
+      id: 'proc-updated',
+      name: 'proc updated',
+      original_version: '01.00.001',
+      publish_version: '01.00.001',
+      publish_policy: 'upsert_current_version',
+      version_strategy: 'keep_current',
+      status: 'updated',
+      operation: 'update_existing',
+    },
+  );
+
+  const updateReports = await __testInternals.commit_process_plans({
+    plans: [
+      {
+        entity_type: 'process',
+        entity_id: 'proc-updated',
+        entity_name: 'proc updated',
+        original_version: '01.00.001',
+        publish_version: '01.00.001',
+        version_strategy: 'keep_current',
+        publish_policy: 'upsert_current_version',
+        row: makeProcessRow({ id: 'proc-updated', version: '01.00.001' }),
+      },
+    ],
+    maxWorkers: 1,
+    env: {
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+      TIANGONG_LCA_API_KEY: 'key',
+    } as NodeJS.ProcessEnv,
+    fetchImpl: async (url, init) => {
+      const method = String(init?.method ?? 'GET');
+      const requestUrl = String(url);
+      if (method === 'GET' && requestUrl.includes('id=eq.proc-updated')) {
+        return {
+          ok: true,
+          status: 200,
+          headers: {
+            get() {
+              return 'application/json';
+            },
+          },
+          async text() {
+            return '[{"id":"proc-updated","version":"01.00.001","state_code":0}]';
+          },
+        };
+      }
+
+      return {
+        ok: true,
+        status: 200,
+        headers: {
+          get() {
+            return 'application/json';
+          },
+        },
+        async text() {
+          return '[{"id":"proc-updated"}]';
+        },
+      };
+    },
+  });
+  assert.deepEqual(updateReports, [
+    {
+      entity_type: 'process',
+      id: 'proc-updated',
+      name: 'proc updated',
+      original_version: '01.00.001',
+      publish_version: '01.00.001',
+      publish_policy: 'upsert_current_version',
+      version_strategy: 'keep_current',
+      status: 'updated',
+      operation: 'update_existing',
+    },
+  ]);
+
+  const failedReports = await __testInternals.commit_process_plans({
+    plans: [
+      {
+        entity_type: 'process',
+        entity_id: 'proc-failed',
+        entity_name: 'proc failed',
+        original_version: '01.00.001',
+        publish_version: '01.00.001',
+        version_strategy: 'keep_current',
+        publish_policy: 'upsert_current_version',
+        row: makeProcessRow({ id: 'proc-failed', version: '01.00.001' }),
+      },
+    ],
+    maxWorkers: 1,
+    env: {
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+      TIANGONG_LCA_API_KEY: 'key',
+    } as NodeJS.ProcessEnv,
+    fetchImpl: async (url, init) => {
+      const method = String(init?.method ?? 'GET');
+      const requestUrl = String(url);
+      if (method === 'GET' && requestUrl.includes('id=eq.proc-failed')) {
+        return {
+          ok: true,
+          status: 200,
+          headers: {
+            get() {
+              return 'application/json';
+            },
+          },
+          async text() {
+            return '[]';
+          },
+        };
+      }
+
+      return {
+        ok: false,
+        status: 409,
+        headers: {
+          get() {
+            return 'application/json';
+          },
+        },
+        async text() {
+          return '{"message":"duplicate"}';
+        },
+      };
+    },
+  });
+  assert.deepEqual(failedReports, [
+    {
+      entity_type: 'process',
+      id: 'proc-failed',
+      name: 'proc failed',
+      original_version: '01.00.001',
+      publish_version: '01.00.001',
+      publish_policy: 'upsert_current_version',
+      version_strategy: 'keep_current',
+      status: 'failed',
+      error: 'HTTP 409 returned from https://example.supabase.co/rest/v1/processes',
+    },
+  ]);
+
+  const stringErrorReports = await __testInternals.commit_process_plans({
+    plans: [
+      {
+        entity_type: 'process',
+        entity_id: 'proc-string-error',
+        entity_name: 'proc string error',
+        original_version: '01.00.001',
+        publish_version: '01.00.001',
+        version_strategy: 'keep_current',
+        publish_policy: 'upsert_current_version',
+        row: makeProcessRow({ id: 'proc-string-error', version: '01.00.001' }),
+      },
+    ],
+    maxWorkers: 1,
+    env: {
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+      TIANGONG_LCA_API_KEY: 'key',
+    } as NodeJS.ProcessEnv,
+    fetchImpl: async () => {
+      throw 'boom-string';
+    },
+  });
+  assert.deepEqual(stringErrorReports, [
+    {
+      entity_type: 'process',
+      id: 'proc-string-error',
+      name: 'proc string error',
+      original_version: '01.00.001',
+      publish_version: '01.00.001',
+      publish_policy: 'upsert_current_version',
+      version_strategy: 'keep_current',
+      status: 'failed',
+      error: 'boom-string',
+    },
+  ]);
+});
+
+test('runFlowReviewedPublishData can use the default flow publish-version implementation for commit mode', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-publish-reviewed-default-commit-'));
+  const flowRowsFile = path.join(dir, 'reviewed-flows.jsonl');
+  const outDir = path.join(dir, 'publish-reviewed');
+  const observed: Array<{ url: string; method: string; body: string | undefined }> = [];
+
+  writeJsonl(flowRowsFile, [makeFlowRow({ id: 'flow-default', version: '01.00.001' })]);
+
+  const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+    observed.push({
+      url: String(input),
+      method: String(init?.method ?? ''),
+      body: typeof init?.body === 'string' ? init.body : undefined,
+    });
+
+    if (observed.length === 1) {
+      return {
+        ok: true,
+        status: 200,
+        headers: {
+          get: () => 'application/json',
+        },
+        text: async () => '[]',
+      };
+    }
+
+    return {
+      ok: true,
+      status: 201,
+      headers: {
+        get: () => 'application/json',
+      },
+      text: async () => '',
+    };
+  }) as unknown as typeof fetch;
+
+  try {
+    const report = await runFlowReviewedPublishData({
+      flowRowsFile,
+      outDir,
+      flowPublishPolicy: 'append_only_bump',
+      commit: true,
+      env: {
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
+        TIANGONG_LCA_API_KEY: 'secret-token',
+      } as NodeJS.ProcessEnv,
+      fetchImpl,
+    });
+
+    assert.equal(report.status, 'completed_flow_publish_reviewed_data');
+    assert.equal(report.counts.success_count, 1);
+    assert.equal(report.counts.failure_count, 0);
+    assert.equal(report.flow_reports[0]?.status, 'inserted');
+    assert.equal(typeof report.generated_at_utc, 'string');
+    assert.match(report.generated_at_utc, /^\d{4}-\d{2}-\d{2}T/u);
+    assert.deepEqual(
+      observed.map((entry) => entry.method),
+      ['GET', 'POST'],
+    );
+    assert.match(observed[1]?.body ?? '', /"id":"flow-default"/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runFlowReviewedPublishData prepares process rows locally, rewrites flow refs, and bumps process versions', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-publish-reviewed-process-dry-run-'));
+  const flowRowsFile = path.join(dir, 'reviewed-flows.json');
+  const processRowsFile = path.join(dir, 'reviewed-processes.json');
+  const outDir = path.join(dir, 'publish-reviewed');
+
+  writeJson(flowRowsFile, [makeFlowRow({ id: 'flow-process', version: '01.00.001' })]);
+  writeJson(processRowsFile, [
+    makeProcessRow({
+      id: 'process-1',
+      version: '01.00.007',
+      exchanges: [
+        makeExchange({
+          internalId: '42',
+          flowId: 'flow-process',
+          flowVersion: '01.00.001',
+          flowText: 'Flow before rewrite',
+          shortDescriptionShape: 'object',
+        }),
+      ],
+    }),
+  ]);
+
+  try {
+    const report = await runFlowReviewedPublishData({
+      flowRowsFile,
+      processRowsFile,
+      outDir,
+      flowPublishPolicy: 'append_only_bump',
+      processPublishPolicy: 'append_only_bump',
+      rewriteProcessFlowRefs: true,
+      now: new Date('2026-03-30T18:00:00.000Z'),
+    });
+
+    assert.equal(report.status, 'prepared_flow_publish_reviewed_data');
+    assert.equal(report.flow_rows_file, flowRowsFile);
+    assert.equal(report.process_rows_file, processRowsFile);
+    assert.equal(report.process_publish_policy, 'append_only_bump');
+    assert.equal(report.rewrite_process_flow_refs, true);
+    assert.deepEqual(report.counts, {
+      input_flow_rows: 1,
+      input_process_rows: 1,
+      original_flow_rows: 0,
+      prepared_flow_rows: 1,
+      prepared_process_rows: 1,
+      skipped_unchanged_flow_rows: 0,
+      rewritten_process_flow_refs: 1,
+      flow_publish_reports: 1,
+      process_publish_reports: 1,
+      success_count: 0,
+      failure_count: 0,
+    });
+    assert.deepEqual(report.process_reports, [
+      {
+        entity_type: 'process',
+        id: 'process-1',
+        name: 'process-1 name',
+        original_version: '01.00.007',
+        publish_version: '01.00.008',
+        publish_policy: 'append_only_bump',
+        version_strategy: 'bump',
+        status: 'prepared',
+      },
+    ]);
+
+    const preparedProcesses = JSON.parse(
+      readFileSync(report.files.prepared_process_rows, 'utf8'),
+    ) as JsonRecord[];
+    assert.equal(preparedProcesses.length, 1);
+    assert.equal((preparedProcesses[0] as JsonRecord).version, '01.00.008');
+
+    const preparedReference = ((
+      (
+        (
+          ((preparedProcesses[0] as JsonRecord).json_ordered as JsonRecord)
+            .processDataSet as JsonRecord
+        ).exchanges as JsonRecord
+      ).exchange as JsonRecord[]
+    )[0]?.referenceToFlowDataSet ?? {}) as JsonRecord;
+    assert.equal(preparedReference['@refObjectId'], 'flow-process');
+    assert.equal(preparedReference['@version'], '01.00.002');
+    assert.equal(preparedReference['@uri'], '../flows/flow-process_01.00.002.xml');
+    assert.equal(Array.isArray(preparedReference['common:shortDescription']), false);
+
+    const rewriteEvidence = readFileSync(report.files.process_ref_rewrite_evidence, 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as JsonRecord);
+    assert.deepEqual(rewriteEvidence, [
+      {
+        process_id: 'process-1',
+        process_version_before_publish: '01.00.007',
+        process_name: 'process-1 name',
+        exchange_internal_id: '42',
+        source_flow_id: 'flow-process',
+        source_flow_version: '01.00.001',
+        target_flow_id: 'flow-process',
+        target_flow_version: '01.00.002',
+        target_flow_name: 'flow-process name',
+      },
+    ]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runFlowReviewedPublishData commits prepared process rows through Supabase REST when process publish is requested', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-publish-reviewed-process-commit-'));
+  const processRowsFile = path.join(dir, 'reviewed-processes.json');
+  const outDir = path.join(dir, 'publish-reviewed');
+  const observed: Array<{ method: string; url: string; body?: string }> = [];
+
+  writeJson(processRowsFile, [makeProcessRow({ id: 'process-commit', version: '01.00.000' })]);
+
+  try {
+    const report = await runFlowReviewedPublishData({
+      processRowsFile,
+      outDir,
+      commit: true,
+      env: {
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+        TIANGONG_LCA_API_KEY: 'key',
+      } as NodeJS.ProcessEnv,
+      fetchImpl: async (url, init) => {
+        observed.push({
+          method: String(init?.method ?? 'GET'),
+          url: String(url),
+          body: typeof init?.body === 'string' ? init.body : undefined,
+        });
+
+        if (observed.length === 1) {
+          return {
+            ok: true,
+            status: 200,
+            headers: {
+              get() {
+                return 'application/json';
+              },
+            },
+            async text() {
+              return '[]';
+            },
+          };
+        }
+
+        return {
+          ok: true,
+          status: 201,
+          headers: {
+            get() {
+              return 'application/json';
+            },
+          },
+          async text() {
+            return '[{"id":"process-commit"}]';
+          },
+        };
+      },
+    });
+
+    assert.equal(report.status, 'completed_flow_publish_reviewed_data');
+    assert.equal(report.counts.success_count, 1);
+    assert.equal(report.counts.failure_count, 0);
+    assert.equal(report.process_reports[0]?.status, 'inserted');
+    assert.equal(report.process_reports[0]?.operation, 'insert');
+    assert.deepEqual(
+      observed.map((entry) => entry.method),
+      ['GET', 'POST'],
+    );
+    assert.match(observed[1]?.body ?? '', /"json_ordered"/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runFlowReviewedPublishData rejects process commit without runtime env or fetch', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-publish-reviewed-process-runtime-'));
+  const processRowsFile = path.join(dir, 'reviewed-processes.json');
+  const outDir = path.join(dir, 'publish-reviewed');
+
+  writeJson(processRowsFile, [makeProcessRow({ id: 'process-runtime', version: '01.00.000' })]);
+
+  try {
+    await assert.rejects(
+      () =>
+        runFlowReviewedPublishData({
+          processRowsFile,
+          outDir,
+          commit: true,
+        }),
+      (error: unknown) =>
+        error instanceof CliError && error.code === 'FLOW_PUBLISH_REVIEWED_PROCESS_FETCH_REQUIRED',
+    );
+
+    await assert.rejects(
+      () =>
+        runFlowReviewedPublishData({
+          processRowsFile,
+          outDir,
+          commit: true,
+          fetchImpl: async () => {
+            throw new Error('should not be called');
+          },
+        }),
+      (error: unknown) =>
+        error instanceof CliError &&
+        error.code === 'FLOW_PUBLISH_REVIEWED_PROCESS_RUNTIME_REQUIRED',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runFlowReviewedPublishData requires at least one flow or process input file', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-publish-reviewed-input-required-'));
+  const outDir = path.join(dir, 'publish-reviewed');
+
+  try {
+    await assert.rejects(
+      () =>
+        runFlowReviewedPublishData({
+          outDir,
+        }),
+      (error: unknown) =>
+        error instanceof CliError && error.code === 'FLOW_PUBLISH_REVIEWED_INPUT_REQUIRED',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('flow publish-reviewed-data helper internals cover validation, compatibility, and edge-case mapping', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-publish-reviewed-internals-'));
+  const inputFile = path.join(dir, 'rows.json');
+  writeJson(inputFile, []);
+
+  try {
+    assert.equal(
+      __testInternals.assert_input_file(inputFile, 'FLOW_PUBLISH_REVIEWED_FLOW_ROWS_REQUIRED'),
+      inputFile,
+    );
+    assert.throws(
+      () => __testInternals.assert_input_file('', 'FLOW_PUBLISH_REVIEWED_FLOW_ROWS_REQUIRED'),
+      (error: unknown) =>
+        error instanceof CliError && error.code === 'FLOW_PUBLISH_REVIEWED_FLOW_ROWS_REQUIRED',
+    );
+    assert.throws(
+      () =>
+        __testInternals.assert_input_file(
+          path.join(dir, 'missing-flow-rows.json'),
+          'FLOW_PUBLISH_REVIEWED_FLOW_ROWS_REQUIRED',
+        ),
+      (error: unknown) =>
+        error instanceof CliError && error.code === 'FLOW_PUBLISH_REVIEWED_FLOW_ROWS_REQUIRED',
+    );
+    assert.equal(__testInternals.assert_optional_input_file(undefined, 'ANY_CODE'), null);
+    assert.throws(
+      () =>
+        __testInternals.assert_optional_input_file(
+          path.join(dir, 'missing.json'),
+          'FLOW_PUBLISH_REVIEWED_ORIGINAL_ROWS_NOT_FOUND',
+        ),
+      (error: unknown) =>
+        error instanceof CliError && error.code === 'FLOW_PUBLISH_REVIEWED_ORIGINAL_ROWS_NOT_FOUND',
+    );
+    assert.equal(__testInternals.assert_out_dir(dir), dir);
+    assert.throws(
+      () => __testInternals.assert_out_dir(''),
+      (error: unknown) =>
+        error instanceof CliError && error.code === 'FLOW_PUBLISH_REVIEWED_OUT_DIR_REQUIRED',
+    );
+
+    assert.equal(__testInternals.clone_json(undefined), undefined);
+    assert.deepEqual(__testInternals.clone_json({ a: [1, 2] }), { a: [1, 2] });
+    assert.equal(__testInternals.json_equal({ a: 1, b: [2] }, { b: [2], a: 1 }), true);
+    assert.equal(__testInternals.json_equal({ a: 1 }, { a: 2 }), false);
+    assert.equal(__testInternals.json_equal({ a: 1 }, { a: 1, b: 2 }), false);
+    assert.equal(__testInternals.json_equal([1], [1, 2]), false);
+    assert.equal(__testInternals.normalize_publish_policy(undefined), 'append_only_bump');
+    assert.equal(__testInternals.normalize_publish_policy(''), 'append_only_bump');
+    assert.equal(__testInternals.normalize_publish_policy('skip'), 'skip');
+    assert.equal(
+      __testInternals.normalize_publish_policy(
+        'upsert_current_version',
+        '--process-publish-policy',
+        'FLOW_PUBLISH_REVIEWED_PROCESS_POLICY_INVALID',
+      ),
+      'upsert_current_version',
+    );
+    assert.throws(
+      () => __testInternals.normalize_publish_policy('bad-policy'),
+      (error: unknown) =>
+        error instanceof CliError && error.code === 'FLOW_PUBLISH_REVIEWED_POLICY_INVALID',
+    );
+    assert.throws(
+      () =>
+        __testInternals.normalize_publish_policy(
+          'bad-policy',
+          '--process-publish-policy',
+          'FLOW_PUBLISH_REVIEWED_PROCESS_POLICY_INVALID',
+        ),
+      (error: unknown) =>
+        error instanceof CliError && error.code === 'FLOW_PUBLISH_REVIEWED_PROCESS_POLICY_INVALID',
+    );
+    assert.equal(__testInternals.bump_ilcd_version('01.02.009'), '01.02.010');
+    assert.equal(__testInternals.bump_ilcd_version(''), '01.01.001');
+    assert.equal(__testInternals.bump_ilcd_version('bad-version'), '01.01.001');
+
+    const rootRow = makeFlowRow({ id: 'flow-root', version: '01.00.009', envelope: 'root' });
+    __testInternals.set_flow_version(rootRow, '01.00.010');
+    assert.equal((rootRow as JsonRecord).version, '01.00.010');
+    const missingPublicationRow = {
+      flowDataSet: {
+        administrativeInformation: {},
+      },
+    } as JsonRecord;
+    __testInternals.set_flow_version(missingPublicationRow, '01.00.011');
+    assert.equal(
+      (
+        ((missingPublicationRow.flowDataSet as JsonRecord).administrativeInformation as JsonRecord)
+          .publicationAndOwnership as JsonRecord
+      )['common:dataSetVersion'],
+      '01.00.011',
+    );
+    const missingAdministrativeRow = {
+      flowDataSet: {},
+    } as JsonRecord;
+    __testInternals.set_flow_version(missingAdministrativeRow, '01.00.012');
+    assert.equal(
+      (
+        (
+          (missingAdministrativeRow.flowDataSet as JsonRecord)
+            .administrativeInformation as JsonRecord
+        ).publicationAndOwnership as JsonRecord
+      )['common:dataSetVersion'],
+      '01.00.012',
+    );
+    const directPayloadRow = {
+      administrativeInformation: {},
+    } as JsonRecord;
+    __testInternals.set_flow_version(directPayloadRow, '01.00.013');
+    assert.equal((directPayloadRow as JsonRecord).version, '01.00.013');
+    assert.equal(
+      (
+        (directPayloadRow.administrativeInformation as JsonRecord)
+          .publicationAndOwnership as JsonRecord
+      )['common:dataSetVersion'],
+      '01.00.013',
+    );
+
+    const directProcessPayloadRow = {
+      administrativeInformation: {},
+    } as JsonRecord;
+    const wrappedProcessRow = makeProcessRow({ id: 'proc-wrapped', version: '01.00.001' });
+    assert.equal(
+      __testInternals.process_dataset_from_row(wrappedProcessRow),
+      (wrappedProcessRow.json_ordered as JsonRecord).processDataSet,
+    );
+    const rootProcessRow = makeProcessRow({
+      id: 'proc-root',
+      version: '01.00.002',
+      envelope: 'root',
+    });
+    assert.equal(
+      __testInternals.process_dataset_from_row(rootProcessRow),
+      (rootProcessRow as JsonRecord).processDataSet,
+    );
+    assert.equal(
+      __testInternals.process_dataset_from_row(directProcessPayloadRow),
+      directProcessPayloadRow,
+    );
+    assert.deepEqual(__testInternals.extract_process_identity(rootProcessRow), {
+      id: 'proc-root',
+      version: '01.00.002',
+      name: 'proc-root name',
+    });
+    assert.deepEqual(
+      __testInternals.extract_process_identity({
+        processDataSet: {
+          processInformation: {
+            dataSetInformation: {
+              'common:UUID': 'proc-default-version',
+              name: {
+                baseName: [lang('proc-default-version name')],
+              },
+            },
+          },
+        },
+      } as JsonRecord),
+      {
+        id: 'proc-default-version',
+        version: '01.00.000',
+        name: 'proc-default-version name',
+      },
+    );
+    assert.deepEqual(
+      __testInternals.extract_process_identity({
+        id: 'proc-fallback-name',
+        processDataSet: {},
+      } as JsonRecord),
+      {
+        id: 'proc-fallback-name',
+        version: '01.00.000',
+        name: 'proc-fallback-name',
+      },
+    );
+    assert.deepEqual(__testInternals.exchange_records(wrappedProcessRow), [
+      makeExchange({ flowId: 'flow-1', flowVersion: '01.00.001', flowText: 'Scope Flow' }),
+    ]);
+
+    const processWithoutPublication = {
+      processDataSet: {
+        administrativeInformation: {},
+      },
+    } as JsonRecord;
+    __testInternals.set_process_version(processWithoutPublication, '01.00.014');
+    assert.equal(
+      (
+        (
+          (processWithoutPublication.processDataSet as JsonRecord)
+            .administrativeInformation as JsonRecord
+        ).publicationAndOwnership as JsonRecord
+      )['common:dataSetVersion'],
+      '01.00.014',
+    );
+
+    const processWithoutAdministrative = {
+      processDataSet: {},
+    } as JsonRecord;
+    __testInternals.set_process_version(processWithoutAdministrative, '01.00.015');
+    assert.equal(
+      (
+        (
+          (processWithoutAdministrative.processDataSet as JsonRecord)
+            .administrativeInformation as JsonRecord
+        ).publicationAndOwnership as JsonRecord
+      )['common:dataSetVersion'],
+      '01.00.015',
+    );
+
+    __testInternals.set_process_version(directProcessPayloadRow, '01.00.016');
+    assert.equal((directProcessPayloadRow as JsonRecord).version, '01.00.016');
+    assert.equal(
+      (
+        (directProcessPayloadRow.administrativeInformation as JsonRecord)
+          .publicationAndOwnership as JsonRecord
+      )['common:dataSetVersion'],
+      '01.00.016',
+    );
+
+    const files = __testInternals.build_output_files(dir);
+    assert.equal(path.basename(files.report), 'publish-report.json');
+    assert.equal(__testInternals.build_local_dataset_uri('flow data set', '', '01.00.001'), '');
+    assert.equal(
+      __testInternals.build_local_dataset_uri('unknown', 'dataset-1', '01.00.001'),
+      '../datasets/dataset-1_01.00.001.xml',
+    );
+    assert.equal(
+      __testInternals.build_local_dataset_uri('flow data set', 'dataset-2', ''),
+      '../flows/dataset-2_01.00.000.xml',
+    );
+    assert.deepEqual(
+      __testInternals.preserve_short_description_shape([{ '@xml:lang': 'zh', '#text': 'old' }], {
+        '@xml:lang': 'en',
+        '#text': 'new',
+      }),
+      [{ '@xml:lang': 'en', '#text': 'new' }],
+    );
+    assert.deepEqual(
+      __testInternals.preserve_short_description_shape([{ '@xml:lang': 'zh', '#text': 'old' }], {
+        '#text': 'new',
+      }),
+      [{ '@xml:lang': 'zh', '#text': 'new' }],
+    );
+    assert.deepEqual(
+      __testInternals.preserve_short_description_shape([{ '#text': 'old' }], {
+        '#text': 'new',
+      }),
+      [{ '@xml:lang': 'en', '#text': 'new' }],
+    );
+    assert.deepEqual(
+      __testInternals.preserve_short_description_shape([], {
+        '@xml:lang': 'en',
+        '#text': 'new',
+      }),
+      [{ '@xml:lang': 'en', '#text': 'new' }],
+    );
+    assert.deepEqual(
+      __testInternals.preserve_short_description_shape(
+        { '@xml:lang': 'zh', '#text': 'old' },
+        { '@xml:lang': 'en', '#text': 'new' },
+      ),
+      { '@xml:lang': 'en', '#text': 'new' },
+    );
+    assert.deepEqual(
+      __testInternals.preserve_short_description_shape(
+        { '@xml:lang': 'zh', '#text': 'old' },
+        {
+          '#text': 'new',
+        },
+      ),
+      { '@xml:lang': 'zh', '#text': 'new' },
+    );
+    assert.deepEqual(
+      __testInternals.preserve_short_description_shape('old', {
+        '@xml:lang': 'en',
+        '#text': 'new',
+      }),
+      { '@xml:lang': 'en', '#text': 'new' },
+    );
+    assert.deepEqual(
+      __testInternals.preserve_short_description_shape(
+        { '#text': 'old' },
+        {
+          '#text': 'new',
+        },
+      ),
+      { '@xml:lang': 'en', '#text': 'new' },
+    );
+    assert.equal(
+      __testInternals.status_from_mode('dry_run', 0),
+      'prepared_flow_publish_reviewed_data',
+    );
+    assert.equal(
+      __testInternals.status_from_mode('commit', 0),
+      'completed_flow_publish_reviewed_data',
+    );
+    assert.equal(
+      __testInternals.status_from_mode('commit', 1),
+      'completed_flow_publish_reviewed_data_with_failures',
+    );
+
+    const skipPrepared = __testInternals.prepare_flow_rows({
+      rows: [makeFlowRow({ id: 'flow-skip' })],
+      policy: 'skip',
+      originalRows: [],
+    });
+    assert.deepEqual(skipPrepared, {
+      preparedRows: [],
+      plans: [],
+      flowVersionMap: {},
+      skippedUnchangedRows: [],
+    });
+
+    const upsertPrepared = __testInternals.prepare_flow_rows({
+      rows: [makeFlowRow({ id: 'flow-upsert', version: '01.00.003' })],
+      policy: 'upsert_current_version',
+      originalRows: [],
+    });
+    assert.equal(upsertPrepared.preparedRows.length, 1);
+    assert.equal(upsertPrepared.plans[0]?.publish_version, '01.00.003');
+    assert.deepEqual(upsertPrepared.flowVersionMap, {});
+
+    const missingIdPrepared = __testInternals.prepare_flow_rows({
+      rows: [
+        {
+          flowDataSet: {
+            flowInformation: {
+              dataSetInformation: {
+                name: {
+                  baseName: {
+                    '@xml:lang': 'en',
+                    '#text': 'nameless flow',
+                  },
+                },
+              },
+            },
+            administrativeInformation: {
+              publicationAndOwnership: {
+                'common:dataSetVersion': '01.00.004',
+              },
+            },
+          },
+        },
+      ],
+      policy: 'append_only_bump',
+      originalRows: [
+        {
+          flowDataSet: {
+            flowInformation: {
+              dataSetInformation: {
+                name: {
+                  baseName: {
+                    '@xml:lang': 'en',
+                    '#text': 'nameless flow',
+                  },
+                },
+              },
+            },
+            administrativeInformation: {
+              publicationAndOwnership: {
+                'common:dataSetVersion': '01.00.004',
+              },
+            },
+          },
+        },
+      ],
+    });
+    assert.equal(missingIdPrepared.preparedRows.length, 1);
+    assert.equal(missingIdPrepared.plans[0]?.entity_id, '');
+    assert.equal(missingIdPrepared.plans[0]?.publish_version, '01.00.005');
+    assert.deepEqual(missingIdPrepared.flowVersionMap, {});
+    assert.deepEqual(missingIdPrepared.skippedUnchangedRows, []);
+
+    const flowIndex = __testInternals.build_flow_index([
+      makeFlowRow({ id: 'flow-index', version: '01.00.021' }),
+    ]);
+    assert.equal(flowIndex.byUuidVersion['flow-index@01.00.021']?.name, 'flow-index name');
+    assert.deepEqual(
+      __testInternals.flow_reference_from_record({
+        id: 'flow-null-short',
+        version: '01.00.022',
+        name: 'flow null short',
+        flowType: '',
+        shortDescription: null,
+        row: {},
+      }),
+      {
+        '@type': 'flow data set',
+        '@refObjectId': 'flow-null-short',
+        '@version': '01.00.022',
+        '@uri': '../flows/flow-null-short_01.00.022.xml',
+        'common:shortDescription': {
+          '@xml:lang': 'en',
+          '#text': 'flow null short',
+        },
+      },
+    );
+    assert.deepEqual(
+      __testInternals.flow_reference_from_record(flowIndex.byUuidVersion['flow-index@01.00.021']),
+      {
+        '@type': 'flow data set',
+        '@refObjectId': 'flow-index',
+        '@version': '01.00.021',
+        '@uri': '../flows/flow-index_01.00.021.xml',
+        'common:shortDescription': {
+          '@xml:lang': 'en',
+          '#text': 'flow-index name',
+        },
+      },
+    );
+    assert.deepEqual(
+      __testInternals.patched_flow_reference(
+        {
+          '@type': '',
+          '@refObjectId': 'old',
+          '@version': 'old',
+          'common:shortDescription': [{ '@xml:lang': 'zh', '#text': 'old name' }],
+        },
+        flowIndex.byUuidVersion['flow-index@01.00.021'],
+      ),
+      {
+        '@type': 'flow data set',
+        '@refObjectId': 'flow-index',
+        '@version': '01.00.021',
+        '@uri': '../flows/flow-index_01.00.021.xml',
+        'common:shortDescription': [{ '@xml:lang': 'en', '#text': 'flow-index name' }],
+      },
+    );
+    assert.deepEqual(
+      __testInternals.patched_flow_reference(
+        'bad-reference',
+        flowIndex.byUuidVersion['flow-index@01.00.021'],
+      ),
+      {
+        '@type': 'flow data set',
+        '@refObjectId': 'flow-index',
+        '@version': '01.00.021',
+        '@uri': '../flows/flow-index_01.00.021.xml',
+        'common:shortDescription': {
+          '@xml:lang': 'en',
+          '#text': 'flow-index name',
+        },
+      },
+    );
+
+    const skipPreparedProcesses = __testInternals.prepare_process_rows({
+      rows: [makeProcessRow({ id: 'proc-skip' })],
+      policy: 'skip',
+      rewriteRefs: true,
+      preparedFlowRows: [],
+      flowVersionMap: {},
+    });
+    assert.deepEqual(skipPreparedProcesses, {
+      preparedRows: [],
+      plans: [],
+      rewriteEvidence: [],
+    });
+
+    assert.deepEqual(
+      __testInternals.process_publish_payload_from_row(
+        makeProcessRow({ id: 'proc-payload', version: '01.00.020' }),
+      ),
+      {
+        processDataSet: (
+          makeProcessRow({ id: 'proc-payload', version: '01.00.020' }).json_ordered as JsonRecord
+        ).processDataSet as JsonRecord,
+      },
+    );
+    assert.deepEqual(
+      __testInternals.build_process_commit_success_report(
+        {
+          entity_type: 'process',
+          entity_id: 'proc-success',
+          entity_name: 'proc success',
+          original_version: '01.00.001',
+          publish_version: '01.00.002',
+          version_strategy: 'bump',
+          publish_policy: 'append_only_bump',
+          row: {},
+        },
+        'skipped_existing',
+      ),
+      {
+        entity_type: 'process',
+        id: 'proc-success',
+        name: 'proc success',
+        original_version: '01.00.001',
+        publish_version: '01.00.002',
+        publish_policy: 'append_only_bump',
+        version_strategy: 'bump',
+        status: 'skipped_existing',
+        operation: 'skipped_existing',
+      },
+    );
+    assert.deepEqual(
+      __testInternals.build_process_commit_failure_report(
+        {
+          entity_type: 'process',
+          entity_id: 'proc-failure',
+          entity_name: 'proc failure',
+          original_version: '01.00.001',
+          publish_version: '01.00.001',
+          version_strategy: 'keep_current',
+          publish_policy: 'upsert_current_version',
+          row: {},
+        },
+        'boom',
+      ),
+      {
+        entity_type: 'process',
+        id: 'proc-failure',
+        name: 'proc failure',
+        original_version: '01.00.001',
+        publish_version: '01.00.001',
+        publish_policy: 'upsert_current_version',
+        version_strategy: 'keep_current',
+        status: 'failed',
+        error: 'boom',
+      },
+    );
+    assert.deepEqual(
+      await __testInternals.map_with_concurrency([1, 2, 3], 2, async (value) => value * 2),
+      [2, 4, 6],
+    );
+    const commitPlans = await __testInternals.commit_process_plans({
+      plans: [
+        {
+          entity_type: 'process',
+          entity_id: 'proc-commit-plan',
+          entity_name: 'proc commit plan',
+          original_version: '01.00.001',
+          publish_version: '01.00.002',
+          version_strategy: 'bump',
+          publish_policy: 'append_only_bump',
+          row: makeProcessRow({ id: 'proc-commit-plan', version: '01.00.002' }),
+        },
+      ],
+      maxWorkers: 1,
+      env: {
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+        TIANGONG_LCA_API_KEY: 'key',
+      } as NodeJS.ProcessEnv,
+      fetchImpl: async (url, init) => {
+        const method = String(init?.method ?? 'GET');
+        if (method === 'GET') {
+          return {
+            ok: true,
+            status: 200,
+            headers: {
+              get() {
+                return 'application/json';
+              },
+            },
+            async text() {
+              return '[]';
+            },
+          };
+        }
+
+        return {
+          ok: true,
+          status: 201,
+          headers: {
+            get() {
+              return 'application/json';
+            },
+          },
+          async text() {
+            return '[{"id":"proc-commit-plan"}]';
+          },
+        };
+      },
+    });
+    assert.equal(commitPlans[0]?.status, 'inserted');
+
+    const rewrittenProcesses = __testInternals.prepare_process_rows({
+      rows: [
+        makeProcessRow({
+          id: 'proc-rewrite',
+          version: '01.00.030',
+          exchanges: [
+            makeExchange({
+              internalId: '3',
+              flowId: 'flow-old',
+              flowVersion: '01.00.001',
+              flowText: 'Old flow',
+            }),
+          ],
+        }),
+      ],
+      policy: 'append_only_bump',
+      rewriteRefs: true,
+      preparedFlowRows: [makeFlowRow({ id: 'flow-old', version: '01.00.002' })],
+      flowVersionMap: {
+        'flow-old@01.00.001': {
+          id: 'flow-old',
+          source_version: '01.00.001',
+          target_version: '01.00.002',
+        },
+      },
+    });
+    assert.equal(rewrittenProcesses.preparedRows.length, 1);
+    assert.equal(rewrittenProcesses.plans[0]?.publish_version, '01.00.031');
+    assert.equal(rewrittenProcesses.rewriteEvidence.length, 1);
+    const rewrittenReference = ((
+      (
+        (
+          ((rewrittenProcesses.preparedRows[0] as JsonRecord).json_ordered as JsonRecord)
+            .processDataSet as JsonRecord
+        ).exchanges as JsonRecord
+      ).exchange as JsonRecord[]
+    )[0]?.referenceToFlowDataSet ?? {}) as JsonRecord;
+    assert.equal(rewrittenReference['@version'], '01.00.002');
+
+    const nonRecordReferenceProcesses = __testInternals.prepare_process_rows({
+      rows: [
+        makeProcessRow({
+          id: 'proc-non-record-ref',
+          version: '01.00.032',
+          exchanges: [
+            {
+              '@dataSetInternalID': '9',
+              exchangeDirection: 'Output',
+              referenceToFlowDataSet: 'not-a-record',
+            },
+          ],
+        }),
+      ],
+      policy: 'append_only_bump',
+      rewriteRefs: true,
+      preparedFlowRows: [makeFlowRow({ id: 'flow-old', version: '01.00.002' })],
+      flowVersionMap: {
+        'flow-old@01.00.001': {
+          id: 'flow-old',
+          source_version: '01.00.001',
+          target_version: '01.00.002',
+        },
+      },
+    });
+    assert.equal(nonRecordReferenceProcesses.rewriteEvidence.length, 0);
+
+    const unmappedProcesses = __testInternals.prepare_process_rows({
+      rows: [
+        makeProcessRow({
+          id: 'proc-unmapped',
+          version: '01.00.033',
+          exchanges: [
+            makeExchange({
+              internalId: '10',
+              flowId: 'flow-unmapped',
+              flowVersion: '01.00.001',
+              flowText: 'Unmapped flow',
+            }),
+          ],
+        }),
+      ],
+      policy: 'append_only_bump',
+      rewriteRefs: true,
+      preparedFlowRows: [makeFlowRow({ id: 'flow-other', version: '01.00.002' })],
+      flowVersionMap: {
+        'flow-old@01.00.001': {
+          id: 'flow-old',
+          source_version: '01.00.001',
+          target_version: '01.00.002',
+        },
+      },
+    });
+    assert.equal(unmappedProcesses.rewriteEvidence.length, 0);
+    const unmappedReference = ((
+      (
+        (
+          ((unmappedProcesses.preparedRows[0] as JsonRecord).json_ordered as JsonRecord)
+            .processDataSet as JsonRecord
+        ).exchanges as JsonRecord
+      ).exchange as JsonRecord[]
+    )[0]?.referenceToFlowDataSet ?? {}) as JsonRecord;
+    assert.equal(unmappedReference['@version'], '01.00.001');
+
+    const missingTargetProcesses = __testInternals.prepare_process_rows({
+      rows: [
+        makeProcessRow({
+          id: 'proc-missing-target',
+          version: '01.00.040',
+          exchanges: [
+            makeExchange({
+              internalId: '4',
+              flowId: 'flow-missing-target',
+              flowVersion: '01.00.001',
+              flowText: 'Missing target',
+            }),
+          ],
+        }),
+      ],
+      policy: 'upsert_current_version',
+      rewriteRefs: true,
+      preparedFlowRows: [makeFlowRow({ id: 'other-flow', version: '01.00.002' })],
+      flowVersionMap: {
+        'flow-missing-target@01.00.001': {
+          id: 'flow-missing-target',
+          source_version: '01.00.001',
+          target_version: '01.00.002',
+        },
+      },
+    });
+    assert.equal(missingTargetProcesses.rewriteEvidence.length, 0);
+    const missingTargetReference = ((
+      (
+        (
+          ((missingTargetProcesses.preparedRows[0] as JsonRecord).json_ordered as JsonRecord)
+            .processDataSet as JsonRecord
+        ).exchanges as JsonRecord
+      ).exchange as JsonRecord[]
+    )[0]?.referenceToFlowDataSet ?? {}) as JsonRecord;
+    assert.equal(missingTargetReference['@version'], '01.00.001');
+
+    const compatReport = __testInternals.build_compat_report({
+      now: new Date('2026-03-30T17:00:00.000Z'),
+      mode: 'commit',
+      preparedRows: 2,
+      successCount: 1,
+      failureCount: 1,
+      maxWorkers: 3,
+      targetUserId: 'user-1',
+      files,
+    });
+    assert.equal(compatReport.status, 'completed_flow_publish_version_with_failures');
+    const compatReportNoFailures = __testInternals.build_compat_report({
+      now: new Date('2026-03-30T17:05:00.000Z'),
+      mode: 'commit',
+      preparedRows: 1,
+      successCount: 1,
+      failureCount: 0,
+      maxWorkers: 1,
+      targetUserId: null,
+      files,
+    });
+    assert.equal(compatReportNoFailures.status, 'completed_flow_publish_version');
+
+    const unkeyedFailureReports = __testInternals.map_commit_reports(
+      [
+        {
+          entity_type: 'flow',
+          entity_id: '',
+          entity_name: 'missing-id',
+          original_version: '01.00.001',
+          publish_version: '01.00.002',
+          version_strategy: 'bump',
+          publish_policy: 'append_only_bump',
+          row: { json_ordered: { flowDataSet: {} } },
+        },
+      ],
+      [],
+      [
+        {
+          id: undefined,
+          json_ordered: {
+            flowDataSet: {
+              administrativeInformation: {
+                publicationAndOwnership: { 'common:dataSetVersion': '01.00.002' },
+              },
+            },
+          },
+          reason: [
+            {
+              validator: 'remote_rest',
+              stage: 'insert',
+              path: '',
+              message: 'missing id',
+              code: 'FLOW_PUBLISH_VERSION_ID_REQUIRED',
+            },
+          ],
+        },
+      ],
+    );
+    assert.equal(unkeyedFailureReports[0]?.status, 'failed');
+
+    const unmatchedReports = __testInternals.map_commit_reports(
+      [
+        {
+          entity_type: 'flow',
+          entity_id: 'flow-unmatched',
+          entity_name: 'flow-unmatched',
+          original_version: '01.00.001',
+          publish_version: '01.00.002',
+          version_strategy: 'bump',
+          publish_policy: 'append_only_bump',
+          row: makeFlowRow({ id: 'flow-unmatched' }),
+        },
+      ],
+      [],
+      [],
+    );
+    assert.equal(unmatchedReports[0]?.status, 'failed');
+    assert.deepEqual(unmatchedReports[0]?.error, [
+      {
+        code: 'UNMATCHED_PUBLISH_RESULT',
+        message: 'Publish result was missing for prepared flow row.',
+      },
+    ]);
+
+    const duplicateKeyReports = __testInternals.map_commit_reports(
+      [
+        {
+          entity_type: 'flow',
+          entity_id: 'flow-dup',
+          entity_name: 'flow-dup',
+          original_version: '01.00.001',
+          publish_version: '01.00.002',
+          version_strategy: 'bump',
+          publish_policy: 'append_only_bump',
+          row: makeFlowRow({ id: 'flow-dup' }),
+        },
+        {
+          entity_type: 'flow',
+          entity_id: 'flow-dup',
+          entity_name: 'flow-dup',
+          original_version: '01.00.001',
+          publish_version: '01.00.002',
+          version_strategy: 'bump',
+          publish_policy: 'append_only_bump',
+          row: makeFlowRow({ id: 'flow-dup' }),
+        },
+      ],
+      [
+        { id: 'flow-dup', version: '01.00.002', operation: 'insert' },
+        { id: 'flow-dup', version: '01.00.002', operation: 'update_existing' },
+      ],
+      [],
+    );
+    assert.deepEqual(
+      duplicateKeyReports.map((report) => report.status),
+      ['inserted', 'updated'],
+    );
+
+    const unkeyedUnmatchedReports = __testInternals.map_commit_reports(
+      [
+        {
+          entity_type: 'flow',
+          entity_id: '',
+          entity_name: 'flow-empty-id',
+          original_version: '01.00.001',
+          publish_version: '01.00.002',
+          version_strategy: 'bump',
+          publish_policy: 'append_only_bump',
+          row: { json_ordered: { flowDataSet: {} } },
+        },
+      ],
+      [],
+      [],
+    );
+    assert.equal(unkeyedUnmatchedReports[0]?.status, 'failed');
+
+    const queue = new Map<string, Array<string | undefined>>([['key', [undefined]]]);
+    assert.equal(__testInternals.shift_queue(queue, 'key'), null);
+    assert.equal(queue.has('key'), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/flow-validate-processes.test.ts
+++ b/test/flow-validate-processes.test.ts
@@ -1,0 +1,269 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { CliError } from '../src/lib/errors.js';
+import { runFlowValidateProcesses } from '../src/lib/flow-regen-product.js';
+
+type JsonRecord = Record<string, unknown>;
+
+function lang(text: string, langCode = 'en'): JsonRecord {
+  return {
+    '@xml:lang': langCode,
+    '#text': text,
+  };
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function writeJsonl(filePath: string, rows: unknown[]): void {
+  writeFileSync(
+    filePath,
+    `${rows.map((row) => JSON.stringify(row)).join('\n')}${rows.length ? '\n' : ''}`,
+    'utf8',
+  );
+}
+
+function makeFlowRow(options: { id: string; version?: string; name?: string }): JsonRecord {
+  const version = options.version ?? '01.00.000';
+  const name = options.name ?? options.id;
+  return {
+    id: options.id,
+    version,
+    json_ordered: {
+      flowDataSet: {
+        flowInformation: {
+          dataSetInformation: {
+            'common:UUID': options.id,
+            name: {
+              baseName: [lang(name)],
+            },
+            'common:shortDescription': [lang(`${name} short`)],
+          },
+        },
+        administrativeInformation: {
+          publicationAndOwnership: {
+            'common:dataSetVersion': version,
+          },
+        },
+      },
+    },
+  };
+}
+
+function makeExchange(options: {
+  internalId?: string;
+  flowId?: string;
+  flowVersion?: string;
+}): JsonRecord {
+  return {
+    '@dataSetInternalID': options.internalId ?? '1',
+    exchangeDirection: 'Output',
+    referenceToFlowDataSet: {
+      '@type': 'flow data set',
+      '@refObjectId': options.flowId ?? '',
+      '@version': options.flowVersion ?? '',
+      '@uri': '../flows/example.xml',
+      'common:shortDescription': [lang('Flow text')],
+    },
+  };
+}
+
+function makeProcessRow(options: {
+  id: string;
+  version?: string;
+  name?: string;
+  qref?: string;
+  exchanges?: JsonRecord[];
+}): JsonRecord {
+  const version = options.version ?? '01.00.000';
+  const exchanges = options.exchanges ?? [makeExchange({ flowId: 'flow-1', flowVersion: version })];
+  return {
+    id: options.id,
+    version,
+    json_ordered: {
+      processDataSet: {
+        processInformation: {
+          dataSetInformation: {
+            'common:UUID': options.id,
+            name: {
+              baseName: [lang(options.name ?? options.id)],
+            },
+          },
+          quantitativeReference: {
+            referenceToReferenceFlow:
+              options.qref ?? String(exchanges[0]?.['@dataSetInternalID'] ?? '1'),
+            functionalUnitOrOther: [],
+          },
+        },
+        administrativeInformation: {
+          publicationAndOwnership: {
+            'common:dataSetVersion': version,
+          },
+        },
+        exchanges: {
+          exchange: exchanges,
+        },
+      },
+    },
+  };
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+test('runFlowValidateProcesses writes validation artifacts and can use injected sdk validation in auto mode', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-validate-processes-ok-'));
+  const originalProcessesFile = path.join(dir, 'original-processes.jsonl');
+  const patchedProcessesFile = path.join(dir, 'patched-processes.jsonl');
+  const scopeFlowFile = path.join(dir, 'scope-flows.jsonl');
+  const outDir = path.join(dir, 'validate');
+
+  const originalRow = makeProcessRow({ id: 'proc-1' });
+  const patchedRow = clone(originalRow);
+
+  writeJsonl(originalProcessesFile, [originalRow]);
+  writeJsonl(patchedProcessesFile, [patchedRow]);
+  writeJsonl(scopeFlowFile, [makeFlowRow({ id: 'flow-1' })]);
+
+  try {
+    const report = await runFlowValidateProcesses(
+      {
+        originalProcessesFile,
+        patchedProcessesFile,
+        scopeFlowFiles: [scopeFlowFile],
+        outDir,
+      },
+      {
+        now: () => new Date('2026-03-30T18:00:00.000Z'),
+        loadSdkModule: () => ({
+          createProcess: () => ({
+            validateEnhanced: () => ({ success: true }),
+          }),
+        }),
+      },
+    );
+
+    assert.equal(report.status, 'completed_local_flow_validate_processes');
+    assert.equal(report.generated_at_utc, '2026-03-30T18:00:00.000Z');
+    assert.equal(report.tidas_mode, 'auto');
+    assert.deepEqual(report.summary, {
+      patched_process_count: 1,
+      passed: 1,
+      failed: 0,
+      tidas_validation: true,
+    });
+    assert.equal(report.results.length, 1);
+    assert.equal(report.results[0]?.ok, true);
+    assert.equal(existsSync(report.files.report), true);
+    assert.equal(existsSync(report.files.failures), true);
+
+    const persistedReport = JSON.parse(readFileSync(report.files.report, 'utf8')) as JsonRecord;
+    assert.deepEqual(persistedReport.summary, report.summary);
+    assert.deepEqual((persistedReport.results as unknown[]).length, 1);
+    assert.equal(readFileSync(report.files.failures, 'utf8'), '');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runFlowValidateProcesses reports patched process failures and honors explicit skip mode', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-validate-processes-failed-'));
+  const originalProcessesFile = path.join(dir, 'original-processes.json');
+  const patchedProcessesFile = path.join(dir, 'patched-processes.json');
+  const scopeFlowFile = path.join(dir, 'scope-flows.json');
+  const outDir = path.join(dir, 'validate');
+
+  const originalRow = makeProcessRow({ id: 'proc-2', version: '01.00.000', qref: '1' });
+  const patchedRow = clone(originalRow);
+  (
+    (
+      ((patchedRow.json_ordered as JsonRecord).processDataSet as JsonRecord)
+        .processInformation as JsonRecord
+    ).quantitativeReference as JsonRecord
+  ).referenceToReferenceFlow = '999';
+  (
+    (
+      (
+        ((patchedRow.json_ordered as JsonRecord).processDataSet as JsonRecord)
+          .exchanges as JsonRecord
+      ).exchange as JsonRecord[]
+    )[0]?.referenceToFlowDataSet as JsonRecord
+  )['@version'] = '';
+
+  writeJson(originalProcessesFile, [originalRow]);
+  writeJson(patchedProcessesFile, [patchedRow]);
+  writeJson(scopeFlowFile, [makeFlowRow({ id: 'flow-1', version: '01.00.000' })]);
+
+  try {
+    const report = await runFlowValidateProcesses({
+      originalProcessesFile,
+      patchedProcessesFile,
+      scopeFlowFiles: [scopeFlowFile],
+      outDir,
+      tidasMode: 'skip',
+    });
+
+    assert.equal(report.tidas_mode, 'skip');
+    assert.deepEqual(report.summary, {
+      patched_process_count: 1,
+      passed: 0,
+      failed: 1,
+      tidas_validation: false,
+    });
+    assert.equal(report.results[0]?.ok, false);
+    assert.deepEqual(
+      report.results[0]?.issues.map((issue) => issue.type),
+      [
+        'non_reference_changes_detected',
+        'quantitative_reference_changed',
+        'missing_flow_reference_after_patch',
+      ],
+    );
+
+    const persistedFailures = readFileSync(report.files.failures, 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as JsonRecord);
+    assert.equal(persistedFailures.length, 1);
+    assert.equal(
+      (persistedFailures[0]?.issues as JsonRecord[]).some(
+        (issue) => issue.type === 'quantitative_reference_changed',
+      ) as boolean,
+      true,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runFlowValidateProcesses rejects missing scope flow inputs', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-validate-processes-missing-scope-'));
+  const originalProcessesFile = path.join(dir, 'original-processes.jsonl');
+  const patchedProcessesFile = path.join(dir, 'patched-processes.jsonl');
+
+  writeJsonl(originalProcessesFile, []);
+  writeJsonl(patchedProcessesFile, []);
+
+  try {
+    await assert.rejects(
+      () =>
+        runFlowValidateProcesses({
+          originalProcessesFile,
+          patchedProcessesFile,
+          scopeFlowFiles: undefined as unknown as string[],
+          outDir: path.join(dir, 'validate'),
+        }),
+      (error: unknown) =>
+        error instanceof CliError &&
+        error.code === 'FLOW_VALIDATE_PROCESSES_SCOPE_FLOW_FILES_REQUIRED',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/lifecyclemodel-auto-build.test.ts
+++ b/test/lifecyclemodel-auto-build.test.ts
@@ -1,0 +1,1902 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  __testInternals,
+  normalizeLifecyclemodelAutoBuildRequest,
+  runLifecyclemodelAutoBuild,
+} from '../src/lib/lifecyclemodel-auto-build.js';
+
+type JsonRecord = Record<string, unknown>;
+
+function writeJson(filePath: string, value: unknown): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function readJson<T>(filePath: string): T {
+  return JSON.parse(readFileSync(filePath, 'utf8')) as T;
+}
+
+function textItem(text: string, lang = 'en'): JsonRecord {
+  return {
+    '@xml:lang': lang,
+    '#text': text,
+  };
+}
+
+function flowRef(flowId: string, shortDescription = flowId): JsonRecord {
+  return {
+    '@refObjectId': flowId,
+    '@type': 'flow data set',
+    '@version': '00.00.001',
+    'common:shortDescription': [textItem(shortDescription, 'en')],
+  };
+}
+
+function createExchange(options: {
+  internalId: string;
+  flowId: string;
+  direction: 'Input' | 'Output';
+  meanAmount: number;
+  shortDescription?: string;
+}): JsonRecord {
+  return {
+    '@dataSetInternalID': options.internalId,
+    exchangeDirection: options.direction,
+    meanAmount: options.meanAmount,
+    referenceToFlowDataSet: flowRef(options.flowId, options.shortDescription ?? options.flowId),
+  };
+}
+
+function createProcessPayload(options: {
+  id: string;
+  version?: string;
+  referenceInternalId: string;
+  exchanges: JsonRecord[];
+  baseName: string;
+  baseNameZh?: string;
+  route?: string;
+  mix?: string;
+  classificationPath?: string[];
+  location?: string;
+  includeEnteringRef?: boolean;
+}): JsonRecord {
+  return {
+    processDataSet: {
+      processInformation: {
+        dataSetInformation: {
+          'common:UUID': options.id,
+          name: {
+            baseName: [
+              textItem(options.baseName, 'en'),
+              textItem(options.baseNameZh ?? options.baseName, 'zh'),
+            ],
+            treatmentStandardsRoutes: [textItem(options.route ?? 'default route', 'en')],
+            mixAndLocationTypes: [textItem(options.mix ?? 'default mix', 'en')],
+          },
+          classificationInformation: {
+            'common:classification': {
+              'common:class': (options.classificationPath ?? ['A', 'B']).map((item) => ({
+                '#text': item,
+              })),
+            },
+          },
+          'common:generalComment': [textItem('existing comment', 'en')],
+        },
+        quantitativeReference: {
+          referenceToReferenceFlow: options.referenceInternalId,
+        },
+        geography: {
+          locationOfOperationSupplyOrProduction: {
+            '@location': options.location ?? 'CN',
+          },
+        },
+        technology: {},
+      },
+      exchanges: {
+        exchange: options.exchanges,
+      },
+      administrativeInformation: {
+        'common:commissionerAndGoal': {},
+        dataEntryBy:
+          options.includeEnteringRef === false
+            ? {}
+            : {
+                'common:referenceToPersonOrEntityEnteringTheData': {
+                  '@refObjectId': 'person-1',
+                },
+              },
+        publicationAndOwnership: {
+          'common:dataSetVersion': options.version ?? '00.00.001',
+          'common:referenceToOwnershipOfDataSet': {
+            '@refObjectId': 'org-1',
+          },
+        },
+      },
+      modellingAndValidation: {
+        complianceDeclarations: {
+          compliance: {},
+        },
+      },
+    },
+  };
+}
+
+function createProcessRunFixture(
+  rootDir: string,
+  runName: string,
+  options?: {
+    wrapFlowDataset?: boolean;
+    singleProcess?: boolean;
+    badProcess?: 'missing_uuid' | 'missing_reference_exchange';
+  },
+): string {
+  const runDir = path.join(rootDir, runName);
+  const statePath = path.join(runDir, 'cache', 'process_from_flow_state.json');
+  const processDir = path.join(runDir, 'exports', 'processes');
+  mkdirSync(processDir, { recursive: true });
+
+  const flowDataSet = {
+    flowInformation: {
+      dataSetInformation: {
+        name: {
+          baseName: [textItem('Target flow', 'en'), textItem('目标流', 'zh')],
+          treatmentStandardsRoutes: [textItem('target route', 'en')],
+          mixAndLocationTypes: [textItem('target mix', 'en')],
+        },
+      },
+    },
+  };
+
+  writeJson(statePath, {
+    flow_summary: {
+      uuid: 'flow-target',
+      base_name: 'Target flow',
+      base_name_en: 'Target flow',
+      base_name_zh: '目标流',
+    },
+    flow_dataset: options?.wrapFlowDataset === false ? flowDataSet : { flowDataSet },
+    technical_description: 'demo lifecycle chain',
+    scope: 'demo scope',
+  });
+
+  const upstream = createProcessPayload({
+    id: 'process-upstream',
+    referenceInternalId: '10',
+    exchanges: [
+      createExchange({
+        internalId: '10',
+        flowId: 'flow-intermediate',
+        direction: 'Output',
+        meanAmount: 2,
+      }),
+    ],
+    baseName: 'Upstream process',
+    classificationPath: ['chemicals', 'intermediate'],
+  });
+
+  const downstream = createProcessPayload({
+    id: 'process-downstream',
+    referenceInternalId: '21',
+    exchanges: [
+      createExchange({
+        internalId: '20',
+        flowId: 'flow-intermediate',
+        direction: 'Input',
+        meanAmount: 4,
+      }),
+      createExchange({
+        internalId: '21',
+        flowId: 'flow-target',
+        direction: 'Output',
+        meanAmount: 1,
+      }),
+    ],
+    baseName: 'Downstream process',
+    classificationPath: ['chemicals', 'target'],
+  });
+
+  const single = createProcessPayload({
+    id: 'process-single',
+    referenceInternalId: '30',
+    exchanges: [
+      createExchange({
+        internalId: '30',
+        flowId: 'flow-target',
+        direction: 'Output',
+        meanAmount: 1,
+      }),
+    ],
+    baseName: 'Single process',
+    classificationPath: ['single'],
+    includeEnteringRef: false,
+  });
+
+  if (options?.singleProcess) {
+    writeJson(path.join(processDir, 'single.json'), single);
+    return runDir;
+  }
+
+  if (options?.badProcess === 'missing_uuid') {
+    const bad = createProcessPayload({
+      id: 'temp-id',
+      referenceInternalId: '30',
+      exchanges: [
+        createExchange({
+          internalId: '30',
+          flowId: 'flow-target',
+          direction: 'Output',
+          meanAmount: 1,
+        }),
+      ],
+      baseName: 'Bad process',
+    }) as { processDataSet: { processInformation: { dataSetInformation: JsonRecord } } };
+    delete bad.processDataSet.processInformation.dataSetInformation['common:UUID'];
+    writeJson(path.join(processDir, 'bad.json'), bad);
+    return runDir;
+  }
+
+  if (options?.badProcess === 'missing_reference_exchange') {
+    const bad = createProcessPayload({
+      id: 'process-bad',
+      referenceInternalId: '999',
+      exchanges: [
+        createExchange({
+          internalId: '30',
+          flowId: 'flow-target',
+          direction: 'Output',
+          meanAmount: 1,
+        }),
+      ],
+      baseName: 'Bad process',
+    });
+    writeJson(path.join(processDir, 'bad.json'), bad);
+    return runDir;
+  }
+
+  writeJson(path.join(processDir, '01-upstream.json'), upstream);
+  writeJson(path.join(processDir, '02-downstream.json'), downstream);
+  return runDir;
+}
+
+test('normalizeLifecyclemodelAutoBuildRequest resolves defaults, run roots, and local runs', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-auto-build-normalize-'));
+  const runDir = createProcessRunFixture(dir, 'run-1');
+  const requestPath = path.join(dir, 'request.json');
+  writeJson(requestPath, {
+    run_label: 'demo-local-build',
+    local_runs: ['./run-1'],
+  });
+
+  try {
+    const normalized = normalizeLifecyclemodelAutoBuildRequest(readJson(requestPath), {
+      inputPath: requestPath,
+      now: new Date('2026-03-30T00:00:00Z'),
+      runIdOverride: 'lm-run-1',
+    });
+
+    assert.equal(normalized.run_id, 'lm-run-1');
+    assert.equal(
+      normalized.run_root,
+      path.join(dir, 'artifacts', 'lifecyclemodel_auto_build', 'lm-run-1'),
+    );
+    assert.deepEqual(normalized.local_runs, [runDir]);
+    assert.equal(normalized.manifest.run_label, 'demo-local-build');
+    assert.equal((normalized.manifest.selection as JsonRecord).mode, 'graph_first_local_build');
+
+    const fallbackRequestPath = path.join(dir, 'fallback-request.json');
+    writeJson(fallbackRequestPath, {
+      run_label: '',
+      local_runs: ['./run-1'],
+    });
+    const fallbackNormalized = normalizeLifecyclemodelAutoBuildRequest(
+      readJson(fallbackRequestPath),
+      {
+        inputPath: fallbackRequestPath,
+      },
+    );
+    assert.match(
+      fallbackNormalized.run_id,
+      /^lifecyclemodel_auto_build_fallback_request_build_\d{8}T\d{6}Z_[a-z0-9_]+$/u,
+    );
+    assert.equal(
+      fallbackNormalized.run_root,
+      path.join(dir, 'artifacts', 'lifecyclemodel_auto_build', fallbackNormalized.run_id),
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('lifecyclemodel auto-build internals cover manifest helpers and graph helpers', () => {
+  const merged = __testInternals.deepMerge(__testInternals.DEFAULT_MANIFEST, {
+    selection: {
+      decision_factors: ['custom factor'],
+    },
+  }) as JsonRecord;
+  assert.deepEqual((merged.selection as JsonRecord).decision_factors, ['custom factor']);
+
+  assert.match(
+    __testInternals.buildSelectionBrief({
+      selection: { decision_factors: ['factor-a'] },
+      discovery: { reference_model_queries: ['cement chain'] },
+    }),
+    /deferred reference query: cement chain/u,
+  );
+  assert.equal(
+    (__testInternals.buildReferenceModelSummary({ discovery: {} }) as JsonRecord).reason,
+    'reference model discovery not requested',
+  );
+  assert.throws(
+    () => __testInternals.normalizeLocalRuns(['./dup', './dup'], '/tmp'),
+    /Duplicate lifecyclemodel auto-build local_run/u,
+  );
+  assert.equal(
+    __testInternals.uuid5FromText('6ba7b811-9dad-11d1-80b4-00c04fd430c8', 'demo-run'),
+    'd39a4235-99d7-5cb9-af5c-849a602563b0',
+  );
+  assert.deepEqual(
+    __testInternals.extractClassificationPath({
+      'common:classification': {
+        'common:class': [{ '#text': 'A' }, { '#text': 'B' }],
+      },
+    }),
+    ['A', 'B'],
+  );
+  assert.equal(__testInternals.classificationOverlap(['A', 'B'], ['A', 'C']), 1);
+  assert.deepEqual(
+    __testInternals.extractFlowDatasetFromState({
+      flow_dataset: { flowDataSet: { id: 'wrapped' } },
+    }),
+    { id: 'wrapped' },
+  );
+  assert.deepEqual(
+    __testInternals.extractFlowDatasetFromState({
+      flow_dataset: { id: 'direct' },
+    }),
+    { id: 'direct' },
+  );
+  assert.equal(__testInternals.formatNumber(0), '0');
+  assert.equal(__testInternals.formatNumber(1 / 3), '0.333333333333333');
+
+  const passThroughMap = {
+    upstream: {
+      processUuid: 'upstream',
+      version: '00.00.001',
+      raw: {},
+      referenceExchangeInternalId: '1',
+      referenceFlowUuid: 'flow-a',
+      referenceDirection: 'Output' as const,
+      referenceAmount: 1,
+      inputAmounts: {},
+      outputAmounts: { 'flow-a': 1 },
+      nameEn: 'Upstream',
+      nameZh: '',
+      routeEn: '',
+      mixEn: '',
+      geographyCode: 'CN',
+      classificationPath: ['a'],
+      tokenSet: new Set(['upstream']),
+      sourceKind: 'local_run_export' as const,
+      sourceLabel: 'run',
+      includedProcessRefCount: 0,
+    },
+    bridge: {
+      processUuid: 'bridge',
+      version: '00.00.001',
+      raw: {},
+      referenceExchangeInternalId: '2',
+      referenceFlowUuid: 'flow-a',
+      referenceDirection: 'Input' as const,
+      referenceAmount: 1,
+      inputAmounts: { 'flow-a': 1 },
+      outputAmounts: { 'flow-a': 1 },
+      nameEn: 'Bridge',
+      nameZh: '',
+      routeEn: '',
+      mixEn: '',
+      geographyCode: 'CN',
+      classificationPath: ['a'],
+      tokenSet: new Set(['bridge']),
+      sourceKind: 'local_run_export' as const,
+      sourceLabel: 'run',
+      includedProcessRefCount: 0,
+    },
+    downstream: {
+      processUuid: 'downstream',
+      version: '00.00.001',
+      raw: {},
+      referenceExchangeInternalId: '3',
+      referenceFlowUuid: 'flow-a',
+      referenceDirection: 'Input' as const,
+      referenceAmount: 1,
+      inputAmounts: { 'flow-a': 1 },
+      outputAmounts: {},
+      nameEn: 'Downstream',
+      nameZh: '',
+      routeEn: '',
+      mixEn: '',
+      geographyCode: 'CN',
+      classificationPath: ['a'],
+      tokenSet: new Set(['downstream']),
+      sourceKind: 'local_run_export' as const,
+      sourceLabel: 'run',
+      includedProcessRefCount: 0,
+    },
+  };
+  const passThroughEdges = __testInternals.inferEdges(passThroughMap);
+  assert.deepEqual(
+    passThroughEdges.map((item) => `${item.src}->${item.dst}`),
+    ['upstream->bridge', 'bridge->downstream'],
+  );
+});
+
+test('lifecyclemodel auto-build utility helpers cover fallback parsing branches', () => {
+  assert.equal(__testInternals.copyJson(undefined), undefined);
+  assert.deepEqual(__testInternals.ensureList('item'), ['item']);
+  assert.deepEqual(__testInternals.ensureList(null), []);
+  assert.equal(__testInternals.numberOrZero(''), 0);
+  assert.equal(__testInternals.numberOrZero('3.5'), 3.5);
+  assert.equal(__testInternals.numberOrZero('bad'), 0);
+  assert.equal(__testInternals.numberOrZero(Infinity), 0);
+
+  assert.equal(__testInternals.firstText([{ '#text': 'from-array' }]), 'from-array');
+  assert.equal(__testInternals.firstText({ '#text': 'from-object' }), 'from-object');
+  assert.equal(__testInternals.firstText({}), '');
+  assert.equal(__testInternals.firstText('plain-text'), 'plain-text');
+  assert.equal(__testInternals.firstText('   '), '');
+  assert.equal(__testInternals.firstText([]), '');
+
+  assert.deepEqual(__testInternals.langTextMap('direct text'), { en: 'direct text' });
+  assert.deepEqual(__testInternals.langTextMap([{ '#text': 'implicit-en' }]), {
+    en: 'implicit-en',
+  });
+  assert.deepEqual(__testInternals.langTextMap([textItem('中文', 'zh')]), { zh: '中文' });
+  assert.equal(__testInternals.localizedText([textItem('Francais', 'fr')], 'fr'), 'Francais');
+  assert.equal(__testInternals.localizedText([textItem('中文', 'zh')], 'zh-cn'), '中文');
+  assert.equal(__testInternals.localizedText([textItem('Deutsch', 'de')], 'zh-hant'), 'Deutsch');
+  assert.equal(__testInternals.localizedText([textItem('English', 'en')], 'fr'), 'English');
+  assert.equal(__testInternals.localizedText([], 'fr'), '');
+  assert.deepEqual(__testInternals.multilangText([textItem('英文', 'zh-cn')]), ['英文', '英文']);
+  assert.deepEqual(__testInternals.multilangFromText('', '中文'), [
+    { '@xml:lang': 'zh', '#text': '中文' },
+  ]);
+
+  assert.deepEqual(__testInternals.buildNameSummary({}), []);
+  assert.deepEqual(
+    __testInternals.buildNameSummary({
+      baseName: [textItem('Base', 'en')],
+      treatmentStandardsRoutes: [textItem('Route', 'en')],
+      mixAndLocationTypes: [textItem('Mix', 'en')],
+      functionalUnitFlowProperties: [textItem('FU', 'en')],
+    }),
+    [{ '@xml:lang': 'en', '#text': 'Base; Route; Mix; FU' }],
+  );
+  assert.deepEqual(
+    __testInternals.buildNameSummary({
+      baseName: [textItem('基础', 'zh')],
+      treatmentStandardsRoutes: [textItem('Voie', 'fr')],
+    }),
+    [
+      { '@xml:lang': 'zh', '#text': '基础; Voie' },
+      { '@xml:lang': 'fr', '#text': '基础; Voie' },
+    ],
+  );
+  assert.deepEqual(
+    __testInternals.buildNameSummary({
+      baseName: [{ '@xml:lang': 'xx', '#text': 'First only' }],
+      treatmentStandardsRoutes: [textItem('Route', 'en')],
+    }),
+    [
+      { '@xml:lang': 'xx', '#text': 'First only; Route' },
+      { '@xml:lang': 'en', '#text': 'First only; Route' },
+    ],
+  );
+  assert.deepEqual(__testInternals.extractClassificationPath({}), []);
+  assert.deepEqual(
+    __testInternals.extractClassificationPath({
+      'common:classification': {
+        'common:class': ['bad', { '#text': 'Valid' }],
+      },
+    }),
+    ['Valid'],
+  );
+
+  assert.throws(() => __testInternals.uuid5FromText('not-a-uuid', 'demo'), /Invalid UUID value/u);
+  assert.equal(__testInternals.formatNumber(0.0000001), '0.0000001');
+  assert.equal(__testInternals.formatNumber(10_000_000), '10000000');
+  assert.equal(__testInternals.toJsonNumber(1.5), 1.5);
+  assert.equal(__testInternals.exchangeAmount({ resultingAmount: '4.2' }), 4.2);
+  assert.deepEqual(
+    __testInternals.cloneExchangeWithAmount(
+      {
+        '@dataSetInternalID': 'old',
+        meanAmount: 1,
+        resultingAmount: 1,
+      },
+      2.5,
+      'new',
+      true,
+    ),
+    {
+      '@dataSetInternalID': 'new',
+      meanAmount: 2.5,
+      resultingAmount: 2.5,
+      quantitativeReference: true,
+    },
+  );
+
+  assert.throws(
+    () => __testInternals.normalizeLocalRuns([], '/tmp'),
+    /must contain at least one run directory/u,
+  );
+  assert.equal(
+    (
+      __testInternals.buildReferenceModelSummary({
+        discovery: { reference_model_queries: ['steel chain'] },
+      }) as JsonRecord
+    ).reason,
+    'reference model discovery is deferred in the first native CLI auto-build slice',
+  );
+  assert.equal(
+    (
+      __testInternals.buildReferenceModelSummary({
+        discovery: 'bad',
+      }) as JsonRecord
+    ).reason,
+    'reference model discovery not requested',
+  );
+  assert.deepEqual(__testInternals.extractFlowDatasetFromState({ flow_dataset: 'bad' }), {});
+  assert.match(__testInternals.buildSelectionBrief({}), /Decision factors:/u);
+});
+
+test('lifecyclemodel auto-build helpers cover publication, record loading, ranking, and topology edge cases', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-auto-build-helpers-'));
+
+  try {
+    assert.deepEqual(
+      __testInternals.resolvePublicationBlock({
+        administrativeInformation: {
+          'common:publicationAndOwnership': { id: 'common' },
+        },
+      }),
+      { id: 'common' },
+    );
+    assert.deepEqual(__testInternals.resolvePublicationBlock({}), {});
+
+    const invalidRootPath = path.join(dir, 'invalid-root.json');
+    writeJson(invalidRootPath, []);
+    assert.throws(
+      () => __testInternals.loadProcessRecord(invalidRootPath, 'local_run_export', dir),
+      /must contain processDataSet/u,
+    );
+
+    const missingRefFlowPath = path.join(dir, 'missing-ref-flow.json');
+    const missingRefFlow = createProcessPayload({
+      id: 'process-missing-ref',
+      referenceInternalId: '10',
+      exchanges: [
+        createExchange({
+          internalId: '10',
+          flowId: 'flow-target',
+          direction: 'Output',
+          meanAmount: 1,
+        }),
+      ],
+      baseName: 'Missing ref flow',
+    }) as {
+      processDataSet: { processInformation: { quantitativeReference?: JsonRecord } };
+    };
+    delete missingRefFlow.processDataSet.processInformation.quantitativeReference;
+    writeJson(missingRefFlowPath, missingRefFlow);
+    assert.throws(
+      () => __testInternals.loadProcessRecord(missingRefFlowPath, 'local_run_export', dir),
+      /missing referenceToReferenceFlow/u,
+    );
+
+    const invalidReferenceExchangePath = path.join(dir, 'invalid-reference-exchange.json');
+    const invalidReferenceExchange = createProcessPayload({
+      id: 'process-invalid-ref',
+      referenceInternalId: '10',
+      exchanges: [{ '@dataSetInternalID': '10', exchangeDirection: 'Output', meanAmount: 1 }],
+      baseName: 'Invalid ref exchange',
+    });
+    writeJson(invalidReferenceExchangePath, invalidReferenceExchange);
+    assert.throws(
+      () =>
+        __testInternals.loadProcessRecord(invalidReferenceExchangePath, 'local_run_export', dir),
+      /reference exchange is incomplete/u,
+    );
+
+    const missingProcessInfoPath = path.join(dir, 'missing-process-info.json');
+    writeJson(missingProcessInfoPath, {
+      processDataSet: {
+        processInformation: 'bad',
+        exchanges: {
+          exchange: [
+            createExchange({
+              internalId: '1',
+              flowId: 'flow-target',
+              direction: 'Output',
+              meanAmount: 1,
+            }),
+          ],
+        },
+      },
+    });
+    assert.throws(
+      () => __testInternals.loadProcessRecord(missingProcessInfoPath, 'local_run_export', dir),
+      /missing referenceToReferenceFlow/u,
+    );
+
+    const invalidDataSetInformationPath = path.join(dir, 'invalid-dataset-info.json');
+    writeJson(invalidDataSetInformationPath, {
+      processDataSet: {
+        processInformation: {
+          dataSetInformation: 'bad',
+          quantitativeReference: {
+            referenceToReferenceFlow: '1',
+          },
+        },
+        exchanges: {
+          exchange: [
+            createExchange({
+              internalId: '1',
+              flowId: 'flow-target',
+              direction: 'Output',
+              meanAmount: 1,
+            }),
+          ],
+        },
+      },
+    });
+    assert.throws(
+      () =>
+        __testInternals.loadProcessRecord(invalidDataSetInformationPath, 'local_run_export', dir),
+      /missing common:UUID/u,
+    );
+
+    const invalidExchangesPath = path.join(dir, 'invalid-exchanges.json');
+    writeJson(invalidExchangesPath, {
+      processDataSet: {
+        processInformation: {
+          dataSetInformation: {
+            'common:UUID': 'invalid-exchanges',
+          },
+          quantitativeReference: {
+            referenceToReferenceFlow: '1',
+          },
+        },
+        exchanges: 'bad',
+      },
+    });
+    assert.throws(
+      () => __testInternals.loadProcessRecord(invalidExchangesPath, 'local_run_export', dir),
+      /reference exchange 1 not found/u,
+    );
+
+    const sparsePath = path.join(dir, 'sparse-valid.json');
+    writeJson(sparsePath, {
+      processDataSet: {
+        processInformation: {
+          dataSetInformation: {
+            'common:UUID': 'sparse-process',
+          },
+          quantitativeReference: {
+            referenceToReferenceFlow: '1',
+          },
+        },
+        exchanges: {
+          exchange: [
+            {
+              '@dataSetInternalID': '1',
+              exchangeDirection: 'Output',
+              resultingAmount: '5',
+              referenceToFlowDataSet: flowRef('flow-target', 'Target'),
+            },
+            {
+              '@dataSetInternalID': '2',
+              exchangeDirection: 'Input',
+            },
+          ],
+        },
+        administrativeInformation: {
+          'common:publicationAndOwnership': {},
+        },
+      },
+    });
+    const sparseRecord = __testInternals.loadProcessRecord(sparsePath, 'local_run_export', dir);
+    assert.equal(sparseRecord.version, '00.00.001');
+    assert.equal(sparseRecord.referenceAmount, 5);
+    assert.equal(sparseRecord.geographyCode, '');
+    assert.equal(Object.keys(sparseRecord.inputAmounts).length, 0);
+
+    const scored = __testInternals.scoreEdgeCandidate(
+      {
+        ...sparseRecord,
+        outputAmounts: {},
+        tokenSet: new Set<string>(),
+        classificationPath: [],
+        geographyCode: '',
+      },
+      {
+        ...sparseRecord,
+        inputAmounts: { 'flow-target': 2 },
+        referenceDirection: 'Input',
+      },
+      'flow-target',
+      2,
+    );
+    assert.equal(scored.confidence, 16);
+
+    const filteredMap = {
+      strong: {
+        ...sparseRecord,
+        processUuid: 'strong',
+        referenceFlowUuid: 'flow-target',
+        referenceDirection: 'Output' as const,
+        outputAmounts: { 'flow-target': 1 },
+        tokenSet: new Set(['shared', 'extra']),
+        classificationPath: ['chem'],
+        geographyCode: 'CN',
+      },
+      weak: {
+        ...sparseRecord,
+        processUuid: 'weak',
+        referenceFlowUuid: 'flow-other',
+        referenceDirection: 'Output' as const,
+        outputAmounts: { 'flow-target': 1 },
+        tokenSet: new Set<string>(),
+        classificationPath: [],
+        geographyCode: '',
+      },
+      dst: {
+        ...sparseRecord,
+        processUuid: 'dst',
+        referenceFlowUuid: 'flow-target',
+        referenceDirection: 'Input' as const,
+        inputAmounts: { 'flow-target': 1 },
+        outputAmounts: {},
+        tokenSet: new Set(['shared']),
+        classificationPath: ['chem'],
+        geographyCode: 'CN',
+      },
+    };
+    assert.deepEqual(
+      __testInternals.inferEdges(filteredMap).map((edge) => `${edge.src}->${edge.dst}`),
+      ['strong->dst'],
+    );
+    assert.deepEqual(
+      __testInternals.inferEdges({
+        lonelyConsumer: {
+          ...sparseRecord,
+          processUuid: 'lonelyConsumer',
+          referenceFlowUuid: 'flow-orphan',
+          referenceDirection: 'Input' as const,
+          inputAmounts: { 'flow-orphan': 1 },
+          outputAmounts: {},
+        },
+      }),
+      [],
+    );
+
+    const orderedEdgeMap = {
+      source: {
+        ...sparseRecord,
+        processUuid: 'source',
+        referenceFlowUuid: 'flow-a',
+        referenceDirection: 'Output' as const,
+        outputAmounts: { 'flow-a': 1, 'flow-b': 1 },
+      },
+      ta: {
+        ...sparseRecord,
+        processUuid: 'ta',
+        referenceFlowUuid: 'flow-a',
+        referenceDirection: 'Input' as const,
+        inputAmounts: { 'flow-a': 1 },
+        outputAmounts: {},
+      },
+      tb: {
+        ...sparseRecord,
+        processUuid: 'tb',
+        referenceFlowUuid: 'flow-b',
+        referenceDirection: 'Input' as const,
+        inputAmounts: { 'flow-b': 1 },
+        outputAmounts: {},
+      },
+      tc: {
+        ...sparseRecord,
+        processUuid: 'tc',
+        referenceFlowUuid: 'flow-a',
+        referenceDirection: 'Input' as const,
+        inputAmounts: { 'flow-a': 1 },
+        outputAmounts: {},
+      },
+    };
+    assert.deepEqual(
+      __testInternals
+        .inferEdges(orderedEdgeMap)
+        .map((edge) => `${edge.flowUuid}:${edge.src}->${edge.dst}`),
+      ['flow-a:source->ta', 'flow-a:source->tc', 'flow-b:source->tb'],
+    );
+    const comparatorEdgeMap = {
+      source: {
+        ...sparseRecord,
+        processUuid: 'source',
+        referenceFlowUuid: 'flow-a',
+        referenceDirection: 'Output' as const,
+        outputAmounts: { 'flow-a': 1 },
+        classificationPath: ['same'],
+        baseNameEn: 'same',
+        baseNameZh: 'same',
+      },
+      dstB: {
+        ...sparseRecord,
+        processUuid: 'dstB',
+        referenceFlowUuid: 'flow-a',
+        referenceDirection: 'Input' as const,
+        inputAmounts: { 'flow-a': 1 },
+        outputAmounts: {},
+        classificationPath: ['same'],
+        baseNameEn: 'same',
+        baseNameZh: 'same',
+      },
+      dstA: {
+        ...sparseRecord,
+        processUuid: 'dstA',
+        referenceFlowUuid: 'flow-a',
+        referenceDirection: 'Input' as const,
+        inputAmounts: { 'flow-a': 1 },
+        outputAmounts: {},
+        classificationPath: ['same'],
+        baseNameEn: 'same',
+        baseNameZh: 'same',
+      },
+    };
+    assert.deepEqual(
+      __testInternals.inferEdges(comparatorEdgeMap).map((edge) => `${edge.src}->${edge.dst}`),
+      ['source->dstA', 'source->dstB'],
+    );
+    const competingProducerMap = {
+      srcB: {
+        ...sparseRecord,
+        processUuid: 'srcB',
+        referenceFlowUuid: 'flow-shared',
+        referenceDirection: 'Output' as const,
+        outputAmounts: { 'flow-shared': 1 },
+        classificationPath: ['same'],
+        tokenSet: new Set(['same']),
+      },
+      srcA: {
+        ...sparseRecord,
+        processUuid: 'srcA',
+        referenceFlowUuid: 'flow-shared',
+        referenceDirection: 'Output' as const,
+        outputAmounts: { 'flow-shared': 1 },
+        classificationPath: ['same'],
+        tokenSet: new Set(['same']),
+      },
+      dstShared: {
+        ...sparseRecord,
+        processUuid: 'dstShared',
+        referenceFlowUuid: 'flow-shared',
+        referenceDirection: 'Input' as const,
+        inputAmounts: { 'flow-shared': 1 },
+        outputAmounts: {},
+        classificationPath: ['same'],
+        tokenSet: new Set(['same']),
+      },
+    };
+    assert.deepEqual(
+      __testInternals.inferEdges(competingProducerMap).map((edge) => `${edge.src}->${edge.dst}`),
+      ['srcA->dstShared', 'srcB->dstShared'],
+    );
+
+    const chooseMap = {
+      alpha: {
+        ...sparseRecord,
+        processUuid: 'alpha',
+        referenceFlowUuid: 'flow-a',
+        referenceDirection: 'Output' as const,
+        outputAmounts: { 'flow-b': 1 },
+      },
+      beta: {
+        ...sparseRecord,
+        processUuid: 'beta',
+        referenceFlowUuid: 'flow-b',
+        referenceDirection: 'Output' as const,
+        outputAmounts: { 'flow-target': 1 },
+      },
+    };
+    assert.equal(
+      __testInternals.chooseReferenceProcess(
+        chooseMap,
+        [],
+        { flow_summary: { uuid: 'flow-target' } },
+        new Set(['alpha', 'beta']),
+      ),
+      'beta',
+    );
+    assert.equal(
+      __testInternals.chooseReferenceProcess(
+        {
+          low: {
+            ...chooseMap.alpha,
+            processUuid: 'low',
+            outputAmounts: {},
+            referenceFlowUuid: 'flow-a',
+          },
+          high: {
+            ...chooseMap.alpha,
+            processUuid: 'high',
+            outputAmounts: { 'flow-z': 1 },
+            referenceFlowUuid: 'flow-z',
+          },
+        },
+        [],
+        { flow_summary: { uuid: 'flow-z' } },
+        new Set(['low', 'high']),
+      ),
+      'high',
+    );
+    assert.equal(
+      __testInternals.chooseReferenceProcess(
+        {
+          high: {
+            ...chooseMap.alpha,
+            processUuid: 'high',
+            outputAmounts: { 'flow-z': 1 },
+            referenceFlowUuid: 'flow-z',
+          },
+          low: {
+            ...chooseMap.alpha,
+            processUuid: 'low',
+            outputAmounts: {},
+            referenceFlowUuid: 'flow-a',
+          },
+        },
+        [],
+        { flow_summary: { uuid: 'flow-z' } },
+        new Set(['high', 'low']),
+      ),
+      'high',
+    );
+    assert.equal(
+      __testInternals.chooseReferenceProcess(
+        {
+          targetCarrier: {
+            ...chooseMap.alpha,
+            processUuid: 'targetCarrier',
+            referenceFlowUuid: 'flow-target',
+            referenceDirection: 'Output' as const,
+            outputAmounts: { 'flow-target': 1 },
+          },
+          targetProxy: {
+            ...chooseMap.alpha,
+            processUuid: 'targetProxy',
+            referenceFlowUuid: 'flow-target',
+            referenceDirection: 'Output' as const,
+            outputAmounts: { 'flow-other': 1 },
+          },
+        },
+        [],
+        { flow_summary: { uuid: 'flow-target' } },
+        new Set(['targetCarrier', 'targetProxy']),
+      ),
+      'targetCarrier',
+    );
+    assert.equal(
+      __testInternals.chooseReferenceProcess(chooseMap, [], {}, new Set(['alpha', 'beta'])),
+      'beta',
+    );
+    assert.equal(
+      __testInternals.chooseReferenceProcess(
+        {
+          indegreeWinner: {
+            ...chooseMap.alpha,
+            processUuid: 'indegreeWinner',
+            outputAmounts: {},
+          },
+          indegreeLoser: {
+            ...chooseMap.alpha,
+            processUuid: 'indegreeLoser',
+            outputAmounts: {},
+          },
+        },
+        [
+          {
+            src: 'x',
+            dst: 'indegreeWinner',
+            flowUuid: 'f',
+            downstreamInputAmount: 1,
+            confidence: 1,
+            reasons: [],
+          },
+          {
+            src: 'y',
+            dst: 'indegreeWinner',
+            flowUuid: 'g',
+            downstreamInputAmount: 1,
+            confidence: 1,
+            reasons: [],
+          },
+          {
+            src: 'z',
+            dst: 'indegreeLoser',
+            flowUuid: 'h',
+            downstreamInputAmount: 1,
+            confidence: 1,
+            reasons: [],
+          },
+        ],
+        {},
+        new Set(['indegreeWinner', 'indegreeLoser']),
+      ),
+      'indegreeWinner',
+    );
+    assert.equal(
+      __testInternals.chooseReferenceProcess(
+        {
+          nonTerminal: {
+            ...chooseMap.alpha,
+            processUuid: 'nonTerminal',
+            outputAmounts: {},
+          },
+          terminal: {
+            ...chooseMap.alpha,
+            processUuid: 'terminal',
+            outputAmounts: {},
+          },
+          sink: {
+            ...chooseMap.alpha,
+            processUuid: 'sink',
+            outputAmounts: {},
+          },
+        },
+        [
+          {
+            src: 'nonTerminal',
+            dst: 'sink',
+            flowUuid: 'f-out',
+            downstreamInputAmount: 1,
+            confidence: 1,
+            reasons: [],
+          },
+        ],
+        {},
+        new Set(['nonTerminal', 'terminal']),
+      ),
+      'terminal',
+    );
+    assert.equal(
+      __testInternals.chooseReferenceProcess(
+        {
+          alphaTerminal: {
+            ...chooseMap.alpha,
+            processUuid: 'alphaTerminal',
+            outputAmounts: {},
+          },
+          betaNonTerminal: {
+            ...chooseMap.alpha,
+            processUuid: 'betaNonTerminal',
+            outputAmounts: {},
+          },
+          sink: {
+            ...chooseMap.alpha,
+            processUuid: 'sink',
+            outputAmounts: {},
+          },
+        },
+        [
+          {
+            src: 'betaNonTerminal',
+            dst: 'sink',
+            flowUuid: 'f-out',
+            downstreamInputAmount: 1,
+            confidence: 1,
+            reasons: [],
+          },
+        ],
+        {},
+        new Set(['alphaTerminal', 'betaNonTerminal']),
+      ),
+      'alphaTerminal',
+    );
+    assert.equal(
+      __testInternals.chooseReferenceProcess(
+        {
+          tieA: {
+            ...chooseMap.alpha,
+            processUuid: 'tieA',
+            outputAmounts: {},
+          },
+          tieB: {
+            ...chooseMap.alpha,
+            processUuid: 'tieB',
+            outputAmounts: {},
+          },
+        },
+        [],
+        {},
+        new Set(['tieA', 'tieB']),
+      ),
+      'tieB',
+    );
+    assert.equal(
+      __testInternals.chooseReferenceProcess(
+        {
+          tieB: {
+            ...chooseMap.alpha,
+            processUuid: 'tieB',
+            outputAmounts: {},
+          },
+          tieA: {
+            ...chooseMap.alpha,
+            processUuid: 'tieA',
+            outputAmounts: {},
+          },
+        },
+        [],
+        {},
+        new Set(['tieB', 'tieA']),
+      ),
+      'tieB',
+    );
+
+    assert.deepEqual(
+      [
+        ...__testInternals.collectReachable('c', [
+          {
+            src: 'a',
+            dst: 'c',
+            flowUuid: 'f',
+            downstreamInputAmount: 1,
+            confidence: 1,
+            reasons: [],
+          },
+          {
+            src: 'a',
+            dst: 'c',
+            flowUuid: 'f2',
+            downstreamInputAmount: 1,
+            confidence: 1,
+            reasons: [],
+          },
+          {
+            src: 'b',
+            dst: 'c',
+            flowUuid: 'f3',
+            downstreamInputAmount: 1,
+            confidence: 1,
+            reasons: [],
+          },
+        ]),
+      ].sort(),
+      ['a', 'b', 'c'],
+    );
+
+    assert.deepEqual(
+      __testInternals.topologicalOrder(new Set(['a', 'b']), [
+        { src: 'a', dst: 'b', flowUuid: 'f', downstreamInputAmount: 1, confidence: 1, reasons: [] },
+        { src: 'b', dst: 'a', flowUuid: 'f', downstreamInputAmount: 1, confidence: 1, reasons: [] },
+        { src: 'c', dst: 'a', flowUuid: 'f', downstreamInputAmount: 1, confidence: 1, reasons: [] },
+      ]),
+      ['a', 'b'],
+    );
+    assert.deepEqual(
+      __testInternals.topologicalOrder(new Set(['a', 'b', 'c']), [
+        { src: 'a', dst: 'b', flowUuid: 'f', downstreamInputAmount: 1, confidence: 1, reasons: [] },
+      ]),
+      ['a', 'b', 'c'],
+    );
+
+    const factorMap = {
+      a: {
+        ...sparseRecord,
+        processUuid: 'a',
+        outputAmounts: { fa: 2 },
+      },
+      b: {
+        ...sparseRecord,
+        processUuid: 'b',
+        outputAmounts: { fb: 0 },
+      },
+      c: {
+        ...sparseRecord,
+        processUuid: 'c',
+        outputAmounts: {},
+      },
+      d: {
+        ...sparseRecord,
+        processUuid: 'd',
+        outputAmounts: {},
+      },
+      e: {
+        ...sparseRecord,
+        processUuid: 'e',
+        outputAmounts: { fe: 1 },
+      },
+    };
+    assert.deepEqual(
+      __testInternals.computeMultiplicationFactors(
+        factorMap,
+        new Set(['a', 'b', 'c', 'd']),
+        [
+          {
+            src: 'a',
+            dst: 'c',
+            flowUuid: 'fa',
+            downstreamInputAmount: 4,
+            confidence: 1,
+            reasons: [],
+          },
+          {
+            src: 'b',
+            dst: 'c',
+            flowUuid: 'fb',
+            downstreamInputAmount: 1,
+            confidence: 1,
+            reasons: [],
+          },
+          {
+            src: 'e',
+            dst: 'c',
+            flowUuid: 'fe',
+            downstreamInputAmount: 1,
+            confidence: 1,
+            reasons: [],
+          },
+        ],
+        ['a', 'b', 'd', 'c'],
+        'c',
+      ),
+      {
+        a: 2,
+        b: 1,
+        c: 1,
+        d: 0,
+      },
+    );
+    assert.deepEqual(
+      __testInternals.computeMultiplicationFactors(
+        {
+          upstream: {
+            ...sparseRecord,
+            processUuid: 'upstream',
+            outputAmounts: {},
+          },
+          final: {
+            ...sparseRecord,
+            processUuid: 'final',
+            outputAmounts: {},
+          },
+        },
+        new Set(['upstream', 'final']),
+        [
+          {
+            src: 'upstream',
+            dst: 'final',
+            flowUuid: 'f1',
+            downstreamInputAmount: 2,
+            confidence: 1,
+            reasons: [],
+          },
+          {
+            src: 'upstream',
+            dst: 'final',
+            flowUuid: 'f2',
+            downstreamInputAmount: 3,
+            confidence: 1,
+            reasons: [],
+          },
+        ],
+        ['upstream', 'final'],
+        'final',
+      ),
+      {
+        upstream: 5,
+        final: 1,
+      },
+    );
+
+    const processInstanceMap = {
+      p1: {
+        ...sparseRecord,
+        processUuid: 'p1',
+        raw: createProcessPayload({
+          id: 'p1',
+          referenceInternalId: '1',
+          exchanges: [
+            createExchange({
+              internalId: '1',
+              flowId: 'flow-a',
+              direction: 'Output',
+              meanAmount: 1,
+            }),
+          ],
+          baseName: 'Process 1',
+        }),
+      },
+      p2: {
+        ...sparseRecord,
+        processUuid: 'p2',
+        raw: createProcessPayload({
+          id: 'p2',
+          referenceInternalId: '2',
+          exchanges: [
+            createExchange({
+              internalId: '2',
+              flowId: 'flow-a',
+              direction: 'Input',
+              meanAmount: 1,
+            }),
+          ],
+          baseName: 'Process 2',
+        }),
+      },
+      p3: {
+        ...sparseRecord,
+        processUuid: 'p3',
+        raw: createProcessPayload({
+          id: 'p3',
+          referenceInternalId: '3',
+          exchanges: [
+            createExchange({
+              internalId: '3',
+              flowId: 'flow-a',
+              direction: 'Input',
+              meanAmount: 1,
+            }),
+          ],
+          baseName: 'Process 3',
+        }),
+      },
+      p4: {
+        ...sparseRecord,
+        processUuid: 'p4',
+        raw: {
+          processDataSet: {
+            processInformation: {},
+          },
+        },
+      },
+      p5: {
+        ...sparseRecord,
+        processUuid: 'p5',
+        raw: {
+          processDataSet: {},
+        },
+      },
+    };
+    processInstanceMap.p1.outputAmounts = { 'flow-a': 1, 'flow-b': 1 };
+    const builtInstances = __testInternals.buildProcessInstances(
+      processInstanceMap,
+      ['p1', 'p2', 'p3', 'p4', 'p5'],
+      [
+        {
+          src: 'skip',
+          dst: 'outside',
+          flowUuid: 'flow-x',
+          downstreamInputAmount: 1,
+          confidence: 1,
+          reasons: [],
+        },
+        {
+          src: 'p1',
+          dst: 'p2',
+          flowUuid: 'flow-a',
+          downstreamInputAmount: 1,
+          confidence: 1,
+          reasons: [],
+        },
+        {
+          src: 'p1',
+          dst: 'p3',
+          flowUuid: 'flow-a',
+          downstreamInputAmount: 1,
+          confidence: 1,
+          reasons: [],
+        },
+        {
+          src: 'p1',
+          dst: 'p4',
+          flowUuid: 'flow-b',
+          downstreamInputAmount: 1,
+          confidence: 1,
+          reasons: [],
+        },
+      ],
+      { p1: 1, p2: 1, p3: 1, p4: 1 },
+    ) as { processInstances: Array<JsonRecord> };
+    const firstInstanceConnections = (builtInstances.processInstances[0]?.connections as JsonRecord)
+      .outputExchange as Array<JsonRecord>;
+    assert.equal(firstInstanceConnections.length, 2);
+    assert.equal(Array.isArray(firstInstanceConnections[0]?.downstreamProcess), true);
+    assert.equal(builtInstances.processInstances[4]?.['@multiplicationFactor'], '0');
+
+    const sparseLifecyclemodel = __testInternals.buildLifecycleModelDataset(
+      'sparse-model',
+      {
+        flow_dataset: {},
+        flow_summary: {},
+      },
+      {
+        sparse: {
+          ...sparseRecord,
+          processUuid: 'sparse',
+          raw: {
+            processDataSet: {
+              processInformation: {
+                quantitativeReference: {
+                  referenceToReferenceFlow: '1',
+                },
+              },
+              exchanges: {
+                exchange: [
+                  {
+                    '@dataSetInternalID': '1',
+                    exchangeDirection: 'Output',
+                    meanAmount: 1,
+                    referenceToFlowDataSet: flowRef('flow-target', 'Target'),
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+      ['sparse'],
+      [],
+      { sparse: 1 },
+      'sparse',
+    ) as { model: JsonRecord };
+    const sparseUseAdvice = (
+      (
+        (
+          (sparseLifecyclemodel.model.lifeCycleModelDataSet as JsonRecord)
+            .modellingAndValidation as JsonRecord
+        ).dataSourcesTreatmentEtc as JsonRecord
+      ).useAdviceForDataSet as Array<JsonRecord>
+    )[0]?.['#text'];
+    assert.match(String(sparseUseAdvice), /Built from local process exports/u);
+
+    const malformedLifecyclemodel = __testInternals.buildLifecycleModelDataset(
+      'malformed-model',
+      {
+        flow_dataset: {
+          flowInformation: {
+            dataSetInformation: {
+              name: 'bad',
+            },
+          },
+        },
+        flow_summary: 'bad',
+      },
+      {
+        malformed: {
+          ...sparseRecord,
+          processUuid: 'malformed',
+          raw: {
+            processDataSet: 'bad',
+          },
+        },
+      },
+      ['malformed'],
+      [],
+      {},
+      'malformed',
+    ) as { model: JsonRecord; summary: JsonRecord };
+    assert.equal(
+      (malformedLifecyclemodel.summary.multiplication_factors as JsonRecord).malformed as string,
+      '0',
+    );
+
+    const commissionerLifecyclemodel = __testInternals.buildLifecycleModelDataset(
+      'commissioner-model',
+      {
+        flow_dataset: {},
+        flow_summary: {},
+      },
+      {
+        commissioner: {
+          ...sparseRecord,
+          processUuid: 'commissioner',
+          raw: {
+            processDataSet: {
+              administrativeInformation: {
+                'common:commissionerAndGoal': {
+                  'common:referenceToCommissioner': {
+                    '@refObjectId': 'commissioner-ref',
+                  },
+                },
+                dataEntryBy: {
+                  'common:referenceToPersonOrEntityEnteringTheData': {
+                    '@refObjectId': 'entry-ref',
+                  },
+                },
+                'common:publicationAndOwnership': {
+                  'common:referenceToOwnershipOfDataSet': {
+                    '@refObjectId': 'owner-ref',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      ['commissioner'],
+      [],
+      { commissioner: 1 },
+      'commissioner',
+    ) as { model: JsonRecord };
+    const commissionerReview = (
+      (
+        (
+          (commissionerLifecyclemodel.model.lifeCycleModelDataSet as JsonRecord)
+            .modellingAndValidation as JsonRecord
+        ).validation as JsonRecord
+      ).review as JsonRecord
+    )['common:referenceToNameOfReviewerAndInstitution'] as JsonRecord;
+    assert.equal(commissionerReview['@refObjectId'], 'commissioner-ref');
+
+    const dataEntryLifecyclemodel = __testInternals.buildLifecycleModelDataset(
+      'data-entry-model',
+      {
+        flow_dataset: {},
+        flow_summary: {},
+      },
+      {
+        dataEntry: {
+          ...sparseRecord,
+          processUuid: 'dataEntry',
+          raw: {
+            processDataSet: {
+              administrativeInformation: {
+                dataEntryBy: {
+                  'common:referenceToPersonOrEntityEnteringTheData': {
+                    '@refObjectId': 'entry-only-ref',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      ['dataEntry'],
+      [],
+      { dataEntry: 1 },
+      'dataEntry',
+    ) as { model: JsonRecord };
+    const dataEntryReview = (
+      (
+        (
+          (dataEntryLifecyclemodel.model.lifeCycleModelDataSet as JsonRecord)
+            .modellingAndValidation as JsonRecord
+        ).validation as JsonRecord
+      ).review as JsonRecord
+    )['common:referenceToNameOfReviewerAndInstitution'] as JsonRecord;
+    assert.equal(dataEntryReview['@refObjectId'], 'entry-only-ref');
+
+    const ownershipFallbackLifecyclemodel = __testInternals.buildLifecycleModelDataset(
+      'ownership-fallback-model',
+      {
+        flow_dataset: {},
+        flow_summary: {},
+      },
+      {
+        ownershipFallback: {
+          ...sparseRecord,
+          processUuid: 'ownershipFallback',
+          raw: {
+            processDataSet: {
+              administrativeInformation: {
+                'common:commissionerAndGoal': 'bad',
+                dataEntryBy: 'bad',
+                'common:publicationAndOwnership': {
+                  'common:referenceToOwnershipOfDataSet': {
+                    '@refObjectId': 'owner-fallback-ref',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      ['ownershipFallback'],
+      [],
+      { ownershipFallback: 1 },
+      'ownershipFallback',
+    ) as { model: JsonRecord };
+    const ownershipFallbackReview = (
+      (
+        (
+          (ownershipFallbackLifecyclemodel.model.lifeCycleModelDataSet as JsonRecord)
+            .modellingAndValidation as JsonRecord
+        ).validation as JsonRecord
+      ).review as JsonRecord
+    )['common:referenceToNameOfReviewerAndInstitution'] as JsonRecord;
+    assert.equal(ownershipFallbackReview['@refObjectId'], 'owner-fallback-ref');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelAutoBuild writes local lifecyclemodel artifacts and reports', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-auto-build-run-'));
+  const runDir = createProcessRunFixture(dir, 'process-run');
+  const requestPath = path.join(dir, 'request.json');
+  writeJson(requestPath, {
+    local_runs: ['./process-run'],
+  });
+
+  try {
+    const report = await runLifecyclemodelAutoBuild({
+      inputPath: requestPath,
+      outDir: './build-root',
+      now: new Date('2026-03-30T01:02:03Z'),
+      cwd: '/tmp/workspace',
+    });
+
+    assert.equal(report.status, 'completed_local_lifecyclemodel_auto_build_run');
+    assert.equal(report.run_root, path.join(dir, 'build-root'));
+    assert.equal(report.local_run_count, 1);
+    assert.equal(report.built_model_count, 1);
+    assert.equal(existsSync(report.files.run_plan), true);
+    assert.equal(existsSync(report.files.selection_brief), true);
+    assert.equal(existsSync(report.files.run_manifest), true);
+    assert.equal(
+      readFileSync(path.join(path.dirname(report.run_root), '.latest_run_id'), 'utf8'),
+      `${report.run_id}\n`,
+    );
+
+    const runManifest = readJson<JsonRecord>(report.files.run_manifest);
+    assert.deepEqual(runManifest.command, [
+      'lifecyclemodel',
+      'auto-build',
+      '--input',
+      requestPath,
+      '--out-dir',
+      './build-root',
+    ]);
+    assert.equal(runManifest.cwd, '/tmp/workspace');
+
+    const runPlan = readJson<JsonRecord>(report.files.run_plan);
+    assert.deepEqual(runPlan.local_runs, [runDir]);
+    const localBuildReports = runPlan.local_build_reports as Array<JsonRecord>;
+    assert.equal(localBuildReports.length, 1);
+
+    const localBuild = report.local_build_reports[0];
+    assert.ok(localBuild);
+    assert.equal(localBuild?.run_name, 'process-run');
+    assert.equal(existsSync(localBuild?.model_file ?? ''), true);
+
+    const model = readJson<JsonRecord>(localBuild?.model_file ?? '');
+    const dataset = model.lifeCycleModelDataSet as JsonRecord;
+    const info = dataset.lifeCycleModelInformation as JsonRecord;
+    const dataSetInformation = info.dataSetInformation as JsonRecord;
+    const quantitativeReference = info.quantitativeReference as JsonRecord;
+    const technology = info.technology as JsonRecord;
+    const processes = technology.processes as JsonRecord;
+    const processInstances = processes.processInstance as Array<JsonRecord>;
+
+    assert.equal(quantitativeReference.referenceToReferenceProcess, '2');
+    assert.equal(
+      (dataSetInformation.referenceToResultingProcess as JsonRecord)['@refObjectId'],
+      (localBuild?.summary.model_uuid as string | undefined) ?? '',
+    );
+    assert.equal(processInstances.length, 2);
+    assert.equal(processInstances[0]?.['@multiplicationFactor'], '2');
+    assert.equal(processInstances[1]?.['@multiplicationFactor'], '1');
+
+    const connections = readJson<Array<JsonRecord>>(localBuild?.connections_file ?? '');
+    assert.equal(connections.length, 1);
+    assert.equal(connections[0]?.flow_uuid, 'flow-intermediate');
+    assert.equal(connections[0]?.src, 'process-upstream');
+    assert.equal(connections[0]?.dst, 'process-downstream');
+
+    const summary = readJson<JsonRecord>(localBuild?.summary_file ?? '');
+    assert.equal(summary.reference_process_uuid, 'process-downstream');
+    assert.equal((summary.multiplication_factors as JsonRecord)['process-upstream'], '2');
+    assert.equal((summary.multiplication_factors as JsonRecord)['process-downstream'], '1');
+
+    const processCatalog = readJson<Array<JsonRecord>>(localBuild?.process_catalog_file ?? '');
+    assert.equal(processCatalog.length, 2);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('lifecyclemodel auto-build internals can assemble a single-process lifecyclemodel', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-auto-build-single-'));
+  const runDir = createProcessRunFixture(dir, 'single-run', {
+    wrapFlowDataset: false,
+    singleProcess: true,
+  });
+
+  try {
+    const record = __testInternals.loadProcessRecord(
+      path.join(runDir, 'exports', 'processes', 'single.json'),
+      'local_run_export',
+      runDir,
+    );
+    const { model, summary } = __testInternals.buildLifecycleModelDataset(
+      'demo-run',
+      readJson<JsonRecord>(path.join(runDir, 'cache', 'process_from_flow_state.json')),
+      { [record.processUuid]: record },
+      [record.processUuid],
+      [],
+      { [record.processUuid]: 1 },
+      record.processUuid,
+    ) as {
+      model: JsonRecord;
+      summary: JsonRecord;
+    };
+
+    assert.equal(summary.model_uuid, 'd39a4235-99d7-5cb9-af5c-849a602563b0');
+    const processInstance = (
+      (
+        ((model.lifeCycleModelDataSet as JsonRecord).lifeCycleModelInformation as JsonRecord)
+          .technology as JsonRecord
+      ).processes as JsonRecord
+    ).processInstance as JsonRecord;
+    assert.equal(processInstance['@dataSetInternalID'], '1');
+    assert.equal('connections' in processInstance, false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelAutoBuild rejects invalid manifests and broken local runs', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-auto-build-errors-'));
+  const requestPath = path.join(dir, 'request.json');
+
+  try {
+    assert.throws(
+      () =>
+        normalizeLifecyclemodelAutoBuildRequest('bad', {
+          inputPath: requestPath,
+        }),
+      /must be a JSON object/u,
+    );
+
+    assert.throws(
+      () =>
+        normalizeLifecyclemodelAutoBuildRequest(
+          {
+            local_runs: ['./run-1'],
+            allow_remote_write: true,
+          },
+          {
+            inputPath: requestPath,
+          },
+        ),
+      /allow_remote_write=true/u,
+    );
+
+    writeJson(requestPath, {
+      local_runs: ['./missing-run'],
+    });
+    await assert.rejects(
+      () =>
+        runLifecyclemodelAutoBuild({
+          inputPath: requestPath,
+        }),
+      /missing state file/u,
+    );
+
+    const noExportsRun = path.join(dir, 'no-exports-run');
+    mkdirSync(path.join(noExportsRun, 'cache'), { recursive: true });
+    writeJson(path.join(noExportsRun, 'cache', 'process_from_flow_state.json'), {
+      flow_summary: { uuid: 'flow-target' },
+      flow_dataset: {},
+    });
+    writeJson(requestPath, {
+      local_runs: ['./no-exports-run'],
+    });
+    await assert.rejects(
+      () =>
+        runLifecyclemodelAutoBuild({
+          inputPath: requestPath,
+        }),
+      /missing exported processes/u,
+    );
+
+    const emptyRun = path.join(dir, 'empty-run');
+    mkdirSync(path.join(emptyRun, 'cache'), { recursive: true });
+    mkdirSync(path.join(emptyRun, 'exports', 'processes'), { recursive: true });
+    writeJson(path.join(emptyRun, 'cache', 'process_from_flow_state.json'), {
+      flow_summary: { uuid: 'flow-target' },
+      flow_dataset: {},
+    });
+    writeJson(requestPath, {
+      local_runs: ['./empty-run'],
+    });
+    await assert.rejects(
+      () =>
+        runLifecyclemodelAutoBuild({
+          inputPath: requestPath,
+        }),
+      /has no exported process JSON files/u,
+    );
+
+    createProcessRunFixture(dir, 'bad-reference-run', {
+      badProcess: 'missing_reference_exchange',
+    });
+    writeJson(requestPath, {
+      local_runs: ['./bad-reference-run'],
+    });
+    await assert.rejects(
+      () =>
+        runLifecyclemodelAutoBuild({
+          inputPath: requestPath,
+        }),
+      /reference exchange 999 not found/u,
+    );
+
+    createProcessRunFixture(dir, 'bad-uuid-run', {
+      badProcess: 'missing_uuid',
+    });
+    writeJson(requestPath, {
+      local_runs: ['./bad-uuid-run'],
+    });
+    await assert.rejects(
+      () =>
+        runLifecyclemodelAutoBuild({
+          inputPath: requestPath,
+        }),
+      /missing common:UUID/u,
+    );
+
+    const invalidStateRun = path.join(dir, 'invalid-state-run');
+    mkdirSync(path.join(invalidStateRun, 'cache'), { recursive: true });
+    mkdirSync(path.join(invalidStateRun, 'exports', 'processes'), { recursive: true });
+    writeJson(path.join(invalidStateRun, 'cache', 'process_from_flow_state.json'), []);
+    writeJson(
+      path.join(invalidStateRun, 'exports', 'processes', 'single.json'),
+      createProcessPayload({
+        id: 'single',
+        referenceInternalId: '1',
+        exchanges: [
+          createExchange({
+            internalId: '1',
+            flowId: 'flow-target',
+            direction: 'Output',
+            meanAmount: 1,
+          }),
+        ],
+        baseName: 'Single',
+      }),
+    );
+    writeJson(requestPath, {
+      local_runs: ['./invalid-state-run'],
+    });
+    await assert.rejects(
+      () =>
+        runLifecyclemodelAutoBuild({
+          inputPath: requestPath,
+        }),
+      /state must be a JSON object/u,
+    );
+
+    const existingRoot = path.join(dir, 'busy-root');
+    mkdirSync(existingRoot, { recursive: true });
+    writeFileSync(path.join(existingRoot, 'keep.txt'), 'busy', 'utf8');
+    createProcessRunFixture(dir, 'good-run');
+    writeJson(requestPath, {
+      local_runs: ['./good-run'],
+      out_dir: './busy-root',
+    });
+    await assert.rejects(
+      () =>
+        runLifecyclemodelAutoBuild({
+          inputPath: requestPath,
+        }),
+      /run root already exists and is not empty/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/lifecyclemodel-orchestrate.test.ts
+++ b/test/lifecyclemodel-orchestrate.test.ts
@@ -1,0 +1,2182 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  __testInternals,
+  runLifecyclemodelOrchestrate,
+} from '../src/lib/lifecyclemodel-orchestrate.js';
+import { CliError } from '../src/lib/errors.js';
+
+type JsonRecord = Record<string, unknown>;
+
+function writeJson(filePath: string, value: unknown): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function readJson<T>(filePath: string): T {
+  return JSON.parse(readFileSync(filePath, 'utf8')) as T;
+}
+
+function textItem(text: string, lang = 'en'): JsonRecord {
+  return {
+    '@xml:lang': lang,
+    '#text': text,
+  };
+}
+
+function createExchange(options: {
+  internalId: string;
+  flowId: string;
+  direction: 'Input' | 'Output';
+  meanAmount: number;
+}): JsonRecord {
+  return {
+    '@dataSetInternalID': options.internalId,
+    exchangeDirection: options.direction,
+    referenceToFlowDataSet: {
+      '@refObjectId': options.flowId,
+      '@type': 'flow data set',
+    },
+    meanAmount: options.meanAmount,
+  };
+}
+
+function createProcessPayload(options: {
+  id: string;
+  referenceInternalId: string;
+  exchanges: JsonRecord[];
+  baseName: string;
+  classificationPath: string[];
+  includeEnteringRef?: boolean;
+}): JsonRecord {
+  return {
+    processDataSet: {
+      processInformation: {
+        dataSetInformation: {
+          'common:UUID': options.id,
+          name: {
+            baseName: [textItem(options.baseName, 'en'), textItem(`${options.baseName}-zh`, 'zh')],
+            treatmentStandardsRoutes: [textItem('route', 'en')],
+            mixAndLocationTypes: [textItem('mix', 'en')],
+          },
+          classificationInformation: {
+            classification: {
+              class: options.classificationPath.map((entry, index) => ({
+                '@level': index + 1,
+                '#text': entry,
+              })),
+            },
+          },
+        },
+        quantitativeReference: {
+          referenceToReferenceFlow: options.referenceInternalId,
+          ...(options.includeEnteringRef === false
+            ? {}
+            : {
+                referenceToFunctionalUnitOrOther: {
+                  '@refObjectId': options.referenceInternalId,
+                },
+              }),
+        },
+      },
+      exchanges: {
+        exchange: options.exchanges,
+      },
+      administrativeInformation: {
+        publicationAndOwnership: {
+          'common:dataSetVersion': '00.00.001',
+        },
+      },
+      modellingAndValidation: {
+        LCIMethodAndAllocation: {
+          typeOfDataSet: 'Unit process, single operation',
+        },
+      },
+      complianceDeclarations: {
+        compliance: {},
+      },
+    },
+  };
+}
+
+function createProcessInstance(options: {
+  instanceId: string;
+  processId: string;
+  version?: string;
+}): JsonRecord {
+  return {
+    '@dataSetInternalID': options.instanceId,
+    '@multiplicationFactor': '1',
+    referenceToProcess: {
+      '@refObjectId': options.processId,
+      '@version': options.version ?? '00.00.001',
+      name: {
+        baseName: [textItem(options.processId, 'en')],
+      },
+    },
+    connections: {
+      outputExchange: [],
+    },
+  };
+}
+
+function createLifecycleModel(options: {
+  id: string;
+  name: string;
+  referenceProcessInstanceId: string;
+  referenceToResultingProcessId: string;
+  instances: JsonRecord[];
+}): JsonRecord {
+  return {
+    lifeCycleModelDataSet: {
+      '@id': options.id,
+      '@version': '00.00.001',
+      lifeCycleModelInformation: {
+        dataSetInformation: {
+          'common:UUID': options.id,
+          name: {
+            baseName: [textItem(options.name, 'en')],
+          },
+          referenceToResultingProcess: {
+            '@refObjectId': options.referenceToResultingProcessId,
+            '@version': '00.00.001',
+          },
+        },
+        quantitativeReference: {
+          referenceToReferenceProcess: options.referenceProcessInstanceId,
+        },
+        technology: {
+          processes: {
+            processInstance: options.instances,
+          },
+        },
+      },
+      administrativeInformation: {
+        publicationAndOwnership: {
+          'common:dataSetVersion': '00.00.001',
+        },
+      },
+    },
+  };
+}
+
+function createProcessRunFixture(rootDir: string, runName: string): string {
+  const runDir = path.join(rootDir, runName);
+  const statePath = path.join(runDir, 'cache', 'process_from_flow_state.json');
+  const processDir = path.join(runDir, 'exports', 'processes');
+  mkdirSync(processDir, { recursive: true });
+
+  writeJson(statePath, {
+    flow_summary: {
+      uuid: 'flow-target',
+      base_name: 'Target flow',
+      base_name_en: 'Target flow',
+      base_name_zh: '目标流',
+    },
+    flow_dataset: {
+      flowDataSet: {
+        flowInformation: {
+          dataSetInformation: {
+            name: {
+              baseName: [textItem('Target flow', 'en'), textItem('目标流', 'zh')],
+              treatmentStandardsRoutes: [textItem('target route', 'en')],
+              mixAndLocationTypes: [textItem('target mix', 'en')],
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const upstream = createProcessPayload({
+    id: 'process-upstream',
+    referenceInternalId: '10',
+    exchanges: [
+      createExchange({
+        internalId: '10',
+        flowId: 'flow-intermediate',
+        direction: 'Output',
+        meanAmount: 2,
+      }),
+    ],
+    baseName: 'Upstream process',
+    classificationPath: ['chemicals', 'intermediate'],
+  });
+  const downstream = createProcessPayload({
+    id: 'process-downstream',
+    referenceInternalId: '21',
+    exchanges: [
+      createExchange({
+        internalId: '20',
+        flowId: 'flow-intermediate',
+        direction: 'Input',
+        meanAmount: 4,
+      }),
+      createExchange({
+        internalId: '21',
+        flowId: 'flow-target',
+        direction: 'Output',
+        meanAmount: 1,
+      }),
+    ],
+    baseName: 'Downstream process',
+    classificationPath: ['chemicals', 'target'],
+  });
+
+  writeJson(path.join(processDir, 'process-upstream_00.00.001.json'), upstream);
+  writeJson(path.join(processDir, 'process-downstream_00.00.001.json'), downstream);
+  return runDir;
+}
+
+function createStaticProjectorRequestFixture(rootDir: string): string {
+  const modelDir = path.join(rootDir, 'projector-static');
+  const processDir = path.join(modelDir, 'processes');
+  mkdirSync(processDir, { recursive: true });
+  const modelPath = path.join(modelDir, 'model.json');
+
+  const process = createProcessPayload({
+    id: 'process-static',
+    referenceInternalId: '99',
+    exchanges: [
+      createExchange({
+        internalId: '99',
+        flowId: 'flow-static',
+        direction: 'Output',
+        meanAmount: 1,
+      }),
+    ],
+    baseName: 'Static process',
+    classificationPath: ['static'],
+    includeEnteringRef: false,
+  });
+  writeJson(path.join(processDir, 'process-static_00.00.001.json'), process);
+  writeJson(
+    modelPath,
+    createLifecycleModel({
+      id: 'lm-static',
+      name: 'Static model',
+      referenceProcessInstanceId: 'static-inst',
+      referenceToResultingProcessId: 'proc-static-result',
+      instances: [
+        createProcessInstance({
+          instanceId: 'static-inst',
+          processId: 'process-static',
+        }),
+      ],
+    }),
+  );
+
+  const requestPath = path.join(modelDir, 'projector-request.json');
+  writeJson(requestPath, {
+    source_model: {
+      json_ordered_path: modelPath,
+    },
+    projection: {
+      mode: 'primary-only',
+      metadata_overrides: {
+        projection_source: 'static-fixture',
+      },
+    },
+    process_sources: {
+      process_json_dirs: [processDir],
+      allow_remote_lookup: false,
+    },
+    publish: {
+      intent: 'prepare_only',
+      prepare_process_payloads: true,
+      prepare_relation_payloads: true,
+    },
+  });
+
+  return requestPath;
+}
+
+function flowFixturePath(): string {
+  return path.resolve(process.cwd(), '../tidas-sdk/test-data/tidas-example-flow.json');
+}
+
+test('lifecyclemodel orchestrate internals normalize plans, warnings, and projector policy', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-orchestrate-internals-'));
+  try {
+    const requestPath = path.join(dir, 'request.json');
+    const plan = __testInternals.buildPlan(
+      {
+        request_id: 'plan-demo',
+        goal: {
+          name: 'Demo goal',
+        },
+        root: {
+          node_id: 'root-model',
+          kind: 'lifecyclemodel',
+          lifecyclemodel: {
+            id: 'lm-root',
+          },
+          requested_action: 'build_submodel',
+          submodel_builder: {
+            manifest: './manifest.json',
+          },
+          projector: {
+            projection_role: 'primary',
+          },
+        },
+        orchestration: {
+          mode: 'collapsed',
+          max_depth: 2,
+          reuse_resulting_process_first: true,
+          allow_process_build: true,
+          allow_submodel_build: true,
+          pin_child_versions: true,
+          stop_at_elementary_flow: false,
+          fail_fast: true,
+        },
+        publish: {
+          intent: 'prepare_only',
+        },
+        nodes: [
+          {
+            node_id: 'child-process',
+            kind: 'process',
+            depends_on: ['unknown-node'],
+            requested_action: 'reuse_existing_process',
+            existing_process_candidates: ['proc-1'],
+          },
+        ],
+      },
+      requestPath,
+      path.join(dir, 'out'),
+      new Date('2026-03-30T00:00:00Z'),
+    );
+
+    assert.equal(plan.nodes.length, 2);
+    assert.equal(plan.invocations.length, 2);
+    assert.match(plan.warnings[0] ?? '', /depends on unknown node/u);
+    assert.equal(plan.nodes[0]?.resolution, 'build_via_lifecyclemodel_automated_builder');
+    assert.equal(plan.nodes[1]?.selected_candidate?.id, 'proc-1');
+    assert.equal(
+      __testInternals.shouldRunProjector(plan.nodes[0]!, plan.nodes[0]!.resolution!),
+      true,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('lifecyclemodel orchestrate plan writes artifacts and publish works without invocation results', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-orchestrate-plan-'));
+  const processRunDir = createProcessRunFixture(dir, 'process-run');
+  const manifestPath = path.join(dir, 'lifecyclemodel-request.json');
+  const requestPath = path.join(dir, 'orchestrate-request.json');
+  const outDir = path.join(dir, 'orchestrator-run');
+
+  writeJson(manifestPath, {
+    local_runs: [processRunDir],
+  });
+  writeJson(requestPath, {
+    request_id: 'plan-only',
+    goal: {
+      name: 'Plan only demo',
+    },
+    root: {
+      node_id: 'root-model',
+      kind: 'lifecyclemodel',
+      lifecyclemodel: {
+        id: 'lm-plan',
+      },
+      requested_action: 'build_submodel',
+      submodel_builder: {
+        manifest: './lifecyclemodel-request.json',
+      },
+    },
+    orchestration: {
+      mode: 'collapsed',
+      max_depth: 1,
+      reuse_resulting_process_first: true,
+      allow_process_build: false,
+      allow_submodel_build: true,
+      pin_child_versions: true,
+      stop_at_elementary_flow: false,
+      fail_fast: true,
+    },
+    publish: {
+      intent: 'prepare_only',
+      prepare_lifecyclemodel_payload: true,
+      prepare_resulting_process_payload: true,
+      prepare_relation_payload: true,
+    },
+  });
+
+  try {
+    const planReport = await runLifecyclemodelOrchestrate({
+      action: 'plan',
+      inputPath: requestPath,
+      outDir,
+      now: new Date('2026-03-30T00:00:00Z'),
+    });
+    assert.equal(planReport.status, 'planned');
+    assert.equal(
+      readJson<JsonRecord>(path.join(outDir, 'assembly-plan.json')).request_id,
+      'plan-only',
+    );
+
+    const publishReport = await runLifecyclemodelOrchestrate({
+      action: 'publish',
+      runDir: outDir,
+      now: new Date('2026-03-30T00:00:00Z'),
+    });
+    assert.equal(publishReport.status, 'prepared_local_publish_bundle');
+    assert.equal(publishReport.counts.lifecyclemodels, 0);
+    assert.equal(publishReport.counts.projected_processes, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('lifecyclemodel orchestrate execute runs CLI-backed builders and publish collects outputs', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-orchestrate-execute-'));
+  const processRunDir = createProcessRunFixture(dir, 'process-run');
+  const manifestPath = path.join(dir, 'lifecyclemodel-request.json');
+  const staticProjectorRequest = createStaticProjectorRequestFixture(dir);
+  const requestPath = path.join(dir, 'orchestrate-request.json');
+  const outDir = path.join(dir, 'orchestrator-run');
+
+  writeJson(manifestPath, {
+    local_runs: [processRunDir],
+  });
+  writeJson(requestPath, {
+    request_id: 'execute-demo',
+    goal: {
+      name: 'Execute demo',
+    },
+    root: {
+      node_id: 'model-live',
+      kind: 'lifecyclemodel',
+      lifecyclemodel: {
+        id: 'lm-live',
+      },
+      requested_action: 'build_submodel',
+      depends_on: ['process-node'],
+      submodel_builder: {
+        manifest: './lifecyclemodel-request.json',
+      },
+      projector: {
+        projection_role: 'primary',
+      },
+    },
+    orchestration: {
+      mode: 'collapsed',
+      max_depth: 2,
+      reuse_resulting_process_first: true,
+      allow_process_build: false,
+      allow_submodel_build: false,
+      pin_child_versions: true,
+      stop_at_elementary_flow: false,
+      fail_fast: true,
+    },
+    publish: {
+      intent: 'prepare_only',
+      prepare_lifecyclemodel_payload: true,
+      prepare_resulting_process_payload: true,
+      prepare_relation_payload: true,
+    },
+    nodes: [
+      {
+        node_id: 'process-node',
+        kind: 'process',
+        requested_action: 'build_process',
+        process_builder: {
+          mode: 'workflow',
+          flow_file: flowFixturePath(),
+        },
+      },
+      {
+        node_id: 'model-dry',
+        kind: 'lifecyclemodel',
+        requested_action: 'build_submodel',
+        submodel_builder: {
+          manifest: './lifecyclemodel-request.json',
+          dry_run: true,
+        },
+        projector: {
+          request: staticProjectorRequest,
+        },
+      },
+    ],
+  });
+
+  try {
+    const executeReport = await runLifecyclemodelOrchestrate({
+      action: 'execute',
+      inputPath: requestPath,
+      outDir,
+      allowProcessBuild: true,
+      allowSubmodelBuild: true,
+      now: new Date('2026-03-30T00:00:00Z'),
+    });
+    assert.equal(executeReport.status, 'completed');
+    assert.equal(executeReport.execution.failed_invocations, 0);
+    assert.equal(executeReport.execution.successful_invocations, 5);
+
+    const publishReport = await runLifecyclemodelOrchestrate({
+      action: 'publish',
+      runDir: outDir,
+      now: new Date('2026-03-30T00:00:00Z'),
+    });
+    assert.equal(publishReport.action, 'publish');
+    assert.equal(publishReport.counts.lifecyclemodels, 1);
+    assert.equal(publishReport.counts.projected_processes, 2);
+    assert.equal(publishReport.counts.process_build_runs, 1);
+
+    const bundle = readJson<JsonRecord>(path.join(outDir, 'publish-bundle.json'));
+    assert.equal((bundle.status as string) ?? '', 'prepared_local_publish_bundle');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('lifecyclemodel orchestrate marks removed legacy process-builder configs as failed and skips later work', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-orchestrate-legacy-fail-'));
+  const processRunDir = createProcessRunFixture(dir, 'process-run');
+  const manifestPath = path.join(dir, 'lifecyclemodel-request.json');
+  const requestPath = path.join(dir, 'orchestrate-request.json');
+  const outDir = path.join(dir, 'orchestrator-run');
+
+  writeJson(manifestPath, {
+    local_runs: [processRunDir],
+  });
+  writeJson(requestPath, {
+    request_id: 'legacy-fail',
+    goal: {
+      name: 'Legacy fail demo',
+    },
+    root: {
+      node_id: 'model-live',
+      kind: 'lifecyclemodel',
+      lifecyclemodel: {
+        id: 'lm-live',
+      },
+      requested_action: 'build_submodel',
+      depends_on: ['legacy-node'],
+      submodel_builder: {
+        manifest: './lifecyclemodel-request.json',
+      },
+      projector: {
+        projection_role: 'primary',
+      },
+    },
+    orchestration: {
+      mode: 'collapsed',
+      max_depth: 2,
+      reuse_resulting_process_first: true,
+      allow_process_build: true,
+      allow_submodel_build: true,
+      pin_child_versions: true,
+      stop_at_elementary_flow: false,
+      fail_fast: true,
+    },
+    publish: {
+      intent: 'prepare_only',
+    },
+    nodes: [
+      {
+        node_id: 'legacy-node',
+        kind: 'process',
+        requested_action: 'build_process',
+        process_builder: {
+          mode: 'langgraph',
+          flow_file: flowFixturePath(),
+        },
+      },
+    ],
+  });
+
+  try {
+    const report = await runLifecyclemodelOrchestrate({
+      action: 'execute',
+      inputPath: requestPath,
+      outDir,
+      now: new Date('2026-03-30T00:00:00Z'),
+    });
+    assert.equal(report.status, 'failed');
+    assert.equal(report.execution.failed_invocations, 1);
+    assert.equal(report.execution.blocked_invocations, 2);
+
+    const firstInvocation = readJson<JsonRecord>(
+      path.join(outDir, 'invocations', 'legacy-node-process-builder.json'),
+    );
+    assert.equal(firstInvocation.status, 'failed');
+    assert.match(String(firstInvocation.error ?? ''), /langgraph/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('lifecyclemodel orchestrate validates required options', async () => {
+  await assert.rejects(
+    () =>
+      runLifecyclemodelOrchestrate({
+        action: 'plan',
+      }),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'LIFECYCLEMODEL_ORCHESTRATE_INPUT_REQUIRED');
+      return true;
+    },
+  );
+
+  await assert.rejects(
+    () =>
+      runLifecyclemodelOrchestrate({
+        action: 'execute',
+        inputPath: '/tmp/request.json',
+      }),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'LIFECYCLEMODEL_ORCHESTRATE_OUT_DIR_REQUIRED');
+      return true;
+    },
+  );
+
+  await assert.rejects(
+    () =>
+      runLifecyclemodelOrchestrate({
+        action: 'publish',
+      }),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'LIFECYCLEMODEL_ORCHESTRATE_RUN_DIR_REQUIRED');
+      return true;
+    },
+  );
+});
+
+test('lifecyclemodel orchestrate helper internals validate primitive values and normalize config shapes', () => {
+  const baseDir = path.join(os.tmpdir(), 'tg-cli-lm-orchestrate-helpers');
+
+  assert.deepEqual(__testInternals.requireObject({ ok: true }, 'request'), { ok: true });
+  assert.throws(
+    () => __testInternals.requireObject(null, 'request'),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'LIFECYCLEMODEL_ORCHESTRATE_INVALID_REQUEST');
+      return true;
+    },
+  );
+
+  assert.equal(
+    __testInternals.requireEnum('build', ['build', 'project'], 'projector.command'),
+    'build',
+  );
+  assert.throws(
+    () => __testInternals.requireEnum('invalid', ['build', 'project'], 'projector.command'),
+    /projector.command must be one of/u,
+  );
+
+  assert.equal(__testInternals.requireBoolean(true, 'flag'), true);
+  assert.throws(() => __testInternals.requireBoolean('true', 'flag'), /flag must be a boolean/u);
+
+  assert.equal(__testInternals.requireInteger(2, 'depth'), 2);
+  assert.throws(
+    () => __testInternals.requireInteger(-1, 'depth'),
+    /depth must be a non-negative integer/u,
+  );
+
+  assert.equal(__testInternals.resolveInputPath(baseDir, ''), null);
+  assert.equal(
+    __testInternals.resolveInputPath(baseDir, 'https://example.com/request.json'),
+    'https://example.com/request.json',
+  );
+  assert.equal(
+    __testInternals.resolveInputPath(baseDir, 'file:///tmp/request.json'),
+    'file:///tmp/request.json',
+  );
+  assert.equal(
+    __testInternals.resolveInputPath(baseDir, './request.json'),
+    path.resolve(baseDir, './request.json'),
+  );
+
+  assert.deepEqual(__testInternals.defaultCandidateSources(), {
+    my_processes: true,
+    team_processes: true,
+    public_processes: true,
+    existing_lifecyclemodels: true,
+    existing_resulting_processes: true,
+  });
+
+  assert.deepEqual(__testInternals.normalizeCandidate('candidate-a'), {
+    id: 'candidate-a',
+    score: 1,
+  });
+  assert.deepEqual(__testInternals.normalizeCandidateList('candidate-single'), [
+    { id: 'candidate-single', score: 1 },
+  ]);
+  assert.deepEqual(
+    __testInternals.normalizeCandidate({ id: 'candidate-b', score: -1, extra: true }),
+    {
+      id: 'candidate-b',
+      score: 1,
+      extra: true,
+    },
+  );
+  assert.throws(
+    () => __testInternals.normalizeCandidate(1),
+    /candidate must be an object or string/u,
+  );
+  assert.throws(
+    () => __testInternals.normalizeCandidate({ score: 3 }),
+    /candidate.id is required/u,
+  );
+
+  assert.deepEqual(
+    __testInternals.normalizeCandidateList([
+      { id: 'low', score: 0 },
+      { id: 'high', score: 3 },
+      'mid',
+    ]),
+    [
+      { id: 'high', score: 3 },
+      { id: 'mid', score: 1 },
+      { id: 'low', score: 0 },
+    ],
+  );
+
+  assert.equal(__testInternals.normalizeRequestedAction(undefined), 'auto');
+  assert.equal(__testInternals.normalizeRequestedAction('cutoff'), 'cutoff');
+  assert.throws(
+    () => __testInternals.normalizeRequestedAction('bad-action'),
+    /requested_action must be one of/u,
+  );
+  assert.deepEqual(__testInternals.normalizeDependsOn(['a', '', null, 'b']), ['a', 'b']);
+
+  assert.equal(__testInternals.normalizeProcessBuilderConfig(null, baseDir), undefined);
+  assert.deepEqual(
+    __testInternals.normalizeProcessBuilderConfig(
+      {
+        mode: 'workflow',
+        flow_file: './flow.json',
+        flow_json: { flowDataSet: {} },
+        run_id: 'run-1',
+        python_bin: 'python3',
+        publish: 1,
+        commit: 1,
+        forward_args: ['--alpha', '', '  ', '--beta'],
+      },
+      baseDir,
+    ),
+    {
+      mode: 'workflow',
+      flow_file: path.resolve(baseDir, './flow.json'),
+      flow_json: { flowDataSet: {} },
+      run_id: 'run-1',
+      python_bin: 'python3',
+      publish: true,
+      commit: true,
+      forward_args: ['--alpha', '--beta'],
+    },
+  );
+
+  assert.equal(__testInternals.normalizeSubmodelBuilderConfig(null, baseDir), undefined);
+  assert.deepEqual(
+    __testInternals.normalizeSubmodelBuilderConfig(
+      {
+        manifest: './manifest.json',
+        out_dir: './out',
+        dry_run: 1,
+      },
+      baseDir,
+    ),
+    {
+      manifest: path.resolve(baseDir, './manifest.json'),
+      out_dir: path.resolve(baseDir, './out'),
+      dry_run: true,
+    },
+  );
+
+  assert.equal(__testInternals.normalizeProjectorConfig(null, baseDir), undefined);
+  assert.deepEqual(
+    __testInternals.normalizeProjectorConfig(
+      {
+        command: 'build',
+        request: './request.json',
+        model_file: 'https://example.com/model.json',
+        out_dir: './projector-out',
+        projection_role: 'all',
+        run_always: 1,
+        publish_processes: 1,
+        publish_relations: 1,
+      },
+      baseDir,
+    ),
+    {
+      command: 'build',
+      request: path.resolve(baseDir, './request.json'),
+      model_file: 'https://example.com/model.json',
+      out_dir: path.resolve(baseDir, './projector-out'),
+      projection_role: 'all',
+      run_always: true,
+      publish_processes: true,
+      publish_relations: true,
+    },
+  );
+});
+
+test('lifecyclemodel orchestrate root/entity helpers, edges, and topo sort cover cycle and fallback branches', () => {
+  const baseDir = path.join(os.tmpdir(), 'tg-cli-lm-orchestrate-root');
+
+  assert.deepEqual(
+    __testInternals.deriveRootNode(
+      {
+        kind: 'reference_flow',
+        flow: { id: 'flow-root', name: 'Flow root' },
+        node_id: 'flow-root-node',
+      },
+      { name: 'Goal' },
+      baseDir,
+    ).entity,
+    { id: 'flow-root', name: 'Flow root' },
+  );
+
+  const processRoot = __testInternals.deriveRootNode(
+    {
+      kind: 'process',
+    },
+    { name: 'Fallback goal' },
+    baseDir,
+  );
+  assert.equal(processRoot.label, 'Fallback goal');
+  assert.deepEqual(processRoot.entity, {});
+
+  assert.deepEqual(
+    __testInternals.deriveRootNode(
+      {
+        kind: 'lifecyclemodel',
+        lifecyclemodel: { id: 'lm-root', name: 'LM root' },
+      },
+      { name: 'Goal' },
+      baseDir,
+    ).entity,
+    { id: 'lm-root', name: 'LM root' },
+  );
+  assert.deepEqual(
+    __testInternals.deriveRootNode(
+      {
+        kind: 'resulting_process',
+        resulting_process: { id: 'rp-1', name: 'Resulting process' },
+      },
+      { name: 'Goal' },
+      baseDir,
+    ).entity,
+    { id: 'rp-1', name: 'Resulting process' },
+  );
+  assert.throws(
+    () => __testInternals.deriveRootNode({ kind: 'unexpected-kind' } as never, {}, baseDir),
+    /node.kind must be one of/u,
+  );
+
+  const defaultNode = __testInternals.normalizeNode({}, 7, baseDir);
+  assert.equal(defaultNode.node_id, 'node-7');
+  assert.equal(defaultNode.kind, 'process');
+  assert.equal(defaultNode.label, 'node-7');
+
+  const normalizedNode = __testInternals.normalizeNode(
+    {
+      id: 'child-node',
+      kind: 'process',
+      process: { id: 'proc-child', name: 'Process child' },
+      parent_node_id: 'parent-node',
+      depends_on: ['dep-b', 'parent-node', '', null],
+      requested_action: 'reuse_existing_process',
+      existing_process_candidates: [
+        { id: 'proc-low', score: 0.1 },
+        { id: 'proc-high', score: 0.9 },
+      ],
+      process_builder: {
+        flow_file: './flow.json',
+      },
+      projector: {
+        request: './projector.json',
+      },
+    },
+    1,
+    baseDir,
+  );
+  assert.equal(normalizedNode.label, 'Process child');
+  assert.deepEqual(normalizedNode.depends_on, ['dep-b', 'parent-node']);
+  assert.equal(normalizedNode.process_builder?.flow_file, path.resolve(baseDir, './flow.json'));
+  assert.equal(normalizedNode.projector?.request, path.resolve(baseDir, './projector.json'));
+  assert.deepEqual(
+    normalizedNode.existing_process_candidates.map((entry) => entry.id),
+    ['proc-high', 'proc-low'],
+  );
+
+  assert.deepEqual(
+    __testInternals.buildEdges(
+      [
+        null,
+        { from: 'child-node', to: 'dep-b' },
+        { from: 'child-node', to: 'dep-b' },
+        { from: 'child-node', to: 'custom-target', relation: 'supplies' },
+        { from: '', to: 'missing' },
+      ],
+      [normalizedNode],
+    ),
+    [
+      { from: 'child-node', to: 'dep-b', relation: 'depends_on' },
+      { from: 'child-node', to: 'custom-target', relation: 'supplies' },
+      { from: 'child-node', to: 'parent-node', relation: 'depends_on' },
+    ],
+  );
+
+  const acyclic = __testInternals.topoSortNodes([
+    {
+      ...normalizedNode,
+      node_id: 'upstream',
+      depends_on: [],
+    },
+    {
+      ...normalizedNode,
+      node_id: 'downstream',
+      depends_on: ['upstream'],
+    },
+  ]);
+  assert.deepEqual(
+    acyclic.ordered.map((entry) => entry.node_id),
+    ['upstream', 'downstream'],
+  );
+
+  const cyclic = __testInternals.topoSortNodes([
+    {
+      ...normalizedNode,
+      node_id: 'cycle-a',
+      depends_on: ['cycle-b'],
+    },
+    {
+      ...normalizedNode,
+      node_id: 'cycle-b',
+      depends_on: ['cycle-a'],
+    },
+  ]);
+  assert.equal(cyclic.ordered.length, 2);
+  assert.match(cyclic.warnings[0] ?? '', /Dependency cycle detected/u);
+});
+
+test('lifecyclemodel orchestrate selectResolution and projector policy cover explicit and automatic branches', () => {
+  const makeNode = (overrides: JsonRecord = {}) =>
+    ({
+      node_id: 'node-1',
+      kind: 'process',
+      label: 'Node 1',
+      entity: {},
+      requested_action: 'auto',
+      depends_on: [],
+      parent_node_id: null,
+      existing_resulting_process_candidates: [],
+      existing_process_candidates: [],
+      existing_lifecyclemodel_candidates: [],
+      planned_invocations: [],
+      ...overrides,
+    }) as JsonRecord;
+
+  const allowAll = {
+    allow_process_build: true,
+    allow_submodel_build: true,
+    reuse_resulting_process_first: true,
+  };
+
+  assert.equal(
+    __testInternals.selectResolution(makeNode({ requested_action: 'cutoff' }) as never, allowAll)
+      .boundary_reason,
+    'explicit_cutoff',
+  );
+  assert.equal(
+    __testInternals.selectResolution(
+      makeNode({ requested_action: 'unresolved' }) as never,
+      allowAll,
+    ).resolution,
+    'unresolved',
+  );
+  assert.equal(
+    __testInternals.selectResolution(
+      makeNode({ requested_action: 'reuse_existing_resulting_process' }) as never,
+      allowAll,
+    ).resolution,
+    'unresolved',
+  );
+  assert.equal(
+    __testInternals.selectResolution(
+      makeNode({
+        requested_action: 'reuse_existing_resulting_process',
+        existing_resulting_process_candidates: [{ id: 'rp-1', score: 1 }],
+      }) as never,
+      allowAll,
+    ).resolution,
+    'reused_existing_resulting_process',
+  );
+  assert.equal(
+    __testInternals.selectResolution(
+      makeNode({ requested_action: 'reuse_existing_process' }) as never,
+      allowAll,
+    ).resolution,
+    'unresolved',
+  );
+  assert.equal(
+    __testInternals.selectResolution(
+      makeNode({
+        requested_action: 'reuse_existing_process',
+        existing_process_candidates: [{ id: 'proc-1', score: 1 }],
+      }) as never,
+      allowAll,
+    ).resolution,
+    'reused_existing_process',
+  );
+  assert.equal(
+    __testInternals.selectResolution(
+      makeNode({ requested_action: 'reuse_existing_model' }) as never,
+      allowAll,
+    ).resolution,
+    'unresolved',
+  );
+  assert.equal(
+    __testInternals.selectResolution(
+      makeNode({
+        requested_action: 'reuse_existing_model',
+        kind: 'lifecyclemodel',
+        existing_lifecyclemodel_candidates: [{ id: 'lm-1', score: 1 }],
+      }) as never,
+      allowAll,
+    ).resolution,
+    'reused_existing_model',
+  );
+  assert.equal(
+    __testInternals.selectResolution(
+      makeNode({ requested_action: 'build_process' }) as never,
+      allowAll,
+    ).resolution,
+    'unresolved',
+  );
+  assert.equal(
+    __testInternals.selectResolution(
+      makeNode({
+        requested_action: 'build_process',
+        process_builder: { mode: 'workflow' },
+      }) as never,
+      {
+        ...allowAll,
+        allow_process_build: false,
+      },
+    ).resolution,
+    'unresolved',
+  );
+  assert.equal(
+    __testInternals.selectResolution(
+      makeNode({
+        requested_action: 'build_process',
+        process_builder: { mode: 'workflow' },
+      }) as never,
+      allowAll,
+    ).resolution,
+    'build_via_process_automated_builder',
+  );
+  assert.equal(
+    __testInternals.selectResolution(
+      makeNode({
+        requested_action: 'build_submodel',
+        kind: 'lifecyclemodel',
+      }) as never,
+      allowAll,
+    ).resolution,
+    'unresolved',
+  );
+  assert.equal(
+    __testInternals.selectResolution(
+      makeNode({
+        requested_action: 'build_submodel',
+        kind: 'lifecyclemodel',
+        submodel_builder: { manifest: '/tmp/manifest.json' },
+      }) as never,
+      {
+        ...allowAll,
+        allow_submodel_build: false,
+      },
+    ).resolution,
+    'unresolved',
+  );
+  assert.equal(
+    __testInternals.selectResolution(
+      makeNode({
+        requested_action: 'build_submodel',
+        kind: 'lifecyclemodel',
+        submodel_builder: { manifest: '/tmp/manifest.json' },
+      }) as never,
+      allowAll,
+    ).resolution,
+    'build_via_lifecyclemodel_automated_builder',
+  );
+
+  assert.equal(
+    __testInternals.selectResolution(
+      makeNode({
+        existing_resulting_process_candidates: [{ id: 'rp-auto', score: 1 }],
+      }) as never,
+      allowAll,
+    ).resolution,
+    'reused_existing_resulting_process',
+  );
+  assert.equal(
+    __testInternals.selectResolution(
+      makeNode({
+        existing_resulting_process_candidates: [{ id: 'rp-auto', score: 1 }],
+        existing_process_candidates: [{ id: 'proc-auto', score: 2 }],
+      }) as never,
+      {
+        ...allowAll,
+        reuse_resulting_process_first: false,
+      },
+    ).resolution,
+    'reused_existing_process',
+  );
+  assert.equal(
+    __testInternals.selectResolution(
+      makeNode({
+        kind: 'subsystem',
+        existing_lifecyclemodel_candidates: [{ id: 'lm-auto', score: 1 }],
+      }) as never,
+      allowAll,
+    ).resolution,
+    'reused_existing_model',
+  );
+  assert.equal(
+    __testInternals.selectResolution(
+      makeNode({
+        kind: 'subsystem',
+        submodel_builder: { manifest: '/tmp/manifest.json' },
+      }) as never,
+      allowAll,
+    ).resolution,
+    'build_via_lifecyclemodel_automated_builder',
+  );
+  assert.equal(
+    __testInternals.selectResolution(
+      makeNode({
+        process_builder: { mode: 'workflow' },
+      }) as never,
+      allowAll,
+    ).resolution,
+    'build_via_process_automated_builder',
+  );
+  assert.equal(
+    __testInternals.selectResolution(
+      makeNode({
+        existing_lifecyclemodel_candidates: [{ id: 'lm-fallback', score: 1 }],
+      }) as never,
+      allowAll,
+    ).resolution,
+    'reused_existing_model',
+  );
+  assert.equal(
+    __testInternals.selectResolution(makeNode() as never, allowAll).resolution,
+    'unresolved',
+  );
+
+  assert.equal(
+    __testInternals.shouldRunProjector(makeNode() as never, 'build_via_process_automated_builder'),
+    false,
+  );
+  assert.equal(
+    __testInternals.shouldRunProjector(
+      makeNode({ projector: { run_always: true } }) as never,
+      'reused_existing_process',
+    ),
+    true,
+  );
+  assert.equal(
+    __testInternals.shouldRunProjector(
+      makeNode({ projector: { run_always: false } }) as never,
+      'reused_existing_model',
+    ),
+    true,
+  );
+});
+
+test('lifecyclemodel orchestrate validates request shapes and buildPlan handles generated ids and duplicate nodes', () => {
+  const validOrchestration = {
+    mode: 'collapsed',
+    max_depth: 1,
+    reuse_resulting_process_first: true,
+    allow_process_build: true,
+    allow_submodel_build: true,
+    pin_child_versions: true,
+    stop_at_elementary_flow: false,
+  };
+
+  const makeValidRequest = (root: JsonRecord): JsonRecord => ({
+    goal: {
+      name: 'Validation goal',
+    },
+    root,
+    orchestration: validOrchestration,
+    publish: {
+      intent: 'prepare_only',
+    },
+  });
+
+  assert.doesNotThrow(() =>
+    __testInternals.validateRequestShape(
+      makeValidRequest({
+        kind: 'reference_flow',
+        flow: { id: 'flow-1' },
+      }),
+    ),
+  );
+  assert.doesNotThrow(() =>
+    __testInternals.validateRequestShape(
+      makeValidRequest({
+        kind: 'process',
+        process: { id: 'proc-1' },
+      }),
+    ),
+  );
+  assert.doesNotThrow(() =>
+    __testInternals.validateRequestShape(
+      makeValidRequest({
+        kind: 'resulting_process',
+        resulting_process: { id: 'rp-1' },
+      }),
+    ),
+  );
+
+  assert.throws(
+    () =>
+      __testInternals.validateRequestShape({
+        ...makeValidRequest({
+          kind: 'process',
+          process: { id: 'proc-1' },
+        }),
+        goal: {},
+      }),
+    /goal.name is required/u,
+  );
+  assert.throws(
+    () =>
+      __testInternals.validateRequestShape(
+        makeValidRequest({
+          kind: 'process',
+          process: {},
+        }),
+      ),
+    /root.process.id is required/u,
+  );
+  assert.throws(
+    () =>
+      __testInternals.validateRequestShape({
+        ...makeValidRequest({
+          kind: 'process',
+          process: { id: 'proc-1' },
+        }),
+        orchestration: {
+          ...validOrchestration,
+          max_depth: -1,
+        },
+      }),
+    /orchestration.max_depth must be a non-negative integer/u,
+  );
+  assert.throws(
+    () =>
+      __testInternals.validateRequestShape({
+        ...makeValidRequest({
+          kind: 'process',
+          process: { id: 'proc-1' },
+        }),
+        publish: {
+          intent: 'invalid',
+        },
+      }),
+    /publish.intent must be one of/u,
+  );
+  assert.throws(
+    () =>
+      __testInternals.validateRequestShape({
+        ...makeValidRequest({
+          kind: 'process',
+          process: { id: 'proc-1' },
+        }),
+        nodes: {},
+      }),
+    /nodes must be an array/u,
+  );
+  assert.throws(
+    () =>
+      __testInternals.validateRequestShape({
+        ...makeValidRequest({
+          kind: 'process',
+          process: { id: 'proc-1' },
+        }),
+        edges: {},
+      }),
+    /edges must be an array/u,
+  );
+
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-orchestrate-build-plan-'));
+  try {
+    const requestPath = path.join(dir, 'request.json');
+    const outDir = path.join(dir, 'out');
+
+    const generatedPlan = __testInternals.buildPlan(
+      {
+        ...makeValidRequest({
+          node_id: 'root',
+          kind: 'process',
+          process: { id: 'proc-root', name: 'Root process' },
+        }),
+        candidate_sources: [],
+        notes: ['keep me', '', '  '],
+        nodes: [
+          {
+            node_id: 'root',
+            kind: 'process',
+            process: { id: 'proc-root', name: 'Root process' },
+            requested_action: 'cutoff',
+          },
+          {
+            node_id: 'root',
+            kind: 'process',
+            process: { id: 'proc-root-duplicate', name: 'Root duplicate' },
+            requested_action: 'unresolved',
+          },
+        ],
+      },
+      requestPath,
+      outDir,
+      new Date('2026-03-31T00:00:00Z'),
+    );
+    assert.match(generatedPlan.request_id, /^run-\d{8}T\d{6}000Z$/u);
+    assert.deepEqual(generatedPlan.notes, ['keep me']);
+    assert.equal(generatedPlan.nodes.length, 1);
+    assert.deepEqual(generatedPlan.candidate_sources, __testInternals.defaultCandidateSources());
+
+    const unresolvedPlan = __testInternals.buildPlan(
+      {
+        request_id: 'boundary-demo',
+        ...makeValidRequest({
+          kind: 'process',
+          process: { id: 'proc-root' },
+        }),
+        nodes: [
+          {
+            node_id: 'cut-node',
+            kind: 'process',
+            process: { id: 'cut-proc' },
+            requested_action: 'cutoff',
+          },
+          {
+            node_id: 'unknown-node',
+            kind: 'process',
+            process: { id: 'unknown-proc' },
+            requested_action: 'unresolved',
+          },
+        ],
+      },
+      requestPath,
+      outDir,
+      new Date('2026-03-31T00:00:00Z'),
+    );
+    assert.deepEqual(
+      unresolvedPlan.boundaries.map((entry) => entry.reason),
+      ['unresolved', 'explicit_cutoff', 'unresolved'],
+    );
+    assert.deepEqual(unresolvedPlan.unresolved, [
+      {
+        node_id: 'proc-root',
+        label: 'Validation goal',
+        reason: 'No reusable candidate or build config satisfied the node policy',
+      },
+      {
+        node_id: 'unknown-node',
+        label: 'unknown-node',
+        reason: 'Explicit unresolved marker provided.',
+      },
+    ]);
+
+    assert.throws(
+      () =>
+        __testInternals.buildPlan(
+          {
+            request_id: 'duplicate-demo',
+            ...makeValidRequest({
+              kind: 'process',
+              process: { id: 'proc-root' },
+            }),
+            nodes: [
+              {
+                node_id: 'dup-node',
+                kind: 'process',
+                process: { id: 'proc-a' },
+              },
+              {
+                node_id: 'dup-node',
+                kind: 'process',
+                process: { id: 'proc-b' },
+              },
+            ],
+          },
+          requestPath,
+          outDir,
+          new Date('2026-03-31T00:00:00Z'),
+        ),
+      /Duplicate node_id: dup-node/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('lifecyclemodel orchestrate helper artifacts cover file checks, inline JSON, statuses, manifests, and publish bundle flags', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-orchestrate-artifacts-'));
+  try {
+    const existingFile = path.join(dir, 'existing.json');
+    writeJson(existingFile, { ok: true });
+    __testInternals.requireFile(existingFile, 'existing fixture');
+    assert.throws(
+      () => __testInternals.requireFile(path.join(dir, 'missing.json'), 'missing fixture'),
+      /Missing missing fixture/u,
+    );
+
+    assert.deepEqual(__testInternals.parseInlineJson({ ok: true }, 'inline payload'), { ok: true });
+    assert.deepEqual(__testInternals.parseInlineJson('{"ok":true}', 'inline payload'), {
+      ok: true,
+    });
+    assert.throws(
+      () => __testInternals.parseInlineJson('[1,2,3]', 'inline payload'),
+      /Invalid inline payload JSON string/u,
+    );
+    assert.throws(
+      () => __testInternals.parseInlineJson(undefined, 'inline payload'),
+      /inline payload must be a JSON object or JSON string/u,
+    );
+
+    const projectionBundlePath = path.join(dir, 'projection-bundle.json');
+    const projectionBundleScalarPath = path.join(dir, 'projection-bundle-scalar.json');
+    const modelFile = path.join(dir, 'model.json');
+    writeJson(modelFile, { lifeCycleModelDataSet: { '@id': 'lm-1' } });
+    writeJson(projectionBundlePath, {
+      projected_processes: [{ id: 'projected-1' }, 1],
+      relations: [{ id: 'relation-1' }, 2],
+    });
+    writeJson(projectionBundleScalarPath, 1);
+
+    const invocationsDir = path.join(dir, 'invocations');
+    mkdirSync(invocationsDir, { recursive: true });
+    writeJson(path.join(invocationsDir, '000-ignore.json'), 1);
+    writeJson(path.join(invocationsDir, '001-valid.json'), {
+      invocation_id: 'loaded-1',
+      node_id: 'completed-node',
+      kind: 'projector',
+      status: 'success',
+      exit_code: 0,
+      result_file: path.join(invocationsDir, '001-valid.json'),
+    });
+
+    assert.deepEqual(__testInternals.loadInvocationResults(path.join(dir, 'missing-dir')), []);
+    assert.deepEqual(__testInternals.loadInvocationResults(invocationsDir), [
+      {
+        invocation_id: 'loaded-1',
+        node_id: 'completed-node',
+        kind: 'projector',
+        status: 'success',
+        exit_code: 0,
+        result_file: path.join(invocationsDir, '001-valid.json'),
+      },
+    ]);
+
+    const plan = {
+      skill: 'lifecyclemodel-recursive-orchestrator',
+      request_id: 'artifact-demo',
+      created_at: '2026-03-31T00:00:00.000Z',
+      request_file: path.join(dir, 'request.json'),
+      goal: { name: 'Artifact goal' },
+      root: { kind: 'process', process: { id: 'proc-root' } },
+      orchestration: { mode: 'collapsed', max_depth: 1 },
+      candidate_sources: { my_processes: true },
+      publish: {
+        intent: '',
+        prepare_lifecyclemodel_payload: false,
+        prepare_resulting_process_payload: false,
+        prepare_relation_payload: true,
+      },
+      notes: ['note-1'],
+      nodes: [
+        {
+          node_id: 'unresolved-node',
+          label: 'Unresolved node',
+          kind: 'process',
+          depends_on: [],
+          resolution: 'unresolved',
+        },
+        {
+          node_id: 'cutoff-node',
+          label: 'Cutoff node',
+          kind: 'process',
+          depends_on: [],
+          resolution: 'cutoff',
+        },
+        {
+          node_id: 'reused-node',
+          label: 'Reused node',
+          kind: 'process',
+          depends_on: [],
+          resolution: 'reused_existing_process',
+          selected_candidate: { id: 'candidate-1', version: '00.00.001' },
+        },
+        {
+          node_id: 'reused-null-node',
+          label: 'Reused null node',
+          kind: 'process',
+          depends_on: [],
+          resolution: 'reused_existing_model',
+          selected_candidate: {},
+        },
+        {
+          node_id: 'planned-node',
+          label: 'Planned node',
+          kind: 'process',
+          depends_on: [],
+          resolution: 'build_via_process_automated_builder',
+        },
+        {
+          node_id: 'failed-node',
+          label: 'Failed node',
+          kind: 'process',
+          depends_on: [],
+          resolution: 'build_via_process_automated_builder',
+        },
+        {
+          node_id: 'blocked-node',
+          label: 'Blocked node',
+          kind: 'process',
+          depends_on: [],
+          resolution: 'build_via_process_automated_builder',
+        },
+        {
+          node_id: 'completed-node',
+          label: 'Completed node',
+          kind: 'lifecyclemodel',
+          depends_on: [],
+          resolution: 'build_via_lifecyclemodel_automated_builder',
+        },
+        {
+          node_id: 'incomplete-node',
+          label: 'Incomplete node',
+          kind: 'process',
+          depends_on: [],
+          resolution: 'build_via_process_automated_builder',
+        },
+      ],
+      edges: [{ from: 'completed-node', to: 'reused-node', relation: 'depends_on' }],
+      invocations: [
+        {
+          invocation_id: 'failed-node:process-builder',
+          node_id: 'failed-node',
+          kind: 'process_builder',
+          artifact_dir: path.join(dir, 'failed-node'),
+        },
+        {
+          invocation_id: 'completed-node:lifecyclemodel-builder',
+          node_id: 'completed-node',
+          kind: 'lifecyclemodel_builder',
+          artifact_dir: path.join(dir, 'completed-node'),
+        },
+        {
+          invocation_id: 'completed-node:projector',
+          node_id: 'completed-node',
+          kind: 'projector',
+          artifact_dir: path.join(dir, 'completed-node-projector'),
+        },
+      ],
+      planner_summary: {
+        status: 'planned',
+        message: 'demo',
+      },
+      warnings: ['warn-1'],
+      unresolved: [
+        { node_id: 'unresolved-node', label: 'Unresolved node', reason: 'missing data' },
+      ],
+      boundaries: [{ node_id: 'cutoff-node', reason: 'explicit_cutoff' }],
+      artifacts: {
+        root: dir,
+        request_normalized: path.join(dir, 'request.normalized.json'),
+        assembly_plan: path.join(dir, 'assembly-plan.json'),
+        graph_manifest: path.join(dir, 'graph-manifest.json'),
+        lineage_manifest: path.join(dir, 'lineage-manifest.json'),
+        boundary_report: path.join(dir, 'boundary-report.json'),
+        invocations_dir: invocationsDir,
+        publish_bundle: path.join(dir, 'publish-bundle.json'),
+        publish_summary: path.join(dir, 'publish-summary.json'),
+      },
+      summary: {
+        node_count: 9,
+        edge_count: 1,
+        invocation_count: 3,
+        unresolved_count: 1,
+      },
+    } as JsonRecord;
+
+    const executionResults = [
+      {
+        invocation_id: 'failed-node:process-builder',
+        node_id: 'failed-node',
+        kind: 'process_builder',
+        status: 'failed',
+        exit_code: 1,
+        result_file: path.join(dir, 'failed-node.json'),
+      },
+      {
+        invocation_id: 'blocked-node:process-builder',
+        node_id: 'blocked-node',
+        kind: 'process_builder',
+        status: 'skipped_due_to_dependency_failed',
+        exit_code: null,
+        result_file: path.join(dir, 'blocked-node.json'),
+      },
+      {
+        invocation_id: 'completed-node:lifecyclemodel-builder',
+        node_id: 'completed-node',
+        kind: 'lifecyclemodel_builder',
+        status: 'success',
+        exit_code: 0,
+        result_file: path.join(dir, 'completed-builder.json'),
+        artifacts: {
+          produced_model_files: [modelFile, '', path.join(dir, 'missing-model.json')],
+          process_catalog_files: [path.join(dir, 'catalog.json')],
+          source_run_dirs: [path.join(dir, 'run-dir')],
+        },
+      },
+      {
+        invocation_id: 'completed-node:projector',
+        node_id: 'completed-node',
+        kind: 'projector',
+        status: 'success',
+        exit_code: 0,
+        result_file: path.join(dir, 'completed-projector.json'),
+        artifacts: {
+          projection_bundle: projectionBundlePath,
+        },
+      },
+      {
+        invocation_id: 'completed-node:projector-scalar',
+        node_id: 'completed-node',
+        kind: 'projector',
+        status: 'success',
+        exit_code: 0,
+        result_file: path.join(dir, 'completed-projector-scalar.json'),
+        artifacts: {
+          projection_bundle: projectionBundleScalarPath,
+        },
+      },
+      {
+        invocation_id: 'incomplete-node:process-builder-a',
+        node_id: 'incomplete-node',
+        kind: 'process_builder',
+        status: 'success',
+        exit_code: 0,
+        result_file: path.join(dir, 'incomplete-a.json'),
+      },
+      {
+        invocation_id: 'incomplete-node:process-builder-b',
+        node_id: 'incomplete-node',
+        kind: 'process_builder',
+        status: 'partial',
+        exit_code: null,
+        result_file: path.join(dir, 'incomplete-b.json'),
+      },
+    ] as JsonRecord[];
+
+    assert.deepEqual(
+      __testInternals.executionStatusByNode(plan as never, executionResults as never),
+      {
+        'unresolved-node': 'unresolved',
+        'cutoff-node': 'cutoff',
+        'reused-node': 'reused',
+        'reused-null-node': 'reused',
+        'planned-node': 'planned',
+        'failed-node': 'failed',
+        'blocked-node': 'blocked',
+        'completed-node': 'completed',
+        'incomplete-node': 'incomplete',
+      },
+    );
+
+    const graphManifest = __testInternals.buildGraphManifest(
+      plan as never,
+      executionResults as never,
+    );
+    assert.equal(graphManifest.stats.completed_invocation_count, 4);
+
+    const lineageManifest = __testInternals.buildLineageManifest(
+      plan as never,
+      executionResults as never,
+    );
+    assert.deepEqual(lineageManifest.published_dependencies, [
+      {
+        node_id: 'reused-node',
+        dependency_type: 'reused_existing_process',
+        candidate_id: 'candidate-1',
+        candidate_version: '00.00.001',
+      },
+      {
+        node_id: 'reused-null-node',
+        dependency_type: 'reused_existing_model',
+        candidate_id: null,
+        candidate_version: null,
+      },
+    ]);
+    assert.deepEqual(lineageManifest.resulting_process_relations, [
+      {
+        id: 'relation-1',
+        node_id: 'completed-node',
+      },
+    ]);
+
+    const boundaryReport = __testInternals.buildBoundaryReport(
+      plan as never,
+      executionResults as never,
+    );
+    assert.deepEqual(boundaryReport.execution_summary, {
+      successful_invocations: 4,
+      failed_invocations: 1,
+      blocked_invocations: 1,
+    });
+
+    assert.equal(
+      __testInternals.inferProjectorModelFile(
+        {
+          config: {
+            model_file: modelFile,
+          },
+        } as never,
+        new Map(),
+      ),
+      modelFile,
+    );
+    assert.equal(
+      __testInternals.inferProjectorModelFile(
+        {
+          config: {},
+          depends_on_invocation_id: 'completed-node:lifecyclemodel-builder',
+        } as never,
+        new Map([
+          [
+            'completed-node:lifecyclemodel-builder',
+            {
+              artifacts: {
+                produced_model_files: [modelFile],
+              },
+            },
+          ],
+        ]) as never,
+      ),
+      modelFile,
+    );
+    assert.equal(
+      __testInternals.inferProjectorModelFile(
+        {
+          config: {},
+          depends_on_invocation_id: 'completed-node:projector',
+        } as never,
+        new Map([
+          [
+            'completed-node:projector',
+            {
+              invocation_id: 'completed-node:projector',
+              node_id: 'completed-node',
+              kind: 'projector',
+              status: 'success',
+              exit_code: 0,
+              result_file: path.join(dir, 'completed-projector.json'),
+              artifacts: {
+                produced_model_files: [],
+              },
+            },
+          ],
+        ]),
+      ),
+      null,
+    );
+    assert.equal(
+      __testInternals.inferProjectorModelFile(
+        {
+          config: {},
+        } as never,
+        new Map(),
+      ),
+      null,
+    );
+
+    assert.deepEqual(__testInternals.normalizeRequestForArtifacts(plan as never), {
+      request_id: 'artifact-demo',
+      goal: { name: 'Artifact goal' },
+      root: { kind: 'process', process: { id: 'proc-root' } },
+      orchestration: { mode: 'collapsed', max_depth: 1 },
+      candidate_sources: { my_processes: true },
+      publish: {
+        intent: '',
+        prepare_lifecyclemodel_payload: false,
+        prepare_resulting_process_payload: false,
+        prepare_relation_payload: true,
+      },
+      nodes: plan.nodes,
+      edges: plan.edges,
+      notes: ['note-1'],
+    });
+
+    const projectorRequest = __testInternals.buildProjectorRequest(
+      {
+        config: {
+          projection_role: 'all',
+        },
+      } as never,
+      modelFile,
+      plan as never,
+      null,
+      [],
+    );
+    assert.deepEqual(projectorRequest.publish, {
+      intent: 'prepare_only',
+      prepare_process_payloads: false,
+      prepare_relation_payloads: true,
+    });
+    const projectorRequestWithExplicitIntent = __testInternals.buildProjectorRequest(
+      {
+        config: {
+          projection_role: 'primary',
+        },
+      } as never,
+      modelFile,
+      {
+        ...plan,
+        publish: {
+          intent: 'publish',
+          prepare_resulting_process_payload: true,
+          prepare_relation_payload: false,
+        },
+      } as never,
+      path.join(dir, 'catalog.json'),
+      [path.join(dir, 'run-dir')],
+    );
+    assert.deepEqual(projectorRequestWithExplicitIntent.publish, {
+      intent: 'publish',
+      prepare_process_payloads: true,
+      prepare_relation_payloads: false,
+    });
+
+    const bundleWithoutPublishables = __testInternals.collectPublishBundle(
+      dir,
+      plan as never,
+      graphManifest,
+      lineageManifest,
+      executionResults as never,
+      false,
+      false,
+    ) as {
+      lifecyclemodels: unknown[];
+      projected_processes: unknown[];
+      resulting_process_relations: unknown[];
+    };
+    assert.equal(bundleWithoutPublishables.lifecyclemodels.length, 0);
+    assert.equal(bundleWithoutPublishables.projected_processes.length, 0);
+    assert.equal(bundleWithoutPublishables.resulting_process_relations.length, 0);
+
+    const bundleWithPublishables = __testInternals.collectPublishBundle(
+      dir,
+      plan as never,
+      graphManifest,
+      lineageManifest,
+      executionResults as never,
+      true,
+      true,
+    ) as {
+      lifecyclemodels: unknown[];
+      projected_processes: unknown[];
+      resulting_process_relations: unknown[];
+    };
+    assert.equal(bundleWithPublishables.lifecyclemodels.length, 1);
+    assert.equal(bundleWithPublishables.projected_processes.length, 1);
+    assert.equal(bundleWithPublishables.resulting_process_relations.length, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('lifecyclemodel orchestrate execution internals cover inline flow payloads and removed python_bin configs', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-orchestrate-exec-internals-'));
+  try {
+    const invocationDir = path.join(dir, 'invocations');
+    const plan = {
+      request_id: 'inline-demo',
+      artifacts: {
+        invocations_dir: invocationDir,
+      },
+    } as JsonRecord;
+    const flowJson = JSON.stringify(readJson<JsonRecord>(flowFixturePath()));
+
+    const inlineResult = await __testInternals.executeProcessBuilderInvocation(
+      {
+        invocation_id: 'inline-node:process-builder',
+        node_id: 'inline-node',
+        kind: 'process_builder',
+        config: {
+          flow_json: flowJson,
+        },
+        artifact_dir: path.join(dir, 'inline-run'),
+      } as never,
+      plan as never,
+      path.join(dir, 'inline-result.json'),
+      new Date('2026-03-31T00:00:00Z'),
+    );
+    assert.equal(inlineResult.status, 'success');
+    assert.match(readFileSync(path.join(dir, 'inline-result.json'), 'utf8'), /inline-node/u);
+
+    await assert.rejects(
+      () =>
+        __testInternals.executeProcessBuilderInvocation(
+          {
+            invocation_id: 'legacy-node:process-builder',
+            node_id: 'legacy-node',
+            kind: 'process_builder',
+            config: {
+              python_bin: 'python3',
+              flow_file: flowFixturePath(),
+            },
+            artifact_dir: path.join(dir, 'legacy-run'),
+          } as never,
+          plan as never,
+          path.join(dir, 'legacy-result.json'),
+          new Date('2026-03-31T00:00:00Z'),
+        ),
+      /python_bin/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('lifecyclemodel orchestrate execute handles missing submodel manifests, blocked dependencies, and missing projector inputs', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-orchestrate-missing-runtime-'));
+  const missingManifestRequest = path.join(dir, 'missing-manifest.request.json');
+  const missingManifestOutDir = path.join(dir, 'missing-manifest-run');
+
+  writeJson(missingManifestRequest, {
+    request_id: 'missing-manifest',
+    goal: {
+      name: 'Missing manifest demo',
+    },
+    root: {
+      node_id: 'model-root',
+      kind: 'lifecyclemodel',
+      lifecyclemodel: {
+        id: 'lm-missing',
+      },
+      requested_action: 'build_submodel',
+      submodel_builder: {},
+      projector: {
+        projection_role: 'primary',
+      },
+    },
+    orchestration: {
+      mode: 'collapsed',
+      max_depth: 1,
+      reuse_resulting_process_first: true,
+      allow_process_build: false,
+      allow_submodel_build: true,
+      pin_child_versions: true,
+      stop_at_elementary_flow: false,
+      fail_fast: false,
+    },
+    publish: {
+      intent: 'prepare_only',
+    },
+  });
+
+  try {
+    const blockedReport = await runLifecyclemodelOrchestrate({
+      action: 'execute',
+      inputPath: missingManifestRequest,
+      outDir: missingManifestOutDir,
+      now: new Date('2026-03-31T00:00:00Z'),
+    });
+    assert.equal(blockedReport.status, 'failed');
+    assert.equal(blockedReport.execution.failed_invocations, 1);
+    assert.equal(blockedReport.execution.blocked_invocations, 1);
+
+    const failedInvocation = readJson<JsonRecord>(
+      path.join(missingManifestOutDir, 'invocations', 'model-root-lifecyclemodel-builder.json'),
+    );
+    assert.match(String(failedInvocation.error ?? ''), /missing submodel_builder\.manifest/u);
+
+    const blockedInvocation = readJson<JsonRecord>(
+      path.join(missingManifestOutDir, 'invocations', 'model-root-projector.json'),
+    );
+    assert.equal(blockedInvocation.status, 'skipped_due_to_dependency_failed');
+
+    const missingProjectorRequest = path.join(dir, 'missing-projector.request.json');
+    const missingProjectorOutDir = path.join(dir, 'missing-projector-run');
+    writeJson(missingProjectorRequest, {
+      request_id: 'missing-projector',
+      goal: {
+        name: 'Missing projector input demo',
+      },
+      root: {
+        node_id: 'model-projector',
+        kind: 'lifecyclemodel',
+        lifecyclemodel: {
+          id: 'lm-projector',
+        },
+        existing_lifecyclemodel_candidates: [
+          {
+            id: 'lm-existing',
+            score: 1,
+          },
+        ],
+        projector: {
+          projection_role: 'primary',
+        },
+      },
+      orchestration: {
+        mode: 'collapsed',
+        max_depth: 1,
+        reuse_resulting_process_first: true,
+        allow_process_build: false,
+        allow_submodel_build: false,
+        pin_child_versions: true,
+        stop_at_elementary_flow: false,
+        fail_fast: false,
+      },
+      publish: {
+        intent: 'prepare_only',
+      },
+    });
+
+    const projectorReport = await runLifecyclemodelOrchestrate({
+      action: 'execute',
+      inputPath: missingProjectorRequest,
+      outDir: missingProjectorOutDir,
+      now: new Date('2026-03-31T00:00:00Z'),
+    });
+    assert.equal(projectorReport.status, 'failed');
+    assert.equal(projectorReport.execution.failed_invocations, 1);
+
+    const projectorInvocation = readJson<JsonRecord>(
+      path.join(missingProjectorOutDir, 'invocations', 'model-projector-projector.json'),
+    );
+    assert.match(
+      String(projectorInvocation.error ?? ''),
+      /requires projector\.request or a prior lifecyclemodel build result/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('lifecyclemodel orchestrate publish includes projector outputs when prepare_relation_payload remains enabled', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lm-orchestrate-publish-flags-'));
+  const runDir = path.join(dir, 'run');
+  const invocationsDir = path.join(runDir, 'invocations');
+  mkdirSync(invocationsDir, { recursive: true });
+
+  const projectionBundlePath = path.join(runDir, 'projection-bundle.json');
+  writeJson(projectionBundlePath, {
+    projected_processes: [{ id: 'projected-1' }],
+    relations: [{ id: 'relation-1' }],
+  });
+
+  writeJson(path.join(runDir, 'assembly-plan.json'), {
+    skill: 'lifecyclemodel-recursive-orchestrator',
+    request_id: 'publish-flags',
+    created_at: '2026-03-31T00:00:00.000Z',
+    request_file: path.join(runDir, 'request.json'),
+    goal: { name: 'Publish flags goal' },
+    root: { kind: 'lifecyclemodel', lifecyclemodel: { id: 'lm-publish' } },
+    orchestration: { mode: 'collapsed', max_depth: 1 },
+    candidate_sources: {},
+    publish: {
+      intent: 'prepare_only',
+      prepare_lifecyclemodel_payload: false,
+      prepare_resulting_process_payload: false,
+      prepare_relation_payload: true,
+    },
+    notes: [],
+    nodes: [],
+    edges: [],
+    invocations: [],
+    planner_summary: {
+      status: 'executed',
+      message: 'publish demo',
+    },
+    warnings: [],
+    unresolved: [],
+    boundaries: [],
+    artifacts: {
+      root: runDir,
+      request_normalized: path.join(runDir, 'request.normalized.json'),
+      assembly_plan: path.join(runDir, 'assembly-plan.json'),
+      graph_manifest: path.join(runDir, 'graph-manifest.json'),
+      lineage_manifest: path.join(runDir, 'lineage-manifest.json'),
+      boundary_report: path.join(runDir, 'boundary-report.json'),
+      invocations_dir: invocationsDir,
+      publish_bundle: path.join(runDir, 'publish-bundle.json'),
+      publish_summary: path.join(runDir, 'publish-summary.json'),
+    },
+    summary: {
+      node_count: 0,
+      edge_count: 0,
+      invocation_count: 0,
+      unresolved_count: 0,
+    },
+  });
+  writeJson(path.join(runDir, 'graph-manifest.json'), {
+    root: {},
+    nodes: [],
+    edges: [],
+    boundaries: [],
+    unresolved: [],
+    stats: {},
+  });
+  writeJson(path.join(runDir, 'lineage-manifest.json'), {
+    root_request: {},
+    builder_invocations: [],
+    node_resolution_log: [],
+    published_dependencies: [],
+    resulting_process_relations: [],
+    unresolved_history: [],
+  });
+  writeJson(path.join(invocationsDir, '000-ignore.json'), 1);
+  writeJson(path.join(invocationsDir, '001-projector.json'), {
+    invocation_id: 'model-projector',
+    node_id: 'model-node',
+    kind: 'projector',
+    status: 'success',
+    exit_code: 0,
+    result_file: path.join(invocationsDir, '001-projector.json'),
+    artifacts: {
+      projection_bundle: projectionBundlePath,
+    },
+  });
+
+  try {
+    const publishReport = await runLifecyclemodelOrchestrate({
+      action: 'publish',
+      runDir,
+      now: new Date('2026-03-31T01:00:00Z'),
+    });
+    assert.equal(publishReport.action, 'publish');
+    assert.equal(publishReport.counts.lifecyclemodels, 0);
+    assert.equal(publishReport.counts.projected_processes, 1);
+    assert.equal(publishReport.counts.resulting_process_relations, 1);
+
+    const publishBundle = readJson<JsonRecord>(path.join(runDir, 'publish-bundle.json'));
+    assert.equal(publishBundle.include_resulting_process_relations, true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/lifecyclemodel-publish-build.test.ts
+++ b/test/lifecyclemodel-publish-build.test.ts
@@ -1,0 +1,345 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  __testInternals,
+  runLifecyclemodelPublishBuild,
+} from '../src/lib/lifecyclemodel-publish-build.js';
+import { runPublish } from '../src/lib/publish.js';
+
+type JsonRecord = Record<string, unknown>;
+
+function writeJson(filePath: string, value: unknown): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function readJson<T>(filePath: string): T {
+  return JSON.parse(readFileSync(filePath, 'utf8')) as T;
+}
+
+function createLifecyclemodelPayload(id: string, version = '01.01.000'): JsonRecord {
+  return {
+    lifeCycleModelDataSet: {
+      lifeCycleModelInformation: {
+        dataSetInformation: {
+          'common:UUID': id,
+          referenceToResultingProcess: {
+            '@refObjectId': `${id}-result`,
+          },
+        },
+        quantitativeReference: {
+          referenceToReferenceProcess: '1',
+        },
+      },
+      administrativeInformation: {
+        publicationAndOwnership: {
+          'common:dataSetVersion': version,
+        },
+      },
+    },
+  };
+}
+
+function createLifecyclemodelRunFixture(
+  rootDir: string,
+  runName: string,
+  modelNames: string[] = ['model-a'],
+  options?: {
+    writeInvocationIndex?: boolean;
+    manifestRunId?: string;
+    validationReport?: JsonRecord;
+  },
+): string {
+  const runRoot = path.join(rootDir, runName);
+  writeJson(path.join(runRoot, 'manifests', 'run-manifest.json'), {
+    schemaVersion: 1,
+    runId: options?.manifestRunId ?? runName,
+  });
+
+  if (options?.writeInvocationIndex !== false) {
+    writeJson(path.join(runRoot, 'manifests', 'invocation-index.json'), {
+      schema_version: 1,
+      invocations: [],
+    });
+  }
+
+  for (const modelName of modelNames) {
+    writeJson(
+      path.join(
+        runRoot,
+        'models',
+        modelName,
+        'tidas_bundle',
+        'lifecyclemodels',
+        `${modelName}.json`,
+      ),
+      createLifecyclemodelPayload(`${modelName}-uuid`),
+    );
+  }
+
+  if (options?.validationReport) {
+    writeJson(
+      path.join(runRoot, 'reports', 'lifecyclemodel-validate-build-report.json'),
+      options.validationReport,
+    );
+  }
+
+  return runRoot;
+}
+
+test('runLifecyclemodelPublishBuild writes lifecyclemodel publish handoff artifacts', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-publish-build-'));
+  const runRoot = createLifecyclemodelRunFixture(dir, 'lm-publish-1', ['model-a', 'model-b']);
+
+  try {
+    const report = await runLifecyclemodelPublishBuild({
+      runDir: runRoot,
+      now: new Date('2026-03-30T00:00:00.000Z'),
+      cwd: '/tmp/lifecyclemodel-publish',
+    });
+
+    assert.equal(report.status, 'prepared_local_lifecyclemodel_publish_bundle');
+    assert.deepEqual(report.counts, {
+      lifecyclemodels: 2,
+    });
+    assert.deepEqual(report.publish_defaults, {
+      commit: false,
+      publish_lifecyclemodels: true,
+      publish_processes: false,
+      publish_sources: false,
+      publish_relations: false,
+      publish_process_build_runs: false,
+      relation_mode: 'local_manifest_only',
+    });
+    assert.deepEqual(report.validation, {
+      available: false,
+      ok: null,
+      report: null,
+    });
+
+    const publishBundle = readJson<JsonRecord>(report.files.publish_bundle);
+    assert.equal((publishBundle.lifecyclemodels as JsonRecord[]).length, 2);
+    assert.equal((publishBundle.relations as JsonRecord[]).length, 0);
+    assert.equal((publishBundle.source_run as JsonRecord).run_manifest instanceof Object, true);
+
+    const publishRequest = readJson<JsonRecord>(report.files.publish_request);
+    assert.deepEqual((publishRequest.inputs as JsonRecord).bundle_paths, ['./publish-bundle.json']);
+    const publishIntent = readJson<JsonRecord>(report.files.publish_intent);
+    assert.equal(publishIntent.command, 'publish run');
+    assert.match(report.next_actions[2], /tiangong publish run/u);
+
+    const invocationIndex = readJson<{ invocations: Array<Record<string, unknown>> }>(
+      report.files.invocation_index,
+    );
+    assert.equal(invocationIndex.invocations.length, 1);
+    assert.deepEqual(invocationIndex.invocations[0]?.command, [
+      'lifecyclemodel',
+      'publish-build',
+      '--run-dir',
+      runRoot,
+    ]);
+
+    const publishRunReport = await runPublish({
+      inputPath: report.files.publish_request,
+      now: new Date('2026-03-30T01:00:00.000Z'),
+    });
+    assert.equal(publishRunReport.status, 'completed');
+    assert.equal(publishRunReport.counts.lifecyclemodels, 2);
+    assert.equal(publishRunReport.lifecyclemodels[0]?.status, 'prepared');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelPublishBuild surfaces validation summary when available', async () => {
+  const dir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-publish-build-validation-'),
+  );
+  const runRoot = createLifecyclemodelRunFixture(dir, 'lm-publish-2', ['model-a'], {
+    writeInvocationIndex: false,
+    validationReport: {
+      ok: false,
+    },
+  });
+
+  try {
+    const report = await runLifecyclemodelPublishBuild({
+      runDir: runRoot,
+    });
+
+    assert.deepEqual(report.validation, {
+      available: true,
+      ok: false,
+      report: path.join(runRoot, 'reports', 'lifecyclemodel-validate-build-report.json'),
+    });
+    assert.equal(readJson<JsonRecord>(report.files.invocation_index).schema_version, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelPublishBuild rejects missing runs and mismatched manifests', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-publish-build-errors-'));
+  const missingRunDir = path.join(dir, 'missing-run');
+  const missingManifestRunDir = path.join(dir, 'lm-publish-missing-manifest');
+  mkdirSync(missingManifestRunDir, { recursive: true });
+  const invalidManifestRunDir = path.join(dir, 'lm-publish-invalid-manifest');
+  writeJson(path.join(invalidManifestRunDir, 'manifests', 'run-manifest.json'), []);
+  const mismatchRunDir = createLifecyclemodelRunFixture(dir, 'lm-publish-3', ['model-a'], {
+    manifestRunId: 'other-run-id',
+  });
+
+  try {
+    await assert.rejects(
+      async () =>
+        runLifecyclemodelPublishBuild({
+          runDir: missingRunDir,
+        }),
+      /run root not found/u,
+    );
+
+    await assert.rejects(
+      async () =>
+        runLifecyclemodelPublishBuild({
+          runDir: missingManifestRunDir,
+        }),
+      /run-manifest artifact not found/u,
+    );
+
+    await assert.rejects(
+      async () =>
+        runLifecyclemodelPublishBuild({
+          runDir: invalidManifestRunDir,
+        }),
+      /run-manifest artifact JSON object/u,
+    );
+
+    await assert.rejects(
+      async () =>
+        runLifecyclemodelPublishBuild({
+          runDir: mismatchRunDir,
+        }),
+      /run manifest runId mismatch/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('lifecyclemodel publish-build internals cover layout, invocation index, validation, and payload edge cases', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-publish-build-helpers-'));
+
+  try {
+    assert.throws(
+      () =>
+        __testInternals.resolveLayout({
+          runDir: '',
+        }),
+      /Missing required --run-dir/u,
+    );
+
+    assert.throws(
+      () =>
+        __testInternals.resolveLayout({
+          runDir: 123 as unknown as string,
+        }),
+      /Missing required --run-dir/u,
+    );
+
+    const layout = __testInternals.buildLayout(path.join(dir, 'lm-publish-helpers'));
+
+    assert.deepEqual(__testInternals.readInvocationIndex(layout), {
+      schema_version: 1,
+      invocations: [],
+    });
+
+    mkdirSync(layout.manifestsDir, { recursive: true });
+    writeJson(layout.invocationIndexPath, {});
+    assert.deepEqual(__testInternals.readInvocationIndex(layout), {
+      schema_version: 1,
+      invocations: [],
+    });
+
+    writeJson(layout.invocationIndexPath, []);
+    assert.throws(
+      () => __testInternals.readInvocationIndex(layout),
+      /Expected lifecyclemodel publish invocation index JSON object/u,
+    );
+
+    writeJson(layout.invocationIndexPath, {
+      invocations: {},
+    });
+    assert.throws(() => __testInternals.readInvocationIndex(layout), /invocations array/u);
+
+    assert.deepEqual(__testInternals.readValidationSummary(layout), {
+      available: false,
+      ok: null,
+      report: null,
+    });
+
+    writeJson(layout.validationReportPath, []);
+    assert.throws(
+      () => __testInternals.readValidationSummary(layout),
+      /validate-build report JSON object/u,
+    );
+
+    writeJson(layout.validationReportPath, {});
+    assert.deepEqual(__testInternals.readValidationSummary(layout), {
+      available: true,
+      ok: false,
+      report: layout.validationReportPath,
+    });
+
+    assert.throws(
+      () => __testInternals.collectLifecyclemodelPayloads(layout),
+      /does not contain any lifecyclemodel payloads/u,
+    );
+
+    mkdirSync(path.join(layout.modelsDir, 'ignored-entry'), { recursive: true });
+    writeJson(
+      path.join(layout.modelsDir, 'model-a', 'tidas_bundle', 'lifecyclemodels', 'model-a.json'),
+      createLifecyclemodelPayload('lm-helper'),
+    );
+    assert.equal(__testInternals.collectLifecyclemodelPayloads(layout).length, 1);
+
+    writeJson(
+      path.join(layout.modelsDir, 'model-b', 'tidas_bundle', 'lifecyclemodels', 'broken.json'),
+      [],
+    );
+    assert.throws(
+      () => __testInternals.collectLifecyclemodelPayloads(layout),
+      /publish payload JSON object/u,
+    );
+
+    const publishRequest = __testInternals.buildPublishRequest();
+    assert.equal((publishRequest.publish as JsonRecord).publish_lifecyclemodels, true);
+    const publishIntent = __testInternals.buildPublishIntent(layout, 2);
+    assert.equal(publishIntent.lifecyclemodel_count, 2);
+    const invocationIndex = __testInternals.buildInvocationIndex(
+      layout,
+      {
+        schema_version: 'bad',
+        invocations: {},
+      },
+      {
+        runDir: layout.runRoot,
+        cwd: '/tmp/publish-cwd',
+      },
+      new Date('2026-03-30T00:00:00.000Z'),
+    );
+    const firstInvocation = (invocationIndex.invocations as JsonRecord[])[0];
+    assert.deepEqual(firstInvocation.command, [
+      'lifecyclemodel',
+      'publish-build',
+      '--run-dir',
+      layout.runRoot,
+    ]);
+    assert.equal(invocationIndex.schema_version, 1);
+    assert.equal(__testInternals.buildNextActions(layout).length, 3);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/lifecyclemodel-validate-build.test.ts
+++ b/test/lifecyclemodel-validate-build.test.ts
@@ -1,0 +1,425 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  __testInternals,
+  runLifecyclemodelValidateBuild,
+} from '../src/lib/lifecyclemodel-validate-build.js';
+import { runValidation, type ValidationRunReport } from '../src/lib/validation.js';
+
+type JsonRecord = Record<string, unknown>;
+
+function writeJson(filePath: string, value: unknown): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function readJson<T>(filePath: string): T {
+  return JSON.parse(readFileSync(filePath, 'utf8')) as T;
+}
+
+function createLifecyclemodelPayload(id: string, version = '01.01.000'): JsonRecord {
+  return {
+    lifeCycleModelDataSet: {
+      lifeCycleModelInformation: {
+        dataSetInformation: {
+          'common:UUID': id,
+          referenceToResultingProcess: {
+            '@refObjectId': `${id}-result`,
+          },
+        },
+        quantitativeReference: {
+          referenceToReferenceProcess: '1',
+        },
+      },
+      administrativeInformation: {
+        publicationAndOwnership: {
+          'common:dataSetVersion': version,
+        },
+      },
+    },
+  };
+}
+
+function createLifecyclemodelRunFixture(
+  rootDir: string,
+  runName: string,
+  modelNames: string[] = ['model-a'],
+  options?: {
+    includeAutoBuildReport?: boolean;
+    writeInvocationIndex?: boolean;
+    manifestRunId?: string;
+  },
+): string {
+  const runRoot = path.join(rootDir, runName);
+  writeJson(path.join(runRoot, 'manifests', 'run-manifest.json'), {
+    schemaVersion: 1,
+    runId: options?.manifestRunId ?? runName,
+  });
+
+  if (options?.writeInvocationIndex !== false) {
+    writeJson(path.join(runRoot, 'manifests', 'invocation-index.json'), {
+      schema_version: 1,
+      invocations: [],
+    });
+  }
+
+  for (const modelName of modelNames) {
+    writeJson(
+      path.join(
+        runRoot,
+        'models',
+        modelName,
+        'tidas_bundle',
+        'lifecyclemodels',
+        `${modelName}.json`,
+      ),
+      createLifecyclemodelPayload(`${modelName}-uuid`),
+    );
+  }
+
+  if (options?.includeAutoBuildReport) {
+    writeJson(path.join(runRoot, 'reports', 'lifecyclemodel-auto-build-report.json'), {
+      status: 'completed_local_lifecyclemodel_auto_build_run',
+    });
+  }
+
+  return runRoot;
+}
+
+function makeValidationRunReport(
+  inputDir: string,
+  ok: boolean,
+  reportFile: string,
+  mode: ValidationRunReport['mode'] = 'auto',
+): ValidationRunReport {
+  return {
+    input_dir: inputDir,
+    mode,
+    ok,
+    summary: {
+      engine_count: mode === 'all' ? 2 : 1,
+      ok_count: ok ? 1 : 0,
+      failed_count: ok ? 0 : 1,
+    },
+    files: {
+      report: reportFile,
+    },
+    reports: [
+      {
+        engine: 'sdk',
+        ok,
+        duration_ms: 0,
+        location: '/tmp/sdk.js',
+        report: {
+          input_dir: inputDir,
+          ok,
+          summary: {
+            category_count: 1,
+            issue_count: ok ? 0 : 1,
+            error_count: ok ? 0 : 1,
+            warning_count: 0,
+            info_count: 0,
+          },
+          categories: [],
+          issues: ok
+            ? []
+            : [
+                {
+                  issue_code: 'schema_error',
+                  severity: 'error',
+                  category: 'lifecyclemodels',
+                  file_path: path.join(inputDir, 'lifecyclemodels', 'demo.json'),
+                  message: 'Broken lifecycle model dataset',
+                  location: '<root>',
+                  context: {},
+                },
+              ],
+        },
+      },
+    ],
+    comparison: null,
+  };
+}
+
+test('runLifecyclemodelValidateBuild validates all local model bundles and writes aggregate artifacts', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-validate-build-'));
+  const runRoot = createLifecyclemodelRunFixture(dir, 'lm-run-1', ['model-a', 'model-b'], {
+    includeAutoBuildReport: true,
+  });
+
+  try {
+    const report = await runLifecyclemodelValidateBuild(
+      {
+        runDir: runRoot,
+        engine: 'all',
+        now: new Date('2026-03-30T00:00:00.000Z'),
+        cwd: '/tmp/lifecyclemodel-validate',
+      },
+      {
+        runValidationImpl: async (options) => {
+          const ok = !options.inputDir.includes('model-b');
+          const reportFile = path.resolve(options.reportFile as string);
+          const result = makeValidationRunReport(options.inputDir, ok, reportFile, 'all');
+          writeJson(reportFile, result);
+          return result;
+        },
+      },
+    );
+
+    assert.equal(report.status, 'completed_lifecyclemodel_validate_build');
+    assert.equal(report.run_id, 'lm-run-1');
+    assert.equal(report.ok, false);
+    assert.equal(report.engine, 'all');
+    assert.deepEqual(report.counts, {
+      models: 2,
+      ok: 1,
+      failed: 1,
+    });
+    assert.equal(
+      report.files.auto_build_report,
+      path.join(runRoot, 'reports', 'lifecyclemodel-auto-build-report.json'),
+    );
+    assert.equal(report.model_reports.length, 2);
+    assert.equal(readJson<JsonRecord>(report.files.report).status, report.status);
+    assert.equal(existsSyncLike(report.model_reports[0]?.report_file ?? ''), true);
+    assert.match(report.next_actions[2] ?? '', /publish-build/u);
+
+    const invocationIndex = readJson<{ invocations: Array<Record<string, unknown>> }>(
+      report.files.invocation_index,
+    );
+    assert.equal(invocationIndex.invocations.length, 1);
+    assert.deepEqual(invocationIndex.invocations[0]?.command, [
+      'lifecyclemodel',
+      'validate-build',
+      '--run-dir',
+      runRoot,
+      '--engine',
+      'all',
+    ]);
+    assert.equal(invocationIndex.invocations[0]?.cwd, '/tmp/lifecyclemodel-validate');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelValidateBuild supports missing optional artifacts and all-ok validation runs', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-validate-build-ok-'));
+  const runRoot = createLifecyclemodelRunFixture(dir, 'lm-run-2', ['model-a'], {
+    writeInvocationIndex: false,
+  });
+
+  try {
+    const report = await runLifecyclemodelValidateBuild(
+      {
+        runDir: runRoot,
+        now: new Date('2026-03-30T00:00:00.000Z'),
+      },
+      {
+        runValidationImpl: async (options) => {
+          const reportFile = path.resolve(options.reportFile as string);
+          const result = makeValidationRunReport(options.inputDir, true, reportFile, 'auto');
+          writeJson(reportFile, result);
+          return result;
+        },
+      },
+    );
+
+    assert.equal(report.ok, true);
+    assert.equal(report.files.auto_build_report, null);
+    assert.equal(report.model_reports.length, 1);
+    assert.equal(readJson<JsonRecord>(report.files.invocation_index).schema_version, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelValidateBuild rejects missing runs and mismatched run manifests', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-validate-build-errors-'));
+  const missingRunDir = path.join(dir, 'missing-run');
+  const missingManifestRunDir = path.join(dir, 'lm-run-missing-manifest');
+  mkdirSync(missingManifestRunDir, { recursive: true });
+  const invalidManifestRunDir = path.join(dir, 'lm-run-invalid-manifest');
+  writeJson(path.join(invalidManifestRunDir, 'manifests', 'run-manifest.json'), []);
+  const mismatchRunDir = createLifecyclemodelRunFixture(dir, 'lm-run-3', ['model-a'], {
+    manifestRunId: 'other-run-id',
+  });
+
+  try {
+    await assert.rejects(
+      async () =>
+        runLifecyclemodelValidateBuild({
+          runDir: missingRunDir,
+        }),
+      /run root not found/u,
+    );
+
+    await assert.rejects(
+      async () =>
+        runLifecyclemodelValidateBuild({
+          runDir: missingManifestRunDir,
+        }),
+      /run-manifest artifact not found/u,
+    );
+
+    await assert.rejects(
+      async () =>
+        runLifecyclemodelValidateBuild({
+          runDir: invalidManifestRunDir,
+        }),
+      /run-manifest artifact JSON object/u,
+    );
+
+    await assert.rejects(
+      async () =>
+        runLifecyclemodelValidateBuild({
+          runDir: mismatchRunDir,
+        }),
+      /run manifest runId mismatch/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('lifecyclemodel validate-build internals cover layout, invocation index, and discovery edge cases', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-validate-build-helpers-'));
+
+  try {
+    assert.throws(
+      () =>
+        __testInternals.resolveLayout({
+          runDir: '',
+        }),
+      /Missing required --run-dir/u,
+    );
+
+    assert.throws(
+      () =>
+        __testInternals.resolveLayout({
+          runDir: 123 as unknown as string,
+        }),
+      /Missing required --run-dir/u,
+    );
+
+    const layout = __testInternals.buildLayout(path.join(dir, 'lm-run-helpers'));
+
+    assert.deepEqual(__testInternals.readInvocationIndex(layout), {
+      schema_version: 1,
+      invocations: [],
+    });
+
+    mkdirSync(layout.manifestsDir, { recursive: true });
+    writeJson(layout.invocationIndexPath, {});
+    assert.deepEqual(__testInternals.readInvocationIndex(layout), {
+      schema_version: 1,
+      invocations: [],
+    });
+
+    writeJson(layout.invocationIndexPath, []);
+    assert.throws(
+      () => __testInternals.readInvocationIndex(layout),
+      /Expected lifecyclemodel validate invocation index JSON object/u,
+    );
+
+    writeJson(layout.invocationIndexPath, {
+      invocations: {},
+    });
+    assert.throws(() => __testInternals.readInvocationIndex(layout), /invocations array/u);
+
+    assert.throws(
+      () => __testInternals.discoverModelEntries(layout),
+      /does not contain any model bundles/u,
+    );
+
+    mkdirSync(path.join(layout.modelsDir, 'ignored-entry'), { recursive: true });
+    mkdirSync(path.join(layout.modelsDir, 'empty-bundle', 'tidas_bundle', 'lifecyclemodels'), {
+      recursive: true,
+    });
+    assert.throws(
+      () => __testInternals.discoverModelEntries(layout),
+      /without lifecyclemodel JSON files/u,
+    );
+
+    rmSync(path.join(layout.modelsDir, 'empty-bundle'), { recursive: true, force: true });
+    writeJson(
+      path.join(layout.modelsDir, 'model-a', 'tidas_bundle', 'lifecyclemodels', 'model-a.json'),
+      createLifecyclemodelPayload('lm-helper'),
+    );
+
+    const entries = __testInternals.discoverModelEntries(layout);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].runName, 'model-a');
+    assert.equal(entries[0].modelFiles.length, 1);
+
+    const invocationIndex = __testInternals.buildInvocationIndex(
+      layout,
+      {
+        schema_version: 'bad',
+        invocations: {},
+      },
+      {
+        runDir: layout.runRoot,
+        engine: 'sdk',
+        cwd: '/tmp/validate-cwd',
+      },
+      new Date('2026-03-30T00:00:00.000Z'),
+    );
+    const firstInvocation = (invocationIndex.invocations as JsonRecord[])[0];
+    assert.deepEqual(firstInvocation.command, [
+      'lifecyclemodel',
+      'validate-build',
+      '--run-dir',
+      layout.runRoot,
+      '--engine',
+      'sdk',
+    ]);
+    assert.equal(invocationIndex.schema_version, 1);
+    assert.equal(__testInternals.buildNextActions(layout).length, 3);
+    assert.equal(__testInternals.resolveValidationImpl({}), runValidation);
+
+    const injectedValidationImpl = async () =>
+      makeValidationRunReport(layout.modelsDir, true, path.join(layout.reportsDir, 'report.json'));
+    assert.equal(
+      __testInternals.resolveValidationImpl({
+        runValidationImpl: injectedValidationImpl,
+      }),
+      injectedValidationImpl,
+    );
+    assert.equal(
+      __testInternals.resolveReportEngine(
+        [
+          {
+            run_name: 'model-a',
+            input_dir: layout.modelsDir,
+            model_files: [],
+            report_file: path.join(layout.reportsDir, 'model-a.json'),
+            validation: makeValidationRunReport(
+              layout.modelsDir,
+              true,
+              path.join(layout.reportsDir, 'model-a.json'),
+              'tools',
+            ),
+          },
+        ],
+        'sdk',
+      ),
+      'tools',
+    );
+    assert.equal(__testInternals.resolveReportEngine([], 'sdk'), 'sdk');
+    assert.equal(__testInternals.resolveReportEngine([], undefined), 'auto');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function existsSyncLike(filePath: string): boolean {
+  try {
+    readFileSync(filePath, 'utf8');
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/test/publish.test.ts
+++ b/test/publish.test.ts
@@ -43,6 +43,28 @@ function makeSource(id: string): Record<string, unknown> {
   };
 }
 
+function makeResponse(options: {
+  ok: boolean;
+  status: number;
+  contentType?: string;
+  body?: string;
+}) {
+  return {
+    ok: options.ok,
+    status: options.status,
+    headers: {
+      get(name: string): string | null {
+        return name.toLowerCase() === 'content-type'
+          ? (options.contentType ?? 'application/json')
+          : null;
+      },
+    },
+    async text(): Promise<string> {
+      return options.body ?? '';
+    },
+  };
+}
+
 test('normalizePublishRequest resolves paths relative to the request file and applies defaults', () => {
   const requestPath = '/tmp/tg-cli-publish/request.json';
   const normalized = normalizePublishRequest(
@@ -397,6 +419,79 @@ test('runPublish honors commit override, defers missing executors, and rejects i
   }
 });
 
+test('runPublish uses default Supabase REST dataset executors when runtime env and fetch are provided', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-publish-default-rest-'));
+  const requestPath = path.join(dir, 'request.json');
+  const observed: Array<{ method: string; url: string; body?: string }> = [];
+
+  writeJson(requestPath, {
+    inputs: {
+      processes: [makeCanonicalProcess('proc-default-rest')],
+      sources: [makeSource('src-default-rest')],
+    },
+    publish: {
+      commit: true,
+    },
+  });
+
+  try {
+    const report = await runPublish({
+      inputPath: requestPath,
+      env: {
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+        TIANGONG_LCA_API_KEY: 'key',
+      } as NodeJS.ProcessEnv,
+      fetchImpl: async (url, init) => {
+        observed.push({
+          method: String(init?.method ?? 'GET'),
+          url: String(url),
+          body: typeof init?.body === 'string' ? init.body : undefined,
+        });
+
+        if (String(url).includes('/processes?select=')) {
+          return makeResponse({
+            ok: true,
+            status: 200,
+            body: '[]',
+          });
+        }
+
+        if (String(url).includes('/sources?select=')) {
+          return makeResponse({
+            ok: true,
+            status: 200,
+            body: '[{"id":"src-default-rest","version":"01.01.000","state_code":0}]',
+          });
+        }
+
+        return makeResponse({
+          ok: true,
+          status: 200,
+          body: '[{"id":"ok"}]',
+        });
+      },
+      now: new Date('2026-03-28T00:00:00Z'),
+    });
+
+    assert.equal(report.processes[0].status, 'executed');
+    assert.equal(report.sources[0].status, 'executed');
+    assert.deepEqual(report.processes[0].execution, {
+      status: 'success',
+      operation: 'insert',
+    });
+    assert.deepEqual(report.sources[0].execution, {
+      status: 'success',
+      operation: 'update_existing',
+    });
+    assert.deepEqual(
+      observed.map((entry) => entry.method),
+      ['GET', 'POST', 'GET', 'PATCH'],
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('runPublish skips disabled publish groups and can clear relation manifests', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-publish-disabled-'));
   const requestPath = path.join(dir, 'request.json');
@@ -586,6 +681,53 @@ test('runPublish rejects non-object dataset files and missing lifecyclemodel ide
         }),
       /Lifecycle model payload missing/u,
     );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runPublish accepts native lifecyclemodel json_ordered payload wrappers', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-publish-native-lifecyclemodel-'));
+  const requestPath = path.join(dir, 'request.json');
+
+  writeJson(requestPath, {
+    inputs: {
+      lifecyclemodels: [
+        {
+          jsonOrdered: {
+            lifeCycleModelDataSet: {
+              lifeCycleModelInformation: {
+                dataSetInformation: {
+                  'common:UUID': 'lm-native-1',
+                  referenceToResultingProcess: {
+                    '@refObjectId': 'lm-native-1-result',
+                  },
+                },
+                quantitativeReference: {
+                  referenceToReferenceProcess: '1',
+                },
+              },
+              administrativeInformation: {
+                publicationAndOwnership: {
+                  'common:dataSetVersion': '02.03.004',
+                },
+              },
+            },
+          },
+        },
+      ],
+    },
+  });
+
+  try {
+    const report = await runPublish({
+      inputPath: requestPath,
+    });
+
+    assert.equal(report.lifecyclemodels.length, 1);
+    assert.equal(report.lifecyclemodels[0].status, 'prepared');
+    assert.equal(report.lifecyclemodels[0].id, 'lm-native-1');
+    assert.equal(report.lifecyclemodels[0].version, '02.03.004');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/supabase-json-ordered-write.test.ts
+++ b/test/supabase-json-ordered-write.test.ts
@@ -1,0 +1,437 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { CliError } from '../src/lib/errors.js';
+import type { FetchLike } from '../src/lib/http.js';
+import {
+  __testInternals,
+  hasSupabaseRestRuntime,
+  syncSupabaseJsonOrderedRecord,
+} from '../src/lib/supabase-json-ordered-write.js';
+
+function makeResponse(options: {
+  ok: boolean;
+  status: number;
+  contentType?: string;
+  body?: string;
+}) {
+  return {
+    ok: options.ok,
+    status: options.status,
+    headers: {
+      get(name: string): string | null {
+        return name.toLowerCase() === 'content-type'
+          ? (options.contentType ?? 'application/json')
+          : null;
+      },
+    },
+    async text(): Promise<string> {
+      return options.body ?? '';
+    },
+  };
+}
+
+test('hasSupabaseRestRuntime checks env completeness', () => {
+  assert.equal(hasSupabaseRestRuntime(undefined), false);
+  assert.equal(hasSupabaseRestRuntime({} as NodeJS.ProcessEnv), false);
+  assert.equal(
+    hasSupabaseRestRuntime({
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+      TIANGONG_LCA_API_KEY: 'key',
+    } as NodeJS.ProcessEnv),
+    true,
+  );
+});
+
+test('supabase json_ordered write inserts when no exact row exists', async () => {
+  const observed: Array<{ method: string; url: string; body?: string }> = [];
+  const fetchImpl: FetchLike = async (url, init) => {
+    observed.push({
+      method: String(init?.method ?? 'GET'),
+      url: String(url),
+      body: typeof init?.body === 'string' ? init.body : undefined,
+    });
+
+    if (observed.length === 1) {
+      return makeResponse({
+        ok: true,
+        status: 200,
+        body: '[]',
+      });
+    }
+
+    return makeResponse({
+      ok: true,
+      status: 201,
+      body: '[{"id":"proc-1"}]',
+    });
+  };
+
+  const result = await syncSupabaseJsonOrderedRecord({
+    table: 'processes',
+    id: 'proc-1',
+    version: '01.00.001',
+    payload: { processDataSet: {} },
+    writeMode: 'upsert_current_version',
+    env: {
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+      TIANGONG_LCA_API_KEY: 'key',
+    } as NodeJS.ProcessEnv,
+    fetchImpl,
+  });
+
+  assert.deepEqual(result, {
+    status: 'success',
+    operation: 'insert',
+  });
+  assert.deepEqual(
+    observed.map((item) => item.method),
+    ['GET', 'POST'],
+  );
+  assert.match(
+    observed[0]?.url ?? '',
+    /\/rest\/v1\/processes\?select=id%2Cversion%2Cstate_code&id=eq\.proc-1&version=eq\.01\.00\.001/u,
+  );
+  assert.match(observed[1]?.body ?? '', /"json_ordered"/u);
+});
+
+test('supabase json_ordered write updates when exact row already exists', async () => {
+  const observed: Array<{ method: string; url: string }> = [];
+  const fetchImpl: FetchLike = async (url, init) => {
+    observed.push({
+      method: String(init?.method ?? 'GET'),
+      url: String(url),
+    });
+
+    if (observed.length === 1) {
+      return makeResponse({
+        ok: true,
+        status: 200,
+        body: '[{"id":"src-1","version":"01.00.001","state_code":0}]',
+      });
+    }
+
+    return makeResponse({
+      ok: true,
+      status: 200,
+      body: '[{"id":"src-1"}]',
+    });
+  };
+
+  const result = await syncSupabaseJsonOrderedRecord({
+    table: 'sources',
+    id: 'src-1',
+    version: '01.00.001',
+    payload: { sourceDataSet: {} },
+    writeMode: 'upsert_current_version',
+    env: {
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/rest/v1',
+      TIANGONG_LCA_API_KEY: 'key',
+    } as NodeJS.ProcessEnv,
+    fetchImpl,
+  });
+
+  assert.equal(result.operation, 'update_existing');
+  assert.deepEqual(
+    observed.map((item) => item.method),
+    ['GET', 'PATCH'],
+  );
+  assert.match(observed[1]?.url ?? '', /\/sources\?id=eq\.src-1&version=eq\.01\.00\.001/u);
+});
+
+test('supabase json_ordered write falls back to update after insert conflict', async () => {
+  const observed: Array<{ method: string; url: string }> = [];
+  const fetchImpl: FetchLike = async (url, init) => {
+    observed.push({
+      method: String(init?.method ?? 'GET'),
+      url: String(url),
+    });
+
+    if (observed.length === 1) {
+      return makeResponse({
+        ok: true,
+        status: 200,
+        body: '[]',
+      });
+    }
+
+    if (observed.length === 2) {
+      return makeResponse({
+        ok: false,
+        status: 409,
+        body: '{"message":"duplicate"}',
+      });
+    }
+
+    if (observed.length === 3) {
+      return makeResponse({
+        ok: true,
+        status: 200,
+        body: '[{"id":"lm-1","version":"01.00.001","state_code":0}]',
+      });
+    }
+
+    return makeResponse({
+      ok: true,
+      status: 200,
+      body: '[{"id":"lm-1"}]',
+    });
+  };
+
+  const result = await syncSupabaseJsonOrderedRecord({
+    table: 'lifecyclemodels',
+    id: 'lm-1',
+    version: '01.00.001',
+    payload: { lifeCycleModelDataSet: {} },
+    writeMode: 'upsert_current_version',
+    env: {
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
+      TIANGONG_LCA_API_KEY: 'key',
+    } as NodeJS.ProcessEnv,
+    fetchImpl,
+  });
+
+  assert.equal(result.operation, 'update_after_insert_error');
+  assert.deepEqual(
+    observed.map((item) => item.method),
+    ['GET', 'POST', 'GET', 'PATCH'],
+  );
+});
+
+test('append-only insert skips existing rows and validates helper branches', async () => {
+  const fetchImpl: FetchLike = async () =>
+    makeResponse({
+      ok: true,
+      status: 200,
+      body: '[{"id":"proc-skip","version":"01.00.001","state_code":0}]',
+    });
+
+  const result = await syncSupabaseJsonOrderedRecord({
+    table: 'processes',
+    id: 'proc-skip',
+    version: '01.00.001',
+    payload: { processDataSet: {} },
+    writeMode: 'append_only_insert',
+    env: {
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+      TIANGONG_LCA_API_KEY: 'key',
+    } as NodeJS.ProcessEnv,
+    fetchImpl,
+  });
+
+  assert.equal(result.operation, 'skipped_existing');
+  assert.equal(
+    __testInternals.buildSelectUrl(
+      'https://example.supabase.co/rest/v1',
+      'processes',
+      'proc-skip',
+      '01.00.001',
+    ),
+    'https://example.supabase.co/rest/v1/processes?select=id%2Cversion%2Cstate_code&id=eq.proc-skip&version=eq.01.00.001',
+  );
+  assert.equal(
+    __testInternals.buildUpdateUrl(
+      'https://example.supabase.co/rest/v1',
+      'processes',
+      'proc-skip',
+      '01.00.001',
+    ),
+    'https://example.supabase.co/rest/v1/processes?id=eq.proc-skip&version=eq.01.00.001',
+  );
+  assert.throws(
+    () => __testInternals.requireNonEmptyToken('', 'dataset id', 'TOKEN_REQUIRED'),
+    /Missing required dataset id/u,
+  );
+  assert.throws(
+    () => __testInternals.parseVisibleRows([{ id: 'ok' }, 'bad'], 'https://example.com/select'),
+    /row 1 was not a JSON object/u,
+  );
+});
+
+test('supabase json_ordered helpers handle empty/text success payloads and invalid visible-row shapes', async () => {
+  await __testInternals.insertJsonOrderedRow({
+    restBaseUrl: 'https://example.supabase.co/rest/v1',
+    table: 'processes',
+    apiKey: 'key',
+    id: 'proc-text',
+    payload: { processDataSet: {} },
+    timeoutMs: 10,
+    fetchImpl: async () =>
+      makeResponse({
+        ok: true,
+        status: 201,
+        contentType: 'text/plain',
+        body: 'created',
+      }),
+  });
+
+  await __testInternals.updateJsonOrderedRow({
+    restBaseUrl: 'https://example.supabase.co/rest/v1',
+    table: 'processes',
+    apiKey: 'key',
+    id: 'proc-empty',
+    version: '01.00.001',
+    payload: { processDataSet: {} },
+    timeoutMs: 10,
+    fetchImpl: async () =>
+      makeResponse({
+        ok: true,
+        status: 200,
+        body: '',
+      }),
+  });
+
+  assert.throws(
+    () => __testInternals.parseVisibleRows('not-an-array', 'https://example.com/select'),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'SUPABASE_REST_RESPONSE_INVALID');
+      return true;
+    },
+  );
+});
+
+test('supabase json_ordered write surfaces remote request failures and invalid JSON', async () => {
+  await assert.rejects(
+    () =>
+      syncSupabaseJsonOrderedRecord({
+        table: 'processes',
+        id: 'proc-http-fail',
+        version: '01.00.001',
+        payload: { processDataSet: {} },
+        writeMode: 'upsert_current_version',
+        env: {
+          TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+          TIANGONG_LCA_API_KEY: 'key',
+        } as NodeJS.ProcessEnv,
+        fetchImpl: async () => ({
+          ok: false,
+          status: 503,
+          headers: {
+            get() {
+              return null;
+            },
+          },
+          async text() {
+            return 'upstream unavailable';
+          },
+        }),
+      }),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'REMOTE_REQUEST_FAILED');
+      return true;
+    },
+  );
+
+  await assert.rejects(
+    () =>
+      syncSupabaseJsonOrderedRecord({
+        table: 'processes',
+        id: 'proc-invalid-json',
+        version: '01.00.001',
+        payload: { processDataSet: {} },
+        writeMode: 'upsert_current_version',
+        env: {
+          TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+          TIANGONG_LCA_API_KEY: 'key',
+        } as NodeJS.ProcessEnv,
+        fetchImpl: async () =>
+          makeResponse({
+            ok: true,
+            status: 200,
+            body: '{"broken"',
+          }),
+      }),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'REMOTE_INVALID_JSON');
+      return true;
+    },
+  );
+});
+
+test('supabase json_ordered write rethrows insert conflicts when the row is still invisible', async () => {
+  const observed: string[] = [];
+  await assert.rejects(
+    () =>
+      syncSupabaseJsonOrderedRecord({
+        table: 'processes',
+        id: 'proc-conflict-missing',
+        version: '01.00.001',
+        payload: { processDataSet: {} },
+        writeMode: 'upsert_current_version',
+        env: {
+          TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+          TIANGONG_LCA_API_KEY: 'key',
+        } as NodeJS.ProcessEnv,
+        fetchImpl: async (_url, init) => {
+          observed.push(String(init?.method ?? 'GET'));
+          if (observed.length === 2) {
+            return makeResponse({
+              ok: false,
+              status: 409,
+              body: '{"message":"duplicate"}',
+            });
+          }
+
+          return makeResponse({
+            ok: true,
+            status: 200,
+            body: '[]',
+          });
+        },
+      }),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'REMOTE_REQUEST_FAILED');
+      return true;
+    },
+  );
+
+  assert.deepEqual(observed, ['GET', 'POST', 'GET']);
+});
+
+test('append-only insert skips rows that appear after an insert conflict', async () => {
+  const observed: string[] = [];
+  const result = await syncSupabaseJsonOrderedRecord({
+    table: 'processes',
+    id: 'proc-conflict-skip',
+    version: '01.00.001',
+    payload: { processDataSet: {} },
+    writeMode: 'append_only_insert',
+    env: {
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+      TIANGONG_LCA_API_KEY: 'key',
+    } as NodeJS.ProcessEnv,
+    fetchImpl: async (_url, init) => {
+      observed.push(String(init?.method ?? 'GET'));
+      if (observed.length === 2) {
+        return makeResponse({
+          ok: false,
+          status: 409,
+          body: '{"message":"duplicate"}',
+        });
+      }
+
+      if (observed.length === 3) {
+        return makeResponse({
+          ok: true,
+          status: 200,
+          body: '[{"id":"proc-conflict-skip","version":"01.00.001","state_code":0}]',
+        });
+      }
+
+      return makeResponse({
+        ok: true,
+        status: 200,
+        body: '[]',
+      });
+    },
+  });
+
+  assert.deepEqual(result, {
+    status: 'success',
+    operation: 'skipped_existing',
+  });
+  assert.deepEqual(observed, ['GET', 'POST', 'GET']);
+});


### PR DESCRIPTION
Closes #39

## Summary
- add executable `tiangong lifecyclemodel auto-build`, `validate-build`, `publish-build`, and `orchestrate` command surfaces
- add CLI-owned flow governance helpers for `publish-reviewed-data`, `build-alias-map`, process-flow scan/plan/apply repair, and local process validation
- update docs, examples, and migration guidance so the remaining skills can delegate to the new CLI surfaces directly

## Key Decisions
- keep the new surfaces file-first, artifact-first, and direct-REST-only; there is no MCP, Python runtime, or shell fallback path inside the CLI
- keep the lifecyclemodel build path local-first and explicit, then let later skills call the resulting run contract instead of re-implementing workflow glue
- keep the flow governance publish / alias / repair helpers in the CLI so the skills repo can stay a thin wrapper layer
- this PR intentionally stacks on `feature/issue-37`; merge the CLI stack top-down from this PR back to `#28`

## Validation
- `npm run lint`
- `npm run prepush:gate`

## Risks / Follow-up
- this PR is part of the still-open stacked CLI chain (`#40 -> #38 -> #36 -> #34 -> #32 -> #30 -> #28`)
- `lca-workspace` still needs the later submodule bump after the repo-side stack lands on `main`

## Workspace Integration
- Requires a later `lca-workspace` submodule bump after merge.
