### PR TITLE
refactor: rename optional review LLM env keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,13 +14,6 @@ TIANGONG_LCA_API_BASE_URL=
 TIANGONG_LCA_API_KEY=
 TIANGONG_LCA_REGION=us-east-1
 
-# Public optional: only used when `tiangong review process --enable-llm`
-# or `tiangong review flow --enable-llm` is enabled.
-
-TIANGONG_LCA_LLM_BASE_URL=
-TIANGONG_LCA_LLM_API_KEY=
-TIANGONG_LCA_LLM_MODEL=
-
 # Internal/preparatory: currently no public `tiangong` command requires these
 # keys, but the repo already contains helper modules that normalize them.
 # Keep them documented here so the checked-in env surface matches the codebase.
@@ -48,3 +41,12 @@ TIANGONG_LCA_COVERAGE=0
 # - `TIANGONG_LCA_TIDAS_SDK_DIR`
 #   The CLI now loads `@tiangong-lca/tidas-sdk` directly from package
 #   dependencies instead of resolving a sibling checkout or CI-injected dist.
+
+# Public optional review-only: ignore this block unless `tiangong review process`
+# or `tiangong review flow` is called with `--enable-llm`.
+# When enabled, point `TIANGONG_LCA_REVIEW_LLM_BASE_URL` at an
+# OpenAI-compatible Responses API base URL. The CLI will call `<base_url>/responses`.
+
+TIANGONG_LCA_REVIEW_LLM_BASE_URL=
+TIANGONG_LCA_REVIEW_LLM_API_KEY=
+TIANGONG_LCA_REVIEW_LLM_MODEL=

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -80,12 +80,12 @@ TIANGONG_LCA_API_KEY=
 TIANGONG_LCA_REGION=us-east-1
 ```
 
-此外，只有在显式启用 `tiangong review process --enable-llm` 或 `tiangong review flow --enable-llm` 时，才会额外使用这一组可选变量：
+此外，只有在显式启用 `tiangong review process --enable-llm` 或 `tiangong review flow --enable-llm` 时，才会额外使用这一组可选变量。这一整组配置默认都是 optional；只有打开 review LLM 模式时才需要填写。`TIANGONG_LCA_REVIEW_LLM_BASE_URL` 应指向一个 OpenAI-compatible Responses API 根地址，CLI 会向 `<base_url>/responses` 发请求：
 
 ```bash
-TIANGONG_LCA_LLM_BASE_URL=
-TIANGONG_LCA_LLM_API_KEY=
-TIANGONG_LCA_LLM_MODEL=
+TIANGONG_LCA_REVIEW_LLM_BASE_URL=
+TIANGONG_LCA_REVIEW_LLM_API_KEY=
+TIANGONG_LCA_REVIEW_LLM_MODEL=
 ```
 
 仓库里还已经存在一组 internal/preparatory env 归一化入口，但当前没有任何公开 `tiangong` 命令消费它们：
@@ -110,7 +110,7 @@ TIANGONG_LCA_UNSTRUCTURED_RETURN_TXT=true
 原因很直接：
 
 - 当前 CLI 已实现命令只直连 TianGong LCA 的 REST / Edge Functions
-- `review process` / `review flow` 的可选语义审核统一走 `TIANGONG_LCA_LLM_*`，不再使用 `OPENAI_*`
+- `review process` / `review flow` 的可选语义审核统一走 review-only 的 `TIANGONG_LCA_REVIEW_LLM_*`，不再使用 `OPENAI_*`
 - `publish run` / `validation run` 只做本地契约和执行收口，不新增远程 env
 - CLI 仓库内部虽然已经有 `kb-search` / `unstructured` 模块，但当前没有任何公开命令消费这些 env
 - `.env.example` 会把这类 key 标成 internal/preparatory，防止代码和文档脱节，也防止调用方误认为它们已经是稳定公开 contract
@@ -127,8 +127,8 @@ TIANGONG_LCA_UNSTRUCTURED_RETURN_TXT=true
 | `lifecyclemodel auto-build | validate-build | publish-build | orchestrate` | 无 |
 | `lifecyclemodel build-resulting-process` | 本地运行默认无；若 request 打开 `process_sources.allow_remote_lookup=true`，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY` |
 | `lifecyclemodel publish-resulting-process` | 无 |
