### PR TITLE
docs: close out migration checklist

### DIFF
--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -4,15 +4,15 @@
 
 当前更准确的判断是：
 
-- `tiangong-lca-cli` 和 `tiangong-lca-skills` 的主运行时路径，已经基本收敛到 TypeScript / Node + `tiangong` CLI
-- 但仓库治理、开发质量门、文档和跨平台验证还没有完全收口
-- 因此现在还不能把这项工作标记为“已经彻底脱离 Python 和无法跨平台的 shell”
+- `tiangong-lca-cli` 和 `tiangong-lca-skills` 的主运行时路径，已经完全收敛到 TypeScript / Node + `tiangong` CLI
+- 仓库治理、开发质量门、公开文档和跨平台验证都已完成闭环
+- 因此现在可以把这项工作标记为“已经彻底脱离 Python 和无法跨平台的 shell”
 
 这份文档记录的是：
 
 - 已经确认完成的部分
-- 还没有完成的阻塞项
-- 一份可以按顺序执行、可以验收的整改 TODO
+- 最终验收证据
+- 一份已经按顺序清完并可回溯的整改 TODO
 
 ## 1. 审计后现状
 
@@ -27,30 +27,30 @@
 - [x] `tiangong-lca-cli` 的本地 coverage 路径已改成 Node-only 脚本，不再依赖 POSIX 风格内联 env 赋值
 - [x] `tiangong-lca-cli` 已增加 coverage-ignore 守卫，并明确禁止用 ignore pragma 逃避测试覆盖
 
-### 1.2 还没有完成
+### 1.2 已完成闭环
 
-- [ ] `tiangong-lca-cli` 的质量门脚本还没有做到真正跨平台
-- [ ] CLI 和 skills 的公开文档仍然默认读者处在 Unix / POSIX shell 环境
-- [ ] `tiangong-lca-skills` 的治理文档还保留 Python 初始化流程残影
-- [ ] 部分参考文档和兼容层还保留 legacy Python 字段或脚本名
-- [ ] “测试全绿 + 100% 覆盖率” 还没有形成跨平台、可自动验证的统一门禁
-- [ ] 目前缺少足够的跨平台 CI 证据来支撑“完全脱离”的结论
+- [x] `tiangong-lca-cli` 的质量门脚本现已做到真正跨平台
+- [x] CLI 和 skills 的公开文档不再默认读者处在 Unix / POSIX shell 环境
+- [x] `tiangong-lca-skills` 的治理文档不再保留 Python 初始化流程残影
+- [x] 参考文档和兼容层里只剩明确标注的 historical Python 提示，不再把 legacy 字段或脚本名当作当前路径
+- [x] “测试全绿 + 100% 覆盖率” 已形成跨平台、可自动验证的统一门禁
+- [x] 现在已有足够的跨平台 CI 证据来支撑“完全脱离”的结论
 
 ## 2. “完全脱离” 的完成定义
 
 只有下面全部满足，才可以把这项工作改回完成态：
 
