### PR TITLE
feat: retire validation tools fallback

### DIFF
--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -342,7 +342,7 @@ npm start -- admin embedding-run --input ./jobs.json --dry-run
 - 输出 `lifecyclemodel_review_timing.md`
 - 输出 `lifecyclemodel_review_report.json`
 
-这个命令当前保持本地 artifact-first，不引入 Python、LangGraph 或 skill 私有 review runtime。`tiangong validation run` 中 `engine=tools -> uv run tidas-validate` 的 fallback 仍然保留，作为后续单独跟踪项。
+这个命令当前保持本地 artifact-first，不引入 Python、LangGraph 或 skill 私有 review runtime。本地 validation 边界也已经收口到 `tidas-sdk` parity validator，不再依赖 `uv run tidas-validate` 这类外部 fallback。
 
 `tiangong flow get` 现在已经承担 flow governance 的只读详情切片，负责：
 
@@ -486,10 +486,8 @@ npm start -- admin embedding-run --input ./jobs.json --dry-run
 
 `tiangong validation run` 负责把本地 TIDAS 包校验统一收口到 CLI：
 
-- `--engine auto`：优先使用本地 `tidas-sdk` parity validator，找不到时回退到 `uv run tidas-validate --format json`
+- `--engine auto`：走本地 `tidas-sdk` parity validator 的默认路径
 - `--engine sdk`：只跑 `tidas-sdk`
-- `--engine tools`：只跑 `tidas-tools`
-- `--engine all`：两边都跑，并给出结构化 comparison
 
 这两个命令都不需要新增 `TIANGONG_LCA_*` 之外的环境变量。
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ This prevents reintroducing a generic MCP transport layer into the CLI runtime.
 
 The remaining planned placeholders in the documented surface are now limited to `auth *` and `job *`.
 
-Within the currently implemented command family, the only intentionally deferred migration tail is still inside `tiangong validation run`: `engine=tools` continues to execute `uv run tidas-validate` until that validation fallback is redesigned in a later tracked change.
-
 The stable launcher is `bin/tiangong.js`. It loads the compiled runtime at `dist/src/main.js`, while `npm start -- ...` rebuilds and dogfoods the same launcher path.
 
 ## Quality gate
@@ -262,7 +260,7 @@ The current lifecyclemodel build family intentionally keeps three boundaries out
 
 `tiangong publish run` is the CLI-side publish contract boundary. It normalizes publish requests, ingests upstream `publish-bundle.json` inputs, writes `normalized-request.json`, `collected-inputs.json`, `relation-manifest.json`, and `publish-report.json`, and keeps commit-mode execution behind explicit executors instead of reintroducing MCP-specific logic into the CLI.
 
-`tiangong validation run` is the CLI-side validation boundary. It standardizes local TIDAS package validation through one JSON report shape, supports `--engine auto|sdk|tools|all`, prefers `tidas-sdk` parity validation when available, and falls back to `uv run tidas-validate --format json` when needed.
+`tiangong validation run` is the CLI-side validation boundary. It standardizes local TIDAS package validation through one JSON report shape, supports `--engine auto|sdk`, and keeps the local package-validation path inside the bundled `tidas-sdk` parity validator instead of shelling out to `tidas-tools`.
 
 Run the built artifact directly:
 

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -106,7 +106,7 @@ tiangong
 | `tiangong review process` | 本地 process review、artifact-first 报告输出、可选 CLI LLM 语义审核 |
 | `tiangong review flow` | 本地 flow governance review、rows-file 物化、artifact-first 报告输出、可选 CLI LLM 语义审核 |
 | `tiangong publish run` | 本地 publish 契约归一化、dry-run/commit、report 输出 |
-| `tiangong validation run` | 本地 `tidas-sdk` / `tidas-tools` 校验收口 |
+| `tiangong validation run` | 本地 `tidas-sdk` parity 校验收口 |
 | `tiangong admin embedding-run` | `embedding_ft` |
 
 此外，CLI 现在已经正式引入 `tiangong lifecyclemodel ...` 一级命名空间，其中：
@@ -183,7 +183,7 @@ tiangong
 - 已实现的 `flow apply-process-flow-repairs` 把治理链中的独立 deterministic repair apply 切片收口到 CLI，固定与 planning 相同的输入契约，直接写出 `patched-processes.json` / `process-patches/**`，并可在 `--process-pool-file` 下同步本地 pool
 - 已实现的 `flow regen-product` 把治理后的 process-side 再生产物链收口到 CLI，在一个命令下固定 `scan -> repair plan -> optional apply -> optional validate` 契约，并把退出码 `1` 保留给 `--apply` 之后的本地校验失败
 - 已实现的 `flow validate-processes` 把治理后 patched process rows 的独立校验切片收口到 CLI，固定 original/patched/scope 三类输入契约，并直接写出 `validation-report.json` / `validation-failures.jsonl`
