### PR TITLE
chore: release cli v0.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/cli",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.101.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Unified TianGong LCA CLI with direct REST adapters and low-entropy command surface.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes tiangong-lca/tiangong-cli#63

## Summary
- Bump @tiangong-lca/cli package metadata from 0.0.2 to 0.0.3 in package.json and package-lock.json.
- Keep the release surface code-identical to the merged main branch so the existing automation can tag and publish the latest delivered CLI features.

## Key Decisions
- Use the existing main-branch tag workflow plus tag-triggered publish workflow instead of creating a manual tag or bypassing trusted publishing.

## Validation
- npm run prepush:gate
- node ./scripts/ci/release-version.cjs assert-unpublished --version 0.0.3
- node ./scripts/ci/check-release-tag.cjs cli cli-v0.0.3
- npm pack --dry-run >/dev/null

## Risks / Rollback
- Low risk: the diff is limited to release version metadata.

## Follow-ups
- After merge, verify the tag-release-from-merge workflow creates cli-v0.0.3 and the publish workflow pushes npm latest to 0.0.3.

## Workspace Integration
- Workspace integration is tracked separately in tiangong-lca/workspace#59 after the child release PR merges.