-- [ ] 两个仓库都不再要求 Python 作为运行时、脚手架或维护工具前提
-- [ ] `npm` / `node` 的核心质量门命令在 macOS、Linux、Windows 上都可直接运行
-- [ ] `.env.example`、README、`DEV_CN.md` 与真实公开 env contract 完全一致，并明确区分 required / optional / internal-only
-- [ ] 默认文档不再把 `bash` / `cp` / `/tmp` / `nvm` 作为唯一可用路径
-- [ ] skills 的治理与校验流程不再要求或暗示 Python 初始化器
-- [ ] 公开 contract 和示例不再把 Python legacy 字段写成“当前输入面的一部分”
-- [ ] CLI 和 skills 不兼容任何 legacy Python 输入面；不保留 Python fallback、兼容别名、兼容归一化层或“先读进来再拒绝”的兼容解析
-- [ ] 仓库不允许通过 `c8 ignore`、`istanbul ignore` 或同类 pragma 跳过未覆盖分支；边缘分支必须用测试覆盖
-- [ ] `npm test`、`npm run test:coverage`、`npm run test:coverage:assert-full`、`npm run prepush:gate` 形成统一的本地与 CI 门禁，并以 100% 覆盖率为硬要求
-- [ ] 有 CI 或等价自动化证据证明 CLI 与 skills wrapper 至少在 Linux + Windows 上可执行
-- [ ] 只有在完成上面所有项后，文档才允许重新使用“迁移已全部完成”或“已经彻底脱离”这类表述
+- [x] 两个仓库都不再要求 Python 作为运行时、脚手架或维护工具前提
+- [x] `npm` / `node` 的核心质量门命令在 macOS、Linux、Windows 上都可直接运行
+- [x] `.env.example`、README、`DEV_CN.md` 与真实公开 env contract 完全一致，并明确区分 required / optional / internal-only
+- [x] 默认文档不再把 `bash` / `cp` / `/tmp` / `nvm` 作为唯一可用路径
+- [x] skills 的治理与校验流程不再要求或暗示 Python 初始化器
+- [x] 公开 contract 和示例不再把 Python legacy 字段写成“当前输入面的一部分”
+- [x] CLI 和 skills 不兼容任何 legacy Python 输入面；不保留 Python fallback、兼容别名、兼容归一化层或“先读进来再拒绝”的兼容解析
+- [x] 仓库不允许通过 `c8 ignore`、`istanbul ignore` 或同类 pragma 跳过未覆盖分支；边缘分支必须用测试覆盖
+- [x] `npm test`、`npm run test:coverage`、`npm run test:coverage:assert-full`、`npm run prepush:gate` 形成统一的本地与 CI 门禁，并以 100% 覆盖率为硬要求
+- [x] 有 CI 或等价自动化证据证明 CLI 与 skills wrapper 至少在 Linux + Windows 上可执行
+- [x] 现在文档可以重新使用“迁移已全部完成”或“已经彻底脱离”这类表述
 
 ## 3. 推荐执行顺序
 
@@ -67,7 +67,7 @@
 
 ### Phase 1：修复 CLI 的跨平台质量门
 
-当前状态：已完成本地脚本与文档收口；Windows / CI 证明仍待 Phase 6 完成。
+当前状态：已完成；本地与远端跨平台质量门都已闭环。
 
 - [x] 补全 `.env.example`，并让它和真实 env contract 对齐当前阻塞：`.env.example` 只列出了 API / LLM 变量，但代码里还存在 `TIANGONG_LCA_KB_SEARCH_*`、`TIANGONG_LCA_UNSTRUCTURED_*` 等 env 面处理目标：先按“公开命令实际消费”与“内部预备模块保留”做分类，再决定哪些 env 必须进入 `.env.example`，哪些应进入单独的 advanced/internal 文档最低要求：不能继续出现“代码里真实使用，但 `.env.example` 和 README / DEV 完全看不见”的 env 涉及文件：`tiangong-lca-cli/.env.example` 涉及文件：`tiangong-lca-cli/README.md` 涉及文件：`tiangong-lca-cli/DEV_CN.md` 涉及文件：`tiangong-lca-cli/src/lib/env.ts` 涉及文件：`tiangong-lca-cli/src/lib/llm.ts` 涉及文件：`tiangong-lca-cli/src/lib/kb-search.ts` 涉及文件：`tiangong-lca-cli/src/lib/unstructured.ts` 验收标准：一个维护者只看 `.env.example` 和 README / DEV，就能知道当前公开支持的 env、可选 env，以及哪些 env 只是内部预备面已完成：`.env.example`、README、`DEV_CN.md` 已补上 public / optional / internal-preparatory 的明确分层
 
@@ -77,9 +77,9 @@
 
 - [x] 确认 `prepush:gate` 只依赖跨平台命令当前要求：`prepush:gate` 依赖 `test:coverage` 处理目标：`npm run prepush:gate` 不再因为 shell 语法差异在 Windows 失败涉及文件：`tiangong-lca-cli/package.json` 验收标准：`npm run prepush:gate` 在至少 Linux + Windows 两个平台上跑通已完成：本地门禁链条已全部转成 `npm` / `node` / `tsx` 路径；Windows 真实验证留给 Phase 6 的 OS matrix
 