-| `review process` | 纯规则 review 默认无；若显式启用 `--enable-llm`，则需要 `TIANGONG_LCA_LLM_BASE_URL`、`TIANGONG_LCA_LLM_API_KEY`、`TIANGONG_LCA_LLM_MODEL` |
-| `review flow` | 纯规则 review 默认无；若显式启用 `--enable-llm`，则需要 `TIANGONG_LCA_LLM_BASE_URL`、`TIANGONG_LCA_LLM_API_KEY`、`TIANGONG_LCA_LLM_MODEL` |
+| `review process` | 纯规则 review 默认无；若显式启用 `--enable-llm`，则需要 `TIANGONG_LCA_REVIEW_LLM_BASE_URL`、`TIANGONG_LCA_REVIEW_LLM_API_KEY`、`TIANGONG_LCA_REVIEW_LLM_MODEL` |
+| `review flow` | 纯规则 review 默认无；若显式启用 `--enable-llm`，则需要 `TIANGONG_LCA_REVIEW_LLM_BASE_URL`、`TIANGONG_LCA_REVIEW_LLM_API_KEY`、`TIANGONG_LCA_REVIEW_LLM_MODEL` |
 | `review lifecyclemodel` | 无 |
 | `flow get` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY` |
 | `flow list` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY` |
@@ -327,7 +327,7 @@ npm exec tiangong -- admin embedding-run --input ./jobs.json --dry-run
 - 输出 `review_summary_v2_1.json`
 - 输出 `process-review-report.json`
 
-这个命令当前保持本地 artifact-first。若显式传入 `--enable-llm`，则通过 CLI 内部统一的 `TIANGONG_LCA_LLM_*` 运行时做可选语义审核；即使 LLM 失败，也不会影响规则层 review 主流程。
+这个命令当前保持本地 artifact-first。若显式传入 `--enable-llm`，则通过 CLI 内部统一的 `TIANGONG_LCA_REVIEW_LLM_*` 运行时做可选语义审核；即使 LLM 失败，也不会影响规则层 review 主流程。
 
 `tiangong review flow` 现在也已经进入可执行状态，负责：
 
@@ -344,7 +344,7 @@ npm exec tiangong -- admin embedding-run --input ./jobs.json --dry-run
 - 输出 `flow_review_timing.md`
 - 输出 `flow_review_report.json`
 
-这个命令同样保持本地 artifact-first。若显式传入 `--enable-llm`，则通过 CLI 内部统一的 `TIANGONG_LCA_LLM_*` 运行时做可选语义审核；当前 CLI 切片明确不支持 `--with-reference-context`，也还没有接入本地 registry enrichment。
+这个命令同样保持本地 artifact-first。若显式传入 `--enable-llm`，则通过 CLI 内部统一的 `TIANGONG_LCA_REVIEW_LLM_*` 运行时做可选语义审核；当前 CLI 切片明确不支持 `--with-reference-context`，也还没有接入本地 registry enrichment。
 
 `tiangong review lifecyclemodel` 现在也已经进入可执行状态，负责：
 

--- a/README.md
+++ b/README.md
@@ -115,12 +115,12 @@ TIANGONG_LCA_API_KEY=
 TIANGONG_LCA_REGION=us-east-1
 ```
 
-Optional env that only applies to implemented commands which opt into semantic review:
+Optional review-only env block: ignore it unless `tiangong review process --enable-llm` or `tiangong review flow --enable-llm` is enabled. `TIANGONG_LCA_REVIEW_LLM_BASE_URL` must point to an OpenAI-compatible Responses API base URL; the CLI calls `<base_url>/responses`.
 
 ```bash
