### PR TITLE
feat: implement lifecyclemodel review command

### DIFF
--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -37,6 +37,7 @@
 - `tiangong lifecyclemodel orchestrate`
 - `tiangong review process`
 - `tiangong review flow`
+- `tiangong review lifecyclemodel`
 - `tiangong flow get`
 - `tiangong flow list`
 - `tiangong flow remediate`
@@ -118,6 +119,7 @@ TIANGONG_LCA_LLM_MODEL=
 | `lifecyclemodel publish-resulting-process` | 无 |
 | `review process` | 纯规则 review 默认无；若显式启用 `--enable-llm`，则需要 `TIANGONG_LCA_LLM_BASE_URL`、`TIANGONG_LCA_LLM_API_KEY`、`TIANGONG_LCA_LLM_MODEL` |
 | `review flow` | 纯规则 review 默认无；若显式启用 `--enable-llm`，则需要 `TIANGONG_LCA_LLM_BASE_URL`、`TIANGONG_LCA_LLM_API_KEY`、`TIANGONG_LCA_LLM_MODEL` |
+| `review lifecyclemodel` | 无 |
 | `flow get` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY` |
 | `flow list` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY` |
 | `flow remediate` | 无 |
@@ -152,6 +154,7 @@ npm start -- lifecyclemodel build-resulting-process --input ./request.json --jso
 npm start -- lifecyclemodel publish-resulting-process --run-dir ./runs/example --publish-processes --publish-relations --json
 npm start -- review process --run-root ./artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir ./review --json
 npm start -- review flow --rows-file ./flows.json --out-dir ./flow-review --json
+npm start -- review lifecyclemodel --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --out-dir ./lifecyclemodel-review --json
 npm start -- flow get --id <flow-id> --version <version> --json
 npm start -- flow list --id <flow-id> --state-code 100 --limit 20 --json
 npm start -- flow remediate --input-file ./invalid-flows.jsonl --out-dir ./flow-remediation --json
@@ -324,6 +327,22 @@ npm start -- admin embedding-run --input ./jobs.json --dry-run
 - 输出 `flow_review_report.json`
 
 这个命令同样保持本地 artifact-first。若显式传入 `--enable-llm`，则通过 CLI 内部统一的 `TIANGONG_LCA_LLM_*` 运行时做可选语义审核；当前 CLI 切片明确不支持 `--with-reference-context`，也还没有接入本地 registry enrichment。
+
+`tiangong review lifecyclemodel` 现在也已经进入可执行状态，负责：
+
+- 从 `--run-dir` 重开一个已有 lifecyclemodel auto-build run
+- 扫描 `models/*/tidas_bundle/lifecyclemodels/*.json`
+- 复用 `summary.json`、`connections.json`、`process-catalog.json`
+- 若存在 `reports/lifecyclemodel-validate-build-report.json`，则聚合其中的 validate findings
+- 输出 `model_summaries.jsonl`
+- 输出 `findings.jsonl`
+- 输出 `lifecyclemodel_review_summary.json`
+- 输出 `lifecyclemodel_review_zh.md`
+- 输出 `lifecyclemodel_review_en.md`
+- 输出 `lifecyclemodel_review_timing.md`
+- 输出 `lifecyclemodel_review_report.json`
+
+这个命令当前保持本地 artifact-first，不引入 Python、LangGraph 或 skill 私有 review runtime。`tiangong validation run` 中 `engine=tools -> uv run tidas-validate` 的 fallback 仍然保留，作为后续单独跟踪项。
 
 `tiangong flow get` 现在已经承担 flow governance 的只读详情切片，负责：
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This prevents reintroducing a generic MCP transport layer into the CLI runtime.
 - `tiangong lifecyclemodel orchestrate`
 - `tiangong review process`
 - `tiangong review flow`
+- `tiangong review lifecyclemodel`
 - `tiangong flow get`
 - `tiangong flow list`
 - `tiangong flow remediate`
@@ -56,11 +57,9 @@ This prevents reintroducing a generic MCP transport layer into the CLI runtime.
 
 ## Remaining planned command surface
 
-The remaining planned workflow command in the currently documented surface is:
+The remaining planned placeholders in the documented surface are now limited to `auth *` and `job *`.
 
-- `tiangong review lifecyclemodel`
-
-That command still prints an explicit `not implemented yet` message and exits with code `2` until the corresponding workflow is migrated into TypeScript.
+Within the currently implemented command family, the only intentionally deferred migration tail is still inside `tiangong validation run`: `engine=tools` continues to execute `uv run tidas-validate` until that validation fallback is redesigned in a later tracked change.
 
 The stable launcher is `bin/tiangong.js`. It loads the compiled runtime at `dist/src/main.js`, while `npm start -- ...` rebuilds and dogfoods the same launcher path.
 
@@ -133,6 +132,7 @@ Command-level env reality:
 | `lifecyclemodel publish-resulting-process` | none |
 | `review process` | none for rule-only review; optional `TIANGONG_LCA_LLM_BASE_URL`, `TIANGONG_LCA_LLM_API_KEY`, and `TIANGONG_LCA_LLM_MODEL` when `--enable-llm` is set |
 | `review flow` | none for rule-only review; optional `TIANGONG_LCA_LLM_BASE_URL`, `TIANGONG_LCA_LLM_API_KEY`, and `TIANGONG_LCA_LLM_MODEL` when `--enable-llm` is set |
+| `review lifecyclemodel` | none |
 | `flow get` | `TIANGONG_LCA_API_BASE_URL`, `TIANGONG_LCA_API_KEY` |
 | `flow list` | `TIANGONG_LCA_API_BASE_URL`, `TIANGONG_LCA_API_KEY` |
 | `flow remediate` | none |
@@ -169,6 +169,7 @@ npm start -- lifecyclemodel build-resulting-process --input ./request.json --jso
 npm start -- lifecyclemodel publish-resulting-process --run-dir ./runs/example --publish-processes --publish-relations --json
 npm start -- review process --run-root ./artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir ./review --json
 npm start -- review flow --rows-file ./flows.json --out-dir ./flow-review --json
+npm start -- review lifecyclemodel --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --out-dir ./lifecyclemodel-review --json
 npm start -- flow get --id <flow-id> --version <version> --json
 npm start -- flow list --id <flow-id> --state-code 100 --limit 20 --json
 npm start -- flow remediate --input-file ./invalid-flows.jsonl --out-dir ./flow-remediation --json
@@ -222,6 +223,8 @@ The current lifecyclemodel build family intentionally keeps three boundaries out
 `tiangong review process` is the first migrated review slice. It reopens one local `process_from_flow` run under `exports/processes/`, replays the existing artifact-first review contract, writes bilingual markdown findings plus structured JSON reports, and keeps optional semantic review behind the CLI-owned `TIANGONG_LCA_LLM_*` abstraction instead of direct `OPENAI_*` calls in a skill script.
 
 `tiangong review flow` is the flow-side local governance review slice. It accepts exactly one of `--rows-file`, `--flows-dir`, or `--run-root`, materializes explicit local flow snapshots when needed, writes `rule_findings.jsonl`, `llm_findings.jsonl`, `findings.jsonl`, `flow_summaries.jsonl`, `similarity_pairs.jsonl`, `flow_review_summary.json`, `flow_review_zh.md`, `flow_review_en.md`, `flow_review_timing.md`, and `flow_review_report.json`, and keeps optional semantic review behind the same CLI-owned `TIANGONG_LCA_LLM_*` abstraction. The current CLI slice is intentionally local-first and does not implement `--with-reference-context` or local registry enrichment yet.
+
+`tiangong review lifecyclemodel` is the lifecyclemodel-side local review slice. It reopens one existing lifecyclemodel build run by `--run-dir`, scans `models/*/tidas_bundle/lifecyclemodels/*.json`, reuses `summary.json`, `connections.json`, `process-catalog.json`, and the aggregate `reports/lifecyclemodel-validate-build-report.json` when present, writes `model_summaries.jsonl`, `findings.jsonl`, `lifecyclemodel_review_summary.json`, `lifecyclemodel_review_zh.md`, `lifecyclemodel_review_en.md`, `lifecyclemodel_review_timing.md`, and `lifecyclemodel_review_report.json`, and stays local-first without introducing Python, LangGraph, or skill-local review runtimes.
 
 `tiangong flow get` is the CLI-owned read-only flow detail surface. It derives a deterministic Supabase REST read path from `TIANGONG_LCA_API_BASE_URL`, resolves one visible flow row by `id` plus optional `version` / `user_id` / `state_code`, falls back to the latest visible version when an exact version lookup misses, and rejects ambiguous visible matches instead of guessing.
 

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -122,7 +122,7 @@ tiangong
 
 - `tiangong review process` 已可执行
 - `tiangong review flow` 已可执行
-- `tiangong review lifecyclemodel` 处于 planned 状态
+- `tiangong review lifecyclemodel` 已可执行
 
 `tiangong flow ...` 也已经开始承接 flow-governance 主链迁移，其中：
 
@@ -183,7 +183,7 @@ tiangong
 - 已实现的 `flow apply-process-flow-repairs` 把治理链中的独立 deterministic repair apply 切片收口到 CLI，固定与 planning 相同的输入契约，直接写出 `patched-processes.json` / `process-patches/**`，并可在 `--process-pool-file` 下同步本地 pool
 - 已实现的 `flow regen-product` 把治理后的 process-side 再生产物链收口到 CLI，在一个命令下固定 `scan -> repair plan -> optional apply -> optional validate` 契约，并把退出码 `1` 保留给 `--apply` 之后的本地校验失败
 - 已实现的 `flow validate-processes` 把治理后 patched process rows 的独立校验切片收口到 CLI，固定 original/patched/scope 三类输入契约，并直接写出 `validation-report.json` / `validation-failures.jsonl`
-- 当前仍未实现的重点命令主要是 `review lifecyclemodel`；其余未迁移子命令继续只提供 help 和固定命名
+- 当前仍然保留的迁移尾巴主要在 `validation run` 的 tools-engine fallback；其余 review / build / publish CLI 面已经进入可执行状态，未迁移子命令只剩 `auth` / `job` 这类 placeholder surface
 - 这样做的目的不是“假装已完成”，而是先固定命令树，再逐个把 workflow 迁入 TypeScript CLI
 
 ### 2.2 已经固定的工程约束
@@ -770,7 +770,7 @@ npm run prepush:gate
   - skill 侧不再保留 shell 兼容壳或 Python / MCP runtime
 - `lifecycleinventory-review`
   - `tiangong review process`
-  - 仍保留 `review lifecyclemodel` 作为未来原生 CLI 增量，不属于遗留 Python runtime
+  - `tiangong review lifecyclemodel`
 - `flow-governance-review`
   - `tiangong review flow`
   - `tiangong flow get`
@@ -827,7 +827,7 @@ npm run prepush:gate
 
 ### 后续只保留原生增量，不再叫“遗留迁移”
 
-- `review lifecyclemodel` 何时实现，取决于是否真的形成稳定业务动作
+- `validation run` 中 `engine=tools -> uv run tidas-validate` 何时移除，取决于统一 validation 收口是否完成
 - lifecyclemodel 的 discovery / AI 选择逻辑，只有在产品面确认需要时才继续抽象成新的 CLI 子命令
 - `auth` / `job` 之类 placeholder surface 只有在真实场景出现时才补齐，而不是为了对称性先做
 - 任何新增能力都必须先定义成 `tiangong <noun> <verb>`，再决定是否要进一步服务化

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -77,7 +77,7 @@ MCP 替代策略也已经固定，不再反复讨论：
 | `process-automated-builder` | `node wrapper (.mjs) -> tiangong process auto-build / resume-build / publish-build / batch-build` | 已完成当前 CLI 收口 | skill 侧已无 Python / LangGraph / MCP fallback |
 | `lifecyclemodel-automated-builder` | `node wrapper (.mjs) -> tiangong lifecyclemodel auto-build / validate-build / publish-build` | 已完成当前 CLI 收口 | discovery / AI 选择若未来需要，按新的 CLI 特性处理，不再算遗留债务 |
 | `lifecyclemodel-resulting-process-builder` | `node wrapper (.mjs) -> tiangong lifecyclemodel build-resulting-process / publish-resulting-process` | 已完成 | resulting-process 模板 |
-| `lifecycleinventory-review` | `node wrapper (.mjs) -> tiangong review process` | 已完成当前 CLI 收口 | `review lifecyclemodel` 是未来原生增量，不是 Python 遗留 |
+| `lifecycleinventory-review` | `node wrapper (.mjs) -> tiangong review process / review lifecyclemodel` | 已完成 | review 入口已经完全走原生 CLI |
 | `flow-governance-review` | `node wrapper (.mjs) -> tiangong review flow / flow ...` | 已完成当前 CLI 收口 | reviewed publish、repair、regen、validate 均已进入 CLI |
 | `lifecyclemodel-recursive-orchestrator` | `node wrapper (.mjs) -> tiangong lifecyclemodel orchestrate` | 已完成 | plan / execute / publish-handoff 已原生化 |
 | `lca-publish-executor` | `node wrapper (.mjs) -> tiangong publish run` | 已完成 | 不再保留私有 publish Python contract |