-- [ ] 把“测试全绿 + 100% 覆盖率” 固化为唯一通过门槛当前状态：本地文档和 `prepush:gate` 已经表达了这个方向，但还没有在跨平台 CI 里形成稳定、可见、不可绕过的统一门禁处理目标：明确以下四个命令的角色并接入门禁： `npm test` `npm run test:coverage` `npm run test:coverage:assert-full` `npm run prepush:gate` 要求：所有测试必须通过，且 `src/**/*.ts` 维持 lines / statements / functions / branches 全部 100% 涉及文件：`tiangong-lca-cli/package.json` 涉及文件：`tiangong-lca-cli/AGENTS.md` 涉及文件：`tiangong-lca-cli/README.md` 涉及文件：`tiangong-lca-cli/DEV_CN.md` 涉及文件：`tiangong-lca-cli/scripts/assert-full-coverage.ts` 验收标准：本地与 CI 都以“测试全绿 + 严格 100% 覆盖率”作为硬门禁，不存在只跑部分测试或只看松散 coverage summary 的路径当前进展：本地 `npm test`、`npm run test:coverage`、`npm run test:coverage:assert-full`、`npm run prepush:gate` 已全部通过；2026-03-31 已把 coverage 断言收敛到 CLI 自有 `src` 文件集合，并在本地按 CI 方式 checkout/build `.ci/tidas-sdk` 后再次执行 `TIANGONG_LCA_TIDAS_SDK_DIR=$PWD/.ci/tidas-sdk npm run test:coverage`、`npm run test:coverage:assert-full`、`npm run prepush:gate` 全部通过且维持 100% 覆盖率；同日又基于合并后的 `main` 补掉 7 处残余 Windows-only 测试假设，并再次本地执行 `npm test` 与 CI 风格 `TIANGONG_LCA_TIDAS_SDK_DIR=$PWD/.ci/tidas-sdk npm run prepush:gate` 通过；repo-local CI workflow 也已接入这些门禁，等待 follow-up 远端 matrix 结果作为最终证据
+- [x] 把“测试全绿 + 100% 覆盖率” 固化为唯一通过门槛当前状态：本地文档和 `prepush:gate` 已经表达了这个方向，但还没有在跨平台 CI 里形成稳定、可见、不可绕过的统一门禁处理目标：明确以下四个命令的角色并接入门禁： `npm test` `npm run test:coverage` `npm run test:coverage:assert-full` `npm run prepush:gate` 要求：所有测试必须通过，且 `src/**/*.ts` 维持 lines / statements / functions / branches 全部 100% 涉及文件：`tiangong-lca-cli/package.json` 涉及文件：`tiangong-lca-cli/AGENTS.md` 涉及文件：`tiangong-lca-cli/README.md` 涉及文件：`tiangong-lca-cli/DEV_CN.md` 涉及文件：`tiangong-lca-cli/scripts/assert-full-coverage.ts` 验收标准：本地与 CI 都以“测试全绿 + 严格 100% 覆盖率”作为硬门禁，不存在只跑部分测试或只看松散 coverage summary 的路径已完成：本地 `npm test`、`npm run test:coverage`、`npm run test:coverage:assert-full`、`npm run prepush:gate` 均已通过；coverage 断言现只聚焦 CLI 自有 `src` 文件集合；在本地按 CI 方式 checkout/build `.ci/tidas-sdk` 后再次执行 `TIANGONG_LCA_TIDAS_SDK_DIR=$PWD/.ci/tidas-sdk npm run test:coverage`、`npm run test:coverage:assert-full`、`npm run prepush:gate` 保持 100% 覆盖率；follow-up PR `tiangong-lca/tiangong-cli#53` 的 `ubuntu-latest` + `windows-latest` matrix 已双绿并合并
 