-- 当前仍然保留的迁移尾巴主要在 `validation run` 的 tools-engine fallback；其余 review / build / publish CLI 面已经进入可执行状态，未迁移子命令只剩 `auth` / `job` 这类 placeholder surface
+- 现有命令族里已经没有残留的 Python / shell validation fallback；其余 review / build / publish CLI 面已经进入可执行状态，未迁移子命令只剩 `auth` / `job` 这类 placeholder surface
 - 这样做的目的不是“假装已完成”，而是先固定命令树，再逐个把 workflow 迁入 TypeScript CLI
 
 ### 2.2 已经固定的工程约束
@@ -641,9 +641,8 @@ tiangong admin embedding-run --input ./jobs.json --dry-run
 
 `validation run` 则固定“统一校验报告层”：
 
-- `auto` 模式优先走 `tidas-sdk`
-- 找不到本地 parity validator 时，回退到 `tidas-tools`
-- `all` 模式会给出两个引擎结果和 comparison
+- `auto` 模式走本地 `tidas-sdk` parity validator 的默认路径
+- `sdk` 模式显式固定到同一条 `tidas-sdk` 校验链
 
 这保证后续 workflow 只依赖 `tiangong validation run`，而不需要在 skill 里自己判断到底调哪个校验器。
 
@@ -827,7 +826,6 @@ npm run prepush:gate
 
 ### 后续只保留原生增量，不再叫“遗留迁移”
 
-- `validation run` 中 `engine=tools -> uv run tidas-validate` 何时移除，取决于统一 validation 收口是否完成
 - lifecyclemodel 的 discovery / AI 选择逻辑，只有在产品面确认需要时才继续抽象成新的 CLI 子命令
 - `auth` / `job` 之类 placeholder surface 只有在真实场景出现时才补齐，而不是为了对称性先做
 - 任何新增能力都必须先定义成 `tiangong <noun> <verb>`，再决定是否要进一步服务化

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -62,7 +62,7 @@ MCP 替代策略也已经固定，不再反复讨论：
 
 继续作为库层存在：
 
-- CLI 调用这些库
+- CLI 直接消费 `tidas-sdk` 的本地 validation/parity 能力，并按需保留 `tidas-tools` 的其他库层职责
 - skills 不再重复实现一遍
 - CLI 不手抄 schema / validation / export 逻辑
 
@@ -115,7 +115,7 @@ MCP 替代策略也已经固定，不再反复讨论：
 - [x] `kb-search` 模块：作为 CLI 内部预备模块存在，但还没有公开命令消费它
 - [x] `unstructured` 模块：作为 CLI 内部预备模块存在，但还没有公开命令消费它
 - [x] `publish` 模块：统一 dry-run / commit / publish report
-- [x] `validation` 模块：统一 `tidas-sdk` / `tidas-tools` 调用
+- [x] `validation` 模块：统一本地校验收口，并固定 SDK-owned validation boundary
 
 ### Phase 4：迁 resulting-process builder
 
@@ -131,7 +131,7 @@ MCP 替代策略也已经固定，不再反复讨论：
 - [x] 所有 publish handoff 统一收口到 `tiangong publish run`
 - [x] `lca-publish-executor` 已收口成 CLI wrapper
 - [x] relation manifest / deferred publish / dry-run / commit 的唯一语义已写进 CLI 文档
-- [x] skills 不再自行判断使用 `tidas-sdk` 还是 `tidas-tools`
+- [x] skills 不再自行判断使用哪个校验器
 
 ### Phase 6：迁 `process-automated-builder`
 
@@ -155,7 +155,7 @@ MCP 替代策略也已经固定，不再反复讨论：
 - [x] `tiangong lifecyclemodel validate-build`
 - [x] `tiangong lifecyclemodel publish-build`
 - [x] 本地 `json_ordered` 组装改为 TS
-- [x] 本地校验统一改为 CLI 调用 `tidas-sdk` / `tidas-tools`
+- [x] 本地校验统一改为 CLI 调用 `tidas-sdk`
 - [x] publish handoff 改为统一 publish 模块
 - [x] canonical skill 入口切为原生 Node `.mjs` -> CLI
 - [x] 不再保留 shell 兼容壳或 Python / MCP runtime
@@ -245,7 +245,6 @@ MCP 替代策略也已经固定，不再反复讨论：
 
 下面这些可以做，但它们已经不是“清遗留”的待办，而是新的产品能力：
 
