### PR TITLE
fix: align CLI dataset writes with dataset commands

### DIFF
--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -421,8 +421,8 @@ npm exec tiangong -- admin embedding-run --input ./jobs.json --dry-run
 `tiangong flow publish-version` 现在已经承担 flow governance 的第一个 CLI 远端写入切片，负责：
 
 - 读取单个 ready-for-publish flow JSON / JSONL 输入
-- 从 `TIANGONG_LCA_API_BASE_URL` 推导 Supabase `/rest/v1/flows` 路径
-- 在 dry-run 或 commit 模式下决定 `insert` / `update_existing` / failure
+- 从 `TIANGONG_LCA_API_BASE_URL` 推导 Supabase REST 预检路径与 Edge Function dataset command 路径；支持 project root、`/functions/v1`、`/rest/v1` 三种 base URL 形态
+- dry-run 通过精确版本可见性预检决定 `would_insert` / `would_update_existing` / failure；commit 则在同一条预检链上调用 `app_dataset_create` / `app_dataset_save_draft`
 - 输出历史兼容的 `mcp_success_list`、`remote_validation_failed`、`mcp_sync_report`
 
 这个命令当前只负责 remediated flow version 的 publish/update 契约，不负责 round2 失败再修复；后续产品侧再生已经由 `tiangong flow regen-product` 单独承接。
@@ -440,7 +440,7 @@ npm exec tiangong -- admin embedding-run --input ./jobs.json --dry-run
 - 输出 `publish-report.json`
 - 保留历史兼容的 `mcp_success_list`、`remote_validation_failed`、`mcp_sync_report`
 
-这个命令现在已经覆盖 flow/process 的本地 reviewed publish 准备阶段；当显式传入 `--commit` 时，prepared flow rows 和 prepared process rows 都会通过 CLI 自己基于 `@supabase/supabase-js` 的 writer layer 执行远端提交，不再依赖任何 legacy skill 路径。
+这个命令现在已经覆盖 flow/process 的本地 reviewed publish 准备阶段；当显式传入 `--commit` 时，prepared flow rows 和 prepared process rows 都会通过 CLI 自己共享的 “REST 预检 + dataset command” writer layer 执行远端提交，不再依赖任何 legacy skill 路径。
 
 `tiangong flow build-alias-map` 现在已经承担 flow governance 的 deterministic alias map 切片，负责：
 
@@ -527,7 +527,7 @@ npm exec tiangong -- admin embedding-run --input ./jobs.json --dry-run
 - 输出 `relation-manifest.json`
 - 输出 `publish-report.json`
 
-当前实现刻意没有把旧 MCP 数据库写入逻辑重新塞回 CLI；commit 模式通过可插拔执行器承接，CLI 先把稳定的输入/输出契约和报告形状固定下来。
+当前实现不会把旧 MCP 数据库写入逻辑重新塞回 CLI；但当提供 Supabase runtime 时，`lifecyclemodels` / `processes` / `sources` 会默认走共享的 dataset command executor：先做 REST 精确可见性预检，再调用 `app_dataset_create` / `app_dataset_save_draft`。如果调用方显式注入 executors，则仍以显式执行器为准。
 
 `tiangong validation run` 负责把本地 TIDAS 包校验统一收口到 CLI：
 

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -84,8 +84,8 @@ tiangong
 | `tiangong flow get` | 统一 CLI 持有的只读 flow 详情读取面；从 `TIANGONG_LCA_API_BASE_URL` 推导 Supabase 目标并通过原生 `@supabase/supabase-js` 按 `id/version/user/state` 读取 |
 | `tiangong flow list` | 统一 CLI 持有的只读 flow 枚举面；通过原生 `@supabase/supabase-js` 保持稳定过滤/排序/分页语义 |
 | `tiangong flow remediate` | 本地 flow governance round1 deterministic remediation、artifact-first 输出 |
-| `tiangong flow publish-version` | 统一 CLI 持有的 remediated-flow publish/update 入口；从 `TIANGONG_LCA_API_BASE_URL` 推导 Supabase 目标并通过原生 `@supabase/supabase-js` 写出稳定 success/failure artifacts |
-| `tiangong flow publish-reviewed-data` | 统一 CLI 持有的 reviewed publish preparation 入口；支持 flow unchanged skip、flow/process append-only bump / current-version upsert、process flow-ref rewrite、本地 `publish-report.json` 与兼容的 flow success/failure artifacts |
+| `tiangong flow publish-version` | 统一 CLI 持有的 remediated-flow publish/update 入口；通过 REST 精确可见性预检 + Edge Function dataset command (`app_dataset_create` / `app_dataset_save_draft`) 写出稳定 success/failure artifacts |
+| `tiangong flow publish-reviewed-data` | 统一 CLI 持有的 reviewed publish preparation 入口；支持 flow unchanged skip、flow/process append-only bump / current-version upsert、process flow-ref rewrite、本地 `publish-report.json` 与兼容的 flow success/failure artifacts，并在 commit 时复用共享 dataset command writer |
 | `tiangong flow build-alias-map` | 独立 deterministic alias map 入口；从 old/new flow snapshots 与可选 seed alias map 生成 alias plan、manual queue 与稳定 alias map |
 | `tiangong flow scan-process-flow-refs` | 独立 process ref 扫描入口；对 local process rows 做 scope/catalog/alias 分类并写出 scan artifacts |
 | `tiangong flow plan-process-flow-repairs` | 独立 deterministic repair planning 入口；从 process/scope/alias/scan 契约生成 repair plan |
@@ -105,7 +105,7 @@ tiangong
 | `tiangong lifecyclemodel orchestrate` | 递归装配的 plan / execute / publish-handoff 命令；写出 graph/lineage/publish bundle 工件，并只调用原生 CLI builder slices |
 | `tiangong review process` | 本地 process review、artifact-first 报告输出、可选 CLI LLM 语义审核 |
 | `tiangong review flow` | 本地 flow governance review、rows-file 物化、artifact-first 报告输出、可选 CLI LLM 语义审核 |
-| `tiangong publish run` | 本地 publish 契约归一化、dry-run/commit、report 输出 |
+| `tiangong publish run` | 本地 publish 契约归一化、dry-run/commit、report 输出；当提供 Supabase runtime 时默认通过共享 dataset command executor 提交 `lifecyclemodels` / `processes` / `sources` |
 | `tiangong validation run` | 本地 `@tiangong-lca/tidas-sdk` 直接依赖校验收口 |
 | `tiangong admin embedding-run` | `embedding_ft` |
 
@@ -175,8 +175,8 @@ tiangong
 - 已实现的 `flow get` 保留 deterministic direct-read 边界，但内部执行已经收口到原生 `@supabase/supabase-js`；支持 `id` + 可选 `version/user_id/state_code` 读取；若精确版本 miss，则回退到最新可见版本；若出现多个同版本可见候选，则直接报 ambiguous
 - 已实现的 `flow list` 保留 deterministic direct-read 边界，但内部执行已经收口到原生 `@supabase/supabase-js`；支持稳定 `id/state_code/type_of_dataset` 过滤、显式 `order=id.asc,version.asc` 默认值，以及 `--all --page-size` 的 offset 分页
 - 已实现的 `flow remediate` 保留旧 invalid-flow 输入与 round1 artifact 契约，但运行时已经收口到 CLI，不再需要 skill 私有 Python remediation 入口