-- [ ] 为覆盖率质量门补一个最小的 Windows 回归验证处理目标：避免后续有人把 POSIX-only 语法重新加回 `package.json` 涉及文件：`tiangong-lca-cli/.github/workflows/*` 或等价 CI 所在位置验收标准：CI 中存在明确的 Windows 任务覆盖 `npm run test:coverage` 当前进展：已新增 repo-local workflow，在 `windows-latest` 上显式运行 `npm run test:coverage`、`npm run test:coverage:assert-full` 和 `npm run prepush:gate`
+- [x] 为覆盖率质量门补一个最小的 Windows 回归验证处理目标：避免后续有人把 POSIX-only 语法重新加回 `package.json` 涉及文件：`tiangong-lca-cli/.github/workflows/*` 或等价 CI 所在位置验收标准：CI 中存在明确的 Windows 任务覆盖 `npm run test:coverage` 已完成：repo-local workflow 已在 `windows-latest` 上显式运行 `npm run test:coverage`、`npm run test:coverage:assert-full` 和 `npm run prepush:gate`，并已随 PR `#53` 远端通过
 
 ### Phase 2：补齐 CLI 的跨平台文档
 
@@ -117,45 +117,45 @@
 
 - [x] 明确 `tiangong-lca-cli` 的 CI 归属当前状态：仓库里没有可见的 repo-local `.github/workflows` 需要先回答：CI 是应该在子仓库内维护，还是在别处统一维护验收标准：这个归属必须写清楚，不能继续处于“默认存在但仓库里看不到”的状态已完成：已在 `tiangong-lca-cli/.github/workflows/quality-gate.yml` 中建立 repo-local 质量门，CLI 的跨平台门禁归属已回到子仓库内可见维护
 
-- [ ] 为 `tiangong-lca-cli` 增加或接入 OS matrix 验证最低要求：`ubuntu-latest` + `windows-latest` 推荐要求：`ubuntu-latest` + `windows-latest` + `macos-latest` 最少命令：`npm ci`、`npm run build`、`npm run lint`、`npm test` 必做命令：`npm run test:coverage`、`npm run test:coverage:assert-full` 推荐命令：`npm run prepush:gate` 验收标准：有自动化记录证明 CLI 至少在 Linux + Windows 上通过，并且 100% 覆盖率门在 CI 中真实执行当前进展：workflow 已配置 `ubuntu-latest` + `windows-latest` matrix，并补上 CI 内显式 checkout/build `tidas-sdk` 与 `TIANGONG_LCA_TIDAS_SDK_DIR` 注入；2026-03-31 本地先补掉了远端 run 暴露出的首批真实缺口：coverage summary 不再把仓内 `.ci/tidas-sdk` 计入 CLI 总分，`process-resume-build` / `process-publish-build` / `publish` / `run` 测试不再写死 POSIX 路径，`state-lock` 边缘测试也改成直接覆盖异常注入而非依赖 Unix 权限和路径长度语义；随后 PR `tiangong-lca/tiangong-cli#52` 在 Windows job 完成前被合并，而该 job 又暴露出 7 处剩余 test-only 路径 / URL / 正则假设，因此已重新打开 child issue `#51` 并基于 merged `main` 拉起 follow-up 修复；这 7 处现已在本地全部修完，并再次按 CI 方式 checkout/build `.ci/tidas-sdk` 后执行 `npm test` 与 `TIANGONG_LCA_TIDAS_SDK_DIR=$PWD/.ci/tidas-sdk npm run prepush:gate` 全通过且保持 100% 覆盖率；等待 follow-up 远端 matrix 复验作为最终自动化证据
+- [x] 为 `tiangong-lca-cli` 增加或接入 OS matrix 验证最低要求：`ubuntu-latest` + `windows-latest` 推荐要求：`ubuntu-latest` + `windows-latest` + `macos-latest` 最少命令：`npm ci`、`npm run build`、`npm run lint`、`npm test` 必做命令：`npm run test:coverage`、`npm run test:coverage:assert-full` 推荐命令：`npm run prepush:gate` 验收标准：有自动化记录证明 CLI 至少在 Linux + Windows 上通过，并且 100% 覆盖率门在 CI 中真实执行已完成：workflow 已配置 `ubuntu-latest` + `windows-latest` matrix，并补上 CI 内显式 checkout/build `tidas-sdk` 与 `TIANGONG_LCA_TIDAS_SDK_DIR` 注入；本地修复了 coverage summary、路径断言、URL/正则和锁文件边缘测试里的全部 Windows-only 假设；最终 follow-up PR `tiangong-lca/tiangong-cli#53` 已在 `ubuntu-latest` + `windows-latest` 上双绿并合并，CLI 的跨平台自动化证据现已成立
 
 - [x] 扩展 `tiangong-lca-skills` 的 `validate-skills` workflow 为 OS matrix 当前状态：只在 `ubuntu-latest` 运行处理目标：至少补 Windows，证明 wrapper + CLI 委托链在 Windows 上成立涉及文件：`tiangong-lca-skills/.github/workflows/validate-skills.yml` 验收标准：`node scripts/validate-skills.mjs` 在 Linux + Windows 上通过当前进展：workflow 已改成 `ubuntu-latest` + `windows-latest` matrix，并补上 CRLF 兼容的 frontmatter 校验；2026-03-31 已再次本地执行 `node scripts/validate-skills.mjs` 通过，并已随 commit `5fbe073` 推送到 PR `tiangong-lca/skills#39`；失败原因、修复内容和复验结果也已补充记录到 PR 评论；远端 run `23807639148` 已确认 `ubuntu-latest` + `windows-latest` 双绿
 
 ### Phase 7：最终审计与关账
 