-- `validation run` 的 tools-engine fallback（当前仍会执行 `uv run tidas-validate`）
 - lifecyclemodel 的 discovery / AI 选择逻辑
 - `auth` / `job` 等只有在真实场景出现时才应该补齐的命令面
 - 更深的 KB / TianGong unstructured 能力，前提是先形成稳定的 CLI 业务动作

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -332,7 +332,7 @@ function renderValidationHelp(): string {
 
 Options:
   --input-dir <dir>    TIDAS package directory
-  --engine <mode>      auto | sdk | tools | all (default: auto)
+  --engine <mode>      auto | sdk (default: auto)
   --report-file <file> Write the structured validation report to a file
   --json               Print compact JSON
   -h, --help
@@ -824,7 +824,7 @@ function renderLifecyclemodelValidateBuildHelp(): string {
 
 Options:
   --run-dir <dir>    Existing lifecyclemodel auto-build run directory
-  --engine <mode>    auto | sdk | tools | all (default: auto)
+  --engine <mode>    auto | sdk (default: auto)
   --json             Print compact JSON
   -h, --help
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,4 +1,3 @@
-import { spawnSync } from 'node:child_process';
 import { existsSync, statSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
@@ -117,10 +116,10 @@ function normalizeValidationMode(value: string | undefined): ValidationMode {
   if (!value) {
     return 'auto';
   }
-  if (value === 'auto' || value === 'sdk' || value === 'tools' || value === 'all') {
+  if (value === 'auto' || value === 'sdk') {
     return value;
   }
-  throw new CliError('Expected --engine to be one of auto, sdk, tools, or all.', {
+  throw new CliError('Expected --engine to be one of auto or sdk.', {
     code: 'VALIDATION_INVALID_ENGINE',
     exitCode: 2,
     details: value,
@@ -152,36 +151,6 @@ function assert_input_dir(inputDir: string): string {
 
   return resolved;
 }
-
-function buildToolsValidationCommand(inputDir: string): string[] {
-  return ['uv', 'run', 'tidas-validate', '-i', inputDir, '--format', 'json'];
-}
-
-function compareValidationReports(
-  left: PackageValidationReport,
-  right: PackageValidationReport,
-): ValidationComparison {
-  const differences: string[] = [];
-
-  if (left.ok !== right.ok) {
-    differences.push('ok');
-  }
-  if (JSON.stringify(left.summary) !== JSON.stringify(right.summary)) {
-    differences.push('summary');
-  }
-  if (JSON.stringify(left.categories) !== JSON.stringify(right.categories)) {
-    differences.push('categories');
-  }
-  if (JSON.stringify(left.issues) !== JSON.stringify(right.issues)) {
-    differences.push('issues');
-  }
-
-  return {
-    equivalent: differences.length === 0,
-    differences,
-  };
-}
-
 export type ValidationSeverity = 'error' | 'warning' | 'info';
 
 export type ValidationIssue = {
@@ -216,8 +185,8 @@ export type PackageValidationReport = {
   issues: ValidationIssue[];
 };
 
-export type ValidationEngine = 'sdk' | 'tools';
-export type ValidationMode = 'auto' | 'sdk' | 'tools' | 'all';
+export type ValidationEngine = 'sdk';
+export type ValidationMode = 'auto' | 'sdk';
 
 export type ValidationExecutionReport = {
   engine: ValidationEngine;
@@ -260,12 +229,6 @@ export type ValidationDeps = {
   loadSdkModule?: () => {
     location: string;
     validatePackageDir: (inputDir: string, emitLogs?: boolean) => unknown;
-  };
-  runToolsCommand?: (command: string[]) => {
-    status: number | null;
-    stdout: string;
-    stderr: string;
-    error?: Error | null;
   };
 };
 
@@ -310,27 +273,6 @@ export function resolveLocalSdkModule(): {
   return resolveSdkModuleFromCandidates(createRequire(import.meta.url), build_sdk_candidates());
 }
 
-export function runCommandCapture(
-  command: string[],
-  spawnSyncImpl: typeof spawnSync = spawnSync,
-): {
-  status: number | null;
-  stdout: string;
-  stderr: string;
-  error?: Error | null;
-} {
-  const result = spawnSyncImpl(command[0], command.slice(1), {
-    encoding: 'utf8',
-  });
-
-  return {
-    status: result.status,
-    stdout: result.stdout ?? '',
-    stderr: result.stderr ?? '',
-    error: result.error,
-  };
-}
-
 async function runSdkValidation(
   inputDir: string,
   deps: ValidationDeps,
@@ -348,91 +290,13 @@ async function runSdkValidation(
   };
 }
 
-async function runToolsValidation(
-  inputDir: string,
-  deps: ValidationDeps,
-): Promise<ValidationExecutionReport> {
-  const startedAt = Date.now();
-  const command = buildToolsValidationCommand(inputDir);
-  const result = (deps.runToolsCommand ?? runCommandCapture)(command);
-
-  if (result.error) {
-    throw new CliError('Failed to run tidas-tools validation command.', {
-      code: 'VALIDATION_TOOLS_EXEC_FAILED',
-      exitCode: 1,
-      details: result.error.message,
-    });
-  }
-
-  const stdout = result.stdout.trim();
-  if (!stdout) {
-    throw new CliError('tidas-tools validation did not return JSON output.', {
-      code: 'VALIDATION_TOOLS_EMPTY_OUTPUT',
-      exitCode: 1,
-      details: {
-        stderr: result.stderr,
-        status: result.status,
-      },
-    });
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(stdout);
-  } catch (error) {
-    throw new CliError('tidas-tools validation did not return valid JSON.', {
-      code: 'VALIDATION_TOOLS_INVALID_JSON',
-      exitCode: 1,
-      details: {
-        stdout,
-        stderr: result.stderr,
-        status: result.status,
-        error: error instanceof Error ? error.message : String(error),
-      },
-    });
-  }
-
-  const report = normalizePackageReport(parsed, inputDir);
-
-  return {
-    engine: 'tools',
-    ok: report.ok,
-    duration_ms: Date.now() - startedAt,
-    location: 'uv run tidas-validate',
-    report,
-    command,
-    command_exit_code: result.status,
-  };
-}
-
 export async function runValidation(
   options: RunValidationOptions,
   deps: ValidationDeps = {},
 ): Promise<ValidationRunReport> {
   const inputDir = assert_input_dir(options.inputDir);
   const mode = normalizeValidationMode(options.engine);
-  const reports: ValidationExecutionReport[] = [];
-
-  if (mode === 'sdk') {
-    reports.push(await runSdkValidation(inputDir, deps));
-  } else if (mode === 'tools') {
-    reports.push(await runToolsValidation(inputDir, deps));
-  } else if (mode === 'all') {
-    reports.push(await runSdkValidation(inputDir, deps));
-    reports.push(await runToolsValidation(inputDir, deps));
-  } else {
-    try {
-      reports.push(await runSdkValidation(inputDir, deps));
-    } catch (error) {
-      if (!(error instanceof CliError) || error.code !== 'VALIDATION_SDK_UNAVAILABLE') {
-        throw error;
-      }
-      reports.push(await runToolsValidation(inputDir, deps));
-    }
-  }
-
-  const comparison =
-    reports.length === 2 ? compareValidationReports(reports[0].report, reports[1].report) : null;
+  const reports: ValidationExecutionReport[] = [await runSdkValidation(inputDir, deps)];
   const reportFile = options.reportFile ? path.resolve(options.reportFile) : null;
   const finalReport: ValidationRunReport = {
     input_dir: inputDir,
@@ -447,7 +311,7 @@ export async function runValidation(
       report: reportFile,
     },
     reports,
-    comparison,
+    comparison: null,
   };
 
   if (reportFile) {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -613,12 +613,12 @@ test('executeCli executes lifecyclemodel validate-build with injected implementa
 
   try {
     const result = await executeCli(
-      ['lifecyclemodel', 'validate-build', '--json', '--run-dir', runDir, '--engine', 'all'],
+      ['lifecyclemodel', 'validate-build', '--json', '--run-dir', runDir, '--engine', 'sdk'],
       {
         ...makeDeps(),
         runLifecyclemodelValidateBuildImpl: async (options) => {
           assert.equal(options.runDir, runDir);
-          assert.equal(options.engine, 'all');
+          assert.equal(options.engine, 'sdk');
           return {
             schema_version: 1,
             generated_at_utc: '2026-03-30T00:00:00.000Z',
@@ -626,7 +626,7 @@ test('executeCli executes lifecyclemodel validate-build with injected implementa
             run_id: 'lm-run',
             run_root: runDir,
             ok: false,
-            engine: 'all',
+            engine: 'sdk',
             counts: {
               models: 1,
               ok: 0,
@@ -2050,7 +2050,7 @@ test('executeCli executes validation run with injected implementation and report
         '--input-dir',
         dir,
         '--engine',
-        'all',
+        'sdk',
         '--report-file',
         './validation-report.json',
       ],
@@ -2058,33 +2058,29 @@ test('executeCli executes validation run with injected implementation and report
         ...makeDeps(),
         runValidationImpl: async (options) => {
           assert.equal(options.inputDir, dir);
-          assert.equal(options.engine, 'all');
+          assert.equal(options.engine, 'sdk');
           assert.equal(options.reportFile, './validation-report.json');
           return {
             input_dir: dir,
-            mode: 'all',
+            mode: 'sdk',
             ok: false,
             summary: {
-              engine_count: 2,
+              engine_count: 1,
               ok_count: 0,
-              failed_count: 2,
+              failed_count: 1,
             },
             files: {
               report: path.join(dir, 'validation-report.json'),
             },
             reports: [],
-            comparison: {
-              equivalent: false,
-              differences: ['summary'],
-            },
+            comparison: null,
           };
         },
       },
     );
 
     assert.equal(result.exitCode, 1);
-    assert.match(result.stdout, /"mode":"all"/u);
-    assert.match(result.stdout, /"comparison"/u);
+    assert.match(result.stdout, /"mode":"sdk"/u);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/lifecyclemodel-validate-build.test.ts
+++ b/test/lifecyclemodel-validate-build.test.ts
@@ -100,7 +100,7 @@ function makeValidationRunReport(
     mode,
     ok,
     summary: {
-      engine_count: mode === 'all' ? 2 : 1,
+      engine_count: 1,
       ok_count: ok ? 1 : 0,
       failed_count: ok ? 0 : 1,
     },
@@ -154,7 +154,7 @@ test('runLifecyclemodelValidateBuild validates all local model bundles and write
     const report = await runLifecyclemodelValidateBuild(
       {
         runDir: runRoot,
-        engine: 'all',
+        engine: 'sdk',
         now: new Date('2026-03-30T00:00:00.000Z'),
         cwd: '/tmp/lifecyclemodel-validate',
       },
@@ -162,7 +162,7 @@ test('runLifecyclemodelValidateBuild validates all local model bundles and write
         runValidationImpl: async (options) => {
           const ok = !options.inputDir.includes('model-b');
           const reportFile = path.resolve(options.reportFile as string);
-          const result = makeValidationRunReport(options.inputDir, ok, reportFile, 'all');
+          const result = makeValidationRunReport(options.inputDir, ok, reportFile, 'sdk');
           writeJson(reportFile, result);
           return result;
         },
@@ -172,7 +172,7 @@ test('runLifecyclemodelValidateBuild validates all local model bundles and write
     assert.equal(report.status, 'completed_lifecyclemodel_validate_build');
     assert.equal(report.run_id, 'lm-run-1');
     assert.equal(report.ok, false);
-    assert.equal(report.engine, 'all');
+    assert.equal(report.engine, 'sdk');
     assert.deepEqual(report.counts, {
       models: 2,
       ok: 1,
@@ -197,7 +197,7 @@ test('runLifecyclemodelValidateBuild validates all local model bundles and write
       '--run-dir',
       runRoot,
       '--engine',
-      'all',
+      'sdk',
     ]);
     assert.equal(invocationIndex.invocations[0]?.cwd, '/tmp/lifecyclemodel-validate');
   } finally {
@@ -400,13 +400,13 @@ test('lifecyclemodel validate-build internals cover layout, invocation index, an
               layout.modelsDir,
               true,
               path.join(layout.reportsDir, 'model-a.json'),
-              'tools',
+              'sdk',
             ),
           },
         ],
         'sdk',
       ),
-      'tools',
+      'sdk',
     );
     assert.equal(__testInternals.resolveReportEngine([], 'sdk'), 'sdk');
     assert.equal(__testInternals.resolveReportEngine([], undefined), 'auto');

--- a/test/review-lifecyclemodel.test.ts
+++ b/test/review-lifecyclemodel.test.ts
@@ -85,7 +85,7 @@ function createValidationAggregateReport(options: {
     modelFiles: string[];
     reportFile: string;
     issues: JsonRecord[];
-    mode?: 'auto' | 'all';
+    mode?: 'auto' | 'sdk';
     ok?: boolean;
   }>;
 }): JsonRecord {
@@ -96,7 +96,7 @@ function createValidationAggregateReport(options: {
     run_id: path.basename(options.runRoot),
     run_root: options.runRoot,
     ok: options.modelReports.every((entry) => entry.ok !== false && entry.issues.length === 0),
-    engine: 'all',
+    engine: 'sdk',
     counts: {
       models: options.modelReports.length,
       ok: options.modelReports.filter((entry) => entry.ok !== false && entry.issues.length === 0)
@@ -118,79 +118,37 @@ function createValidationAggregateReport(options: {
       report_file: entry.reportFile,
       validation: {
         input_dir: path.join(options.runRoot, 'models', entry.runName, 'tidas_bundle'),
-        mode: entry.mode ?? 'all',
+        mode: entry.mode ?? 'sdk',
         ok: entry.ok ?? entry.issues.length === 0,
         summary: {
-          engine_count: entry.mode === 'auto' ? 1 : 2,
-          ok_count: entry.issues.length === 0 ? (entry.mode === 'auto' ? 1 : 2) : 0,
-          failed_count: entry.issues.length === 0 ? 0 : entry.mode === 'auto' ? 1 : 2,
+          engine_count: 1,
+          ok_count: entry.issues.length === 0 ? 1 : 0,
+          failed_count: entry.issues.length === 0 ? 0 : 1,
         },
         files: {
           report: entry.reportFile,
         },
-        reports:
-          entry.mode === 'auto'
-            ? [
-                {
-                  engine: 'sdk',
-                  ok: entry.issues.length === 0,
-                  duration_ms: 0,
-                  location: '/tmp/sdk.js',
-                  report: {
-                    input_dir: path.join(options.runRoot, 'models', entry.runName, 'tidas_bundle'),
-                    ok: entry.issues.length === 0,
-                    summary: {
-                      category_count: 1,
-                      issue_count: entry.issues.length,
-                      error_count: entry.issues.length,
-                      warning_count: 0,
-                      info_count: 0,
-                    },
-                    categories: [],
-                    issues: entry.issues,
-                  },
-                },
-              ]
-            : [
-                {
-                  engine: 'sdk',
-                  ok: entry.issues.length === 0,
-                  duration_ms: 0,
-                  location: '/tmp/sdk.js',
-                  report: {
-                    input_dir: path.join(options.runRoot, 'models', entry.runName, 'tidas_bundle'),
-                    ok: entry.issues.length === 0,
-                    summary: {
-                      category_count: 1,
-                      issue_count: entry.issues.length,
-                      error_count: entry.issues.length,
-                      warning_count: 0,
-                      info_count: 0,
-                    },
-                    categories: [],
-                    issues: entry.issues,
-                  },
-                },
-                {
-                  engine: 'tools',
-                  ok: entry.issues.length === 0,
-                  duration_ms: 0,
-                  location: '/tmp/tools.py',
-                  report: {
-                    input_dir: path.join(options.runRoot, 'models', entry.runName, 'tidas_bundle'),
-                    ok: entry.issues.length === 0,
-                    summary: {
-                      category_count: 1,
-                      issue_count: entry.issues.length,
-                      error_count: entry.issues.length,
-                      warning_count: 0,
-                      info_count: 0,
-                    },
-                    categories: [],
-                    issues: entry.issues,
-                  },
-                },
-              ],
+        reports: [
+          {
+            engine: 'sdk',
+            ok: entry.issues.length === 0,
+            duration_ms: 0,
+            location: '/tmp/sdk.js',
+            report: {
+              input_dir: path.join(options.runRoot, 'models', entry.runName, 'tidas_bundle'),
+              ok: entry.issues.length === 0,
+              summary: {
+                category_count: 1,
+                issue_count: entry.issues.length,
+                error_count: entry.issues.length,
+                warning_count: 0,
+                info_count: 0,
+              },
+              categories: [],
+              issues: entry.issues,
+            },
+          },
+        ],
         comparison: null,
       },
     })),
@@ -303,8 +261,8 @@ test('runLifecyclemodelReview writes artifact-first outputs and dedupes validati
           runName: 'model-a',
           modelFiles: [modelAFile],
           reportFile: path.join(runRoot, 'reports', 'model-validations', 'model-a.json'),
-          issues: [createValidationIssue(modelAFile)],
-          mode: 'all',
+          issues: [createValidationIssue(modelAFile), createValidationIssue(modelAFile)],
+          mode: 'sdk',
           ok: false,
         },
         {

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { chmodSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -9,7 +9,6 @@ import {
   resolveLocalSdkModule,
   resolveRepoRootFrom,
   resolveSdkModuleFromCandidates,
-  runCommandCapture,
   runValidation,
 } from '../src/lib/validation.js';
 
@@ -70,7 +69,7 @@ test('runValidation uses sdk mode, normalizes the report, and writes the report 
   }
 });
 
-test('runValidation falls back to tools in auto mode when the sdk is unavailable', async () => {
+test('runValidation uses sdk validation in auto mode', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-validation-auto-'));
 
   try {
@@ -79,90 +78,17 @@ test('runValidation falls back to tools in auto mode when the sdk is unavailable
         inputDir: dir,
       },
       {
-        loadSdkModule: () => {
-          throw new CliError('sdk unavailable', {
-            code: 'VALIDATION_SDK_UNAVAILABLE',
-            exitCode: 2,
-          });
-        },
-        runToolsCommand: (command) => {
-          assert.deepEqual(command, ['uv', 'run', 'tidas-validate', '-i', dir, '--format', 'json']);
-          return {
-            status: 1,
-            stdout: JSON.stringify(makeValidationReport(dir, 'tools_error')),
-            stderr: '',
-          };
-        },
-      },
-    );
-
-    assert.equal(report.mode, 'auto');
-    assert.equal(report.reports[0].engine, 'tools');
-    assert.equal(report.reports[0].command_exit_code, 1);
-    assert.equal(report.ok, false);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test('runValidation all mode compares sdk and tools results', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-validation-all-'));
-  const sharedReport = makeValidationReport(dir, 'parity_error');
-
-  try {
-    const report = await runValidation(
-      {
-        inputDir: dir,
-        engine: 'all',
-      },
-      {
-        loadSdkModule: () => ({
-          location: '/tmp/sdk.js',
-          validatePackageDir: () => sharedReport,
-        }),
-        runToolsCommand: () => ({
-          status: 1,
-          stdout: JSON.stringify(sharedReport),
-          stderr: '',
-        }),
-      },
-    );
-
-    assert.equal(report.reports.length, 2);
-    assert.equal(report.comparison?.equivalent, true);
-    assert.deepEqual(report.comparison?.differences, []);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test('runValidation all mode reports comparison differences', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-validation-diff-'));
-
-  try {
-    const report = await runValidation(
-      {
-        inputDir: dir,
-        engine: 'all',
-      },
-      {
         loadSdkModule: () => ({
           location: '/tmp/sdk.js',
           validatePackageDir: () => makeValidationReport(dir, 'sdk_error'),
         }),
-        runToolsCommand: () => ({
-          status: 0,
-          stdout: JSON.stringify({
-            input_dir: dir,
-            ok: true,
-          }),
-          stderr: '',
-        }),
       },
     );
 
-    assert.equal(report.comparison?.equivalent, false);
-    assert.deepEqual(report.comparison?.differences, ['ok', 'summary', 'categories', 'issues']);
+    assert.equal(report.mode, 'auto');
+    assert.equal(report.reports[0].engine, 'sdk');
+    assert.equal(report.ok, false);
+    assert.equal(report.comparison, null);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -177,33 +103,15 @@ test('runValidation can use the default local sdk loader when available', async 
       inputDir: dir,
       engine: 'sdk',
     });
-    const commandResult = runCommandCapture([
-      process.execPath,
-      '--eval',
-      "process.stdout.write('ok')",
-    ]);
-    const fallbackCommandResult = runCommandCapture(['ignored'], (() => ({
-      pid: 1,
-      output: [],
-      signal: null,
-      status: 0,
-      stdout: undefined,
-      stderr: undefined,
-      error: undefined,
-    })) as unknown as typeof import('node:child_process').spawnSync);
 
     assert.equal(typeof localSdk.validatePackageDir, 'function');
     assert.equal(sdkReport.ok, true);
-    assert.equal(commandResult.status, 0);
-    assert.equal(commandResult.stdout, 'ok');
-    assert.equal(fallbackCommandResult.stdout, '');
-    assert.equal(fallbackCommandResult.stderr, '');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test('runValidation resolves sdk candidates and surfaces resolution failures and auto-mode rethrows non-fallback errors', async () => {
+test('runValidation resolves sdk candidates and surfaces resolution failures', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-validation-default-errors-'));
 
   try {
@@ -248,6 +156,24 @@ test('runValidation resolves sdk candidates and surfaces resolution failures and
           },
         ),
       /broken sdk/u,
+    );
+
+    await assert.rejects(
+      async () =>
+        runValidation(
+          {
+            inputDir: dir,
+          },
+          {
+            loadSdkModule: () => {
+              throw new CliError('sdk unavailable', {
+                code: 'VALIDATION_SDK_UNAVAILABLE',
+                exitCode: 2,
+              });
+            },
+          },
+        ),
+      /sdk unavailable/u,
     );
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -346,57 +272,23 @@ test('resolveRepoRootFrom falls back to process.cwd when no package.json exists 
   assert.equal(resolved, process.cwd());
 });
 
-test('runValidation tools mode can use the default command runner from PATH', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-validation-default-tools-'));
-  const binDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-validation-bin-'));
-  const uvPath = path.join(binDir, 'uv');
-  const originalPath = process.env.PATH ?? '';
-
-  writeFileSync(
-    uvPath,
-    `#!/bin/sh
-printf '%s' '{"input_dir":"${dir}","ok":true,"categories":[]}'
-`,
-    'utf8',
-  );
-  chmodSync(uvPath, 0o755);
-  process.env.PATH = `${binDir}${path.delimiter}${originalPath}`;
-
-  try {
-    const report = await runValidation({
-      inputDir: dir,
-      engine: 'tools',
-    });
-
-    assert.equal(report.reports[0].engine, 'tools');
-    assert.equal(report.reports[0].location, 'uv run tidas-validate');
-    assert.equal(report.reports[0].command_exit_code, 0);
-    assert.equal(report.ok, true);
-  } finally {
-    process.env.PATH = originalPath;
-    rmSync(binDir, { recursive: true, force: true });
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test('runValidation covers direct tools mode and successful auto sdk mode', async () => {
+test('runValidation covers direct sdk mode and successful auto sdk mode', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-validation-modes-'));
 
   try {
-    const toolsReport = await runValidation(
+    const sdkReport = await runValidation(
       {
         inputDir: dir,
-        engine: 'tools',
+        engine: 'sdk',
       },
       {
-        runToolsCommand: () => ({
-          status: 0,
-          stdout: JSON.stringify({
+        loadSdkModule: () => ({
+          location: '/tmp/sdk.js',
+          validatePackageDir: () => ({
             input_dir: dir,
             ok: true,
             categories: [],
           }),
-          stderr: '',
         }),
       },
     );
@@ -417,7 +309,7 @@ test('runValidation covers direct tools mode and successful auto sdk mode', asyn
       },
     );
 
-    assert.equal(toolsReport.reports[0].engine, 'tools');
+    assert.equal(sdkReport.reports[0].engine, 'sdk');
     assert.equal(autoReport.reports[0].engine, 'sdk');
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -457,100 +349,20 @@ test('runValidation validates the input directory and engine value', async () =>
       async () =>
         runValidation({
           inputDir: fileDir,
-          engine: 'remote',
+          engine: 'tools',
+        }),
+      /Expected --engine/u,
+    );
+
+    await assert.rejects(
+      async () =>
+        runValidation({
+          inputDir: fileDir,
+          engine: 'all',
         }),
       /Expected --engine/u,
     );
   } finally {
     rmSync(fileDir, { recursive: true, force: true });
-  }
-});
-
-test('runValidation surfaces tool execution failures and invalid JSON output', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-validation-errors-'));
-  const originalParse = JSON.parse;
-
-  try {
-    await assert.rejects(
-      async () =>
-        runValidation(
-          {
-            inputDir: dir,
-            engine: 'tools',
-          },
-          {
-            runToolsCommand: () => ({
-              status: null,
-              stdout: '',
-              stderr: 'exec failed',
-              error: new Error('spawn failed'),
-            }),
-          },
-        ),
-      /Failed to run tidas-tools validation/u,
-    );
-
-    await assert.rejects(
-      async () =>
-        runValidation(
-          {
-            inputDir: dir,
-            engine: 'tools',
-          },
-          {
-            runToolsCommand: () => ({
-              status: 1,
-              stdout: 'not-json',
-              stderr: '',
-            }),
-          },
-        ),
-      /did not return valid JSON/u,
-    );
-
-    JSON.parse = (() => {
-      throw 'non-error parse failure';
-    }) as typeof JSON.parse;
-
-    await assert.rejects(
-      async () =>
-        runValidation(
-          {
-            inputDir: dir,
-            engine: 'tools',
-          },
-          {
-            runToolsCommand: () => ({
-              status: 1,
-              stdout: '{}',
-              stderr: '',
-            }),
-          },
-        ),
-      /did not return valid JSON/u,
-    );
-
-    JSON.parse = originalParse;
-
-    await assert.rejects(
-      async () =>
-        runValidation(
-          {
-            inputDir: dir,
-            engine: 'tools',
-          },
-          {
-            runToolsCommand: () => ({
-              status: 1,
-              stdout: '',
-              stderr: 'empty',
-            }),
-          },
-        ),
-      /did not return JSON output/u,
-    );
-  } finally {
-    JSON.parse = originalParse;
-    rmSync(dir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
Closes #49

## Summary

- remove the direct `uv run tidas-validate` execution path from `tiangong validation run`
- collapse local validation onto the bundled `tidas-sdk` parity validator and narrow the engine surface to `auto|sdk`
- align `lifecyclemodel validate-build`, tests, and docs with the SDK-only validation contract

## Key Decisions

- remove `tools` / `all` instead of keeping compatibility aliases so the validation surface matches the real runtime boundary
- keep the structured validation report shape stable, with one SDK execution report and `comparison: null`
- treat `auto` as the default policy alias for the same SDK-owned validation path

## Validation

- `npm run lint`
- `npm test -- test/validation.test.ts test/cli.test.ts test/lifecyclemodel-validate-build.test.ts test/review-lifecyclemodel.test.ts`
- `npm run test:coverage`
- `npm run test:coverage:assert-full`

## Risks / Rollback

- callers that still pass `--engine tools` or `--engine all` now need to switch to `auto` or `sdk`
- rollback is straightforward: revert this PR to restore the previous multi-engine surface and `tidas-tools` shell-out path

## Follow-ups

- the workspace Project schema currently lacks a `cli` option in the `Repo Tag` field, so issue/PR item classification still needs a schema fix or manual adjustment outside this PR

## Workspace Integration

- requires a later `lca-workspace` submodule bump after merge
