### PR TITLE
docs: add cli release runbook

### DIFF
--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -77,6 +77,8 @@ npm run build
 - PR 合并后，`.github/workflows/tag-release-from-merge.yml` 自动创建 `cli-vX.Y.Z`
 - `.github/workflows/publish.yml` 再从这个不可变 tag 通过 npm Trusted Publishing 发布
 
+值班发布步骤见 [docs/release-runbook.md](./docs/release-runbook.md)。
+
 一次性的仓库 secret、workflow 文件名和 npm Trusted Publisher 配置见 [docs/release-setup.md](./docs/release-setup.md)。
 
 发布到 npm 之后，可直接安装：

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -844,6 +844,8 @@ CLI 现在额外有一条独立于质量门的 npm 发布链路：
 - 合并到 `main` 后，`tag-release-from-merge.yml` 自动创建 `cli-vX.Y.Z`
 - `publish.yml` 从该 tag 触发 npm Trusted Publishing
 
+每次发版的 operator runbook 见 [release-runbook.md](./release-runbook.md)。
+
 一次性的仓库 secret 和 npm Trusted Publisher 配置见 [release-setup.md](./release-setup.md)。
 
 ## 7. 与 `tiangong-lca-skills` 的关系

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,0 +1,148 @@
+# CLI Release Runbook
+
+This document is the operator runbook for each `@tiangong-lca/cli` release.
+
+Use this document for:
+
+- per-release prechecks
+- version bump PR execution
+- post-merge release verification
+- workspace follow-up
+
+Do not use this document for one-time repository or npm registry setup.
+For one-time setup, see [release-setup.md](./release-setup.md).
+
+## Preconditions
+
+Before starting a release:
+
+- work from the latest `main`
+- keep the release-prep change scoped to CLI package version metadata
+- confirm npm has not already published the target version
+
+Useful commands:
+
+```bash
+git fetch origin
+git checkout main
+git merge --ff-only origin/main
+
+npm ci
+npm run prepush:gate
+node ./scripts/ci/release-version.cjs next-version --part patch
+node ./scripts/ci/release-version.cjs assert-unpublished --version <x.y.z>
+npm pack --dry-run >/dev/null
+```
+
+`next-version` is only a helper for choosing the next version. The actual release version is whatever you put into `package.json`.
+
+## Release-Prep PR
+
+1. Create a dedicated branch from `main`.
+2. Update the CLI package version metadata:
+   - `package.json`
+   - `package-lock.json`
+3. Keep the PR focused on the release bump.
+4. Open a normal PR and wait for `quality-gate` to pass.
+5. Merge the PR into `main`.
+
+Release automation starts only after the version bump PR is merged into `main`.
+
+## Post-Merge Checks
+
+After the PR merges, verify the release in this order.
+
+### 1. Tag workflow
+
+The merge to `main` should trigger:
+
+- `.github/workflows/tag-release-from-merge.yml`
+
+Check:
+
+```bash
+gh run list --repo tiangong-lca/tiangong-cli --workflow "Tag Release From Merge" --limit 3
+gh api repos/tiangong-lca/tiangong-cli/git/ref/tags/cli-v<x.y.z>
+```
+
+Expected result:
+
+- the workflow finishes successfully
+- tag `cli-v<x.y.z>` exists
+
+### 2. Publish workflow
+
+The release tag should trigger:
+
+- `.github/workflows/publish.yml`
+
+Check:
+
+```bash
+gh run list --repo tiangong-lca/tiangong-cli --workflow "Publish Package" --limit 3
+gh run watch <publish-run-id> --repo tiangong-lca/tiangong-cli
+```
+
+Expected result:
+
+- `Publish Package` finishes successfully
+
+### 3. npm registry
+
+Confirm npm has the expected version:
+
+```bash
+npm view @tiangong-lca/cli version
+npm view @tiangong-lca/cli dist-tags --json
+```
+
+Expected result:
+
+- `version` equals `<x.y.z>`
+- `latest` points to `<x.y.z>` unless this release intentionally uses a different dist-tag strategy
+
+Do not update the workspace pointer until npm verification succeeds.
+
+## Workspace Follow-Up
+
+If the workspace tracks the CLI submodule, bump the workspace pointer only after:
+
+- the child PR is merged
+- the release tag exists
+- the publish workflow succeeds
+- npm resolves to the new version
+
+From the workspace root, the release-aware helper can collapse that sequence into one command:
+
+```bash
+uv run python .agents/skills/lca-workspace-delivery-workflow/scripts/workflow_ops.py finalize-release-child-delivery \
+  --repo cli \
+  --issue <cli-issue-number> \
+  --pr <cli-pr-number> \
+  --parent <workspace-parent-issue-number>
+```
+
+For the CLI repo, that helper defaults to:
+
+- package: `@tiangong-lca/cli`
+- tag workflow: `Tag Release From Merge`
+- publish workflow: `Publish Package`
+- tag prefix: `cli-v`
+- npm dist-tag check: `latest`
+
+## Failure Handling
+
+- If the version bump PR is not merged, no release should happen.
+- If tag creation fails, fix the workflow or repository secret/config first. Do not manually continue the workspace bump.
+- If publish fails, inspect the failed GitHub Actions run and npm/Trusted Publisher configuration before retrying the release flow.
+- If npm does not show the expected version yet, wait for registry propagation before treating the release as failed.
+
+## Operator Checklist
+
+- `package.json` and `package-lock.json` both bumped
+- release-prep PR merged into `main`
+- `Tag Release From Merge` succeeded
+- `cli-v<x.y.z>` exists
+- `Publish Package` succeeded
+- `npm view @tiangong-lca/cli version` equals `<x.y.z>`
+- workspace pointer updated only after all checks above passed

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -9,8 +9,7 @@ Use this document for:
 - post-merge release verification
 - workspace follow-up
 
-Do not use this document for one-time repository or npm registry setup.
-For one-time setup, see [release-setup.md](./release-setup.md).
+Do not use this document for one-time repository or npm registry setup. For one-time setup, see [release-setup.md](./release-setup.md).
 
 ## Preconditions
 

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -2,6 +2,8 @@
 
 This document captures the one-time repository and registry configuration required for the `tiangong-lca-cli` npm release workflows.
 
+For the repeatable per-release operator steps, see [release-runbook.md](./release-runbook.md).
+
 Recommended model:
 
 - maintainers open a normal release-prep PR from `main`


### PR DESCRIPTION
Closes tiangong-lca/tiangong-cli#65

## Summary
- Add an operator-facing CLI release runbook that separates one-time setup from each-release execution.
- Link the new runbook from DEV_CN.md, IMPLEMENTATION_GUIDE_CN.md, and release-setup.md.

## Key Decisions
- Keep the runbook focused on operator checkpoints and commands instead of repeating the one-time Trusted Publisher setup instructions.

## Validation
- git -C tiangong-lca-cli diff --check HEAD~1 HEAD
- Reviewed the runbook steps against the current tag-release-from-merge and publish workflows.

## Risks / Rollback
- Low risk: documentation-only change.

## Workspace Integration
- Requires a later workspace submodule bump after this CLI PR merges.