-- [ ] 重新跑代码扫描推荐扫描项： `rg --files -g '*.py' -g '*.sh'` `rg -n 'init_skill\\.py|quick_validate\\.py|run_lifecyclemodel_review\\.py|validate\\.py'` `rg -n 'curl -o-|install\\.sh \\| bash|cp \\.env\\.example \\.env|TIANGONG_LCA_COVERAGE=1'` 验收标准：结果只剩明确允许的历史说明，且不再出现在主路径文档和质量门里
+- [x] 重新跑代码扫描推荐扫描项： `rg --files -g '*.py' -g '*.sh'` `rg -n 'init_skill\\.py|quick_validate\\.py|run_lifecyclemodel_review\\.py|validate\\.py'` `rg -n 'curl -o-|install\\.sh \\| bash|cp \\.env\\.example \\.env|TIANGONG_LCA_COVERAGE=1'` 验收标准：结果只剩明确允许的历史说明，且不再出现在主路径文档和质量门里已完成：`tiangong-lca-cli` 与 `tiangong-lca-skills` 均未再发现运行时 `.py` / `.sh` 文件；命中项只剩 checklist 自身的历史整改记录，以及 `tiangong-lca-skills/lifecyclemodel-automated-builder/references/source-analysis.md` 中明确标注为 historical upstream note 的 `validate.py` 背景说明
 
-- [ ] 重新跑最小 smoke test 推荐命令： `node ./bin/tiangong.js --help` `node ./bin/tiangong.js doctor --json` `node ./scripts/validate-skills.mjs --help` 以及至少两个 representative wrapper 的 `--help` 验收标准：所有入口都只经过 Node / CLI 路径，不再依赖 Python 或 shell shim
+- [x] 重新跑最小 smoke test 推荐命令： `node ./bin/tiangong.js --help` `node ./bin/tiangong.js doctor --json` `node ./scripts/validate-skills.mjs --help` 以及至少两个 representative wrapper 的 `--help` 验收标准：所有入口都只经过 Node / CLI 路径，不再依赖 Python 或 shell shim已完成：`node ./bin/tiangong.js --help`、`node ./bin/tiangong.js doctor --json`、`node ./scripts/validate-skills.mjs --help`、`node ./process-automated-builder/scripts/run-process-automated-builder.mjs --help`、`node ./lifecyclemodel-recursive-orchestrator/scripts/run-lifecyclemodel-recursive-orchestrator.mjs --help` 均已执行，入口链路只经过 Node / CLI
 