-- 已实现的 `flow publish-version` 直接从 `TIANGONG_LCA_API_BASE_URL` 推导 `/rest/v1/flows` 写入目标，并通过原生 `@supabase/supabase-js` 支持 dry-run/commit；同时保留 `mcp_success_list`、`remote_validation_failed`、`mcp_sync_report` 这些历史文件名
-- 已实现的 `flow publish-reviewed-data` 负责 reviewed publish preparation 阶段：支持 `--original-flow-rows-file` unchanged skip、flow/process `skip | append_only_bump | upsert_current_version`、`prepared-flow-rows.json` / `prepared-process-rows.json` / `flow-version-map.json` / `skipped-unchanged-flow-rows.json` / `process-flow-ref-rewrite-evidence.jsonl` / `publish-report.json` 输出，并在 `--commit` 时通过同一条 `@supabase/supabase-js` writer layer 同时执行 prepared flow rows 与 prepared process rows 的远端写入
+- 已实现的 `flow publish-version` 先做 `/rest/v1/flows` 精确版本可见性预检，再通过 `app_dataset_create` / `app_dataset_save_draft` 提交远端写入；`TIANGONG_LCA_API_BASE_URL` 可传 project root、`/functions/v1` 或 `/rest/v1`，同时继续保留 `mcp_success_list`、`remote_validation_failed`、`mcp_sync_report` 这些历史文件名
+- 已实现的 `flow publish-reviewed-data` 负责 reviewed publish preparation 阶段：支持 `--original-flow-rows-file` unchanged skip、flow/process `skip | append_only_bump | upsert_current_version`、`prepared-flow-rows.json` / `prepared-process-rows.json` / `flow-version-map.json` / `skipped-unchanged-flow-rows.json` / `process-flow-ref-rewrite-evidence.jsonl` / `publish-report.json` 输出，并在 `--commit` 时通过同一条共享 dataset command writer layer 同时执行 prepared flow rows 与 prepared process rows 的远端写入
 - 已实现的 `flow build-alias-map` 把治理链中的 deterministic alias-map 构建切片收口到 CLI，固定 old/new flow snapshots 与可选 `seed-alias-map` 输入契约，并直接写出 `alias-plan.json` / `flow-alias-map.json` / `manual-review-queue.jsonl` / `alias-summary.json`
 - 已实现的 `flow scan-process-flow-refs` 把治理链中的独立 process ref scan 切片收口到 CLI，固定 process/scope/catalog/alias 输入契约，并直接写出 `scan-summary.json` / `scan-findings.json` / `scan-findings.jsonl`
 - 已实现的 `flow plan-process-flow-repairs` 把治理链中的独立 deterministic repair planning 切片收口到 CLI，固定 process/scope/alias/scan 输入契约，并直接写出 `repair-plan.json` / `manual-review-queue.jsonl` / `repair-summary.json`
@@ -574,8 +574,9 @@ tiangong admin embedding-run --input ./jobs.json --dry-run
 它负责：
 
 - 读取 ready-for-publish flow JSON / JSONL 输入
-- 从 `TIANGONG_LCA_API_BASE_URL` 推导 Supabase `/rest/v1/flows` 路径
-- 在 dry-run 或 commit 模式下执行 `would_insert`、`would_update_existing`、`insert`、`update_existing`
+- 从 `TIANGONG_LCA_API_BASE_URL` 推导 Supabase REST 预检路径与 Edge Function dataset command 路径；支持 project root、`/functions/v1`、`/rest/v1`
+- dry-run 通过精确版本可见性预检执行 `would_insert`、`would_update_existing` 或失败判定
+- commit 通过同一条预检链调用 `app_dataset_create` / `app_dataset_save_draft`，并在需要时落到 `insert`、`update_existing`、`update_after_insert_error`
 - 输出 `flows_tidas_sdk_plus_classification_mcp_success_list.json`
 - 输出 `flows_tidas_sdk_plus_classification_remote_validation_failed.jsonl`
 - 输出 `flows_tidas_sdk_plus_classification_mcp_sync_report.json`
@@ -698,13 +699,15 @@ tiangong admin embedding-run --input ./jobs.json --dry-run
 - 统一 `dry-run` / `commit` override
 - 识别 canonical process payload 与 projection payload
 - 产出结构化 `publish-report.json`
-- 把真正的 commit 执行动作留给显式 executor
+- 在提供 Supabase runtime 时，默认通过共享 dataset command executor 提交 `lifecyclemodels` / `processes` / `sources`
+- 允许调用方继续为其他类别或自定义链路注入显式 executor
 
 这样做的好处是：
 
 - CLI 先稳定输入/输出合同
 - 不把旧 MCP transport 重新带回命令树
-- 后续真有直连 REST publish executor 时，只需要接到同一模块，不需要再改调用方契约
+- REST 预检、Edge Function 提交、artifact 报告都复用同一条 writer 链
+- 即使后续扩充更多 dataset 类别，也不需要再改调用方契约
 
 `validation run` 则固定“统一校验报告层”：
 