@@ -245,7 +245,7 @@ MCP 替代策略也已经固定，不再反复讨论：
 
 下面这些可以做，但它们已经不是“清遗留”的待办，而是新的产品能力：
 
-- `tiangong review lifecyclemodel`
+- `validation run` 的 tools-engine fallback（当前仍会执行 `uv run tidas-validate`）
 - lifecyclemodel 的 discovery / AI 选择逻辑
 - `auth` / `job` 等只有在真实场景出现时才应该补齐的命令面
 - 更深的 KB / TianGong unstructured 能力，前提是先形成稳定的 CLI 业务动作

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,6 +71,11 @@ import {
   type RunFlowReviewOptions,
 } from './lib/review-flow.js';
 import {
+  runLifecyclemodelReview,
+  type LifecyclemodelReviewReport,
+  type RunLifecyclemodelReviewOptions,
+} from './lib/review-lifecyclemodel.js';
+import {
   runFlowRemediate,
   type FlowRemediationReport,
   type RunFlowRemediateOptions,
@@ -155,6 +160,9 @@ export type CliDeps = {
   ) => Promise<ProcessPublishBuildReport>;
   runProcessReviewImpl?: (options: RunProcessReviewOptions) => Promise<ProcessReviewReport>;
   runFlowReviewImpl?: (options: RunFlowReviewOptions) => Promise<FlowReviewReport>;
+  runLifecyclemodelReviewImpl?: (
+    options: RunLifecyclemodelReviewOptions,
+  ) => Promise<LifecyclemodelReviewReport>;
   runFlowRemediateImpl?: (options: RunFlowRemediateOptions) => Promise<FlowRemediationReport>;
   runFlowGetImpl?: (options: RunFlowGetOptions) => Promise<FlowGetReport>;
   runFlowListImpl?: (options: RunFlowListOptions) => Promise<FlowListReport>;
@@ -216,14 +224,13 @@ Implemented Commands:
   process    get | auto-build | resume-build | publish-build | batch-build
   flow       get | list | remediate | publish-version | publish-reviewed-data | build-alias-map | scan-process-flow-refs | plan-process-flow-repairs | apply-process-flow-repairs | regen-product | validate-processes
   lifecyclemodel auto-build | validate-build | publish-build | build-resulting-process | publish-resulting-process | orchestrate
-  review     process | flow
+  review     process | flow | lifecyclemodel
   publish    run
   validation run
   admin      embedding-run
 
 Planned Surface (not implemented yet):
   auth       whoami | doctor-auth
-  review     lifecyclemodel
   job        get | wait | logs
 
 Planned commands currently print an explicit "not implemented yet" message and exit with code 2.
@@ -254,6 +261,7 @@ Examples:
   tiangong flow validate-processes --original-processes-file ./before.jsonl --patched-processes-file ./after.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-validation
   tiangong review process --run-root ./artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir ./review
   tiangong review flow --rows-file ./flows.json --out-dir ./review
+  tiangong review lifecyclemodel --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --out-dir ./lifecyclemodel-review
   tiangong publish run --input ./publish-request.json --dry-run
   tiangong validation run --input-dir ./package --engine auto
   tiangong admin embedding-run --input ./jobs.json
@@ -636,9 +644,7 @@ function renderReviewHelp(): string {
 Implemented Subcommands:
   process      Review one local process build run and emit artifact-first findings
   flow         Review local flow governance snapshots and emit artifact-first findings
-
-Planned Subcommands:
-  lifecyclemodel Review lifecycle model build artifacts through the unified CLI
+  lifecyclemodel Review one local lifecyclemodel build run and emit artifact-first findings
 
 Examples:
   tiangong review --help
@@ -688,6 +694,26 @@ Options:
   --methodology-id <name>   Label written into methodology-backed rule findings (default: built_in)
   --json                    Print compact JSON
   -h, --help
+`.trim();
+}
+
+function renderReviewLifecyclemodelHelp(): string {
+  return `Usage:
+  tiangong review lifecyclemodel --run-dir <dir> --out-dir <dir> [options]
+
+Options:
+  --run-dir <dir>          Existing lifecyclemodel auto-build run directory
+  --out-dir <dir>          Review artifact output directory
+  --start-ts <iso>         Optional run start timestamp
+  --end-ts <iso>           Optional run end timestamp
+  --logic-version <name>   Review logic version label (default: lifecyclemodel-review-v1.0)
+  --json                   Print compact JSON
+  -h, --help
+
+This command:
+  - reads one existing lifecyclemodel build run under models/*/tidas_bundle/lifecyclemodels
+  - aggregates validate-build findings when reports/lifecyclemodel-validate-build-report.json is present
+  - emits artifact-first model summaries, findings, markdown review notes, and a structured report
 `.trim();
 }
 
@@ -911,26 +937,6 @@ Examples:
   tiangong process publish-build --run-id <id> --help
   tiangong process batch-build --input ./batch-request.json --help
 `.trim();
-}
-
-const reviewPlannedHelp = {
-  lifecyclemodel: `Usage:
-  tiangong review lifecyclemodel --input <file> [options]
-
-Planned contract:
-  - load one lifecycle model build run or normalized review request
-  - emit artifact-first lifecycle model review findings and handoff metadata
-  - keep semantic review behind the CLI LLM abstraction instead of skill-local logic
-
-Status:
-  Planned command. Execution is not implemented yet.
-`.trim(),
-} as const;
-
-type ReviewPlannedSubcommand = keyof typeof reviewPlannedHelp;
-
-function isReviewPlannedSubcommand(value: string | null): value is ReviewPlannedSubcommand {
-  return Boolean(value && value in reviewPlannedHelp);
 }
 
 function renderDoctorText(report: ReturnType<typeof buildDoctorReport>): string {
@@ -2192,6 +2198,49 @@ function parseReviewFlowFlags(args: string[]): {
   };
 }
 
+function parseReviewLifecyclemodelFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  runDir: string;
+  outDir: string;
+  startTs: string | undefined;
+  endTs: string | undefined;
+  logicVersion: string | undefined;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        'run-dir': { type: 'string' },
+        'out-dir': { type: 'string' },
+        'start-ts': { type: 'string' },
+        'end-ts': { type: 'string' },
+        'logic-version': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    runDir: typeof values['run-dir'] === 'string' ? values['run-dir'] : '',
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : '',
+    startTs: typeof values['start-ts'] === 'string' ? values['start-ts'] : undefined,
+    endTs: typeof values['end-ts'] === 'string' ? values['end-ts'] : undefined,
+    logicVersion: typeof values['logic-version'] === 'string' ? values['logic-version'] : undefined,
+  };
+}
+
 function parseLifecyclemodelPublishFlags(args: string[]): {
   help: boolean;
   json: boolean;
@@ -2598,6 +2647,7 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
     const processPublishBuildImpl = deps.runProcessPublishBuildImpl ?? runProcessPublishBuild;
     const processReviewImpl = deps.runProcessReviewImpl ?? runProcessReview;
     const flowReviewImpl = deps.runFlowReviewImpl ?? runFlowReview;
+    const lifecyclemodelReviewImpl = deps.runLifecyclemodelReviewImpl ?? runLifecyclemodelReview;
     const flowRemediateImpl = deps.runFlowRemediateImpl ?? runFlowRemediate;
     const flowGetImpl = deps.runFlowGetImpl ?? runFlowGet;
     const flowListImpl = deps.runFlowListImpl ?? runFlowList;
@@ -3351,15 +3401,25 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
       };
     }
 
-    if (command === 'review' && isReviewPlannedSubcommand(subcommand)) {
-      if (commandArgs.includes('--help') || commandArgs.includes('-h')) {
-        return {
-          exitCode: 0,
-          stdout: `${reviewPlannedHelp[subcommand]}\n`,
-          stderr: '',
-        };
+    if (command === 'review' && subcommand === 'lifecyclemodel') {
+      const reviewFlags = parseReviewLifecyclemodelFlags(commandArgs);
+      if (reviewFlags.help) {
+        return { exitCode: 0, stdout: `${renderReviewLifecyclemodelHelp()}\n`, stderr: '' };
       }
-      return plannedCommand(command, subcommand);
+
+      const report = await lifecyclemodelReviewImpl({
+        runDir: reviewFlags.runDir,
+        outDir: reviewFlags.outDir,
+        startTs: reviewFlags.startTs,
+        endTs: reviewFlags.endTs,
+        logicVersion: reviewFlags.logicVersion,
+      });
+
+      return {
+        exitCode: 0,
+        stdout: stringifyJson(report, reviewFlags.json),
+        stderr: '',
+      };
     }
 
     return plannedCommand(command, subcommand ?? undefined);

--- a/src/lib/review-lifecyclemodel.ts
+++ b/src/lib/review-lifecyclemodel.ts
@@ -1,0 +1,1249 @@
+import { existsSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import {
+  readJsonArtifact,
+  writeJsonArtifact,
+  writeJsonLinesArtifact,
+  writeTextArtifact,
+} from './artifacts.js';
+import { CliError } from './errors.js';
+import type { ValidationIssue } from './validation.js';
+
+type JsonObject = Record<string, unknown>;
+
+type ModelEntry = {
+  runName: string;
+  modelFiles: string[];
+  summaryPath: string;
+  connectionsPath: string;
+  processCatalogPath: string;
+};
+
+type ModelFileReviewInfo = {
+  modelFile: string;
+  modelUuid: string;
+  modelVersion: string;
+  referenceProcessInternalId: string | null;
+  resultingProcessUuid: string | null;
+  processInstanceCount: number;
+  zeroMultiplicationFactorCount: number;
+};
+
+type LifecyclemodelValidationAggregate = {
+  ok: boolean | null;
+  reportPath: string | null;
+  modelReports: Map<string, LifecyclemodelModelValidationSummary>;
+};
+
+type LifecyclemodelModelValidationSummary = {
+  ok: boolean | null;
+  reportFile: string | null;
+  engineCount: number;
+  issues: ValidationIssue[];
+};
+
+type SeverityCounts = {
+  error: number;
+  warning: number;
+  info: number;
+};
+
+export type LifecyclemodelReviewFinding = {
+  run_name: string;
+  model_file: string | null;
+  severity: 'error' | 'warning' | 'info';
+  rule_id: string;
+  source: 'validation' | 'review';
+  message: string;
+  evidence: JsonObject;
+};
+
+export type LifecyclemodelReviewModelSummary = {
+  run_name: string;
+  model_files: string[];
+  model_uuids: string[];
+  model_versions: string[];
+  reference_process_uuids: string[];
+  reference_process_internal_ids: string[];
+  resulting_process_uuids: string[];
+  summary_process_count: number | null;
+  process_instance_count: number;
+  summary_edge_count: number | null;
+  connection_count: number | null;
+  process_catalog_count: number | null;
+  multiplication_factor_count: number;
+  zero_multiplication_factor_count: number;
+  validation: {
+    available: boolean;
+    ok: boolean | null;
+    report_file: string | null;
+    engine_count: number;
+    issue_count: number;
+  };
+  artifacts: {
+    summary: string | null;
+    connections: string | null;
+    process_catalog: string | null;
+  };
+  finding_count: number;
+  severity_counts: SeverityCounts;
+};
+
+export type LifecyclemodelReviewReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: 'completed_local_lifecyclemodel_review';
+  run_id: string;
+  run_root: string;
+  out_dir: string;
+  logic_version: string;
+  model_count: number;
+  finding_count: number;
+  severity_counts: SeverityCounts;
+  validation: {
+    available: boolean;
+    ok: boolean | null;
+    report: string | null;
+  };
+  files: {
+    run_manifest: string;
+    invocation_index: string;
+    validation_report: string | null;
+    model_summaries: string;
+    findings: string;
+    summary: string;
+    review_zh: string;
+    review_en: string;
+    timing: string;
+    report: string;
+  };
+  model_summaries: LifecyclemodelReviewModelSummary[];
+  next_actions: string[];
+};
+
+export type RunLifecyclemodelReviewOptions = {
+  runDir: string;
+  outDir: string;
+  startTs?: string;
+  endTs?: string;
+  logicVersion?: string;
+  now?: () => Date;
+  cwd?: string;
+};
+
+export type LifecyclemodelReviewLayout = {
+  runId: string;
+  runRoot: string;
+  outDir: string;
+  modelsDir: string;
+  reportsDir: string;
+  manifestsDir: string;
+  runManifestPath: string;
+  invocationIndexPath: string;
+  validationReportPath: string;
+  modelSummariesPath: string;
+  findingsPath: string;
+  summaryPath: string;
+  reviewZhPath: string;
+  reviewEnPath: string;
+  timingPath: string;
+  reportPath: string;
+};
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized || null;
+}
+
+function deepGet(value: unknown, pathParts: string[]): unknown {
+  let current: unknown = value;
+  for (const part of pathParts) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+    current = current[part];
+  }
+  return current;
+}
+
+function listify(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (value === undefined || value === null) {
+    return [];
+  }
+  return [value];
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function toNonNegativeInteger(value: unknown): number | null {
+  const parsed = toNumber(value);
+  if (parsed === null || !Number.isInteger(parsed) || parsed < 0) {
+    return null;
+  }
+  return parsed;
+}
+
+function uniqueStrings(values: Array<string | null | undefined>): string[] {
+  return [
+    ...new Set(
+      values.filter(
+        (value): value is string => typeof value === 'string' && value.trim().length > 0,
+      ),
+    ),
+  ];
+}
+
+function copyJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function emptySeverityCounts(): SeverityCounts {
+  return {
+    error: 0,
+    warning: 0,
+    info: 0,
+  };
+}
+
+function severityCounts(findings: LifecyclemodelReviewFinding[]): SeverityCounts {
+  return findings.reduce<SeverityCounts>((counts, finding) => {
+    counts[finding.severity] += 1;
+    return counts;
+  }, emptySeverityCounts());
+}
+
+function readRequiredJsonObject(
+  filePath: string,
+  missingCode: string,
+  invalidCode: string,
+  label: string,
+): JsonObject {
+  if (!existsSync(filePath)) {
+    throw new CliError(`Required lifecyclemodel ${label} artifact not found: ${filePath}`, {
+      code: missingCode,
+      exitCode: 2,
+      details: { filePath, label },
+    });
+  }
+
+  const value = readJsonArtifact(filePath);
+  if (!isRecord(value)) {
+    throw new CliError(`Expected lifecyclemodel ${label} artifact JSON object: ${filePath}`, {
+      code: invalidCode,
+      exitCode: 2,
+      details: { filePath, label },
+    });
+  }
+
+  return value;
+}
+
+function readOptionalJsonObject(
+  filePath: string,
+  invalidCode: string,
+  label: string,
+): JsonObject | null {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  const value = readJsonArtifact(filePath);
+  if (!isRecord(value)) {
+    throw new CliError(`Expected lifecyclemodel ${label} artifact JSON object: ${filePath}`, {
+      code: invalidCode,
+      exitCode: 2,
+      details: { filePath, label },
+    });
+  }
+
+  return value;
+}
+
+function readOptionalJsonArray(
+  filePath: string,
+  invalidCode: string,
+  label: string,
+): unknown[] | null {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  const value = readJsonArtifact(filePath);
+  if (!Array.isArray(value)) {
+    throw new CliError(`Expected lifecyclemodel ${label} artifact JSON array: ${filePath}`, {
+      code: invalidCode,
+      exitCode: 2,
+      details: { filePath, label },
+    });
+  }
+
+  return value;
+}
+
+function buildLayout(runRoot: string, outDir: string): LifecyclemodelReviewLayout {
+  const runId = path.basename(runRoot);
+  return {
+    runId,
+    runRoot,
+    outDir,
+    modelsDir: path.join(runRoot, 'models'),
+    reportsDir: path.join(runRoot, 'reports'),
+    manifestsDir: path.join(runRoot, 'manifests'),
+    runManifestPath: path.join(runRoot, 'manifests', 'run-manifest.json'),
+    invocationIndexPath: path.join(runRoot, 'manifests', 'invocation-index.json'),
+    validationReportPath: path.join(
+      runRoot,
+      'reports',
+      'lifecyclemodel-validate-build-report.json',
+    ),
+    modelSummariesPath: path.join(outDir, 'model_summaries.jsonl'),
+    findingsPath: path.join(outDir, 'findings.jsonl'),
+    summaryPath: path.join(outDir, 'lifecyclemodel_review_summary.json'),
+    reviewZhPath: path.join(outDir, 'lifecyclemodel_review_zh.md'),
+    reviewEnPath: path.join(outDir, 'lifecyclemodel_review_en.md'),
+    timingPath: path.join(outDir, 'lifecyclemodel_review_timing.md'),
+    reportPath: path.join(outDir, 'lifecyclemodel_review_report.json'),
+  };
+}
+
+function resolveLayout(options: RunLifecyclemodelReviewOptions): LifecyclemodelReviewLayout {
+  const runDir = nonEmptyString(options.runDir);
+  if (!runDir) {
+    throw new CliError('Missing required --run-dir for review lifecyclemodel.', {
+      code: 'LIFECYCLEMODEL_REVIEW_RUN_DIR_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  const outDir = nonEmptyString(options.outDir);
+  if (!outDir) {
+    throw new CliError('Missing required --out-dir for review lifecyclemodel.', {
+      code: 'LIFECYCLEMODEL_REVIEW_OUT_DIR_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  return buildLayout(path.resolve(runDir), path.resolve(outDir));
+}
+
+function ensureRunRootExists(layout: LifecyclemodelReviewLayout): void {
+  if (!existsSync(layout.runRoot)) {
+    throw new CliError(`lifecyclemodel review run root not found: ${layout.runRoot}`, {
+      code: 'LIFECYCLEMODEL_REVIEW_RUN_NOT_FOUND',
+      exitCode: 2,
+    });
+  }
+}
+
+function readRequiredRunManifest(layout: LifecyclemodelReviewLayout): JsonObject {
+  const manifest = readRequiredJsonObject(
+    layout.runManifestPath,
+    'LIFECYCLEMODEL_REVIEW_RUN_MANIFEST_MISSING',
+    'LIFECYCLEMODEL_REVIEW_RUN_MANIFEST_INVALID',
+    'run-manifest',
+  );
+
+  const manifestRunId = nonEmptyString(manifest.runId);
+  if (manifestRunId && manifestRunId !== layout.runId) {
+    throw new CliError(
+      `lifecyclemodel review run manifest runId mismatch: ${layout.runManifestPath}`,
+      {
+        code: 'LIFECYCLEMODEL_REVIEW_RUN_MANIFEST_MISMATCH',
+        exitCode: 2,
+        details: {
+          expected: layout.runId,
+          actual: manifestRunId,
+        },
+      },
+    );
+  }
+
+  return manifest;
+}
+
+function readInvocationIndex(layout: LifecyclemodelReviewLayout): JsonObject {
+  if (!existsSync(layout.invocationIndexPath)) {
+    return {
+      schema_version: 1,
+      invocations: [],
+    };
+  }
+
+  const value = readJsonArtifact(layout.invocationIndexPath);
+  if (!isRecord(value)) {
+    throw new CliError(
+      `Expected lifecyclemodel review invocation index JSON object: ${layout.invocationIndexPath}`,
+      {
+        code: 'LIFECYCLEMODEL_REVIEW_INVOCATION_INDEX_INVALID',
+        exitCode: 2,
+      },
+    );
+  }
+
+  if (value.invocations === undefined) {
+    return {
+      schema_version: 1,
+      invocations: [],
+    };
+  }
+
+  if (!Array.isArray(value.invocations)) {
+    throw new CliError(
+      `Expected lifecyclemodel review invocation index to contain an invocations array: ${layout.invocationIndexPath}`,
+      {
+        code: 'LIFECYCLEMODEL_REVIEW_INVOCATION_INDEX_INVALID',
+        exitCode: 2,
+      },
+    );
+  }
+
+  return value;
+}
+
+function discoverModelEntries(layout: LifecyclemodelReviewLayout): ModelEntry[] {
+  const runNames = existsSync(layout.modelsDir) ? readdirSync(layout.modelsDir).sort() : [];
+  const entries = runNames.flatMap((runName) => {
+    const lifecyclemodelsDir = path.join(
+      layout.modelsDir,
+      runName,
+      'tidas_bundle',
+      'lifecyclemodels',
+    );
+    if (!existsSync(lifecyclemodelsDir)) {
+      return [];
+    }
+
+    const modelFiles = readdirSync(lifecyclemodelsDir)
+      .filter((entry) => entry.endsWith('.json'))
+      .sort()
+      .map((entry) => path.join(lifecyclemodelsDir, entry));
+
+    if (modelFiles.length === 0) {
+      throw new CliError(
+        `lifecyclemodel review found a bundle without lifecyclemodel JSON files: ${lifecyclemodelsDir}`,
+        {
+          code: 'LIFECYCLEMODEL_REVIEW_MODELS_EMPTY',
+          exitCode: 2,
+        },
+      );
+    }
+
+    return [
+      {
+        runName,
+        modelFiles,
+        summaryPath: path.join(layout.modelsDir, runName, 'summary.json'),
+        connectionsPath: path.join(layout.modelsDir, runName, 'connections.json'),
+        processCatalogPath: path.join(layout.modelsDir, runName, 'process-catalog.json'),
+      },
+    ];
+  });
+
+  if (entries.length === 0) {
+    throw new CliError(
+      `lifecyclemodel review run does not contain any model bundles: ${layout.modelsDir}`,
+      {
+        code: 'LIFECYCLEMODEL_REVIEW_MODELS_NOT_FOUND',
+        exitCode: 2,
+      },
+    );
+  }
+
+  return entries;
+}
+
+function normalizeValidationIssue(raw: unknown): ValidationIssue {
+  if (!isRecord(raw)) {
+    return {
+      issue_code: 'validation_issue',
+      severity: 'error',
+      category: 'unknown',
+      file_path: '<unknown>',
+      message: String(raw),
+      location: '<root>',
+      context: {},
+    };
+  }
+
+  const severity =
+    raw.severity === 'warning' || raw.severity === 'info' || raw.severity === 'error'
+      ? raw.severity
+      : 'error';
+
+  return {
+    issue_code: nonEmptyString(raw.issue_code) ?? 'validation_issue',
+    severity,
+    category: nonEmptyString(raw.category) ?? 'unknown',
+    file_path: nonEmptyString(raw.file_path) ?? '<unknown>',
+    message: nonEmptyString(raw.message) ?? JSON.stringify(raw),
+    location: nonEmptyString(raw.location) ?? '<root>',
+    context: isRecord(raw.context) ? raw.context : {},
+  };
+}
+
+function collectValidationIssues(validation: JsonObject): ValidationIssue[] {
+  const executionReports = Array.isArray(validation.reports) ? validation.reports : [];
+  const seen = new Set<string>();
+  const issues: ValidationIssue[] = [];
+
+  executionReports.forEach((report) => {
+    if (!isRecord(report) || !isRecord(report.report)) {
+      return;
+    }
+
+    const rawIssues = Array.isArray(report.report.issues) ? report.report.issues : [];
+    rawIssues.forEach((rawIssue) => {
+      const issue = normalizeValidationIssue(rawIssue);
+      const key = JSON.stringify([
+        issue.issue_code,
+        issue.severity,
+        issue.category,
+        issue.file_path,
+        issue.message,
+        issue.location,
+      ]);
+      if (seen.has(key)) {
+        return;
+      }
+      seen.add(key);
+      issues.push(issue);
+    });
+  });
+
+  return issues;
+}
+
+function readValidationAggregate(
+  layout: LifecyclemodelReviewLayout,
+): LifecyclemodelValidationAggregate {
+  const aggregate = readOptionalJsonObject(
+    layout.validationReportPath,
+    'LIFECYCLEMODEL_REVIEW_VALIDATION_REPORT_INVALID',
+    'validate-build report',
+  );
+
+  if (!aggregate) {
+    return {
+      ok: null,
+      reportPath: null,
+      modelReports: new Map(),
+    };
+  }
+
+  if (aggregate.model_reports !== undefined && !Array.isArray(aggregate.model_reports)) {
+    throw new CliError(
+      `Expected lifecyclemodel validate-build report to contain a model_reports array: ${layout.validationReportPath}`,
+      {
+        code: 'LIFECYCLEMODEL_REVIEW_VALIDATION_REPORT_INVALID',
+        exitCode: 2,
+      },
+    );
+  }
+
+  const modelReports = new Map<string, LifecyclemodelModelValidationSummary>();
+  for (const rawEntry of Array.isArray(aggregate.model_reports) ? aggregate.model_reports : []) {
+    if (!isRecord(rawEntry)) {
+      throw new CliError(
+        `Expected lifecyclemodel validate-build model report entry JSON object: ${layout.validationReportPath}`,
+        {
+          code: 'LIFECYCLEMODEL_REVIEW_VALIDATION_REPORT_INVALID',
+          exitCode: 2,
+        },
+      );
+    }
+
+    const runName = nonEmptyString(rawEntry.run_name);
+    if (!runName || !isRecord(rawEntry.validation)) {
+      throw new CliError(
+        `Expected lifecyclemodel validate-build model report entry to contain run_name and validation: ${layout.validationReportPath}`,
+        {
+          code: 'LIFECYCLEMODEL_REVIEW_VALIDATION_REPORT_INVALID',
+          exitCode: 2,
+        },
+      );
+    }
+
+    const validation = rawEntry.validation;
+    const executionReports = Array.isArray(validation.reports) ? validation.reports : [];
+    modelReports.set(runName, {
+      ok: typeof validation.ok === 'boolean' ? validation.ok : null,
+      reportFile: nonEmptyString(rawEntry.report_file),
+      engineCount: executionReports.length,
+      issues: collectValidationIssues(validation),
+    });
+  }
+
+  return {
+    ok: typeof aggregate.ok === 'boolean' ? aggregate.ok : null,
+    reportPath: layout.validationReportPath,
+    modelReports,
+  };
+}
+
+function modelRoot(value: JsonObject): JsonObject {
+  return isRecord(value.lifeCycleModelDataSet)
+    ? (value.lifeCycleModelDataSet as JsonObject)
+    : value;
+}
+
+function readModelFileReviewInfo(filePath: string): ModelFileReviewInfo {
+  const payload = readJsonArtifact(filePath);
+  if (!isRecord(payload)) {
+    throw new CliError(`Expected lifecyclemodel review payload JSON object: ${filePath}`, {
+      code: 'LIFECYCLEMODEL_REVIEW_MODEL_INVALID',
+      exitCode: 2,
+    });
+  }
+
+  const root = modelRoot(payload);
+  const processInstances = listify(
+    deepGet(root, ['lifeCycleModelInformation', 'technology', 'processes', 'processInstance']),
+  ).filter(isRecord);
+  const zeroMultiplicationFactorCount = processInstances.filter(
+    (instance) => toNumber(instance['@multiplicationFactor']) === 0,
+  ).length;
+
+  return {
+    modelFile: filePath,
+    modelUuid:
+      nonEmptyString(
+        deepGet(root, ['lifeCycleModelInformation', 'dataSetInformation', 'common:UUID']),
+      ) ?? path.basename(filePath),
+    modelVersion:
+      nonEmptyString(
+        deepGet(root, [
+          'administrativeInformation',
+          'publicationAndOwnership',
+          'common:dataSetVersion',
+        ]),
+      ) ?? 'unknown',
+    referenceProcessInternalId: nonEmptyString(
+      deepGet(root, [
+        'lifeCycleModelInformation',
+        'quantitativeReference',
+        'referenceToReferenceProcess',
+      ]),
+    ),
+    resultingProcessUuid: nonEmptyString(
+      deepGet(root, [
+        'lifeCycleModelInformation',
+        'dataSetInformation',
+        'referenceToResultingProcess',
+        '@refObjectId',
+      ]),
+    ),
+    processInstanceCount: processInstances.length,
+    zeroMultiplicationFactorCount,
+  };
+}
+
+function makeFinding(
+  runName: string,
+  modelFile: string | null,
+  severity: LifecyclemodelReviewFinding['severity'],
+  ruleId: string,
+  source: LifecyclemodelReviewFinding['source'],
+  message: string,
+  evidence: JsonObject,
+): LifecyclemodelReviewFinding {
+  return {
+    run_name: runName,
+    model_file: modelFile,
+    severity,
+    rule_id: ruleId,
+    source,
+    message,
+    evidence,
+  };
+}
+
+function buildModelReview(
+  entry: ModelEntry,
+  validationAggregate: LifecyclemodelValidationAggregate,
+): {
+  summary: LifecyclemodelReviewModelSummary;
+  findings: LifecyclemodelReviewFinding[];
+} {
+  const summaryArtifact = readOptionalJsonObject(
+    entry.summaryPath,
+    'LIFECYCLEMODEL_REVIEW_SUMMARY_INVALID',
+    'summary',
+  );
+  const connections = readOptionalJsonArray(
+    entry.connectionsPath,
+    'LIFECYCLEMODEL_REVIEW_CONNECTIONS_INVALID',
+    'connections',
+  );
+  const processCatalog = readOptionalJsonArray(
+    entry.processCatalogPath,
+    'LIFECYCLEMODEL_REVIEW_PROCESS_CATALOG_INVALID',
+    'process-catalog',
+  );
+  const modelFileInfos = entry.modelFiles.map((modelFile) => readModelFileReviewInfo(modelFile));
+  const validation = validationAggregate.modelReports.get(entry.runName) ?? {
+    ok: null,
+    reportFile: null,
+    engineCount: 0,
+    issues: [],
+  };
+
+  const findings: LifecyclemodelReviewFinding[] = [];
+  validation.issues.forEach((issue) => {
+    findings.push(
+      makeFinding(
+        entry.runName,
+        issue.file_path,
+        issue.severity,
+        `validation:${issue.issue_code}`,
+        'validation',
+        issue.message,
+        {
+          category: issue.category,
+          location: issue.location,
+          context: issue.context,
+        },
+      ),
+    );
+  });
+
+  const modelUuids = uniqueStrings(modelFileInfos.map((info) => info.modelUuid));
+  const modelVersions = uniqueStrings(modelFileInfos.map((info) => info.modelVersion));
+  const resultingProcessUuids = uniqueStrings(
+    modelFileInfos.map((info) => info.resultingProcessUuid),
+  );
+  const referenceProcessInternalIds = uniqueStrings(
+    modelFileInfos.map((info) => info.referenceProcessInternalId),
+  );
+  const referenceProcessUuids = uniqueStrings([
+    nonEmptyString(summaryArtifact?.reference_process_uuid),
+  ]);
+  const processInstanceCount = modelFileInfos.reduce(
+    (sum, info) => sum + info.processInstanceCount,
+    0,
+  );
+  const zeroMultiplicationFactorCount = modelFileInfos.reduce(
+    (sum, info) => sum + info.zeroMultiplicationFactorCount,
+    0,
+  );
+  const summaryProcessCount = toNonNegativeInteger(summaryArtifact?.process_count);
+  const summaryEdgeCount = toNonNegativeInteger(summaryArtifact?.edge_count);
+  const multiplicationFactors = isRecord(summaryArtifact?.multiplication_factors)
+    ? (summaryArtifact?.multiplication_factors as JsonObject)
+    : null;
+  const multiplicationFactorCount = multiplicationFactors
+    ? Object.keys(multiplicationFactors).length
+    : 0;
+
+  if (!summaryArtifact) {
+    findings.push(
+      makeFinding(
+        entry.runName,
+        entry.modelFiles[0] ?? null,
+        'warning',
+        'missing_model_summary',
+        'review',
+        'Model bundle is missing summary.json generated by lifecyclemodel auto-build.',
+        {
+          summary_path: entry.summaryPath,
+        },
+      ),
+    );
+  }
+
+  if (!connections) {
+    findings.push(
+      makeFinding(
+        entry.runName,
+        entry.modelFiles[0] ?? null,
+        'warning',
+        'missing_connections_artifact',
+        'review',
+        'Model bundle is missing connections.json generated by lifecyclemodel auto-build.',
+        {
+          connections_path: entry.connectionsPath,
+        },
+      ),
+    );
+  }
+
+  if (!processCatalog) {
+    findings.push(
+      makeFinding(
+        entry.runName,
+        entry.modelFiles[0] ?? null,
+        'warning',
+        'missing_process_catalog',
+        'review',
+        'Model bundle is missing process-catalog.json generated by lifecyclemodel auto-build.',
+        {
+          process_catalog_path: entry.processCatalogPath,
+        },
+      ),
+    );
+  }
+
+  if (referenceProcessUuids.length === 0) {
+    findings.push(
+      makeFinding(
+        entry.runName,
+        entry.modelFiles[0] ?? null,
+        'warning',
+        'missing_reference_process_uuid',
+        'review',
+        'Review could not resolve reference_process_uuid from summary.json.',
+        {
+          summary_path: summaryArtifact ? entry.summaryPath : null,
+        },
+      ),
+    );
+  }
+
+  if (resultingProcessUuids.length === 0) {
+    findings.push(
+      makeFinding(
+        entry.runName,
+        entry.modelFiles[0] ?? null,
+        'warning',
+        'missing_resulting_process_ref',
+        'review',
+        'Review could not resolve referenceToResultingProcess from the lifecyclemodel payload.',
+        {
+          model_files: entry.modelFiles,
+        },
+      ),
+    );
+  }
+
+  if (processInstanceCount === 0) {
+    findings.push(
+      makeFinding(
+        entry.runName,
+        entry.modelFiles[0] ?? null,
+        'error',
+        'empty_process_instances',
+        'review',
+        'Lifecyclemodel payload does not contain any processInstance entries.',
+        {
+          model_files: entry.modelFiles,
+        },
+      ),
+    );
+  }
+
+  if (summaryProcessCount !== null && summaryProcessCount !== processInstanceCount) {
+    findings.push(
+      makeFinding(
+        entry.runName,
+        entry.modelFiles[0] ?? null,
+        'warning',
+        'process_count_mismatch',
+        'review',
+        'summary.json process_count does not match the number of processInstance entries in the payload.',
+        {
+          summary_process_count: summaryProcessCount,
+          process_instance_count: processInstanceCount,
+        },
+      ),
+    );
+  }
+
+  if (connections && summaryEdgeCount !== null && connections.length !== summaryEdgeCount) {
+    findings.push(
+      makeFinding(
+        entry.runName,
+        entry.modelFiles[0] ?? null,
+        'warning',
+        'edge_count_mismatch',
+        'review',
+        'summary.json edge_count does not match the connections.json row count.',
+        {
+          summary_edge_count: summaryEdgeCount,
+          connection_count: connections.length,
+        },
+      ),
+    );
+  }
+
+  if (processCatalog && processCatalog.length !== processInstanceCount) {
+    findings.push(
+      makeFinding(
+        entry.runName,
+        entry.modelFiles[0] ?? null,
+        'warning',
+        'process_catalog_count_mismatch',
+        'review',
+        'process-catalog.json row count does not match the number of processInstance entries in the payload.',
+        {
+          process_catalog_count: processCatalog.length,
+          process_instance_count: processInstanceCount,
+        },
+      ),
+    );
+  }
+
+  if (
+    summaryArtifact &&
+    multiplicationFactors &&
+    multiplicationFactorCount !== processInstanceCount
+  ) {
+    findings.push(
+      makeFinding(
+        entry.runName,
+        entry.modelFiles[0] ?? null,
+        'warning',
+        'multiplication_factor_count_mismatch',
+        'review',
+        'summary.json multiplication_factors count does not match the number of processInstance entries in the payload.',
+        {
+          multiplication_factor_count: multiplicationFactorCount,
+          process_instance_count: processInstanceCount,
+        },
+      ),
+    );
+  }
+
+  const counts = severityCounts(findings);
+  return {
+    summary: {
+      run_name: entry.runName,
+      model_files: entry.modelFiles,
+      model_uuids: modelUuids,
+      model_versions: modelVersions,
+      reference_process_uuids: referenceProcessUuids,
+      reference_process_internal_ids: referenceProcessInternalIds,
+      resulting_process_uuids: resultingProcessUuids,
+      summary_process_count: summaryProcessCount,
+      process_instance_count: processInstanceCount,
+      summary_edge_count: summaryEdgeCount,
+      connection_count: connections ? connections.length : null,
+      process_catalog_count: processCatalog ? processCatalog.length : null,
+      multiplication_factor_count: multiplicationFactorCount,
+      zero_multiplication_factor_count: zeroMultiplicationFactorCount,
+      validation: {
+        available: validationAggregate.reportPath !== null,
+        ok: validation.ok,
+        report_file: validation.reportFile,
+        engine_count: validation.engineCount,
+        issue_count: validation.issues.length,
+      },
+      artifacts: {
+        summary: summaryArtifact ? entry.summaryPath : null,
+        connections: connections ? entry.connectionsPath : null,
+        process_catalog: processCatalog ? entry.processCatalogPath : null,
+      },
+      finding_count: findings.length,
+      severity_counts: counts,
+    },
+    findings,
+  };
+}
+
+function buildInvocationIndex(
+  layout: LifecyclemodelReviewLayout,
+  invocationIndex: JsonObject,
+  options: RunLifecyclemodelReviewOptions,
+  now: Date,
+): JsonObject {
+  const priorInvocations = Array.isArray(invocationIndex.invocations)
+    ? [...invocationIndex.invocations]
+    : [];
+  const command = [
+    'review',
+    'lifecyclemodel',
+    '--run-dir',
+    options.runDir,
+    '--out-dir',
+    options.outDir,
+  ];
+
+  if (nonEmptyString(options.logicVersion)) {
+    command.push('--logic-version', options.logicVersion as string);
+  }
+  if (nonEmptyString(options.startTs)) {
+    command.push('--start-ts', options.startTs as string);
+  }
+  if (nonEmptyString(options.endTs)) {
+    command.push('--end-ts', options.endTs as string);
+  }
+
+  return {
+    ...invocationIndex,
+    schema_version:
+      typeof invocationIndex.schema_version === 'number' ? invocationIndex.schema_version : 1,
+    invocations: [
+      ...priorInvocations,
+      {
+        command,
+        cwd: options.cwd ?? process.cwd(),
+        created_at: now.toISOString(),
+        run_id: layout.runId,
+        run_root: layout.runRoot,
+        report_path: layout.reportPath,
+      },
+    ],
+  };
+}
+
+function buildNextActions(
+  layout: LifecyclemodelReviewLayout,
+  validationAggregate: LifecyclemodelValidationAggregate,
+): string[] {
+  return [
+    `inspect: ${layout.findingsPath}`,
+    validationAggregate.reportPath
+      ? `inspect: ${validationAggregate.reportPath}`
+      : `run: tiangong lifecyclemodel validate-build --run-dir ${layout.runRoot}`,
+    `run: tiangong lifecyclemodel publish-build --run-dir ${layout.runRoot}`,
+  ];
+}
+
+function renderZhReview(options: {
+  runId: string;
+  logicVersion: string;
+  runRoot: string;
+  modelSummaries: LifecyclemodelReviewModelSummary[];
+  findings: LifecyclemodelReviewFinding[];
+  validation: LifecyclemodelReviewReport['validation'];
+}): string {
+  const lines = [
+    '# lifecyclemodel_review_zh\n',
+    `- run_id: \`${options.runId}\`\n`,
+    `- logic_version: \`${options.logicVersion}\`\n`,
+    `- run_root: \`${options.runRoot}\`\n`,
+    '\n## 总览\n',
+    `- model bundle 数量: **${options.modelSummaries.length}**\n`,
+    `- findings 数量: **${options.findings.length}**\n`,
+    `- validation report: \`${options.validation.available ? 'available' : 'missing'}\`\n`,
+  ];
+
+  lines.push(
+    '\n## 模型摘要\n|run name|model uuid 数|processInstance|connections|validation issues|findings|\n|---|---:|---:|---:|---:|---:|\n',
+  );
+  options.modelSummaries.forEach((summary) => {
+    lines.push(
+      `|${summary.run_name}|${summary.model_uuids.length}|${summary.process_instance_count}|${summary.connection_count ?? 0}|${summary.validation.issue_count}|${summary.finding_count}|\n`,
+    );
+  });
+
+  lines.push('\n## Findings\n');
+  if (options.findings.length === 0) {
+    lines.push('- 未发现新的 lifecyclemodel review findings。\n');
+  } else {
+    lines.push('\n|run name|severity|source|rule id|message|\n|---|---|---|---|---|\n');
+    options.findings.slice(0, 200).forEach((finding) => {
+      lines.push(
+        `|${finding.run_name}|${finding.severity}|${finding.source}|${finding.rule_id}|${finding.message.replace(/\|/gu, '/')}|\n`,
+      );
+    });
+  }
+
+  lines.push(
+    '\n## 说明\n',
+    '- 当前 review lifecyclemodel 保持 local-first / artifact-first，只读取现有 build run 与 validate-build 产物。\n',
+    '- 当前命令不引入 Python、LangGraph 或 skill 私有 review runtime。\n',
+  );
+
+  return lines.join('');
+}
+
+function renderEnReview(options: {
+  runId: string;
+  logicVersion: string;
+  runRoot: string;
+  modelSummaries: LifecyclemodelReviewModelSummary[];
+  findings: LifecyclemodelReviewFinding[];
+  validation: LifecyclemodelReviewReport['validation'];
+}): string {
+  const lines = [
+    '# lifecyclemodel_review_en\n',
+    `- run_id: \`${options.runId}\`\n`,
+    `- logic_version: \`${options.logicVersion}\`\n`,
+    `- run_root: \`${options.runRoot}\`\n`,
+    '\n## Summary\n',
+    `- model bundles: **${options.modelSummaries.length}**\n`,
+    `- findings: **${options.findings.length}**\n`,
+    `- validation report: \`${options.validation.available ? 'available' : 'missing'}\`\n`,
+  ];
+
+  lines.push(
+    '\n## Model overview\n|run name|model uuids|process instances|connections|validation issues|findings|\n|---|---:|---:|---:|---:|---:|\n',
+  );
+  options.modelSummaries.forEach((summary) => {
+    lines.push(
+      `|${summary.run_name}|${summary.model_uuids.length}|${summary.process_instance_count}|${summary.connection_count ?? 0}|${summary.validation.issue_count}|${summary.finding_count}|\n`,
+    );
+  });
+
+  if (options.findings.length > 0) {
+    lines.push('\n## Findings\n');
+    options.findings.slice(0, 100).forEach((finding) => {
+      lines.push(`- [${finding.severity}] ${finding.run_name}: ${finding.message}\n`);
+    });
+  }
+
+  return lines.join('');
+}
+
+function renderTiming(options: {
+  runId: string;
+  startTs?: string;
+  endTs?: string;
+  modelCount: number;
+}): string {
+  const lines = ['# lifecyclemodel_review_timing\n', `- run_id: \`${options.runId}\`\n`];
+  if (options.startTs && options.endTs) {
+    const started = Date.parse(options.startTs);
+    const ended = Date.parse(options.endTs);
+    if (!Number.isFinite(started) || !Number.isFinite(ended)) {
+      throw new CliError('Expected --start-ts and --end-ts to be valid ISO timestamps.', {
+        code: 'LIFECYCLEMODEL_REVIEW_INVALID_TIMESTAMP',
+        exitCode: 2,
+      });
+    }
+
+    lines.push(`- start: \`${options.startTs}\`\n`);
+    lines.push(`- end: \`${options.endTs}\`\n`);
+    lines.push(`- total elapsed: **${((ended - started) / 60_000).toFixed(2)} min**\n`);
+  }
+
+  lines.push(`- model bundles reviewed: \`${options.modelCount}\`\n`);
+  lines.push(
+    '- major time consumers: model JSON parsing, validation issue aggregation, artifact checks.\n',
+  );
+  return lines.join('');
+}
+
+export async function runLifecyclemodelReview(
+  options: RunLifecyclemodelReviewOptions,
+): Promise<LifecyclemodelReviewReport> {
+  const layout = resolveLayout(options);
+  ensureRunRootExists(layout);
+  readRequiredRunManifest(layout);
+  const invocationIndex = readInvocationIndex(layout);
+  const validationAggregate = readValidationAggregate(layout);
+  const modelEntries = discoverModelEntries(layout);
+  const logicVersion = options.logicVersion?.trim() || 'lifecyclemodel-review-v1.0';
+  const now = options.now ?? (() => new Date());
+  const generatedAt = now();
+
+  const reviewedModels = modelEntries.map((entry) => buildModelReview(entry, validationAggregate));
+  const modelSummaries = reviewedModels.map((model) => model.summary);
+  const findings = reviewedModels.flatMap((model) => model.findings);
+  const report: LifecyclemodelReviewReport = {
+    schema_version: 1,
+    generated_at_utc: generatedAt.toISOString(),
+    status: 'completed_local_lifecyclemodel_review',
+    run_id: layout.runId,
+    run_root: layout.runRoot,
+    out_dir: layout.outDir,
+    logic_version: logicVersion,
+    model_count: modelSummaries.length,
+    finding_count: findings.length,
+    severity_counts: severityCounts(findings),
+    validation: {
+      available: validationAggregate.reportPath !== null,
+      ok: validationAggregate.ok,
+      report: validationAggregate.reportPath,
+    },
+    files: {
+      run_manifest: layout.runManifestPath,
+      invocation_index: layout.invocationIndexPath,
+      validation_report: validationAggregate.reportPath,
+      model_summaries: layout.modelSummariesPath,
+      findings: layout.findingsPath,
+      summary: layout.summaryPath,
+      review_zh: layout.reviewZhPath,
+      review_en: layout.reviewEnPath,
+      timing: layout.timingPath,
+      report: layout.reportPath,
+    },
+    model_summaries: modelSummaries,
+    next_actions: buildNextActions(layout, validationAggregate),
+  };
+
+  writeJsonArtifact(
+    layout.invocationIndexPath,
+    buildInvocationIndex(layout, invocationIndex, options, generatedAt),
+  );
+  writeJsonLinesArtifact(layout.modelSummariesPath, modelSummaries);
+  writeJsonLinesArtifact(layout.findingsPath, findings);
+  writeJsonArtifact(layout.summaryPath, {
+    run_id: report.run_id,
+    logic_version: report.logic_version,
+    model_count: report.model_count,
+    finding_count: report.finding_count,
+    severity_counts: copyJson(report.severity_counts),
+    validation: copyJson(report.validation),
+  });
+  writeTextArtifact(
+    layout.reviewZhPath,
+    renderZhReview({
+      runId: report.run_id,
+      logicVersion: report.logic_version,
+      runRoot: report.run_root,
+      modelSummaries,
+      findings,
+      validation: report.validation,
+    }),
+  );
+  writeTextArtifact(
+    layout.reviewEnPath,
+    renderEnReview({
+      runId: report.run_id,
+      logicVersion: report.logic_version,
+      runRoot: report.run_root,
+      modelSummaries,
+      findings,
+      validation: report.validation,
+    }),
+  );
+  writeTextArtifact(
+    layout.timingPath,
+    renderTiming({
+      runId: report.run_id,
+      startTs: options.startTs,
+      endTs: options.endTs,
+      modelCount: report.model_count,
+    }),
+  );
+  writeJsonArtifact(layout.reportPath, report);
+
+  return report;
+}
+
+export const __testInternals = {
+  buildLayout,
+  resolveLayout,
+  readInvocationIndex,
+  discoverModelEntries,
+  readValidationAggregate,
+  readModelFileReviewInfo,
+  buildModelReview,
+  buildInvocationIndex,
+  buildNextActions,
+  renderZhReview,
+  renderEnReview,
+  renderTiming,
+};

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -14,6 +14,7 @@ import type {
 } from '../src/lib/flow-regen-product.js';
 import type { RunFlowRemediateOptions } from '../src/lib/flow-remediate.js';
 import type { RunFlowReviewOptions } from '../src/lib/review-flow.js';
+import type { RunLifecyclemodelReviewOptions } from '../src/lib/review-lifecyclemodel.js';
 
 const dotEnvStatus: DotEnvLoadResult = {
   loaded: false,
@@ -183,6 +184,20 @@ test('executeCli returns help for publish and validation subcommands', async () 
     ),
   );
   assert.match(reviewFlowHelp.stdout, /--similarity-threshold/u);
+
+  const reviewLifecyclemodelHelp = await executeCli(
+    ['review', 'lifecyclemodel', '--help'],
+    makeDeps(),
+  );
+  assert.equal(reviewLifecyclemodelHelp.exitCode, 0);
+  assert.match(
+    reviewLifecyclemodelHelp.stdout,
+    /tiangong review lifecyclemodel --run-dir <dir> --out-dir <dir>/u,
+  );
+  assert.match(
+    reviewLifecyclemodelHelp.stdout,
+    /aggregates validate-build findings when reports\/lifecyclemodel-validate-build-report\.json is present/u,
+  );
 
   const flowRemediateHelp = await executeCli(['flow', 'remediate', '--help'], makeDeps());
   assert.equal(flowRemediateHelp.exitCode, 0);
@@ -1975,6 +1990,14 @@ test('executeCli returns parsing errors for invalid lifecyclemodel, process, and
   assert.equal(orchestrateResult.stdout, '');
   assert.match(orchestrateResult.stderr, /INVALID_ARGS/u);
 
+  const reviewLifecyclemodelResult = await executeCli(
+    ['review', 'lifecyclemodel', '--bad-flag'],
+    makeDeps(),
+  );
+  assert.equal(reviewLifecyclemodelResult.exitCode, 2);
+  assert.equal(reviewLifecyclemodelResult.stdout, '');
+  assert.match(reviewLifecyclemodelResult.stderr, /INVALID_ARGS/u);
+
   const invalidOrchestrateActionResult = await executeCli(
     ['lifecyclemodel', 'orchestrate', 'bad-action'],
     makeDeps(),
@@ -2272,19 +2295,91 @@ test('executeCli validates missing required flow regen-product inputs once the c
   assert.match(result.stderr, /FLOW_REGEN_PROCESSES_FILE_REQUIRED/u);
 });
 
-test('executeCli returns planned command message and dedicated help for review lifecyclemodel', async () => {
-  const lifecyclemodelResult = await executeCli(['review', 'lifecyclemodel'], makeDeps());
-  assert.equal(lifecyclemodelResult.exitCode, 2);
-  assert.equal(lifecyclemodelResult.stdout, '');
-  assert.match(lifecyclemodelResult.stderr, /Command 'review lifecyclemodel'/u);
+test('executeCli dispatches review lifecyclemodel to the implemented CLI module', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-lifecyclemodel-dispatch-'));
 
-  const lifecyclemodelHelpResult = await executeCli(
-    ['review', 'lifecyclemodel', '--help'],
-    makeDeps(),
-  );
-  assert.equal(lifecyclemodelHelpResult.exitCode, 0);
-  assert.match(lifecyclemodelHelpResult.stdout, /Planned contract:/u);
-  assert.match(lifecyclemodelHelpResult.stdout, /lifecycle model build run/u);
+  try {
+    let observedOptions: RunLifecyclemodelReviewOptions | undefined;
+    const result = await executeCli(
+      [
+        'review',
+        'lifecyclemodel',
+        '--run-dir',
+        path.join(dir, 'run'),
+        '--out-dir',
+        path.join(dir, 'review'),
+        '--start-ts',
+        '2026-03-30T00:00:00.000Z',
+        '--end-ts',
+        '2026-03-30T00:05:00.000Z',
+        '--logic-version',
+        'review-v1',
+        '--json',
+      ],
+      {
+        ...makeDeps(),
+        runLifecyclemodelReviewImpl: async (options) => {
+          observedOptions = options;
+          return {
+            schema_version: 1,
+            generated_at_utc: '2026-03-30T00:06:00.000Z',
+            status: 'completed_local_lifecyclemodel_review',
+            run_id: 'lm-run-001',
+            run_root: path.join(dir, 'run'),
+            out_dir: path.join(dir, 'review'),
+            logic_version: 'review-v1',
+            model_count: 1,
+            finding_count: 0,
+            severity_counts: {
+              error: 0,
+              warning: 0,
+              info: 0,
+            },
+            validation: {
+              available: true,
+              ok: true,
+              report: path.join(dir, 'run', 'reports', 'lifecyclemodel-validate-build-report.json'),
+            },
+            files: {
+              run_manifest: path.join(dir, 'run', 'manifests', 'run-manifest.json'),
+              invocation_index: path.join(dir, 'run', 'manifests', 'invocation-index.json'),
+              validation_report: path.join(
+                dir,
+                'run',
+                'reports',
+                'lifecyclemodel-validate-build-report.json',
+              ),
+              model_summaries: path.join(dir, 'review', 'model_summaries.jsonl'),
+              findings: path.join(dir, 'review', 'findings.jsonl'),
+              summary: path.join(dir, 'review', 'lifecyclemodel_review_summary.json'),
+              review_zh: path.join(dir, 'review', 'lifecyclemodel_review_zh.md'),
+              review_en: path.join(dir, 'review', 'lifecyclemodel_review_en.md'),
+              timing: path.join(dir, 'review', 'lifecyclemodel_review_timing.md'),
+              report: path.join(dir, 'review', 'lifecyclemodel_review_report.json'),
+            },
+            model_summaries: [],
+            next_actions: ['inspect: findings'],
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.deepEqual(observedOptions, {
+      runDir: path.join(dir, 'run'),
+      outDir: path.join(dir, 'review'),
+      startTs: '2026-03-30T00:00:00.000Z',
+      endTs: '2026-03-30T00:05:00.000Z',
+      logicVersion: 'review-v1',
+    });
+
+    const payload = JSON.parse(result.stdout) as { status: string; logic_version: string };
+    assert.equal(payload.status, 'completed_local_lifecyclemodel_review');
+    assert.equal(payload.logic_version, 'review-v1');
+    assert.equal(result.stderr, '');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test('executeCli dispatches review flow to the implemented CLI module', async () => {

--- a/test/review-lifecyclemodel.test.ts
+++ b/test/review-lifecyclemodel.test.ts
@@ -1,0 +1,1030 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { __testInternals, runLifecyclemodelReview } from '../src/lib/review-lifecyclemodel.js';
+
+type JsonRecord = Record<string, unknown>;
+
+function writeJson(filePath: string, value: unknown): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function readJson<T>(filePath: string): T {
+  return JSON.parse(readFileSync(filePath, 'utf8')) as T;
+}
+
+function createProcessInstance(id: string, multiplicationFactor: string | number): JsonRecord {
+  return {
+    '@id': id,
+    '@multiplicationFactor': String(multiplicationFactor),
+  };
+}
+
+function createLifecyclemodelPayload(options: {
+  id: string;
+  version?: string;
+  referenceProcessInternalId?: string;
+  resultingProcessId?: string;
+  processInstances?: JsonRecord[];
+}): JsonRecord {
+  return {
+    lifeCycleModelDataSet: {
+      lifeCycleModelInformation: {
+        dataSetInformation: {
+          'common:UUID': options.id,
+          ...(options.resultingProcessId
+            ? {
+                referenceToResultingProcess: {
+                  '@refObjectId': options.resultingProcessId,
+                },
+              }
+            : {}),
+        },
+        quantitativeReference: {
+          referenceToReferenceProcess: options.referenceProcessInternalId ?? '1',
+        },
+        technology: {
+          processes: {
+            processInstance:
+              options.processInstances && options.processInstances.length === 1
+                ? options.processInstances[0]
+                : (options.processInstances ?? []),
+          },
+        },
+      },
+      administrativeInformation: {
+        publicationAndOwnership: {
+          'common:dataSetVersion': options.version ?? '01.00.000',
+        },
+      },
+    },
+  };
+}
+
+function createValidationIssue(filePath: string): JsonRecord {
+  return {
+    issue_code: 'schema_error',
+    severity: 'error',
+    category: 'lifecyclemodels',
+    file_path: filePath,
+    message: 'Broken lifecycle model dataset',
+    location: '<root>',
+    context: {
+      detail: 'demo',
+    },
+  };
+}
+
+function createValidationAggregateReport(options: {
+  runRoot: string;
+  modelReports: Array<{
+    runName: string;
+    modelFiles: string[];
+    reportFile: string;
+    issues: JsonRecord[];
+    mode?: 'auto' | 'all';
+    ok?: boolean;
+  }>;
+}): JsonRecord {
+  return {
+    schema_version: 1,
+    generated_at_utc: '2026-03-30T00:00:00.000Z',
+    status: 'completed_lifecyclemodel_validate_build',
+    run_id: path.basename(options.runRoot),
+    run_root: options.runRoot,
+    ok: options.modelReports.every((entry) => entry.ok !== false && entry.issues.length === 0),
+    engine: 'all',
+    counts: {
+      models: options.modelReports.length,
+      ok: options.modelReports.filter((entry) => entry.ok !== false && entry.issues.length === 0)
+        .length,
+      failed: options.modelReports.filter((entry) => entry.ok === false || entry.issues.length > 0)
+        .length,
+    },
+    files: {
+      run_manifest: path.join(options.runRoot, 'manifests', 'run-manifest.json'),
+      invocation_index: path.join(options.runRoot, 'manifests', 'invocation-index.json'),
+      auto_build_report: null,
+      report: path.join(options.runRoot, 'reports', 'lifecyclemodel-validate-build-report.json'),
+      model_reports_dir: path.join(options.runRoot, 'reports', 'model-validations'),
+    },
+    model_reports: options.modelReports.map((entry) => ({
+      run_name: entry.runName,
+      input_dir: path.join(options.runRoot, 'models', entry.runName, 'tidas_bundle'),
+      model_files: entry.modelFiles,
+      report_file: entry.reportFile,
+      validation: {
+        input_dir: path.join(options.runRoot, 'models', entry.runName, 'tidas_bundle'),
+        mode: entry.mode ?? 'all',
+        ok: entry.ok ?? entry.issues.length === 0,
+        summary: {
+          engine_count: entry.mode === 'auto' ? 1 : 2,
+          ok_count: entry.issues.length === 0 ? (entry.mode === 'auto' ? 1 : 2) : 0,
+          failed_count: entry.issues.length === 0 ? 0 : entry.mode === 'auto' ? 1 : 2,
+        },
+        files: {
+          report: entry.reportFile,
+        },
+        reports:
+          entry.mode === 'auto'
+            ? [
+                {
+                  engine: 'sdk',
+                  ok: entry.issues.length === 0,
+                  duration_ms: 0,
+                  location: '/tmp/sdk.js',
+                  report: {
+                    input_dir: path.join(options.runRoot, 'models', entry.runName, 'tidas_bundle'),
+                    ok: entry.issues.length === 0,
+                    summary: {
+                      category_count: 1,
+                      issue_count: entry.issues.length,
+                      error_count: entry.issues.length,
+                      warning_count: 0,
+                      info_count: 0,
+                    },
+                    categories: [],
+                    issues: entry.issues,
+                  },
+                },
+              ]
+            : [
+                {
+                  engine: 'sdk',
+                  ok: entry.issues.length === 0,
+                  duration_ms: 0,
+                  location: '/tmp/sdk.js',
+                  report: {
+                    input_dir: path.join(options.runRoot, 'models', entry.runName, 'tidas_bundle'),
+                    ok: entry.issues.length === 0,
+                    summary: {
+                      category_count: 1,
+                      issue_count: entry.issues.length,
+                      error_count: entry.issues.length,
+                      warning_count: 0,
+                      info_count: 0,
+                    },
+                    categories: [],
+                    issues: entry.issues,
+                  },
+                },
+                {
+                  engine: 'tools',
+                  ok: entry.issues.length === 0,
+                  duration_ms: 0,
+                  location: '/tmp/tools.py',
+                  report: {
+                    input_dir: path.join(options.runRoot, 'models', entry.runName, 'tidas_bundle'),
+                    ok: entry.issues.length === 0,
+                    summary: {
+                      category_count: 1,
+                      issue_count: entry.issues.length,
+                      error_count: entry.issues.length,
+                      warning_count: 0,
+                      info_count: 0,
+                    },
+                    categories: [],
+                    issues: entry.issues,
+                  },
+                },
+              ],
+        comparison: null,
+      },
+    })),
+  };
+}
+
+function writeMinimalRunManifest(runRoot: string, runId = path.basename(runRoot)): void {
+  writeJson(path.join(runRoot, 'manifests', 'run-manifest.json'), {
+    schemaVersion: 1,
+    runId,
+  });
+}
+
+function writeLifecyclemodelBundle(
+  runRoot: string,
+  runName: string,
+  value: JsonRecord,
+  fileName = `${runName}.json`,
+): string {
+  const modelFile = path.join(
+    runRoot,
+    'models',
+    runName,
+    'tidas_bundle',
+    'lifecyclemodels',
+    fileName,
+  );
+  writeJson(modelFile, value);
+  return modelFile;
+}
+
+test('runLifecyclemodelReview writes artifact-first outputs and dedupes validation findings', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-lifecyclemodel-'));
+  const runRoot = path.join(dir, 'lm-run-1');
+  const outDir = path.join(dir, 'review');
+
+  writeJson(path.join(runRoot, 'manifests', 'run-manifest.json'), {
+    schemaVersion: 1,
+    runId: 'lm-run-1',
+  });
+  writeJson(path.join(runRoot, 'manifests', 'invocation-index.json'), {
+    schema_version: 1,
+    invocations: [],
+  });
+
+  const modelAFile = path.join(
+    runRoot,
+    'models',
+    'model-a',
+    'tidas_bundle',
+    'lifecyclemodels',
+    'model-a.json',
+  );
+  writeJson(
+    modelAFile,
+    createLifecyclemodelPayload({
+      id: 'model-a-uuid',
+      resultingProcessId: 'process-a-result',
+      referenceProcessInternalId: '10',
+      processInstances: [createProcessInstance('a-1', 1), createProcessInstance('a-2', 0)],
+    }),
+  );
+  writeJson(path.join(runRoot, 'models', 'model-a', 'summary.json'), {
+    run_name: 'model-a',
+    model_uuid: 'model-a-uuid',
+    model_version: '01.00.000',
+    reference_process_uuid: 'process-a',
+    reference_process_internal_id: '10',
+    reference_to_resulting_process_uuid: 'process-a-result',
+    process_count: 3,
+    edge_count: 2,
+    multiplication_factors: {
+      'a-1': '1',
+    },
+  });
+  writeJson(path.join(runRoot, 'models', 'model-a', 'connections.json'), [
+    {
+      src: 'process-a',
+      dst: 'process-b',
+    },
+  ]);
+  writeJson(path.join(runRoot, 'models', 'model-a', 'process-catalog.json'), [
+    {
+      process_uuid: 'process-a',
+    },
+  ]);
+
+  const modelBFile = path.join(
+    runRoot,
+    'models',
+    'model-b',
+    'tidas_bundle',
+    'lifecyclemodels',
+    'model-b.json',
+  );
+  writeJson(
+    modelBFile,
+    createLifecyclemodelPayload({
+      id: 'model-b-uuid',
+      processInstances: [],
+    }),
+  );
+
+  writeJson(
+    path.join(runRoot, 'reports', 'lifecyclemodel-validate-build-report.json'),
+    createValidationAggregateReport({
+      runRoot,
+      modelReports: [
+        {
+          runName: 'model-a',
+          modelFiles: [modelAFile],
+          reportFile: path.join(runRoot, 'reports', 'model-validations', 'model-a.json'),
+          issues: [createValidationIssue(modelAFile)],
+          mode: 'all',
+          ok: false,
+        },
+        {
+          runName: 'model-b',
+          modelFiles: [modelBFile],
+          reportFile: path.join(runRoot, 'reports', 'model-validations', 'model-b.json'),
+          issues: [],
+          mode: 'auto',
+          ok: true,
+        },
+      ],
+    }),
+  );
+
+  try {
+    const report = await runLifecyclemodelReview({
+      runDir: runRoot,
+      outDir,
+      logicVersion: 'review-v1',
+      startTs: '2026-03-30T00:00:00.000Z',
+      endTs: '2026-03-30T00:10:00.000Z',
+      now: () => new Date('2026-03-30T00:11:00.000Z'),
+      cwd: '/tmp/lifecyclemodel-review',
+    });
+
+    assert.equal(report.status, 'completed_local_lifecyclemodel_review');
+    assert.equal(report.logic_version, 'review-v1');
+    assert.equal(report.model_count, 2);
+    assert.equal(report.finding_count, 11);
+    assert.deepEqual(report.severity_counts, {
+      error: 2,
+      warning: 9,
+      info: 0,
+    });
+    assert.deepEqual(report.validation, {
+      available: true,
+      ok: false,
+      report: path.join(runRoot, 'reports', 'lifecyclemodel-validate-build-report.json'),
+    });
+    assert.equal(report.generated_at_utc, '2026-03-30T00:11:00.000Z');
+    assert.ok(existsSync(report.files.model_summaries));
+    assert.ok(existsSync(report.files.findings));
+    assert.ok(existsSync(report.files.summary));
+    assert.ok(existsSync(report.files.review_zh));
+    assert.ok(existsSync(report.files.review_en));
+    assert.ok(existsSync(report.files.timing));
+    assert.ok(existsSync(report.files.report));
+
+    const modelSummaries = readFileSync(report.files.model_summaries, 'utf8')
+      .trim()
+      .split(/\r?\n/u)
+      .map((line) => JSON.parse(line) as { run_name: string; finding_count: number });
+    assert.deepEqual(
+      modelSummaries.map((entry) => entry.run_name),
+      ['model-a', 'model-b'],
+    );
+    assert.deepEqual(
+      modelSummaries.map((entry) => entry.finding_count),
+      [5, 6],
+    );
+
+    const findings = readFileSync(report.files.findings, 'utf8')
+      .trim()
+      .split(/\r?\n/u)
+      .map((line) => JSON.parse(line) as { rule_id: string; run_name: string });
+    assert.equal(findings.filter((entry) => entry.rule_id === 'validation:schema_error').length, 1);
+    assert.ok(
+      findings.some(
+        (entry) => entry.rule_id === 'missing_process_catalog' && entry.run_name === 'model-b',
+      ),
+    );
+
+    const summary = readJson<{
+      model_count: number;
+      finding_count: number;
+      validation: { available: boolean; ok: boolean | null; report: string | null };
+    }>(report.files.summary);
+    assert.equal(summary.model_count, 2);
+    assert.equal(summary.finding_count, 11);
+    assert.deepEqual(summary.validation, {
+      available: true,
+      ok: false,
+      report: path.join(runRoot, 'reports', 'lifecyclemodel-validate-build-report.json'),
+    });
+
+    const zhReview = readFileSync(report.files.review_zh, 'utf8');
+    assert.match(zhReview, /模型摘要/u);
+    assert.match(zhReview, /当前命令不引入 Python、LangGraph/u);
+
+    const timing = readFileSync(report.files.timing, 'utf8');
+    assert.match(timing, /10\.00 min/u);
+
+    const invocationIndex = readJson<{ invocations: Array<{ command: string[]; cwd: string }> }>(
+      report.files.invocation_index,
+    );
+    assert.equal(invocationIndex.invocations.length, 1);
+    assert.deepEqual(invocationIndex.invocations[0]?.command, [
+      'review',
+      'lifecyclemodel',
+      '--run-dir',
+      runRoot,
+      '--out-dir',
+      outDir,
+      '--logic-version',
+      'review-v1',
+      '--start-ts',
+      '2026-03-30T00:00:00.000Z',
+      '--end-ts',
+      '2026-03-30T00:10:00.000Z',
+    ]);
+    assert.equal(invocationIndex.invocations[0]?.cwd, '/tmp/lifecyclemodel-review');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelReview supports missing validation reports and consistent single-model bundles', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-lifecyclemodel-ok-'));
+  const runRoot = path.join(dir, 'lm-run-2');
+  const outDir = path.join(dir, 'review');
+
+  writeJson(path.join(runRoot, 'manifests', 'run-manifest.json'), {
+    schemaVersion: 1,
+    runId: 'lm-run-2',
+  });
+  const modelFile = path.join(
+    runRoot,
+    'models',
+    'model-ok',
+    'tidas_bundle',
+    'lifecyclemodels',
+    'model-ok.json',
+  );
+  writeJson(
+    modelFile,
+    createLifecyclemodelPayload({
+      id: 'model-ok-uuid',
+      resultingProcessId: 'process-ok-result',
+      referenceProcessInternalId: '99',
+      processInstances: [createProcessInstance('ok-1', 1)],
+    }),
+  );
+  writeJson(path.join(runRoot, 'models', 'model-ok', 'summary.json'), {
+    run_name: 'model-ok',
+    model_uuid: 'model-ok-uuid',
+    model_version: '01.00.000',
+    reference_process_uuid: 'process-ok',
+    reference_process_internal_id: '99',
+    reference_to_resulting_process_uuid: 'process-ok-result',
+    process_count: 1,
+    edge_count: 0,
+    multiplication_factors: {
+      'ok-1': '1',
+    },
+  });
+  writeJson(path.join(runRoot, 'models', 'model-ok', 'connections.json'), []);
+  writeJson(path.join(runRoot, 'models', 'model-ok', 'process-catalog.json'), [
+    {
+      process_uuid: 'process-ok',
+    },
+  ]);
+
+  try {
+    const report = await runLifecyclemodelReview({
+      runDir: runRoot,
+      outDir,
+      now: () => new Date('2026-03-30T00:00:00.000Z'),
+    });
+
+    assert.equal(report.finding_count, 0);
+    assert.deepEqual(report.validation, {
+      available: false,
+      ok: null,
+      report: null,
+    });
+    assert.deepEqual(report.next_actions, [
+      `inspect: ${path.join(outDir, 'findings.jsonl')}`,
+      `run: tiangong lifecyclemodel validate-build --run-dir ${runRoot}`,
+      `run: tiangong lifecyclemodel publish-build --run-dir ${runRoot}`,
+    ]);
+    assert.equal(report.model_summaries[0]?.validation.available, false);
+    assert.equal(report.model_summaries[0]?.process_instance_count, 1);
+    assert.equal(report.model_summaries[0]?.zero_multiplication_factor_count, 0);
+    assert.equal(readJson<{ finding_count: number }>(report.files.summary).finding_count, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelReview rejects invalid inputs, missing runs, and malformed timestamps', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-lifecyclemodel-errors-'));
+  const invalidRunRoot = path.join(dir, 'lm-run-invalid');
+  const noModelsRunRoot = path.join(dir, 'lm-run-no-models');
+  const badTimestampRunRoot = path.join(dir, 'lm-run-bad-ts');
+  const outDir = path.join(dir, 'review');
+
+  writeJson(path.join(invalidRunRoot, 'manifests', 'run-manifest.json'), []);
+  writeJson(path.join(noModelsRunRoot, 'manifests', 'run-manifest.json'), {
+    schemaVersion: 1,
+    runId: 'lm-run-no-models',
+  });
+  writeJson(path.join(badTimestampRunRoot, 'manifests', 'run-manifest.json'), {
+    schemaVersion: 1,
+    runId: 'lm-run-bad-ts',
+  });
+  writeJson(
+    path.join(
+      badTimestampRunRoot,
+      'models',
+      'model-one',
+      'tidas_bundle',
+      'lifecyclemodels',
+      'model-one.json',
+    ),
+    createLifecyclemodelPayload({
+      id: 'model-one-uuid',
+      resultingProcessId: 'process-one-result',
+      processInstances: [createProcessInstance('one-1', 1)],
+    }),
+  );
+  writeJson(path.join(badTimestampRunRoot, 'models', 'model-one', 'summary.json'), {
+    run_name: 'model-one',
+    model_uuid: 'model-one-uuid',
+    model_version: '01.00.000',
+    reference_process_uuid: 'process-one',
+    process_count: 1,
+    edge_count: 0,
+    multiplication_factors: {
+      'one-1': '1',
+    },
+  });
+  writeJson(path.join(badTimestampRunRoot, 'models', 'model-one', 'connections.json'), []);
+  writeJson(path.join(badTimestampRunRoot, 'models', 'model-one', 'process-catalog.json'), [
+    {
+      process_uuid: 'process-one',
+    },
+  ]);
+
+  try {
+    await assert.rejects(
+      async () =>
+        runLifecyclemodelReview({
+          runDir: '',
+          outDir,
+        }),
+      /Missing required --run-dir/u,
+    );
+
+    await assert.rejects(
+      async () =>
+        runLifecyclemodelReview({
+          runDir: path.join(dir, 'missing'),
+          outDir,
+        }),
+      /run root not found/u,
+    );
+
+    await assert.rejects(
+      async () =>
+        runLifecyclemodelReview({
+          runDir: invalidRunRoot,
+          outDir,
+        }),
+      /run-manifest artifact JSON object/u,
+    );
+
+    await assert.rejects(
+      async () =>
+        runLifecyclemodelReview({
+          runDir: noModelsRunRoot,
+          outDir,
+        }),
+      /does not contain any model bundles/u,
+    );
+
+    await assert.rejects(
+      async () =>
+        runLifecyclemodelReview({
+          runDir: badTimestampRunRoot,
+          outDir,
+          startTs: 'bad-start',
+          endTs: 'bad-end',
+        }),
+      /valid ISO timestamps/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('review lifecyclemodel internals cover invocation index and model discovery edge cases', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-lifecyclemodel-internals-'));
+  const runRoot = path.join(dir, 'lm-run-internals');
+  const outDir = path.join(dir, 'review');
+  const layout = __testInternals.buildLayout(runRoot, outDir);
+
+  try {
+    assert.throws(
+      () =>
+        __testInternals.resolveLayout({
+          runDir: runRoot,
+          outDir: '',
+        }),
+      /Missing required --out-dir/u,
+    );
+
+    writeJson(layout.invocationIndexPath, []);
+    assert.throws(
+      () => __testInternals.readInvocationIndex(layout),
+      /invocation index JSON object/u,
+    );
+
+    writeJson(layout.invocationIndexPath, {
+      schema_version: 1,
+    });
+    assert.deepEqual(__testInternals.readInvocationIndex(layout), {
+      schema_version: 1,
+      invocations: [],
+    });
+
+    writeJson(layout.invocationIndexPath, {
+      schema_version: 1,
+      invocations: {},
+    });
+    assert.throws(() => __testInternals.readInvocationIndex(layout), /invocations array/u);
+
+    mkdirSync(path.join(layout.modelsDir, 'skip-me'), { recursive: true });
+    const keptModelFile = writeLifecyclemodelBundle(
+      runRoot,
+      'keep-me',
+      createLifecyclemodelPayload({
+        id: 'keep-me-uuid',
+        resultingProcessId: 'keep-result',
+        processInstances: [createProcessInstance('keep-1', 1)],
+      }),
+    );
+    const discovered = __testInternals.discoverModelEntries(layout);
+    assert.deepEqual(
+      discovered.map((entry) => entry.runName),
+      ['keep-me'],
+    );
+    assert.deepEqual(discovered[0]?.modelFiles, [keptModelFile]);
+
+    const emptyRunRoot = path.join(dir, 'lm-run-empty-dir');
+    const emptyLayout = __testInternals.buildLayout(emptyRunRoot, path.join(dir, 'review-empty'));
+    mkdirSync(path.join(emptyLayout.modelsDir, 'empty-bundle', 'tidas_bundle', 'lifecyclemodels'), {
+      recursive: true,
+    });
+    assert.throws(
+      () => __testInternals.discoverModelEntries(emptyLayout),
+      /without lifecyclemodel JSON files/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('review lifecyclemodel validation helpers cover invalid report shapes and normalization fallbacks', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-lifecyclemodel-validation-'));
+  const runRoot = path.join(dir, 'lm-run-validation');
+  const outDir = path.join(dir, 'review');
+  const layout = __testInternals.buildLayout(runRoot, outDir);
+
+  try {
+    writeJson(layout.validationReportPath, {
+      ok: 'maybe',
+    });
+    const missingModelReports = __testInternals.readValidationAggregate(layout);
+    assert.equal(missingModelReports.ok, null);
+    assert.equal(missingModelReports.reportPath, layout.validationReportPath);
+    assert.equal(missingModelReports.modelReports.size, 0);
+
+    writeJson(layout.validationReportPath, {
+      ok: 'still-maybe',
+      model_reports: [
+        {
+          run_name: 'model-a',
+          report_file: '   ',
+          validation: {
+            ok: 'still-maybe',
+            reports: {},
+          },
+        },
+      ],
+    });
+    const reportsFallback = __testInternals.readValidationAggregate(layout);
+    const modelAFallback = reportsFallback.modelReports.get('model-a');
+    assert.equal(reportsFallback.ok, null);
+    assert.equal(modelAFallback?.ok, null);
+    assert.equal(modelAFallback?.reportFile, null);
+    assert.equal(modelAFallback?.engineCount, 0);
+    assert.deepEqual(modelAFallback?.issues, []);
+
+    writeJson(layout.validationReportPath, {
+      ok: false,
+      model_reports: [
+        {
+          run_name: 'model-b',
+          report_file: '',
+          validation: {
+            ok: false,
+            reports: [
+              null,
+              {
+                report: null,
+              },
+              {
+                report: {
+                  issues: {},
+                },
+              },
+              {
+                report: {
+                  issues: [123, { severity: 'weird' }],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    const normalized = __testInternals.readValidationAggregate(layout);
+    const modelB = normalized.modelReports.get('model-b');
+    assert.equal(modelB?.engineCount, 4);
+    assert.deepEqual(modelB?.issues, [
+      {
+        issue_code: 'validation_issue',
+        severity: 'error',
+        category: 'unknown',
+        file_path: '<unknown>',
+        message: '123',
+        location: '<root>',
+        context: {},
+      },
+      {
+        issue_code: 'validation_issue',
+        severity: 'error',
+        category: 'unknown',
+        file_path: '<unknown>',
+        message: '{"severity":"weird"}',
+        location: '<root>',
+        context: {},
+      },
+    ]);
+
+    writeJson(layout.validationReportPath, {
+      ok: true,
+      model_reports: {},
+    });
+    assert.throws(() => __testInternals.readValidationAggregate(layout), /model_reports array/u);
+
+    writeJson(layout.validationReportPath, {
+      ok: true,
+      model_reports: [123],
+    });
+    assert.throws(
+      () => __testInternals.readValidationAggregate(layout),
+      /model report entry JSON object/u,
+    );
+
+    writeJson(layout.validationReportPath, {
+      ok: true,
+      model_reports: [
+        {
+          run_name: 'model-c',
+        },
+      ],
+    });
+    assert.throws(
+      () => __testInternals.readValidationAggregate(layout),
+      /contain run_name and validation/u,
+    );
+
+    const invocationIndex = __testInternals.buildInvocationIndex(
+      layout,
+      {
+        schema_version: 'bad',
+        invocations: {},
+      },
+      {
+        runDir: runRoot,
+        outDir,
+      },
+      new Date('2026-03-30T00:00:00.000Z'),
+    );
+    assert.equal(invocationIndex.schema_version, 1);
+    assert.deepEqual(invocationIndex.invocations, [
+      {
+        command: ['review', 'lifecyclemodel', '--run-dir', runRoot, '--out-dir', outDir],
+        cwd: process.cwd(),
+        created_at: '2026-03-30T00:00:00.000Z',
+        run_id: 'lm-run-validation',
+        run_root: runRoot,
+        report_path: layout.reportPath,
+      },
+    ]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('review lifecyclemodel model helpers cover direct payload roots, fallbacks, and invalid artifacts', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-lifecyclemodel-model-'));
+
+  try {
+    const directModelPath = path.join(dir, 'direct-model.json');
+    writeJson(directModelPath, {
+      lifeCycleModelInformation: {
+        quantitativeReference: {
+          referenceToReferenceProcess: 'ref-1',
+        },
+        technology: {
+          processes: {
+            processInstance: createProcessInstance('proc-1', 'oops'),
+          },
+        },
+      },
+      administrativeInformation: {},
+    });
+    const directInfo = __testInternals.readModelFileReviewInfo(directModelPath);
+    assert.equal(directInfo.modelUuid, 'direct-model.json');
+    assert.equal(directInfo.modelVersion, 'unknown');
+    assert.equal(directInfo.referenceProcessInternalId, 'ref-1');
+    assert.equal(directInfo.resultingProcessUuid, null);
+    assert.equal(directInfo.processInstanceCount, 1);
+    assert.equal(directInfo.zeroMultiplicationFactorCount, 0);
+
+    const missingProcessesPath = path.join(dir, 'no-processes.json');
+    writeJson(missingProcessesPath, {
+      lifeCycleModelInformation: {
+        quantitativeReference: {},
+      },
+    });
+    const missingProcessesInfo = __testInternals.readModelFileReviewInfo(missingProcessesPath);
+    assert.equal(missingProcessesInfo.processInstanceCount, 0);
+    assert.equal(missingProcessesInfo.zeroMultiplicationFactorCount, 0);
+
+    const invalidModelPath = path.join(dir, 'invalid-model.json');
+    writeJson(invalidModelPath, []);
+    assert.throws(
+      () => __testInternals.readModelFileReviewInfo(invalidModelPath),
+      /payload JSON object/u,
+    );
+
+    const emptyModelFilesReview = __testInternals.buildModelReview(
+      {
+        runName: 'missing-artifacts',
+        modelFiles: [],
+        summaryPath: path.join(dir, 'missing-artifacts', 'summary.json'),
+        connectionsPath: path.join(dir, 'missing-artifacts', 'connections.json'),
+        processCatalogPath: path.join(dir, 'missing-artifacts', 'process-catalog.json'),
+      },
+      {
+        ok: null,
+        reportPath: null,
+        modelReports: new Map(),
+      },
+    );
+    assert.ok(
+      emptyModelFilesReview.findings.some(
+        (finding) => finding.rule_id === 'missing_model_summary' && finding.model_file === null,
+      ),
+    );
+    assert.ok(
+      emptyModelFilesReview.findings.some(
+        (finding) =>
+          finding.rule_id === 'missing_connections_artifact' && finding.model_file === null,
+      ),
+    );
+    assert.ok(
+      emptyModelFilesReview.findings.some(
+        (finding) => finding.rule_id === 'missing_process_catalog' && finding.model_file === null,
+      ),
+    );
+    assert.ok(
+      emptyModelFilesReview.findings.some(
+        (finding) =>
+          finding.rule_id === 'missing_reference_process_uuid' && finding.model_file === null,
+      ),
+    );
+    assert.ok(
+      emptyModelFilesReview.findings.some(
+        (finding) =>
+          finding.rule_id === 'missing_resulting_process_ref' && finding.model_file === null,
+      ),
+    );
+    assert.ok(
+      emptyModelFilesReview.findings.some(
+        (finding) => finding.rule_id === 'empty_process_instances' && finding.model_file === null,
+      ),
+    );
+
+    const mismatchEntry = {
+      runName: 'mismatch-artifacts',
+      modelFiles: [],
+      summaryPath: path.join(dir, 'mismatch-artifacts', 'summary.json'),
+      connectionsPath: path.join(dir, 'mismatch-artifacts', 'connections.json'),
+      processCatalogPath: path.join(dir, 'mismatch-artifacts', 'process-catalog.json'),
+    };
+    writeJson(mismatchEntry.summaryPath, {
+      process_count: 2,
+      edge_count: 3,
+      multiplication_factors: {
+        only: '1',
+      },
+    });
+    writeJson(mismatchEntry.connectionsPath, [{ src: 'a', dst: 'b' }]);
+    writeJson(mismatchEntry.processCatalogPath, [{ process_uuid: 'a' }]);
+    const mismatchedReview = __testInternals.buildModelReview(mismatchEntry, {
+      ok: null,
+      reportPath: null,
+      modelReports: new Map(),
+    });
+    assert.ok(
+      mismatchedReview.findings.some(
+        (finding) => finding.rule_id === 'process_count_mismatch' && finding.model_file === null,
+      ),
+    );
+    assert.ok(
+      mismatchedReview.findings.some(
+        (finding) => finding.rule_id === 'edge_count_mismatch' && finding.model_file === null,
+      ),
+    );
+    assert.ok(
+      mismatchedReview.findings.some(
+        (finding) =>
+          finding.rule_id === 'process_catalog_count_mismatch' && finding.model_file === null,
+      ),
+    );
+    assert.ok(
+      mismatchedReview.findings.some(
+        (finding) =>
+          finding.rule_id === 'multiplication_factor_count_mismatch' && finding.model_file === null,
+      ),
+    );
+
+    const invalidArtifactsDir = path.join(dir, 'invalid-artifacts');
+    const validModelFile = path.join(invalidArtifactsDir, 'model.json');
+    writeJson(
+      validModelFile,
+      createLifecyclemodelPayload({
+        id: 'valid-model-uuid',
+        processInstances: [createProcessInstance('valid-1', 1)],
+      }),
+    );
+    const invalidArtifactsEntry = {
+      runName: 'invalid-artifacts',
+      modelFiles: [validModelFile],
+      summaryPath: path.join(invalidArtifactsDir, 'summary.json'),
+      connectionsPath: path.join(invalidArtifactsDir, 'connections.json'),
+      processCatalogPath: path.join(invalidArtifactsDir, 'process-catalog.json'),
+    };
+
+    writeJson(invalidArtifactsEntry.summaryPath, []);
+    assert.throws(
+      () =>
+        __testInternals.buildModelReview(invalidArtifactsEntry, {
+          ok: null,
+          reportPath: null,
+          modelReports: new Map(),
+        }),
+      /summary artifact JSON object/u,
+    );
+
+    writeJson(invalidArtifactsEntry.summaryPath, {});
+    writeJson(invalidArtifactsEntry.connectionsPath, {});
+    assert.throws(
+      () =>
+        __testInternals.buildModelReview(invalidArtifactsEntry, {
+          ok: null,
+          reportPath: null,
+          modelReports: new Map(),
+        }),
+      /connections artifact JSON array/u,
+    );
+
+    writeJson(invalidArtifactsEntry.connectionsPath, []);
+    writeJson(invalidArtifactsEntry.processCatalogPath, {});
+    assert.throws(
+      () =>
+        __testInternals.buildModelReview(invalidArtifactsEntry, {
+          ok: null,
+          reportPath: null,
+          modelReports: new Map(),
+        }),
+      /process-catalog artifact JSON array/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelReview rejects missing run manifests and mismatched run ids', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-lifecyclemodel-manifest-'));
+  const missingManifestRunRoot = path.join(dir, 'lm-run-missing-manifest');
+  const mismatchRunRoot = path.join(dir, 'lm-run-mismatch');
+  const outDir = path.join(dir, 'review');
+
+  mkdirSync(missingManifestRunRoot, { recursive: true });
+  writeMinimalRunManifest(mismatchRunRoot, 'some-other-run-id');
+
+  try {
+    await assert.rejects(
+      async () =>
+        runLifecyclemodelReview({
+          runDir: missingManifestRunRoot,
+          outDir,
+        }),
+      /run-manifest artifact not found/u,
+    );
+
+    await assert.rejects(
+      async () =>
+        runLifecyclemodelReview({
+          runDir: mismatchRunRoot,
+          outDir,
+        }),
+      /run manifest runId mismatch/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #45

## Summary
- Implement tiangong review lifecyclemodel as a local-first command that reuses lifecyclemodel auto-build and validate-build artifacts.
- Update CLI help and touched docs so lifecyclemodel review is marked implemented and the validation tools fallback remains the only deferred migration tail.
- Add lifecyclemodel review dispatch and artifact edge-case coverage so the CLI gate stays at full coverage.

## Key Decisions
- Reuse the existing lifecyclemodel run layout and validate-build aggregate report instead of introducing a new review request schema.
- Keep the review slice CLI-native and artifact-first without Python, LangGraph, or skill-local runtime dependencies.

## Validation
- npm run prepush:gate

## Risks / Rollback
- Low risk: the new command only reads existing local artifacts and does not change publish or validation execution paths.

## Follow-ups
- Keep the tiangong validation run tools-engine fallback as a separately tracked later item.

## Workspace Integration
- Requires a later lca-workspace submodule bump after merge; tracked in tiangong-lca/workspace#26.