-- [ ] 只有在所有验收项完成后，再更新迁移结论处理目标：把“基本完成”改回“完全脱离”验收标准：这一步必须是最后一步，不能提前写结论
+- [x] 只有在所有验收项完成后，再更新迁移结论处理目标：把“基本完成”改回“完全脱离”验收标准：这一步必须是最后一步，不能提前写结论已完成：现在可以重新使用“迁移已全部完成”与“已经彻底脱离 Python 和无法跨平台 shell”这类表述
 
 ## 5. 文件级工作面
 
 ### 5.1 `tiangong-lca-cli`
 
-- [ ] `package.json`
-- [ ] `.env.example`
-- [ ] `README.md`
-- [ ] `DEV_CN.md`
-- [ ] `docs/IMPLEMENTATION_GUIDE_CN.md`
-- [ ] `src/lib/lifecyclemodel-orchestrate.ts`
-- [ ] `src/lib/env.ts`
-- [ ] `src/lib/llm.ts`
-- [ ] `src/lib/kb-search.ts`
-- [ ] `src/lib/unstructured.ts`
-- [ ] `test/lifecyclemodel-orchestrate.test.ts`
-- [ ] `scripts/*` 中新增跨平台辅助脚本（如需要）
-- [ ] `.github/workflows/*` 或等价 CI 位置（如由该仓库维护）
+- [x] `package.json`
+- [x] `.env.example`
+- [x] `README.md`
+- [x] `DEV_CN.md`
+- [x] `docs/IMPLEMENTATION_GUIDE_CN.md`
+- [x] `src/lib/lifecyclemodel-orchestrate.ts`
+- [x] `src/lib/env.ts`
+- [x] `src/lib/llm.ts`
+- [x] `src/lib/kb-search.ts`
+- [x] `src/lib/unstructured.ts`
+- [x] `test/lifecyclemodel-orchestrate.test.ts`
+- [x] `scripts/*` 中新增跨平台辅助脚本（如需要）
+- [x] `.github/workflows/*` 或等价 CI 位置（如由该仓库维护）
 
 ### 5.2 `tiangong-lca-skills`
 
-- [ ] `AGENTS.md`
-- [ ] `README.md`
-- [ ] `README.zh-CN.md`
-- [ ] `scripts/validate-skills.mjs`
-- [ ] `lifecyclemodel-automated-builder/references/source-analysis.md`
-- [ ] 各 skill `assets/` 下的 user-facing 示例文件
-- [ ] `.github/workflows/validate-skills.yml`
+- [x] `AGENTS.md`
+- [x] `README.md`
+- [x] `README.zh-CN.md`
+- [x] `scripts/validate-skills.mjs`
+- [x] `lifecyclemodel-automated-builder/references/source-analysis.md`
+- [x] 各 skill `assets/` 下的 user-facing 示例文件
+- [x] `.github/workflows/validate-skills.yml`
 
 ## 6. 已经做完但不应回退的项
 
@@ -174,6 +174,4 @@
 
 > 一个 agent 要完成工作时，是否只需要知道 `tiangong` 命令树，并且在 macOS / Linux / Windows 上都能按文档和质量门执行，而不需要知道 skills 内部的 Python、MCP、shell 兼容层细节？
 
-当前答案还不是“完全是”。
-
-把这份 TODO 清完之后，才可以把答案改成“是”。
+当前答案已经是“是”。


### PR DESCRIPTION
Closes tiangong-lca/tiangong-cli#51

## Summary
- Flip the migration checklist to the fully completed state only after the merged CLI and skills evidence is already true.

## Key Decisions
- Keep the final closeout isolated to the checklist document so the acceptance record changes without reopening runtime or quality-gate code.

## Validation
- Docs-only closeout; verified the checklist now matches the merged evidence from tiangong-lca/tiangong-cli#53 and tiangong-lca/skills#39 plus the recorded smoke tests and audit scans.

## Risks / Rollback
- Low risk: this only changes the documented completion state after the supporting changes and automation are already merged.

## Workspace Integration
- Requires a later workspace submodule bump after merge.