--- a/src/lib/dataset-command.ts
+++ b/src/lib/dataset-command.ts
@@ -1,0 +1,224 @@
+import { CliError } from './errors.js';
+import type { ResponseLike } from './http.js';
+import {
+  createSupabaseFetch,
+  deriveSupabaseFunctionsBaseUrl,
+  type SupabaseDataRuntime,
+} from './supabase-client.js';
+
+type JsonObject = Record<string, unknown>;
+
+export type DatasetCommandTable =
+  | 'contacts'
+  | 'sources'
+  | 'unitgroups'
+  | 'flowproperties'
+  | 'flows'
+  | 'processes'
+  | 'lifecyclemodels';
+
+export type DatasetCommandName = 'create' | 'save_draft';
+
+type DatasetCommandFailurePayload = {
+  ok: false;
+  code: string;
+  message: string;
+  details?: unknown;
+};
+
+type DatasetCommandSuccessEnvelope = {
+  ok: true;
+  data?: unknown;
+};
+
+export type DatasetCommandCreateInput = {
+  table: DatasetCommandTable;
+  id: string;
+  jsonOrdered: unknown;
+  modelId?: string | null;
+  ruleVerification?: boolean | null;
+};
+
+export type DatasetCommandSaveDraftInput = DatasetCommandCreateInput & {
+  version: string;
+};
+
+export type DatasetCommandClient = {
+  create: (input: DatasetCommandCreateInput) => Promise<unknown>;
+  saveDraft: (input: DatasetCommandSaveDraftInput) => Promise<unknown>;
+};
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function trimToken(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function command_endpoint(command: DatasetCommandName): string {
+  return command === 'create' ? 'app_dataset_create' : 'app_dataset_save_draft';
+}
+
+export function buildDatasetCommandUrl(apiBaseUrl: string, command: DatasetCommandName): string {
+  return `${deriveSupabaseFunctionsBaseUrl(apiBaseUrl)}/${command_endpoint(command)}`;
+}
+
+export function buildDatasetCommandHeaders(
+  region: string | null | undefined,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  const normalizedRegion = trimToken(region);
+  if (normalizedRegion) {
+    headers['x-region'] = normalizedRegion;
+  }
+  return headers;
+}
+
+export function buildDatasetCommandBody(
+  command: DatasetCommandName,
+  input: DatasetCommandCreateInput | DatasetCommandSaveDraftInput,
+): JsonObject {
+  const body: JsonObject = {
+    table: input.table,
+    id: input.id,
+    jsonOrdered: input.jsonOrdered,
+  };
+
+  if (command === 'save_draft') {
+    body.version = (input as DatasetCommandSaveDraftInput).version;
+  }
+
+  if ('modelId' in input && input.modelId !== undefined) {
+    body.modelId = input.modelId;
+  }
+
+  if ('ruleVerification' in input && input.ruleVerification !== undefined) {
+    body.ruleVerification = input.ruleVerification;
+  }
+
+  return body;
+}
+
+function parseJsonText(rawText: string, url: string): unknown {
+  try {
+    return JSON.parse(rawText);
+  } catch (error) {
+    throw new CliError(`Remote response was not valid JSON for ${url}`, {
+      code: 'REMOTE_INVALID_JSON',
+      exitCode: 1,
+      details: String(error),
+    });
+  }
+}
+
+function isDatasetCommandFailurePayload(value: unknown): value is DatasetCommandFailurePayload {
+  return (
+    isRecord(value) &&
+    value.ok === false &&
+    typeof value.code === 'string' &&
+    typeof value.message === 'string'
+  );
+}
+
+function unwrapDatasetCommandPayload(payload: unknown): unknown {
+  if (isDatasetCommandFailurePayload(payload)) {
+    throw new CliError(payload.message, {
+      code: 'REMOTE_REQUEST_FAILED',
+      exitCode: 1,
+      details: `${payload.code}: ${payload.message}`,
+    });
+  }
+
+  if (isRecord(payload) && payload.ok === true && 'data' in payload) {
+    return (payload as DatasetCommandSuccessEnvelope).data ?? null;
+  }
+
+  return payload;
+}
+
+function parseDatasetCommandResponse(
+  response: ResponseLike,
+  url: string,
+  rawText: string,
+): unknown {
+  const contentType = response.headers.get('content-type') ?? '';
+  const parsed =
+    rawText.length === 0
+      ? null
+      : contentType.includes('application/json')
+        ? parseJsonText(rawText, url)
+        : rawText;
+
+  if (!response.ok) {
+    if (isDatasetCommandFailurePayload(parsed)) {
+      throw new CliError(`HTTP ${response.status} returned from ${url}`, {
+        code: 'REMOTE_REQUEST_FAILED',
+        exitCode: 1,
+        details: `${parsed.code}: ${parsed.message}`,
+      });
+    }
+
+    throw new CliError(`HTTP ${response.status} returned from ${url}`, {
+      code: 'REMOTE_REQUEST_FAILED',
+      exitCode: 1,
+      details: typeof parsed === 'string' ? parsed : rawText || undefined,
+    });
+  }
+
+  return unwrapDatasetCommandPayload(parsed);
+}
+
+async function executeDatasetCommand(
+  fetchWithAuth: typeof fetch,
+  url: string,
+  headers: Record<string, string>,
+  body: JsonObject,
+): Promise<unknown> {
+  const response = await fetchWithAuth(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+  return parseDatasetCommandResponse(response, url, await response.text());
+}
+
+export function createDatasetCommandClient(options: {
+  runtime: SupabaseDataRuntime;
+  fetchImpl: (input: string, init?: RequestInit) => Promise<ResponseLike>;
+  timeoutMs: number;
+  region?: string | null;
+}): DatasetCommandClient {
+  const fetchWithAuth = createSupabaseFetch(options.fetchImpl, options.timeoutMs, options.runtime);
+  const headers = buildDatasetCommandHeaders(options.region);
+  const createUrl = buildDatasetCommandUrl(options.runtime.apiBaseUrl, 'create');
+  const saveDraftUrl = buildDatasetCommandUrl(options.runtime.apiBaseUrl, 'save_draft');
+
+  return {
+    create: (input) =>
+      executeDatasetCommand(
+        fetchWithAuth,
+        createUrl,
+        headers,
+        buildDatasetCommandBody('create', input),
+      ),
+    saveDraft: (input) =>
+      executeDatasetCommand(
+        fetchWithAuth,
+        saveDraftUrl,
+        headers,
+        buildDatasetCommandBody('save_draft', input),
+      ),
+  };
+}
+
+export const __testInternals = {
+  buildDatasetCommandBody,
+  buildDatasetCommandHeaders,
+  buildDatasetCommandUrl,
+  command_endpoint,
+  parseDatasetCommandResponse,
+  unwrapDatasetCommandPayload,
+};

--- a/src/lib/flow-publish-version.ts
+++ b/src/lib/flow-publish-version.ts
@@ -1,6 +1,8 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { writeJsonArtifact, writeJsonLinesArtifact } from './artifacts.js';
+import { createDatasetCommandClient, type DatasetCommandClient } from './dataset-command.js';
+import { readRuntimeEnv } from './env.js';
 import { CliError } from './errors.js';
 import {
   coerceText,
@@ -14,7 +16,6 @@ import {
   createSupabaseDataClient,
   requireSupabaseRestRuntime,
   runSupabaseArrayQuery,
-  runSupabaseMutation,
 } from './supabase-client.js';
 import { createSupabaseDataRuntime } from './supabase-session.js';
 
@@ -446,45 +447,36 @@ function build_error_reasons(stage: string, error: unknown): FlowPublishFailureR
 }
 
 async function insert_flow_version(options: {
-  client: SupabaseDataClient;
-  restBaseUrl: string;
+  commandClient: DatasetCommandClient;
   rowId: string;
   payload: JsonRecord;
 }): Promise<void> {
-  const url = `${options.restBaseUrl.replace(/\/+$/u, '')}/flows`;
-  await runSupabaseMutation(
-    options.client.from('flows').insert({
-      id: options.rowId,
-      json_ordered: options.payload,
-    }),
-    url,
-  );
+  await options.commandClient.create({
+    table: 'flows',
+    id: options.rowId,
+    jsonOrdered: options.payload,
+  });
 }
 
 async function update_flow_version(options: {
-  client: SupabaseDataClient;
-  restBaseUrl: string;
+  commandClient: DatasetCommandClient;
   rowId: string;
   version: string;
   payload: JsonRecord;
 }): Promise<void> {
-  const url = build_update_url(options.restBaseUrl, options.rowId, options.version);
-  await runSupabaseMutation(
-    options.client
-      .from('flows')
-      .update({
-        json_ordered: options.payload,
-      })
-      .eq('id', options.rowId)
-      .eq('version', options.version),
-    url,
-  );
+  await options.commandClient.saveDraft({
+    table: 'flows',
+    id: options.rowId,
+    version: options.version,
+    jsonOrdered: options.payload,
+  });
 }
 
 async function sync_one_row(options: {
   row: JsonRecord;
   mode: FlowPublishMode;
   client: SupabaseDataClient;
+  commandClient: DatasetCommandClient;
   restBaseUrl: string;
   targetUserIdOverride: string | null;
 }): Promise<FlowPublishOutcome> {
@@ -541,8 +533,7 @@ async function sync_one_row(options: {
 
     if (ownBefore) {
       await update_flow_version({
-        client: options.client,
-        restBaseUrl: options.restBaseUrl,
+        commandClient: options.commandClient,
         rowId,
         version,
         payload,
@@ -569,8 +560,7 @@ async function sync_one_row(options: {
 
     try {
       await insert_flow_version({
-        client: options.client,
-        restBaseUrl: options.restBaseUrl,
+        commandClient: options.commandClient,
         rowId,
         payload,
       });
@@ -593,8 +583,7 @@ async function sync_one_row(options: {
       if (ownAfter) {
         try {
           await update_flow_version({
-            client: options.client,
-            restBaseUrl: options.restBaseUrl,
+            commandClient: options.commandClient,
             rowId,
             version,
             payload,
@@ -697,6 +686,12 @@ export async function runFlowPublishVersion(
     now,
   });
   const { client, restBaseUrl } = createSupabaseDataClient(runtime, fetchImpl, timeoutMs);
+  const commandClient = createDatasetCommandClient({
+    runtime,
+    fetchImpl,
+    timeoutMs,
+    region: readRuntimeEnv(options.env ?? process.env).region,
+  });
   const targetUserIdOverride = normalize_token(options.targetUserId ?? null);
   const files = build_output_files(outDir);
 
@@ -716,6 +711,7 @@ export async function runFlowPublishVersion(
       row,
       mode,
       client,
+      commandClient,
       restBaseUrl,
       targetUserIdOverride,
     }),

--- a/src/lib/remote.ts
+++ b/src/lib/remote.ts
@@ -3,7 +3,7 @@ import { readRuntimeEnv } from './env.js';
 import type { FetchLike } from './http.js';
 import { postJson } from './http.js';
 import { readJsonInput, stringifyJson } from './io.js';
-import { requireSupabaseRestRuntime } from './supabase-client.js';
+import { deriveSupabaseFunctionsBaseUrl, requireSupabaseRestRuntime } from './supabase-client.js';
 import { resolveSupabaseUserSession } from './supabase-session.js';
 
 type RemoteCommandSpec = {
@@ -46,7 +46,7 @@ export type RemoteCommandOptions = {
 };
 
 function buildUrl(baseUrl: string, endpoint: string): string {
-  return `${baseUrl.replace(/\/+$/u, '')}/${endpoint}`;
+  return `${deriveSupabaseFunctionsBaseUrl(baseUrl)}/${endpoint}`;
 }
 
 function buildHeaders(

--- a/src/lib/supabase-client.ts
+++ b/src/lib/supabase-client.ts
@@ -117,6 +117,9 @@ export function deriveSupabaseRestBaseUrl(apiBaseUrl: string): string {
   return `${deriveSupabaseProjectBaseUrl(apiBaseUrl)}/rest/v1`;
 }
 
+export const deriveSupabaseFunctionsBaseUrl = (apiBaseUrl: string): string =>
+  `${deriveSupabaseProjectBaseUrl(apiBaseUrl)}/functions/v1`;
+
 function mergeSignals(signal: AbortSignal | null | undefined, timeoutMs: number): AbortSignal {
   const timeoutSignal = AbortSignal.timeout(timeoutMs);
   return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
@@ -374,8 +377,10 @@ export function createSupabaseDataClient(
   fetchImpl: FetchLike,
   timeoutMs: number,
 ) {
+  const projectBaseUrl = deriveSupabaseProjectBaseUrl(runtime.apiBaseUrl);
+
   return {
-    client: createClient(deriveSupabaseProjectBaseUrl(runtime.apiBaseUrl), runtime.publishableKey, {
+    client: createClient(projectBaseUrl, runtime.publishableKey, {
       auth: {
         autoRefreshToken: false,
         persistSession: false,
@@ -385,7 +390,8 @@ export function createSupabaseDataClient(
         fetch: createSupabaseFetch(fetchImpl, timeoutMs, runtime),
       },
     }),
-    restBaseUrl: deriveSupabaseRestBaseUrl(runtime.apiBaseUrl),
+    restBaseUrl: deriveSupabaseRestBaseUrl(projectBaseUrl),
+    functionsBaseUrl: deriveSupabaseFunctionsBaseUrl(projectBaseUrl),
   };
 }
 

--- a/src/lib/supabase-json-ordered-write.ts
+++ b/src/lib/supabase-json-ordered-write.ts
@@ -1,10 +1,11 @@
+import { createDatasetCommandClient, type DatasetCommandClient } from './dataset-command.js';
+import { readRuntimeEnv } from './env.js';
 import { CliError } from './errors.js';
 import type { FetchLike } from './http.js';
 import {
   createSupabaseDataClient,
   requireSupabaseRestRuntime,
   runSupabaseArrayQuery,
-  runSupabaseMutation,
 } from './supabase-client.js';
 import { createSupabaseDataRuntime } from './supabase-session.js';
 
@@ -112,45 +113,35 @@ async function exactVisibleRows(options: {
 }
 
 async function insertJsonOrderedRow(options: {
-  client: SupabaseDataClient;
-  restBaseUrl: string;
+  commandClient: DatasetCommandClient;
   table: SupabaseJsonOrderedTable;
   id: string;
   payload: JsonObject;
   extraData?: JsonObject;
 }): Promise<void> {
-  const url = `${options.restBaseUrl.replace(/\/+$/u, '')}/${options.table}`;
-  await runSupabaseMutation(
-    options.client.from(options.table).insert({
-      id: options.id,
-      json_ordered: options.payload,
-      ...(options.extraData ?? {}),
-    }),
-    url,
-  );
+  await options.commandClient.create({
+    table: options.table,
+    id: options.id,
+    jsonOrdered: options.payload,
+    ...commandOptionsFromExtraData(options.extraData),
+  });
 }
 
 async function updateJsonOrderedRow(options: {
-  client: SupabaseDataClient;
-  restBaseUrl: string;
+  commandClient: DatasetCommandClient;
   table: SupabaseJsonOrderedTable;
   id: string;
   version: string;
   payload: JsonObject;
   extraData?: JsonObject;
 }): Promise<void> {
-  const url = buildUpdateUrl(options.restBaseUrl, options.table, options.id, options.version);
-  await runSupabaseMutation(
-    options.client
-      .from(options.table)
-      .update({
-        json_ordered: options.payload,
-        ...(options.extraData ?? {}),
-      })
-      .eq('id', options.id)
-      .eq('version', options.version),
-    url,
-  );
+  await options.commandClient.saveDraft({
+    table: options.table,
+    id: options.id,
+    version: options.version,
+    jsonOrdered: options.payload,
+    ...commandOptionsFromExtraData(options.extraData),
+  });
 }
 
 function requireNonEmptyToken(value: string, label: string, code: string): string {
@@ -162,6 +153,34 @@ function requireNonEmptyToken(value: string, label: string, code: string): strin
     });
   }
   return normalized;
+}
+
+function commandOptionsFromExtraData(extraData?: JsonObject): {
+  modelId?: string | null;
+  ruleVerification?: boolean | null;
+} {
+  if (!extraData) {
+    return {};
+  }
+
+  const result: {
+    modelId?: string | null;
+    ruleVerification?: boolean | null;
+  } = {};
+
+  if ('modelId' in extraData || 'model_id' in extraData) {
+    const modelIdValue = extraData.modelId ?? extraData.model_id;
+    result.modelId = modelIdValue === null ? null : trimToken(modelIdValue) || null;
+  }
+
+  if ('ruleVerification' in extraData || 'rule_verification' in extraData) {
+    const ruleVerificationValue = extraData.ruleVerification ?? extraData.rule_verification;
+    if (typeof ruleVerificationValue === 'boolean' || ruleVerificationValue === null) {
+      result.ruleVerification = ruleVerificationValue;
+    }
+  }
+
+  return result;
 }
 
 export function hasSupabaseRestRuntime(env: NodeJS.ProcessEnv | undefined): boolean {
@@ -200,6 +219,12 @@ export async function syncSupabaseJsonOrderedRecord(options: {
     timeoutMs,
   });
   const { client, restBaseUrl } = createSupabaseDataClient(runtime, options.fetchImpl, timeoutMs);
+  const commandClient = createDatasetCommandClient({
+    runtime,
+    fetchImpl: options.fetchImpl,
+    timeoutMs,
+    region: readRuntimeEnv(options.env).region,
+  });
 
   const visibleBefore = await exactVisibleRows({
     client,
@@ -218,8 +243,7 @@ export async function syncSupabaseJsonOrderedRecord(options: {
 
   if (visibleBefore.length > 0) {
     await updateJsonOrderedRow({
-      client,
-      restBaseUrl,
+      commandClient,
       table: options.table,
       id,
       version,
@@ -234,8 +258,7 @@ export async function syncSupabaseJsonOrderedRecord(options: {
 
   try {
     await insertJsonOrderedRow({
-      client,
-      restBaseUrl,
+      commandClient,
       table: options.table,
       id,
       payload: options.payload,
@@ -266,8 +289,7 @@ export async function syncSupabaseJsonOrderedRecord(options: {
     }
 
     await updateJsonOrderedRow({
-      client,
-      restBaseUrl,
+      commandClient,
       table: options.table,
       id,
       version,
@@ -286,6 +308,7 @@ export const __testInternals = {
   buildUpdateUrl,
   parseVisibleRows,
   exactVisibleRows,
+  commandOptionsFromExtraData,
   insertJsonOrderedRow,
   updateJsonOrderedRow,
   requireNonEmptyToken,

--- a/test/dataset-command.test.ts
+++ b/test/dataset-command.test.ts
@@ -1,0 +1,288 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { CliError } from '../src/lib/errors.js';
+import { createDatasetCommandClient, __testInternals } from '../src/lib/dataset-command.js';
+
+function makeResponse(options: {
+  ok: boolean;
+  status: number;
+  contentType?: string;
+  body?: string;
+}) {
+  return {
+    ok: options.ok,
+    status: options.status,
+    headers: {
+      get(name: string): string | null {
+        return name.toLowerCase() === 'content-type'
+          ? (options.contentType ?? 'application/json')
+          : null;
+      },
+    },
+    async text(): Promise<string> {
+      return options.body ?? '';
+    },
+  };
+}
+
+const runtime = {
+  apiBaseUrl: 'https://example.supabase.co/rest/v1',
+  publishableKey: 'sb-publishable-key',
+  getAccessToken: async () => 'access-token',
+  refreshAccessToken: async () => 'refreshed-access-token',
+};
+
+test('dataset command helpers derive URLs, headers, bodies, and unwrap success envelopes', () => {
+  assert.equal(__testInternals.command_endpoint('create'), 'app_dataset_create');
+  assert.equal(__testInternals.command_endpoint('save_draft'), 'app_dataset_save_draft');
+  assert.equal(
+    __testInternals.buildDatasetCommandUrl('https://example.supabase.co', 'create'),
+    'https://example.supabase.co/functions/v1/app_dataset_create',
+  );
+  assert.equal(
+    __testInternals.buildDatasetCommandUrl('https://example.supabase.co/rest/v1', 'save_draft'),
+    'https://example.supabase.co/functions/v1/app_dataset_save_draft',
+  );
+  assert.deepEqual(__testInternals.buildDatasetCommandHeaders('us-east-1'), {
+    'Content-Type': 'application/json',
+    'x-region': 'us-east-1',
+  });
+  assert.deepEqual(__testInternals.buildDatasetCommandHeaders('  '), {
+    'Content-Type': 'application/json',
+  });
+  assert.deepEqual(
+    __testInternals.buildDatasetCommandBody('create', {
+      table: 'flows',
+      id: 'flow-1',
+      jsonOrdered: { flowDataSet: {} },
+      ruleVerification: false,
+    }),
+    {
+      table: 'flows',
+      id: 'flow-1',
+      jsonOrdered: { flowDataSet: {} },
+      ruleVerification: false,
+    },
+  );
+  assert.deepEqual(
+    __testInternals.buildDatasetCommandBody('save_draft', {
+      table: 'processes',
+      id: 'proc-1',
+      version: '01.00.001',
+      jsonOrdered: { processDataSet: {} },
+      modelId: 'model-1',
+    }),
+    {
+      table: 'processes',
+      id: 'proc-1',
+      version: '01.00.001',
+      jsonOrdered: { processDataSet: {} },
+      modelId: 'model-1',
+    },
+  );
+  assert.deepEqual(
+    __testInternals.unwrapDatasetCommandPayload({
+      ok: true,
+      data: { id: 'flow-1', version: '01.00.001' },
+    }),
+    { id: 'flow-1', version: '01.00.001' },
+  );
+  assert.equal(
+    __testInternals.unwrapDatasetCommandPayload({
+      ok: true,
+      data: null,
+    }),
+    null,
+  );
+  assert.equal(__testInternals.unwrapDatasetCommandPayload('plain-text'), 'plain-text');
+
+  assert.throws(
+    () =>
+      __testInternals.unwrapDatasetCommandPayload({
+        ok: false,
+        code: 'DATASET_OWNER_REQUIRED',
+        message: 'Only the dataset owner can save draft changes',
+      }),
+    (error) =>
+      error instanceof CliError &&
+      error.code === 'REMOTE_REQUEST_FAILED' &&
+      error.details === 'DATASET_OWNER_REQUIRED: Only the dataset owner can save draft changes',
+  );
+});
+
+test('dataset command client posts create and save-draft requests to edge-function endpoints', async () => {
+  const observed: Array<{ url: string; method: string; headers: Headers; body: string }> = [];
+  let callCount = 0;
+  const client = createDatasetCommandClient({
+    runtime,
+    fetchImpl: async (url, init) => {
+      observed.push({
+        url,
+        method: String(init?.method ?? ''),
+        headers: new Headers(init?.headers),
+        body: typeof init?.body === 'string' ? init.body : '',
+      });
+      callCount += 1;
+      return makeResponse({
+        ok: true,
+        status: 200,
+        body: JSON.stringify({
+          ok: true,
+          command: callCount === 1 ? 'dataset_create' : 'dataset_save_draft',
+          data: callCount === 1 ? { id: 'flow-1' } : { id: 'flow-1', version: '01.00.001' },
+        }),
+      });
+    },
+    timeoutMs: 25,
+    region: 'us-east-1',
+  });
+
+  assert.deepEqual(
+    await client.create({
+      table: 'flows',
+      id: 'flow-1',
+      jsonOrdered: { flowDataSet: {} },
+      ruleVerification: null,
+    }),
+    { id: 'flow-1' },
+  );
+  assert.deepEqual(
+    await client.saveDraft({
+      table: 'processes',
+      id: 'proc-1',
+      version: '01.00.001',
+      jsonOrdered: { processDataSet: {} },
+      modelId: 'model-1',
+    }),
+    { id: 'flow-1', version: '01.00.001' },
+  );
+
+  assert.deepEqual(
+    observed.map((entry) => [entry.method, entry.url]),
+    [
+      ['POST', 'https://example.supabase.co/functions/v1/app_dataset_create'],
+      ['POST', 'https://example.supabase.co/functions/v1/app_dataset_save_draft'],
+    ],
+  );
+  assert.equal(observed[0]?.headers.get('Authorization'), 'Bearer access-token');
+  assert.equal(observed[0]?.headers.get('apikey'), 'sb-publishable-key');
+  assert.equal(observed[0]?.headers.get('x-region'), 'us-east-1');
+  assert.deepEqual(JSON.parse(observed[0]?.body ?? '{}'), {
+    table: 'flows',
+    id: 'flow-1',
+    jsonOrdered: { flowDataSet: {} },
+    ruleVerification: null,
+  });
+  assert.deepEqual(JSON.parse(observed[1]?.body ?? '{}'), {
+    table: 'processes',
+    id: 'proc-1',
+    version: '01.00.001',
+    jsonOrdered: { processDataSet: {} },
+    modelId: 'model-1',
+  });
+});
+
+test('dataset command client maps structured command failures to CliError', async () => {
+  const client = createDatasetCommandClient({
+    runtime,
+    fetchImpl: async () =>
+      makeResponse({
+        ok: false,
+        status: 403,
+        body: JSON.stringify({
+          ok: false,
+          code: 'DATASET_OWNER_REQUIRED',
+          message: 'Only the dataset owner can save draft changes',
+        }),
+      }),
+    timeoutMs: 25,
+    region: null,
+  });
+
+  await assert.rejects(
+    () =>
+      client.saveDraft({
+        table: 'sources',
+        id: 'src-1',
+        version: '01.00.001',
+        jsonOrdered: { sourceDataSet: {} },
+      }),
+    (error) =>
+      error instanceof CliError &&
+      error.code === 'REMOTE_REQUEST_FAILED' &&
+      error.details === 'DATASET_OWNER_REQUIRED: Only the dataset owner can save draft changes',
+  );
+});
+
+test('dataset command response parsing handles plain text and invalid JSON branches', async () => {
+  assert.equal(
+    __testInternals.parseDatasetCommandResponse(
+      makeResponse({
+        ok: true,
+        status: 200,
+        contentType: 'text/plain',
+        body: 'created',
+      }),
+      'https://example.supabase.co/functions/v1/app_dataset_create',
+      'created',
+    ),
+    'created',
+  );
+
+  assert.throws(
+    () =>
+      __testInternals.parseDatasetCommandResponse(
+        makeResponse({
+          ok: true,
+          status: 200,
+          contentType: 'application/json',
+          body: '{broken-json',
+        }),
+        'https://example.supabase.co/functions/v1/app_dataset_create',
+        '{broken-json',
+      ),
+    (error) => error instanceof CliError && error.code === 'REMOTE_INVALID_JSON',
+  );
+
+  assert.throws(
+    () =>
+      __testInternals.parseDatasetCommandResponse(
+        makeResponse({
+          ok: false,
+          status: 500,
+          contentType: 'text/plain',
+          body: 'upstream unavailable',
+        }),
+        'https://example.supabase.co/functions/v1/app_dataset_save_draft',
+        'upstream unavailable',
+      ),
+    (error) =>
+      error instanceof CliError &&
+      error.code === 'REMOTE_REQUEST_FAILED' &&
+      error.details === 'upstream unavailable',
+  );
+
+  assert.throws(
+    () =>
+      __testInternals.parseDatasetCommandResponse(
+        {
+          ok: false,
+          status: 500,
+          headers: {
+            get() {
+              return null;
+            },
+          },
+          async text() {
+            return '';
+          },
+        },
+        'https://example.supabase.co/functions/v1/app_dataset_save_draft',
+        '',
+      ),
+    (error) =>
+      error instanceof CliError &&
+      error.code === 'REMOTE_REQUEST_FAILED' &&
+      error.details === undefined,
+  );
+});

--- a/test/flow-publish-reviewed-data.test.ts
+++ b/test/flow-publish-reviewed-data.test.ts
@@ -676,7 +676,7 @@ test('flow publish reviewed data process helpers unwrap root payloads and map up
       publish_policy: 'upsert_current_version',
       version_strategy: 'keep_current',
       status: 'failed',
-      error: 'HTTP 409 returned from https://example.supabase.co/rest/v1/processes',
+      error: '{"message":"duplicate"}',
     },
   ]);
 
@@ -930,14 +930,14 @@ test('runFlowReviewedPublishData commits prepared process rows through Supabase 
 
         return {
           ok: true,
-          status: 201,
+          status: 200,
           headers: {
             get() {
               return 'application/json';
             },
           },
           async text() {
-            return '[{"id":"process-commit"}]';
+            return '{"ok":true,"command":"dataset_create","data":{"id":"process-commit"}}';
           },
         };
       }),
@@ -952,7 +952,7 @@ test('runFlowReviewedPublishData commits prepared process rows through Supabase 
       observed.map((entry) => entry.method),
       ['GET', 'POST'],
     );
-    assert.match(observed[1]?.body ?? '', /"json_ordered"/u);
+    assert.match(observed[1]?.body ?? '', /"jsonOrdered"/u);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/flow-publish-version.test.ts
+++ b/test/flow-publish-version.test.ts
@@ -256,20 +256,34 @@ test('runFlowPublishVersion commit executes update, insert, fallback update, and
           {
             body: [{ id: 'flow-1', version: '01.00.001', user_id: 'user-1', state_code: 100 }],
           },
-          { contentType: 'text/plain', rawText: 'patched' },
+          {
+            body: { ok: true, command: 'dataset_save_draft', data: { id: 'flow-1' } },
+          },
           { body: [] },
-          { contentType: '', rawText: '' },
+          {
+            body: { ok: true, command: 'dataset_create', data: { id: 'flow-2' } },
+          },
           { body: [] },
-          { ok: false, status: 409, contentType: 'text/plain', rawText: 'duplicate' },
+          {
+            ok: false,
+            status: 409,
+            body: { ok: false, code: 'DUPLICATE_VERSION', message: 'duplicate' },
+          },
           {
             body: [{ id: 'flow-3', version: '01.00.001', user_id: 'user-3', state_code: 100 }],
           },
-          { body: [] },
+          {
+            body: { ok: true, command: 'dataset_save_draft', data: { id: 'flow-3' } },
+          },
           {
             body: [{ id: 'flow-4', version: '01.00.001', user_id: 'other-user', state_code: 40 }],
           },
           { body: [] },
-          { ok: false, status: 500, contentType: 'application/json', body: { message: 'boom' } },
+          {
+            ok: false,
+            status: 500,
+            body: { ok: false, code: 'INTERNAL_ERROR', message: 'boom' },
+          },
           { body: [] },
         ],
         observed,
@@ -313,11 +327,11 @@ test('runFlowPublishVersion commit executes update, insert, fallback update, and
 
     assert.deepEqual(
       observed.map((entry) => entry.method),
-      ['GET', 'PATCH', 'GET', 'POST', 'GET', 'POST', 'GET', 'PATCH', 'GET', 'GET', 'POST', 'GET'],
+      ['GET', 'POST', 'GET', 'POST', 'GET', 'POST', 'GET', 'POST', 'GET', 'GET', 'POST', 'GET'],
     );
-    assert.match(observed[1]?.url ?? '', /version=eq\.01\.00\.001/u);
-    assert.match(observed[3]?.url ?? '', /\/rest\/v1\/flows$/u);
-    assert.match(observed[1]?.body ?? '', /json_ordered/u);
+    assert.match(observed[1]?.url ?? '', /\/functions\/v1\/app_dataset_save_draft$/u);
+    assert.match(observed[3]?.url ?? '', /\/functions\/v1\/app_dataset_create$/u);
+    assert.match(observed[1]?.body ?? '', /"jsonOrdered"/u);
     assert.match(observed[3]?.body ?? '', /"id":"flow-2"/u);
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -560,11 +574,19 @@ test('runFlowPublishVersion surfaces update-after-insert-error failures when fal
       fetchImpl: makeFetchQueue(
         [
           { body: [] },
-          { ok: false, status: 409, contentType: 'text/plain', rawText: 'duplicate' },
+          {
+            ok: false,
+            status: 409,
+            body: { ok: false, code: 'DUPLICATE_VERSION', message: 'duplicate' },
+          },
           {
             body: [{ id: 'flow-1', version: '01.00.001', user_id: 'user-1', state_code: 100 }],
           },
-          { ok: false, status: 500, contentType: 'text/plain', rawText: 'patch failed' },
+          {
+            ok: false,
+            status: 500,
+            body: { ok: false, code: 'SAVE_DRAFT_FAILED', message: 'patch failed' },
+          },
         ],
         observed,
       ),
@@ -579,7 +601,7 @@ test('runFlowPublishVersion surfaces update-after-insert-error failures when fal
     });
     assert.deepEqual(
       observed.map((entry) => entry.method),
-      ['GET', 'POST', 'GET', 'PATCH'],
+      ['GET', 'POST', 'GET', 'POST'],
     );
 
     const failures = readFileSync(report.files.remote_failed, 'utf8')

--- a/test/publish.test.ts
+++ b/test/publish.test.ts
@@ -436,8 +436,8 @@ test('runPublish honors commit override, defers missing executors, and rejects i
   }
 });
 
-test('runPublish uses default Supabase REST dataset executors when runtime env and fetch are provided', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-publish-default-rest-'));
+test('runPublish uses default Supabase dataset command executors when runtime env and fetch are provided', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-publish-default-dataset-command-'));
   const requestPath = path.join(dir, 'request.json');
   const observed: Array<{ method: string; url: string; body?: string }> = [];
 
@@ -502,8 +502,24 @@ test('runPublish uses default Supabase REST dataset executors when runtime env a
     });
     assert.deepEqual(
       observed.map((entry) => entry.method),
-      ['GET', 'POST', 'GET', 'PATCH'],
+      ['GET', 'POST', 'GET', 'POST'],
     );
+    assert.match(observed[0].url, /\/rest\/v1\/processes\?select=/u);
+    assert.match(observed[1].url, /\/functions\/v1\/app_dataset_create$/u);
+    assert.match(observed[2].url, /\/rest\/v1\/sources\?select=/u);
+    assert.match(observed[3].url, /\/functions\/v1\/app_dataset_save_draft$/u);
+
+    assert.deepEqual(JSON.parse(observed[1].body ?? '{}'), {
+      table: 'processes',
+      id: 'proc-default-rest',
+      jsonOrdered: makeCanonicalProcess('proc-default-rest'),
+    });
+    assert.deepEqual(JSON.parse(observed[3].body ?? '{}'), {
+      table: 'sources',
+      id: 'src-default-rest',
+      version: '01.01.000',
+      jsonOrdered: makeSource('src-default-rest'),
+    });
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/supabase-client.test.ts
+++ b/test/supabase-client.test.ts
@@ -6,6 +6,7 @@ import {
   buildSupabaseAuthHeaders,
   createSupabaseDataClient,
   createSupabaseFetch,
+  deriveSupabaseFunctionsBaseUrl,
   deriveSupabaseProjectBaseUrl,
   deriveSupabaseRestBaseUrl,
   requireSupabaseRestRuntime,
@@ -78,6 +79,10 @@ test('requireSupabaseRestRuntime, URL derivation, and auth headers follow the sh
   assert.equal(
     deriveSupabaseRestBaseUrl('https://example.supabase.co/functions/v1'),
     'https://example.supabase.co/rest/v1',
+  );
+  assert.equal(
+    deriveSupabaseFunctionsBaseUrl('https://example.supabase.co/rest/v1'),
+    'https://example.supabase.co/functions/v1',
   );
   assert.throws(
     () => deriveSupabaseProjectBaseUrl('https://example.supabase.co/unsupported/path'),
@@ -539,8 +544,8 @@ test('runSupabaseMutation covers success, CliError passthrough, and wrapped fail
   );
 });
 
-test('createSupabaseDataClient returns a configured rest base URL', () => {
-  const { client, restBaseUrl } = createSupabaseDataClient(
+test('createSupabaseDataClient returns configured rest and functions base URLs', () => {
+  const { client, restBaseUrl, functionsBaseUrl } = createSupabaseDataClient(
     {
       apiBaseUrl: 'https://example.supabase.co/functions/v1',
       publishableKey: 'sb-publishable-key',
@@ -559,4 +564,5 @@ test('createSupabaseDataClient returns a configured rest base URL', () => {
 
   assert.ok(client);
   assert.equal(restBaseUrl, 'https://example.supabase.co/rest/v1');
+  assert.equal(functionsBaseUrl, 'https://example.supabase.co/functions/v1');
 });

--- a/test/supabase-json-ordered-write.test.ts
+++ b/test/supabase-json-ordered-write.test.ts
@@ -2,7 +2,6 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { CliError } from '../src/lib/errors.js';
 import type { FetchLike } from '../src/lib/http.js';
-import { createSupabaseDataClient } from '../src/lib/supabase-client.js';
 import {
   __testInternals,
   hasSupabaseRestRuntime,
@@ -78,8 +77,8 @@ test('supabase json_ordered write inserts when no exact row exists', async () =>
 
     return makeResponse({
       ok: true,
-      status: 201,
-      body: '[{"id":"proc-1"}]',
+      status: 200,
+      body: '{"ok":true,"command":"dataset_create","data":{"id":"proc-1"}}',
     });
   });
 
@@ -108,7 +107,8 @@ test('supabase json_ordered write inserts when no exact row exists', async () =>
     observed[0]?.url ?? '',
     /\/rest\/v1\/processes\?select=id%2Cversion%2Cstate_code&id=eq\.proc-1&version=eq\.01\.00\.001/u,
   );
-  assert.match(observed[1]?.body ?? '', /"json_ordered"/u);
+  assert.match(observed[1]?.url ?? '', /\/functions\/v1\/app_dataset_create$/u);
+  assert.match(observed[1]?.body ?? '', /"jsonOrdered"/u);
 });
 
 test('supabase json_ordered write updates when exact row already exists', async () => {
@@ -130,7 +130,7 @@ test('supabase json_ordered write updates when exact row already exists', async 
     return makeResponse({
       ok: true,
       status: 200,
-      body: '[{"id":"src-1"}]',
+      body: '{"ok":true,"command":"dataset_save_draft","data":{"id":"src-1"}}',
     });
   });
 
@@ -150,9 +150,9 @@ test('supabase json_ordered write updates when exact row already exists', async 
   assert.equal(result.operation, 'update_existing');
   assert.deepEqual(
     observed.map((item) => item.method),
-    ['GET', 'PATCH'],
+    ['GET', 'POST'],
   );
-  assert.match(observed[1]?.url ?? '', /\/sources\?id=eq\.src-1&version=eq\.01\.00\.001/u);
+  assert.match(observed[1]?.url ?? '', /\/functions\/v1\/app_dataset_save_draft$/u);
 });
 
 test('supabase json_ordered write falls back to update after insert conflict', async () => {
@@ -190,7 +190,7 @@ test('supabase json_ordered write falls back to update after insert conflict', a
     return makeResponse({
       ok: true,
       status: 200,
-      body: '[{"id":"lm-1"}]',
+      body: '{"ok":true,"command":"dataset_save_draft","data":{"id":"lm-1"}}',
     });
   });
 
@@ -210,7 +210,7 @@ test('supabase json_ordered write falls back to update after insert conflict', a
   assert.equal(result.operation, 'update_after_insert_error');
   assert.deepEqual(
     observed.map((item) => item.method),
-    ['GET', 'POST', 'GET', 'PATCH'],
+    ['GET', 'POST', 'GET', 'POST'],
   );
 });
 
@@ -266,53 +266,58 @@ test('append-only insert skips existing rows and validates helper branches', asy
 });
 
 test('supabase json_ordered helpers handle empty/text success payloads and invalid visible-row shapes', async () => {
-  const insertClient = createSupabaseDataClient(
-    {
-      apiBaseUrl: 'https://example.supabase.co',
-      publishableKey: 'sb-publishable-key',
-      getAccessToken: async () => 'access-token',
-      refreshAccessToken: async () => 'refreshed-access-token',
-    },
-    async () =>
-      makeResponse({
-        ok: true,
-        status: 201,
-        contentType: 'text/plain',
-        body: 'created',
-      }),
-    10,
-  );
   await __testInternals.insertJsonOrderedRow({
-    client: insertClient.client,
-    restBaseUrl: 'https://example.supabase.co/rest/v1',
+    commandClient: {
+      create: async () => 'created',
+      saveDraft: async () => null,
+    },
     table: 'processes',
     id: 'proc-text',
     payload: { processDataSet: {} },
   });
 
-  const updateClient = createSupabaseDataClient(
-    {
-      apiBaseUrl: 'https://example.supabase.co',
-      publishableKey: 'sb-publishable-key',
-      getAccessToken: async () => 'access-token',
-      refreshAccessToken: async () => 'refreshed-access-token',
-    },
-    async () =>
-      makeResponse({
-        ok: true,
-        status: 200,
-        body: '',
-      }),
-    10,
-  );
   await __testInternals.updateJsonOrderedRow({
-    client: updateClient.client,
-    restBaseUrl: 'https://example.supabase.co/rest/v1',
+    commandClient: {
+      create: async () => null,
+      saveDraft: async () => null,
+    },
     table: 'processes',
     id: 'proc-empty',
     version: '01.00.001',
     payload: { processDataSet: {} },
   });
+
+  assert.deepEqual(__testInternals.commandOptionsFromExtraData({ model_id: 'model-1' }), {
+    modelId: 'model-1',
+  });
+  assert.deepEqual(
+    __testInternals.commandOptionsFromExtraData({
+      modelId: 'model-2',
+      rule_verification: false,
+    }),
+    {
+      modelId: 'model-2',
+      ruleVerification: false,
+    },
+  );
+  assert.deepEqual(
+    __testInternals.commandOptionsFromExtraData({
+      model_id: null,
+      rule_verification: null,
+    }),
+    {
+      modelId: null,
+      ruleVerification: null,
+    },
+  );
+  assert.deepEqual(
+    __testInternals.commandOptionsFromExtraData({
+      model_id: '   ',
+    }),
+    {
+      modelId: null,
+    },
+  );
 
   assert.throws(
     () => __testInternals.parseVisibleRows('not-an-array', 'https://example.com/select'),


### PR DESCRIPTION
Closes #67

## Summary
- replace raw PostgREST dataset mutations with authenticated dataset command calls (`app_dataset_create` / `app_dataset_save_draft`) for flow publish and the shared json_ordered writer path
- keep REST exact-row preflight and existing artifact/report semantics while allowing `TIANGONG_LCA_API_BASE_URL` to be passed as project root, `/functions/v1`, or `/rest/v1`
- update publish-path tests and Chinese implementation docs to reflect the new transport contract

## Validation
- `npm test`
- `npm run lint`
- `npm run prepush:gate`
- real remote smoke test:
  - created flow `f917dd2d-af88-4696-9e9f-8c01f5310e8e` @ `00.00.001` via `flow publish-version --commit`
  - read back the same row via `flow get`
  - updated the same draft row successfully via `flow publish-version --commit`

## Notes
- dry-run still treats an owned exact visible row as `would_update_existing` without pre-checking `state_code`; the backend still remains the source of truth for rejecting non-draft `save_draft` writes
