### PR TITLE
chore: prepare cli v0.0.4 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/cli",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.101.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Unified TianGong LCA CLI with direct REST adapters and low-entropy command surface.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes tiangong-lca/tiangong-cli#70

## Summary
- Bump @tiangong-lca/cli version metadata from 0.0.3 to 0.0.4 in package.json and package-lock.json.

## Key Decisions
- Keep the release-prep PR scoped to version metadata only so the existing tag-driven release automation can create cli-v0.0.4 from main without unrelated changes.

## Validation
- node ./scripts/ci/release-version.cjs assert-unpublished --version 0.0.4
- npm run prepush:gate
- npm pack --dry-run >/dev/null

## Risks / Rollback
- Low risk: this change only updates release metadata and depends on the existing tag and publish workflows after merge.

## Follow-ups
- After merge, verify Tag Release From Merge creates cli-v0.0.4 and Publish Package succeeds before any workspace follow-up.

## Workspace Integration
- Workspace follow-up, if needed, should wait until the npm release is visible and verified.