-TIANGONG_LCA_LLM_BASE_URL=
-TIANGONG_LCA_LLM_API_KEY=
-TIANGONG_LCA_LLM_MODEL=
+TIANGONG_LCA_REVIEW_LLM_BASE_URL=
+TIANGONG_LCA_REVIEW_LLM_API_KEY=
+TIANGONG_LCA_REVIEW_LLM_MODEL=
 ```
 
 Internal/preparatory env surface already normalized in the repo, but not consumed by any current public `tiangong` command:
@@ -158,8 +158,8 @@ Command-level env reality:
 | `lifecyclemodel orchestrate` | none |
 | `lifecyclemodel build-resulting-process` | none for local-only runs; `TIANGONG_LCA_API_BASE_URL` and `TIANGONG_LCA_API_KEY` when `process_sources.allow_remote_lookup=true` |
 | `lifecyclemodel publish-resulting-process` | none |
-| `review process` | none for rule-only review; optional `TIANGONG_LCA_LLM_BASE_URL`, `TIANGONG_LCA_LLM_API_KEY`, and `TIANGONG_LCA_LLM_MODEL` when `--enable-llm` is set |
-| `review flow` | none for rule-only review; optional `TIANGONG_LCA_LLM_BASE_URL`, `TIANGONG_LCA_LLM_API_KEY`, and `TIANGONG_LCA_LLM_MODEL` when `--enable-llm` is set |
+| `review process` | none for rule-only review; optional `TIANGONG_LCA_REVIEW_LLM_BASE_URL`, `TIANGONG_LCA_REVIEW_LLM_API_KEY`, and `TIANGONG_LCA_REVIEW_LLM_MODEL` when `--enable-llm` is set |
+| `review flow` | none for rule-only review; optional `TIANGONG_LCA_REVIEW_LLM_BASE_URL`, `TIANGONG_LCA_REVIEW_LLM_API_KEY`, and `TIANGONG_LCA_REVIEW_LLM_MODEL` when `--enable-llm` is set |
 | `review lifecyclemodel` | none |
 | `flow get` | `TIANGONG_LCA_API_BASE_URL`, `TIANGONG_LCA_API_KEY` |
 | `flow list` | `TIANGONG_LCA_API_BASE_URL`, `TIANGONG_LCA_API_KEY` |
@@ -175,7 +175,7 @@ Command-level env reality:
 | `publish run` | none |
 | `validation run` | none |
 
-This CLI does not currently require KB, TianGong unstructured service, MCP, or `OPENAI_*` env keys for any public command. Optional semantic review now goes through the canonical `TIANGONG_LCA_LLM_*` keys instead of legacy provider-specific names. The repo already contains internal helper modules for KB and TianGong unstructured integrations; their env keys are listed in `.env.example` as internal/preparatory only, not as a public command contract.
+This CLI does not currently require KB, TianGong unstructured service, MCP, or `OPENAI_*` env keys for any public command. Optional semantic review now goes through the review-only `TIANGONG_LCA_REVIEW_LLM_*` keys instead of legacy provider-specific names. Those variables are optional as a block and only apply when `--enable-llm` is set on supported review commands. The repo already contains internal helper modules for KB and TianGong unstructured integrations; their env keys are listed in `.env.example` as internal/preparatory only, not as a public command contract.
 
 Run the CLI:
 
@@ -248,9 +248,9 @@ The current lifecyclemodel build family intentionally keeps three boundaries out
 
 `tiangong lifecyclemodel orchestrate` is the native recursive assembly command for multi-node product-system runs. `plan` writes `assembly-plan.json`, `graph-manifest.json`, `lineage-manifest.json`, and `boundary-report.json`; `execute` invokes only native CLI-backed builder slices and records per-invocation results under `invocations/`; `publish` reopens one orchestrator run and prepares `publish-bundle.json` plus `publish-summary.json` from prior local artifacts. The `process_builder` request surface is now intentionally narrow: only CLI-native local-build fields are accepted, and extra builder knobs are rejected during request normalization.
 
-`tiangong review process` is the first migrated review slice. It reopens one local `process_from_flow` run under `exports/processes/`, replays the existing artifact-first review contract, writes bilingual markdown findings plus structured JSON reports, and keeps optional semantic review behind the CLI-owned `TIANGONG_LCA_LLM_*` abstraction instead of direct `OPENAI_*` calls in a skill script.
+`tiangong review process` is the first migrated review slice. It reopens one local `process_from_flow` run under `exports/processes/`, replays the existing artifact-first review contract, writes bilingual markdown findings plus structured JSON reports, and keeps optional semantic review behind the CLI-owned `TIANGONG_LCA_REVIEW_LLM_*` abstraction instead of direct `OPENAI_*` calls in a skill script.
 
-`tiangong review flow` is the flow-side local governance review slice. It accepts exactly one of `--rows-file`, `--flows-dir`, or `--run-root`, materializes explicit local flow snapshots when needed, writes `rule_findings.jsonl`, `llm_findings.jsonl`, `findings.jsonl`, `flow_summaries.jsonl`, `similarity_pairs.jsonl`, `flow_review_summary.json`, `flow_review_zh.md`, `flow_review_en.md`, `flow_review_timing.md`, and `flow_review_report.json`, and keeps optional semantic review behind the same CLI-owned `TIANGONG_LCA_LLM_*` abstraction. The current CLI slice is intentionally local-first and does not implement `--with-reference-context` or local registry enrichment yet.
+`tiangong review flow` is the flow-side local governance review slice. It accepts exactly one of `--rows-file`, `--flows-dir`, or `--run-root`, materializes explicit local flow snapshots when needed, writes `rule_findings.jsonl`, `llm_findings.jsonl`, `findings.jsonl`, `flow_summaries.jsonl`, `similarity_pairs.jsonl`, `flow_review_summary.json`, `flow_review_zh.md`, `flow_review_en.md`, `flow_review_timing.md`, and `flow_review_report.json`, and keeps optional semantic review behind the same CLI-owned `TIANGONG_LCA_REVIEW_LLM_*` abstraction. The current CLI slice is intentionally local-first and does not implement `--with-reference-context` or local registry enrichment yet.
 
 `tiangong review lifecyclemodel` is the lifecyclemodel-side local review slice. It reopens one existing lifecyclemodel build run by `--run-dir`, scans `models/*/tidas_bundle/lifecyclemodels/*.json`, reuses `summary.json`, `connections.json`, `process-catalog.json`, and the aggregate `reports/lifecyclemodel-validate-build-report.json` when present, writes `model_summaries.jsonl`, `findings.jsonl`, `lifecyclemodel_review_summary.json`, `lifecyclemodel_review_zh.md`, `lifecyclemodel_review_en.md`, `lifecyclemodel_review_timing.md`, and `lifecyclemodel_review_report.json`, and stays local-first without introducing Python, LangGraph, or skill-local review runtimes.
 

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -169,8 +169,8 @@ tiangong
 - `publish-resulting-process` 当前负责生成本地 publish handoff 产物，还没有把提交语义直接并入 `publish run`
 - 已实现的 `lifecyclemodel orchestrate` 把递归装配的 `plan | execute | publish` 三个动作统一收口到 CLI，并直接复用原生 `process auto-build`、`lifecyclemodel auto-build`、`lifecyclemodel build-resulting-process` slices
 - `lifecyclemodel orchestrate` 的 `process_builder` request schema 已删除旧 builder 控制项，只保留 CLI-native 本地构建字段，并在归一化阶段拒绝额外键；不再保留任何 Python fallback 配置面
-- 已实现的 `review process` 保留本地 artifact-first review contract，把规则核查、报告输出和可选 LLM 语义审核统一收口到 CLI；语义审核只使用 `TIANGONG_LCA_LLM_*`，不再透出 `OPENAI_*`
-- 已实现的 `review flow` 保留本地 artifact-first governance review contract，把 flow 摘要、相似对、规则 findings、可选 LLM findings 和双语 markdown 报告统一收口到 CLI；语义审核同样只使用 `TIANGONG_LCA_LLM_*`
+- 已实现的 `review process` 保留本地 artifact-first review contract，把规则核查、报告输出和可选 LLM 语义审核统一收口到 CLI；语义审核只使用 `TIANGONG_LCA_REVIEW_LLM_*`，不再透出 `OPENAI_*`
+- 已实现的 `review flow` 保留本地 artifact-first governance review contract，把 flow 摘要、相似对、规则 findings、可选 LLM findings 和双语 markdown 报告统一收口到 CLI；语义审核同样只使用 `TIANGONG_LCA_REVIEW_LLM_*`
 - `review flow` 当前明确不支持 `--with-reference-context`，也还没有接入本地 registry enrichment；这部分仍需后续迁移切片单独落地
 - 已实现的 `flow get` 保留 deterministic direct-read 边界，但内部执行已经收口到原生 `@supabase/supabase-js`；支持 `id` + 可选 `version/user_id/state_code` 读取；若精确版本 miss，则回退到最新可见版本；若出现多个同版本可见候选，则直接报 ambiguous
 - 已实现的 `flow list` 保留 deterministic direct-read 边界，但内部执行已经收口到原生 `@supabase/supabase-js`；支持稳定 `id/state_code/type_of_dataset` 过滤、显式 `order=id.asc,version.asc` 默认值，以及 `--all --page-size` 的 offset 分页
@@ -424,7 +424,7 @@ tiangong admin embedding-run --input ./jobs.json --dry-run
 - 从 `--run-root` 读取 `exports/processes/*.json`
 - 延续现有 v2.1 review 规则做基础信息核查、物料平衡核查和单位疑似问题记录
 - 写出中英文 markdown review、timing、unit issue log、summary 和 report
-- 在显式启用 `--enable-llm` 时，通过 CLI 的 `TIANGONG_LCA_LLM_*` 运行时做可选语义审核
+- 在显式启用 `--enable-llm` 时，通过 CLI 的 `TIANGONG_LCA_REVIEW_LLM_*` 运行时做可选语义审核
 
 它现在还不负责：
 
@@ -443,7 +443,7 @@ tiangong admin embedding-run --input ./jobs.json --dry-run
 - 输出 `flow_summaries.jsonl`、`similarity_pairs.jsonl`
 - 输出 `flow_review_summary.json`、`flow_review_zh.md`、`flow_review_en.md`、`flow_review_timing.md`
 - 输出 `flow_review_report.json`
-- 在显式启用 `--enable-llm` 时，通过 CLI 的 `TIANGONG_LCA_LLM_*` 运行时做可选语义审核
+- 在显式启用 `--enable-llm` 时，通过 CLI 的 `TIANGONG_LCA_REVIEW_LLM_*` 运行时做可选语义审核
 
 它现在还不负责：
 
@@ -658,12 +658,12 @@ TIANGONG_LCA_API_KEY=
 TIANGONG_LCA_REGION=us-east-1
 ```
 
-按需启用的可选变量：
+按需启用的可选 review-only 变量：只有显式启用 `tiangong review process --enable-llm` 或 `tiangong review flow --enable-llm` 时才需要配置。`TIANGONG_LCA_REVIEW_LLM_BASE_URL` 应指向 OpenAI-compatible Responses API 根地址，CLI 会向 `<base_url>/responses` 发请求。
 
 ```bash
-TIANGONG_LCA_LLM_BASE_URL=
-TIANGONG_LCA_LLM_API_KEY=
-TIANGONG_LCA_LLM_MODEL=
+TIANGONG_LCA_REVIEW_LLM_BASE_URL=
+TIANGONG_LCA_REVIEW_LLM_API_KEY=
+TIANGONG_LCA_REVIEW_LLM_MODEL=
 ```
 
 仓库中已归一化、但当前没有任何公开 `tiangong` 命令消费的 internal/preparatory 变量：
@@ -693,8 +693,8 @@ TIANGONG_LCA_COVERAGE=0
 - internal/preparatory 和 test-only env 也要在 `.env.example` 里显式列出，避免代码与文档脱节
 - 不为了历史实现或未来猜测保留 alias
 - 不引入 `SUPABASE_URL`、`SUPABASE_KEY`、`TIANGONG_LCA_TIDAS_SDK_DIR` 这类额外兼容层；原生 Supabase client 一律从 `TIANGONG_LCA_API_*` 派生，`@tiangong-lca/tidas-sdk` 一律走直接依赖
-- `review process` 的可选语义审核统一走 `TIANGONG_LCA_LLM_*`，不再引入 `OPENAI_*`
-- `review flow` 的可选语义审核也统一走 `TIANGONG_LCA_LLM_*`，不再引入 `OPENAI_*`
+- `review process` 的可选语义审核统一走 review-only 的 `TIANGONG_LCA_REVIEW_LLM_*`，不再引入 `OPENAI_*`
+- `review flow` 的可选语义审核也统一走 review-only 的 `TIANGONG_LCA_REVIEW_LLM_*`，不再引入 `OPENAI_*`
 - `publish run` / `validation run` 都是本地契约与执行收口，不新增远程 env
 - `TIANGONG_LCA_KB_SEARCH_*` 与 `TIANGONG_LCA_UNSTRUCTURED_*` 目前只属于 internal/preparatory 层，不属于公开命令契约
 
@@ -710,8 +710,8 @@ TIANGONG_LCA_COVERAGE=0
 | `lifecyclemodel auto-build | validate-build | publish-build | orchestrate` | 无 |
 | `lifecyclemodel build-resulting-process` | 本地运行默认无；若 request 开启 `process_sources.allow_remote_lookup=true`，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY` |
 | `lifecyclemodel publish-resulting-process` | 无 |
-| `review process` | 纯规则 review 默认无；若显式开启 `--enable-llm`，则需要 `TIANGONG_LCA_LLM_BASE_URL`、`TIANGONG_LCA_LLM_API_KEY`、`TIANGONG_LCA_LLM_MODEL` |
-| `review flow` | 纯规则 review 默认无；若显式开启 `--enable-llm`，则需要 `TIANGONG_LCA_LLM_BASE_URL`、`TIANGONG_LCA_LLM_API_KEY`、`TIANGONG_LCA_LLM_MODEL` |
+| `review process` | 纯规则 review 默认无；若显式开启 `--enable-llm`，则需要 `TIANGONG_LCA_REVIEW_LLM_BASE_URL`、`TIANGONG_LCA_REVIEW_LLM_API_KEY`、`TIANGONG_LCA_REVIEW_LLM_MODEL` |
+| `review flow` | 纯规则 review 默认无；若显式开启 `--enable-llm`，则需要 `TIANGONG_LCA_REVIEW_LLM_BASE_URL`、`TIANGONG_LCA_REVIEW_LLM_API_KEY`、`TIANGONG_LCA_REVIEW_LLM_MODEL` |
 | `review lifecyclemodel` | 无 |
 | `flow get` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY` |
 | `flow list` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY` |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -665,8 +665,8 @@ Options:
   --start-ts <iso>          Optional run start timestamp
   --end-ts <iso>            Optional run end timestamp
   --logic-version <name>    Review logic version label (default: v2.1)
-  --enable-llm              Enable optional semantic review via the CLI LLM client
-  --llm-model <name>        Override TIANGONG_LCA_LLM_MODEL for this command
+  --enable-llm              Enable optional review-only semantic review via the CLI LLM client
+  --llm-model <name>        Override TIANGONG_LCA_REVIEW_LLM_MODEL for this review command
   --llm-max-processes <n>   Cap how many process summaries are sent to the LLM (default: 8)
   --json                    Print compact JSON
   -h, --help
@@ -686,8 +686,8 @@ Options:
   --start-ts <iso>          Optional run start timestamp
   --end-ts <iso>            Optional run end timestamp
   --logic-version <name>    Review logic version label (default: flow-v1.0-cli)
-  --enable-llm              Enable optional semantic review via the CLI LLM client
-  --llm-model <name>        Override TIANGONG_LCA_LLM_MODEL for this command
+  --enable-llm              Enable optional review-only semantic review via the CLI LLM client
+  --llm-model <name>        Override TIANGONG_LCA_REVIEW_LLM_MODEL for this review command
   --llm-max-flows <n>       Cap how many flow summaries are sent to the LLM (default: 120)
   --llm-batch-size <n>      Cap how many flow summaries each LLM batch sends (default: 20)
   --similarity-threshold <n> Similarity threshold for duplicate-candidate warnings (default: 0.92)

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -8,16 +8,16 @@ import type { FetchLike } from './http.js';
 import { readJsonArtifact, writeJsonArtifact, writeJsonLinesArtifact } from './artifacts.js';
 
 export const LLM_ENV_KEYS = {
-  baseUrl: 'TIANGONG_LCA_LLM_BASE_URL',
-  apiKey: 'TIANGONG_LCA_LLM_API_KEY',
-  model: 'TIANGONG_LCA_LLM_MODEL',
+  baseUrl: 'TIANGONG_LCA_REVIEW_LLM_BASE_URL',
+  apiKey: 'TIANGONG_LCA_REVIEW_LLM_API_KEY',
+  model: 'TIANGONG_LCA_REVIEW_LLM_MODEL',
 } as const;
 
 export const LLM_ENV_SPECS: EnvSpec[] = [
   {
     key: LLM_ENV_KEYS.baseUrl,
     required: true,
-    description: 'LLM responses API base URL',
+    description: 'Review LLM OpenAI-compatible Responses API base URL',
   },
   {
     key: LLM_ENV_KEYS.apiKey,

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -8,9 +8,9 @@ import { extractLlmOutput, extractLlmUsage, invokeLlm, readLlmRuntimeEnv } from 
 
 test('readLlmRuntimeEnv returns canonical TianGong LCA LLM env keys', () => {
   const runtime = readLlmRuntimeEnv({
-    TIANGONG_LCA_LLM_BASE_URL: 'https://llm.example/v1',
-    TIANGONG_LCA_LLM_API_KEY: 'secret-token',
-    TIANGONG_LCA_LLM_MODEL: 'gpt-5.4',
+    TIANGONG_LCA_REVIEW_LLM_BASE_URL: 'https://llm.example/v1',
+    TIANGONG_LCA_REVIEW_LLM_API_KEY: 'secret-token',
+    TIANGONG_LCA_REVIEW_LLM_MODEL: 'gpt-5.4',
   });
 
   assert.deepEqual(runtime, {
@@ -486,7 +486,7 @@ test('invokeLlm validates required canonical LLM env values', async () => {
         },
         timeoutMs: 20,
       }),
-    /TIANGONG_LCA_LLM_BASE_URL/u,
+    /TIANGONG_LCA_REVIEW_LLM_BASE_URL/u,
   );
 
   await assert.rejects(
@@ -505,7 +505,7 @@ test('invokeLlm validates required canonical LLM env values', async () => {
         },
         timeoutMs: 20,
       }),
-    /TIANGONG_LCA_LLM_API_KEY/u,
+    /TIANGONG_LCA_REVIEW_LLM_API_KEY/u,
   );
 
   await assert.rejects(
@@ -524,7 +524,7 @@ test('invokeLlm validates required canonical LLM env values', async () => {
         },
         timeoutMs: 20,
       }),
-    /TIANGONG_LCA_LLM_MODEL/u,
+    /TIANGONG_LCA_REVIEW_LLM_MODEL/u,
   );
 });
 

--- a/test/review-flow.test.ts
+++ b/test/review-flow.test.ts
@@ -261,9 +261,9 @@ test('runFlowReview supports flows-dir input and CLI-owned LLM semantic review',
       llmMaxFlows: 1,
       methodologyId: 'custom-method',
       env: {
-        TIANGONG_LCA_LLM_BASE_URL: 'https://llm.example/v1',
-        TIANGONG_LCA_LLM_API_KEY: 'llm-key',
-        TIANGONG_LCA_LLM_MODEL: 'gpt-5.4-mini',
+        TIANGONG_LCA_REVIEW_LLM_BASE_URL: 'https://llm.example/v1',
+        TIANGONG_LCA_REVIEW_LLM_API_KEY: 'llm-key',
+        TIANGONG_LCA_REVIEW_LLM_MODEL: 'gpt-5.4-mini',
       } as NodeJS.ProcessEnv,
       fetchImpl: createLlmFetch(
         JSON.stringify({
@@ -975,9 +975,9 @@ test('review-flow internal llm helpers cover disabled, fallback, invalid-json, a
     llmMaxFlows: 10,
     llmBatchSize: 2,
     env: {
-      TIANGONG_LCA_LLM_BASE_URL: 'https://llm.example/v1',
-      TIANGONG_LCA_LLM_API_KEY: 'llm-key',
-      TIANGONG_LCA_LLM_MODEL: 'gpt-5.4-mini',
+      TIANGONG_LCA_REVIEW_LLM_BASE_URL: 'https://llm.example/v1',
+      TIANGONG_LCA_REVIEW_LLM_API_KEY: 'llm-key',
+      TIANGONG_LCA_REVIEW_LLM_MODEL: 'gpt-5.4-mini',
     } as NodeJS.ProcessEnv,
     fetchImpl: createLlmFetch('not-json-response'),
     outDir: dir,
@@ -996,9 +996,9 @@ test('review-flow internal llm helpers cover disabled, fallback, invalid-json, a
       llmMaxFlows: 10,
       llmBatchSize: 2,
       env: {
-        TIANGONG_LCA_LLM_BASE_URL: 'https://llm.example/v1',
-        TIANGONG_LCA_LLM_API_KEY: 'llm-key',
-        TIANGONG_LCA_LLM_MODEL: 'gpt-5.4-mini',
+        TIANGONG_LCA_REVIEW_LLM_BASE_URL: 'https://llm.example/v1',
+        TIANGONG_LCA_REVIEW_LLM_API_KEY: 'llm-key',
+        TIANGONG_LCA_REVIEW_LLM_MODEL: 'gpt-5.4-mini',
       } as NodeJS.ProcessEnv,
       outDir: path.join(dir, 'failure-run'),
       runId: 'failure',
@@ -1261,9 +1261,9 @@ test('review-flow LLM review deduplicates fallback findings from single-item bat
       llmMaxFlows: 1,
       llmBatchSize: 1,
       env: {
-        TIANGONG_LCA_LLM_BASE_URL: 'https://llm.example/v1',
-        TIANGONG_LCA_LLM_API_KEY: 'llm-key',
-        TIANGONG_LCA_LLM_MODEL: 'gpt-5.4-mini',
+        TIANGONG_LCA_REVIEW_LLM_BASE_URL: 'https://llm.example/v1',
+        TIANGONG_LCA_REVIEW_LLM_API_KEY: 'llm-key',
+        TIANGONG_LCA_REVIEW_LLM_MODEL: 'gpt-5.4-mini',
       } as NodeJS.ProcessEnv,
       fetchImpl: createLlmFetch(
         JSON.stringify({
@@ -1398,9 +1398,9 @@ test('review-flow direct runtime helpers cover materialization, non-array findin
       llmMaxFlows: 0,
       llmBatchSize: 2,
       env: {
-        TIANGONG_LCA_LLM_BASE_URL: 'https://llm.example/v1',
-        TIANGONG_LCA_LLM_API_KEY: 'llm-key',
-        TIANGONG_LCA_LLM_MODEL: 'gpt-5.4-mini',
+        TIANGONG_LCA_REVIEW_LLM_BASE_URL: 'https://llm.example/v1',
+        TIANGONG_LCA_REVIEW_LLM_API_KEY: 'llm-key',
+        TIANGONG_LCA_REVIEW_LLM_MODEL: 'gpt-5.4-mini',
       } as NodeJS.ProcessEnv,
       fetchImpl: createLlmFetch(JSON.stringify({ findings: { not: 'an-array' } })),
       outDir: path.join(dir, 'no-array'),
@@ -1415,9 +1415,9 @@ test('review-flow direct runtime helpers cover materialization, non-array findin
       llmMaxFlows: 2,
       llmBatchSize: 2,
       env: {
-        TIANGONG_LCA_LLM_BASE_URL: 'https://llm.example/v1',
-        TIANGONG_LCA_LLM_API_KEY: 'llm-key',
-        TIANGONG_LCA_LLM_MODEL: 'gpt-5.4-mini',
+        TIANGONG_LCA_REVIEW_LLM_BASE_URL: 'https://llm.example/v1',
+        TIANGONG_LCA_REVIEW_LLM_API_KEY: 'llm-key',
+        TIANGONG_LCA_REVIEW_LLM_MODEL: 'gpt-5.4-mini',
       } as NodeJS.ProcessEnv,
       fetchImpl: createLlmFetch(
         JSON.stringify({
@@ -1445,9 +1445,9 @@ test('review-flow direct runtime helpers cover materialization, non-array findin
       llmMaxFlows: 2,
       llmBatchSize: 2,
       env: {
-        TIANGONG_LCA_LLM_BASE_URL: 'https://llm.example/v1',
-        TIANGONG_LCA_LLM_API_KEY: 'llm-key',
-        TIANGONG_LCA_LLM_MODEL: 'gpt-5.4-mini',
+        TIANGONG_LCA_REVIEW_LLM_BASE_URL: 'https://llm.example/v1',
+        TIANGONG_LCA_REVIEW_LLM_API_KEY: 'llm-key',
+        TIANGONG_LCA_REVIEW_LLM_MODEL: 'gpt-5.4-mini',
       } as NodeJS.ProcessEnv,
       fetchImpl: (async () => {
         throw 'string failure';

--- a/test/review-process.test.ts
+++ b/test/review-process.test.ts
@@ -227,9 +227,9 @@ test('runProcessReview can invoke the CLI LLM client and persist semantic review
       enableLlm: true,
       llmMaxProcesses: 2,
       env: {
-        TIANGONG_LCA_LLM_BASE_URL: 'https://llm.example/v1',
-        TIANGONG_LCA_LLM_API_KEY: 'llm-key',
-        TIANGONG_LCA_LLM_MODEL: 'gpt-5.4',
+        TIANGONG_LCA_REVIEW_LLM_BASE_URL: 'https://llm.example/v1',
+        TIANGONG_LCA_REVIEW_LLM_API_KEY: 'llm-key',
+        TIANGONG_LCA_REVIEW_LLM_MODEL: 'gpt-5.4',
       } as NodeJS.ProcessEnv,
       fetchImpl: createLlmFetch(
         JSON.stringify({
@@ -689,9 +689,9 @@ test('review-process internals cover helper branches and rendering fallbacks', a
     enableLlm: true,
     llmModel: 'override-model',
     env: {
-      TIANGONG_LCA_LLM_BASE_URL: 'https://llm.example/v1',
-      TIANGONG_LCA_LLM_API_KEY: 'llm-key',
-      TIANGONG_LCA_LLM_MODEL: 'gpt-5.4',
+      TIANGONG_LCA_REVIEW_LLM_BASE_URL: 'https://llm.example/v1',
+      TIANGONG_LCA_REVIEW_LLM_API_KEY: 'llm-key',
+      TIANGONG_LCA_REVIEW_LLM_MODEL: 'gpt-5.4',
     } as NodeJS.ProcessEnv,
     fetchImpl: createLlmFetch('not json'),
     outDir: path.join(os.tmpdir(), 'tg-cli-review-process-internals-2'),
@@ -705,9 +705,9 @@ test('review-process internals cover helper branches and rendering fallbacks', a
     enableLlm: true,
     llmModel: undefined,
     env: {
-      TIANGONG_LCA_LLM_BASE_URL: 'https://llm.example/v1',
-      TIANGONG_LCA_LLM_API_KEY: 'llm-key',
-      TIANGONG_LCA_LLM_MODEL: 'gpt-5.4',
+      TIANGONG_LCA_REVIEW_LLM_BASE_URL: 'https://llm.example/v1',
+      TIANGONG_LCA_REVIEW_LLM_API_KEY: 'llm-key',
+      TIANGONG_LCA_REVIEW_LLM_MODEL: 'gpt-5.4',
     } as NodeJS.ProcessEnv,
     fetchImpl: (async () => {
       throw 'boom';


### PR DESCRIPTION
Closes #57

## Summary
- Rename the optional review-only LLM env contract from TIANGONG_LCA_LLM_* to TIANGONG_LCA_REVIEW_LLM_* in the CLI runtime, help text, and tests.
- Clarify in .env.example, README, DEV_CN, and IMPLEMENTATION_GUIDE_CN that the block is optional, only applies to review commands with --enable-llm, and expects an OpenAI-compatible Responses API base URL.
- Move the optional review LLM env block to the end of .env.example so the always-required public API keys stay at the top and internal/preparatory keys remain grouped in the middle.

## Key Decisions
- Do not keep the old TIANGONG_LCA_LLM_* aliases; the public contract is renamed directly so the review-only scope is explicit.

## Validation
- npm test -- --test test/llm.test.ts --test test/review-process.test.ts --test test/review-flow.test.ts --test test/cli.test.ts
- npm run prepush:gate

## Risks / Rollback
- Low risk: the change is limited to env naming, docs/help text, and review-command tests; repo-local coverage remains 100%.

## Workspace Integration
- After merge, lca-workspace still needs a tiangong-lca-cli submodule bump before tiangong-lca/workspace#42 can close.