### PR TITLE
fix: harden CLI publish and remote review contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage/
 dist/
 .eslintcache
 package-lock.json
+artifacts/

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -25,6 +25,7 @@
 - `tiangong search process`
 - `tiangong search lifecyclemodel`
 - `tiangong process get`
+- `tiangong process list`
 - `tiangong process auto-build`
 - `tiangong process resume-build`
 - `tiangong process publish-build`
@@ -149,7 +150,7 @@ TIANGONG_LCA_UNSTRUCTURED_RETURN_TXT=true
 | `doctor` | 无 |
 | `search flow | process | lifecyclemodel` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY`（`TIANGONG_LCA_REGION` 可选） |
 | `admin embedding-run` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY`（`TIANGONG_LCA_REGION` 可选） |
-| `process get` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` |
+| `process get | list` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` |
 | `process auto-build | resume-build | publish-build | batch-build` | 无 |
 | `lifecyclemodel auto-build | validate-build | publish-build | orchestrate` | 无 |
 | `lifecyclemodel build-resulting-process` | 本地运行默认无；若 request 打开 `process_sources.allow_remote_lookup=true`，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` |
@@ -187,6 +188,7 @@ npm exec tiangong -- doctor
 npm exec tiangong -- doctor --json
 npm exec tiangong -- search flow --input ./request.json --dry-run
 npm exec tiangong -- process get --id <process-id> --version <version> --json
+npm exec tiangong -- process list --state-code 100 --limit 20 --json
 npm exec tiangong -- process auto-build --input ./examples/process-auto-build.request.json --json
 npm exec tiangong -- process resume-build --run-id <run-id> --json
 npm exec tiangong -- process publish-build --run-id <run-id> --json
@@ -197,6 +199,7 @@ npm exec tiangong -- lifecyclemodel publish-build --run-dir ./artifacts/lifecycl
 npm exec tiangong -- lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir ./artifacts/lifecyclemodel_recursive/<run_id> --json
 npm exec tiangong -- lifecyclemodel build-resulting-process --input ./request.json --json
 npm exec tiangong -- lifecyclemodel publish-resulting-process --run-dir ./runs/example --publish-processes --publish-relations --json
+npm exec tiangong -- review process --rows-file ./process-list-report.json --out-dir ./review --json
 npm exec tiangong -- review process --run-root ./artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir ./review --json
 npm exec tiangong -- review flow --rows-file ./flows.json --out-dir ./flow-review --json
 npm exec tiangong -- review lifecyclemodel --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --out-dir ./lifecyclemodel-review --json
@@ -526,6 +529,11 @@ npm exec tiangong -- admin embedding-run --input ./jobs.json --dry-run
 - 输出 `collected-inputs.json`
 - 输出 `relation-manifest.json`
 - 输出 `publish-report.json`
+
+`publish run` 的 `out_dir` 路径规则固定如下：
+
+- request 里的 `out_dir` / `output_dir` 与 CLI 的 `--out-dir` 覆盖值，只要是相对路径，都按 request 文件所在目录解析
+- 如果希望输出位置不受 request 文件位置影响，传绝对路径，不要依赖当前 shell `cwd`
 
 当前实现不会把旧 MCP 数据库写入逻辑重新塞回 CLI；但当提供 Supabase runtime 时，`lifecyclemodels` / `processes` / `sources` 会默认走共享的 dataset command executor：先做 REST 精确可见性预检，再调用 `app_dataset_create` / `app_dataset_save_draft`。如果调用方显式注入 executors，则仍以显式执行器为准。
 

--- a/README.md
+++ b/README.md
@@ -4,19 +4,21 @@ Package: `@tiangong-lca/cli` Executable: `tiangong` Node: `24.x`
 
 ## Run
 
-Use the published CLI directly:
+One-off published run:
 
 ```bash
-npx -y @tiangong-lca/cli@latest --help
-npx -y @tiangong-lca/cli@latest doctor
-npx -y @tiangong-lca/cli@latest flow --help
+npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong --help
+npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong doctor
+npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong flow --help
 ```
 
-Optional global install:
+Install the published CLI:
 
 ```bash
 npm install --global @tiangong-lca/cli
 tiangong --help
+tiangong doctor
+tiangong flow --help
 ```
 
 Run from this repository:
@@ -76,9 +78,9 @@ Minimal `search flow` request:
 Run:
 
 ```bash
-npx -y @tiangong-lca/cli@latest search flow --input ./search-flow.request.json --json
-npx -y @tiangong-lca/cli@latest search process --input ./search-process.request.json --json
-npx -y @tiangong-lca/cli@latest search lifecyclemodel --input ./search-lifecyclemodel.request.json --json
+tiangong search flow --input ./search-flow.request.json --json
+tiangong search process --input ./search-process.request.json --json
+tiangong search lifecyclemodel --input ./search-lifecyclemodel.request.json --json
 ```
 
 Empty search results should be treated as empty whether the response is `[]` or `{"data":[]}`.
@@ -86,9 +88,10 @@ Empty search results should be treated as empty whether the response is `[]` or 
 ## Read
 
 ```bash
-npx -y @tiangong-lca/cli@latest flow get --id <flow-id> --version <version> --json
-npx -y @tiangong-lca/cli@latest flow list --id <flow-id> --state-code 100 --limit 20 --json
-npx -y @tiangong-lca/cli@latest process get --id <process-id> --version <version> --json
+tiangong flow get --id <flow-id> --version <version> --json
+tiangong flow list --id <flow-id> --state-code 100 --limit 20 --json
+tiangong process get --id <process-id> --version <version> --json
+tiangong process list --state-code 100 --limit 20 --json
 ```
 
 ## Real DB Flow Review
@@ -135,15 +138,15 @@ npx -y @tiangong-lca/cli@latest process get --id <process-id> --version <version
 Run:
 
 ```bash
-npx -y @tiangong-lca/cli@latest flow fetch-rows \
+tiangong flow fetch-rows \
   --refs-file ./flow-refs.json \
   --out-dir ./flow-fetch
 
-npx -y @tiangong-lca/cli@latest review flow \
+tiangong review flow \
   --rows-file ./flow-fetch/review-input-rows.jsonl \
   --out-dir ./flow-review
 
-npx -y @tiangong-lca/cli@latest flow materialize-decisions \
+tiangong flow materialize-decisions \
   --decision-file ./approved-decisions.json \
   --flow-rows-file ./flow-fetch/review-input-rows.jsonl \
   --out-dir ./flow-decisions
@@ -167,10 +170,15 @@ Key `flow materialize-decisions` outputs:
 ## Other Common Commands
 
 ```bash
-npx -y @tiangong-lca/cli@latest review process --run-root ./artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir ./review
-npx -y @tiangong-lca/cli@latest publish run --input ./publish-request.json --dry-run
-npx -y @tiangong-lca/cli@latest doctor --json
+tiangong review process --rows-file ./process-list-report.json --out-dir ./review
+tiangong review process --run-root ./artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir ./review
+tiangong publish run --input ./publish-request.json --dry-run
+tiangong doctor --json
 ```
+
+For `publish run`, relative `out_dir` values from either the request body or `--out-dir` are resolved against the request file directory, not the shell `cwd`. Use an absolute path when you want a fixed destination independent of the request file location.
+
+For `review process`, `--rows-file` accepts either raw process rows as JSON/JSONL or the full JSON report emitted by `tiangong process list --json`, as long as it contains a `rows` array.
 
 ## More Docs
 
@@ -181,10 +189,10 @@ npx -y @tiangong-lca/cli@latest doctor --json
 ## Help
 
 ```bash
-npx -y @tiangong-lca/cli@latest --help
-npx -y @tiangong-lca/cli@latest flow --help
-npx -y @tiangong-lca/cli@latest review --help
-npx -y @tiangong-lca/cli@latest process --help
-npx -y @tiangong-lca/cli@latest lifecyclemodel --help
-npx -y @tiangong-lca/cli@latest publish --help
+tiangong --help
+tiangong flow --help
+tiangong review --help
+tiangong process --help
+tiangong lifecyclemodel --help
+tiangong publish --help
 ```

--- a/bin/tiangong.js
+++ b/bin/tiangong.js
@@ -1,12 +1,25 @@
 #!/usr/bin/env node
 
-import { existsSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const entryPath = path.join(rootDir, 'dist', 'src', 'main.js');
+
+export function resolveInvokedUrl(argv1 = process.argv[1]) {
+  if (!argv1) {
+    return null;
+  }
+
+  const resolvedPath = path.resolve(argv1);
+  try {
+    return pathToFileURL(realpathSync(resolvedPath)).href;
+  } catch {
+    return pathToFileURL(resolvedPath).href;
+  }
+}
 
 export async function runFromBin(argv = process.argv.slice(2), env = process.env) {
   if (!existsSync(entryPath)) {
@@ -20,7 +33,7 @@ export async function runFromBin(argv = process.argv.slice(2), env = process.env
   return main(argv, env);
 }
 
-const invokedUrl = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : null;
+const invokedUrl = resolveInvokedUrl(process.argv[1]);
 
 if (invokedUrl && import.meta.url === invokedUrl) {
   try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import type { DotEnvLoadResult } from './lib/dotenv.js';
 import { CliError, toErrorPayload } from './lib/errors.js';
 import type { FetchLike } from './lib/http.js';
 import { stringifyJson } from './lib/io.js';
+import { loadCliPackageVersion } from './lib/package-version.js';
 import {
   runLifecyclemodelAutoBuild,
   type LifecyclemodelAutoBuildReport,
@@ -45,6 +46,11 @@ import {
   type RunProcessGetOptions,
 } from './lib/process-get.js';
 import {
+  runProcessList,
+  type ProcessListReport,
+  type RunProcessListOptions,
+} from './lib/process-list.js';
+import {
   runProcessBatchBuild,
   type ProcessBatchBuildReport,
   type RunProcessBatchBuildOptions,
@@ -59,6 +65,11 @@ import {
   type ProcessPublishBuildReport,
   type RunProcessPublishBuildOptions,
 } from './lib/process-publish-build.js';
+import {
+  runProcessSaveDraft,
+  type ProcessSaveDraftReport,
+  type RunProcessSaveDraftOptions,
+} from './lib/process-save-draft-run.js';
 import { runPublish, type PublishReport, type RunPublishOptions } from './lib/publish.js';
 import {
   runProcessReview,
@@ -156,6 +167,7 @@ export type CliDeps = {
     options: RunLifecyclemodelOrchestrateOptions,
   ) => Promise<LifecyclemodelOrchestrateReport>;
   runProcessGetImpl?: (options: RunProcessGetOptions) => Promise<ProcessGetReport>;
+  runProcessListImpl?: (options: RunProcessListOptions) => Promise<ProcessListReport>;
   runProcessAutoBuildImpl?: (
     options: RunProcessAutoBuildOptions,
   ) => Promise<ProcessAutoBuildReport>;
@@ -168,6 +180,9 @@ export type CliDeps = {
   runProcessPublishBuildImpl?: (
     options: RunProcessPublishBuildOptions,
   ) => Promise<ProcessPublishBuildReport>;
+  runProcessSaveDraftImpl?: (
+    options: RunProcessSaveDraftOptions,
+  ) => Promise<ProcessSaveDraftReport>;
   runProcessReviewImpl?: (options: RunProcessReviewOptions) => Promise<ProcessReviewReport>;
   runFlowReviewImpl?: (options: RunFlowReviewOptions) => Promise<FlowReviewReport>;
   runLifecyclemodelReviewImpl?: (
@@ -235,7 +250,7 @@ Commands:
 Implemented Commands:
   doctor     show environment diagnostics
   search     flow | process | lifecyclemodel
-  process    get | auto-build | resume-build | publish-build | batch-build
+  process    get | list | auto-build | resume-build | publish-build | save-draft | batch-build
   flow       get | list | fetch-rows | materialize-decisions | remediate | publish-version | publish-reviewed-data | build-alias-map | scan-process-flow-refs | plan-process-flow-repairs | apply-process-flow-repairs | regen-product | validate-processes
   lifecyclemodel auto-build | validate-build | publish-build | build-resulting-process | publish-resulting-process | orchestrate
   review     process | flow | lifecyclemodel
@@ -254,9 +269,11 @@ Examples:
   tiangong search flow --input ./request.json
   tiangong search process --input ./request.json --dry-run
   tiangong process get --id <process-id>
+  tiangong process list --state-code 100 --limit 20
   tiangong process auto-build --input ./pff-request.json
   tiangong process resume-build --run-id <id>
   tiangong process publish-build --run-id <id>
+  tiangong process save-draft --input ./patched-processes.jsonl --dry-run
   tiangong process batch-build --input ./batch-request.json
   tiangong lifecyclemodel auto-build --input ./lifecyclemodel-auto-build.request.json
   tiangong lifecyclemodel validate-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id>
@@ -275,6 +292,7 @@ Examples:
   tiangong flow apply-process-flow-repairs --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-repair-apply
   tiangong flow regen-product --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-regeneration --apply
   tiangong flow validate-processes --original-processes-file ./before.jsonl --patched-processes-file ./after.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-validation
+  tiangong review process --rows-file ./processes.jsonl --out-dir ./review
   tiangong review process --run-root ./artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir ./review
   tiangong review flow --rows-file ./flows.json --out-dir ./review
   tiangong review lifecyclemodel --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --out-dir ./lifecyclemodel-review
@@ -358,6 +376,9 @@ Options:
   --dry-run            Force publish.commit=false
   --json               Print compact JSON
   -h, --help
+
+Path rule:
+  Relative out_dir values from the request body or --out-dir resolve from the request file directory.
 `.trim();
 }
 
@@ -733,7 +754,7 @@ function renderReviewHelp(): string {
   tiangong review <subcommand> [options]
 
 Implemented Subcommands:
-  process      Review one local process build run and emit artifact-first findings
+  process      Review process build runs or rows-file snapshots and emit artifact-first findings
   flow         Review local flow governance snapshots and emit artifact-first findings
   lifecyclemodel Review one local lifecyclemodel build run and emit artifact-first findings
 
@@ -747,11 +768,12 @@ Examples:
 
 function renderReviewProcessHelp(): string {
   return `Usage:
-  tiangong review process --run-root <dir> --run-id <id> --out-dir <dir> [options]
+  tiangong review process (--rows-file <file> | --run-root <dir>) --out-dir <dir> [options]
 
 Options:
+  --rows-file <file>        Process rows JSON/JSONL file; full process list reports with rows[] are also accepted
   --run-root <dir>          Process build run root containing exports/processes
-  --run-id <id>             Process build run identifier
+  --run-id <id>             Optional review run identifier; defaults to the rows-file name or run-root basename
   --out-dir <dir>           Review artifact output directory
   --start-ts <iso>          Optional run start timestamp
   --end-ts <iso>            Optional run end timestamp
@@ -976,6 +998,34 @@ Runtime note:
 `.trim();
 }
 
+function renderProcessListHelp(): string {
+  return `Usage:
+  tiangong process list [options]
+
+Options:
+  --id <process-id>               Repeatable exact process UUID filter
+  --version <version>             Optional dataset version filter
+  --user-id <user-id>             Optional owner filter for private rows
+  --state-code <code>             Repeatable visibility filter such as 0 or 100
+  --order <expr>                  Deterministic PostgREST order expression (default: id.asc,version.asc)
+  --limit <n>                     Page size for one request (default: 100)
+  --offset <n>                    Row offset for one request (default: 0)
+  --all                           Fetch all matching rows via offset pagination
+  --page-size <n>                 Page size when --all is used (default: 100)
+  --json                          Print compact JSON
+  -h, --help
+
+Required env:
+  TIANGONG_LCA_API_BASE_URL
+  TIANGONG_LCA_API_KEY
+  TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY
+
+Runtime note:
+  The CLI derives a native @supabase/supabase-js client and deterministic read target from TIANGONG_LCA_API_BASE_URL,
+  and authenticates that client with the resolved user access token.
+`.trim();
+}
+
 function renderProcessResumeBuildHelp(): string {
   return `Usage:
   tiangong process resume-build [--run-id <id>] [--run-dir <dir>] [options]
@@ -1000,6 +1050,32 @@ Options:
 `.trim();
 }
 
+function renderProcessSaveDraftHelp(): string {
+  return `Usage:
+  tiangong process save-draft --input <file> [options]
+
+Options:
+  --input <file>     Process rows JSON/JSONL file or publish-request.json
+  --out-dir <dir>    Run root written relative to cwd when a relative path is passed
+  --commit           Execute remote save-draft writes
+  --dry-run          Keep the command local-only (default)
+  --json             Print compact JSON
+  -h, --help
+
+Environment:
+  none for local dry-run
+  TIANGONG_LCA_API_BASE_URL, TIANGONG_LCA_API_KEY, and TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY
+  when --commit executes remote writes
+
+Outputs written under --out-dir:
+  - inputs/normalized-input.json
+  - outputs/save-draft-rpc/selected-processes.jsonl
+  - outputs/save-draft-rpc/progress.jsonl
+  - outputs/save-draft-rpc/failures.jsonl
+  - outputs/save-draft-rpc/summary.json
+`.trim();
+}
+
 function renderProcessBatchBuildHelp(): string {
   return `Usage:
   tiangong process batch-build --input <file> [options]
@@ -1018,17 +1094,21 @@ function renderProcessHelp(): string {
 
 Implemented Subcommands:
   get          Load one process dataset by identifier through direct Supabase access
+  list         List visible process rows through direct Supabase access
   auto-build   Prepare a local process-from-flow run scaffold and artifact workspace
   resume-build Prepare a local resume handoff from one existing process build run
   publish-build Prepare publish handoff artifacts from one existing process build run
+  save-draft   Save canonical process datasets through the state-aware draft-maintenance path
   batch-build  Run multiple process auto-build requests through one batch-oriented CLI surface
 
 Examples:
   tiangong process --help
   tiangong process get --id <process-id>
+  tiangong process list --state-code 100 --limit 20 --help
   tiangong process auto-build --help
   tiangong process resume-build --run-id <id> --help
   tiangong process publish-build --run-id <id> --help
+  tiangong process save-draft --input ./patched-processes.jsonl --help
   tiangong process batch-build --input ./batch-request.json --help
 `.trim();
 }
@@ -2191,8 +2271,9 @@ function parseFlowListFlags(args: string[]): {
 function parseReviewProcessFlags(args: string[]): {
   help: boolean;
   json: boolean;
-  runRoot: string;
-  runId: string;
+  rowsFile: string | undefined;
+  runRoot: string | undefined;
+  runId: string | undefined;
   outDir: string;
   startTs: string | undefined;
   endTs: string | undefined;
@@ -2210,6 +2291,7 @@ function parseReviewProcessFlags(args: string[]): {
       options: {
         help: { type: 'boolean', short: 'h' },
         json: { type: 'boolean' },
+        'rows-file': { type: 'string' },
         'run-root': { type: 'string' },
         'run-id': { type: 'string' },
         'out-dir': { type: 'string' },
@@ -2246,8 +2328,9 @@ function parseReviewProcessFlags(args: string[]): {
   return {
     help: Boolean(values.help),
     json: Boolean(values.json),
-    runRoot: typeof values['run-root'] === 'string' ? values['run-root'] : '',
-    runId: typeof values['run-id'] === 'string' ? values['run-id'] : '',
+    rowsFile: typeof values['rows-file'] === 'string' ? values['rows-file'] : undefined,
+    runRoot: typeof values['run-root'] === 'string' ? values['run-root'] : undefined,
+    runId: typeof values['run-id'] === 'string' ? values['run-id'] : undefined,
     outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : '',
     startTs: typeof values['start-ts'] === 'string' ? values['start-ts'] : undefined,
     endTs: typeof values['end-ts'] === 'string' ? values['end-ts'] : undefined,
@@ -2670,6 +2753,130 @@ function parseProcessGetFlags(args: string[]): {
   };
 }
 
+function parseProcessListFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  ids: string[];
+  version: string | null;
+  userId: string | null;
+  stateCodes: number[];
+  limit: number | null;
+  offset: number | null;
+  all: boolean;
+  pageSize: number | null;
+  order: string | null;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        id: { type: 'string', multiple: true },
+        version: { type: 'string' },
+        'user-id': { type: 'string' },
+        'state-code': { type: 'string', multiple: true },
+        limit: { type: 'string' },
+        offset: { type: 'string' },
+        all: { type: 'boolean' },
+        'page-size': { type: 'string' },
+        order: { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  const parseOptionalPositiveIntegerFlag = (
+    value: unknown,
+    label: string,
+    code: string,
+  ): number | null => {
+    if (typeof value !== 'string') {
+      return null;
+    }
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      throw new CliError(`Expected ${label} to be a positive integer.`, {
+        code,
+        exitCode: 2,
+      });
+    }
+    return parsed;
+  };
+
+  const parseOptionalNonNegativeIntegerFlag = (
+    value: unknown,
+    label: string,
+    code: string,
+  ): number | null => {
+    if (typeof value !== 'string') {
+      return null;
+    }
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isInteger(parsed) || parsed < 0) {
+      throw new CliError(`Expected ${label} to be a non-negative integer.`, {
+        code,
+        exitCode: 2,
+      });
+    }
+    return parsed;
+  };
+
+  const parseStateCodeValues = (value: unknown): number[] => {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+    return value.map((entry) => {
+      const parsed = Number.parseInt(String(entry), 10);
+      if (!Number.isInteger(parsed) || parsed < 0) {
+        throw new CliError('Expected --state-code to be a non-negative integer.', {
+          code: 'INVALID_PROCESS_LIST_STATE_CODE',
+          exitCode: 2,
+        });
+      }
+      return parsed;
+    });
+  };
+  const toStringArray = (value: unknown): string[] =>
+    Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : [];
+
+  if (values['page-size'] !== undefined && !values.all) {
+    throw new CliError('Use --page-size only with --all.', {
+      code: 'PROCESS_LIST_PAGE_SIZE_REQUIRES_ALL',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    ids: toStringArray(values.id),
+    version: typeof values.version === 'string' ? values.version : null,
+    userId: typeof values['user-id'] === 'string' ? values['user-id'] : null,
+    stateCodes: parseStateCodeValues(values['state-code']),
+    limit: parseOptionalPositiveIntegerFlag(values.limit, '--limit', 'INVALID_PROCESS_LIST_LIMIT'),
+    offset: parseOptionalNonNegativeIntegerFlag(
+      values.offset,
+      '--offset',
+      'INVALID_PROCESS_LIST_OFFSET',
+    ),
+    all: Boolean(values.all),
+    pageSize: parseOptionalPositiveIntegerFlag(
+      values['page-size'],
+      '--page-size',
+      'INVALID_PROCESS_LIST_PAGE_SIZE',
+    ),
+    order: typeof values.order === 'string' ? values.order : null,
+  };
+}
+
 function parseProcessResumeBuildFlags(args: string[]): {
   help: boolean;
   json: boolean;
@@ -2735,6 +2942,51 @@ function parseProcessPublishBuildFlags(args: string[]): {
     json: Boolean(values.json),
     runId: typeof values['run-id'] === 'string' ? values['run-id'] : '',
     runDir: typeof values['run-dir'] === 'string' ? values['run-dir'] : null,
+  };
+}
+
+function parseProcessSaveDraftFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  inputPath: string;
+  outDir: string | null;
+  commit: boolean;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        input: { type: 'string' },
+        'out-dir': { type: 'string' },
+        commit: { type: 'boolean' },
+        'dry-run': { type: 'boolean' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  if (values.commit && values['dry-run']) {
+    throw new CliError('Cannot pass both --commit and --dry-run.', {
+      code: 'INVALID_PROCESS_SAVE_DRAFT_MODE',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    inputPath: typeof values.input === 'string' ? values.input : '',
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : null,
+    commit: Boolean(values.commit),
   };
 }
 
@@ -2813,10 +3065,12 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
     const lifecyclemodelOrchestrateImpl =
       deps.runLifecyclemodelOrchestrateImpl ?? runLifecyclemodelOrchestrate;
     const processGetImpl = deps.runProcessGetImpl ?? runProcessGet;
+    const processListImpl = deps.runProcessListImpl ?? runProcessList;
     const processAutoBuildImpl = deps.runProcessAutoBuildImpl ?? runProcessAutoBuild;
     const processBatchBuildImpl = deps.runProcessBatchBuildImpl ?? runProcessBatchBuild;
     const processResumeBuildImpl = deps.runProcessResumeBuildImpl ?? runProcessResumeBuild;
     const processPublishBuildImpl = deps.runProcessPublishBuildImpl ?? runProcessPublishBuild;
+    const processSaveDraftImpl = deps.runProcessSaveDraftImpl ?? runProcessSaveDraft;
     const processReviewImpl = deps.runProcessReviewImpl ?? runProcessReview;
     const flowReviewImpl = deps.runFlowReviewImpl ?? runFlowReview;
     const lifecyclemodelReviewImpl = deps.runLifecyclemodelReviewImpl ?? runLifecyclemodelReview;
@@ -2840,7 +3094,7 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
     const flowValidateProcessesImpl = deps.runFlowValidateProcessesImpl ?? runFlowValidateProcesses;
 
     if (flags.version) {
-      return { exitCode: 0, stdout: '0.0.1\n', stderr: '' };
+      return { exitCode: 0, stdout: `${loadCliPackageVersion(import.meta.url)}\n`, stderr: '' };
     }
 
     if (!command || command === 'help' || flags.help) {
@@ -3077,6 +3331,37 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
       };
     }
 
+    if (command === 'process' && subcommand === 'list') {
+      const processFlags = parseProcessListFlags(commandArgs);
+      if (processFlags.help) {
+        return {
+          exitCode: 0,
+          stdout: `${renderProcessListHelp()}\n`,
+          stderr: '',
+        };
+      }
+
+      const report = await processListImpl({
+        ids: processFlags.ids,
+        version: processFlags.version,
+        userId: processFlags.userId,
+        stateCodes: processFlags.stateCodes,
+        limit: processFlags.limit,
+        offset: processFlags.offset,
+        all: processFlags.all,
+        pageSize: processFlags.pageSize,
+        order: processFlags.order,
+        env: deps.env,
+        fetchImpl: deps.fetchImpl,
+      });
+
+      return {
+        exitCode: 0,
+        stdout: stringifyJson(report, processFlags.json),
+        stderr: '',
+      };
+    }
+
     if (command === 'process' && subcommand === 'auto-build') {
       const processFlags = parseProcessAutoBuildFlags(commandArgs);
       if (processFlags.help) {
@@ -3138,6 +3423,31 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
 
       return {
         exitCode: 0,
+        stdout: stringifyJson(report, processFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'process' && subcommand === 'save-draft') {
+      const processFlags = parseProcessSaveDraftFlags(commandArgs);
+      if (processFlags.help) {
+        return {
+          exitCode: 0,
+          stdout: `${renderProcessSaveDraftHelp()}\n`,
+          stderr: '',
+        };
+      }
+
+      const report = await processSaveDraftImpl({
+        inputPath: processFlags.inputPath,
+        outDir: processFlags.outDir,
+        commit: processFlags.commit,
+        env: deps.env,
+        fetchImpl: deps.fetchImpl,
+      });
+
+      return {
+        exitCode: report.status === 'completed_with_failures' ? 1 : 0,
         stdout: stringifyJson(report, processFlags.json),
         stderr: '',
       };
@@ -3568,6 +3878,7 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
       }
 
       const report = await processReviewImpl({
+        rowsFile: reviewFlags.rowsFile,
         runRoot: reviewFlags.runRoot,
         runId: reviewFlags.runId,
         outDir: reviewFlags.outDir,

--- a/src/lib/dataset-command.ts
+++ b/src/lib/dataset-command.ts
@@ -1,10 +1,13 @@
 import { CliError } from './errors.js';
-import type { ResponseLike } from './http.js';
+import type { FetchLike } from './http.js';
+import { postJson, requireRemoteOkPayload } from './http.js';
 import {
-  createSupabaseFetch,
-  deriveSupabaseFunctionsBaseUrl,
+  buildSupabaseAuthHeaders,
+  deriveSupabaseProjectBaseUrl,
+  requireSupabaseRestRuntime,
   type SupabaseDataRuntime,
 } from './supabase-client.js';
+import { createSupabaseDataRuntime } from './supabase-session.js';
 
 type JsonObject = Record<string, unknown>;
 
@@ -17,208 +20,202 @@ export type DatasetCommandTable =
   | 'processes'
   | 'lifecyclemodels';
 
-export type DatasetCommandName = 'create' | 'save_draft';
-
-type DatasetCommandFailurePayload = {
-  ok: false;
-  code: string;
-  message: string;
-  details?: unknown;
-};
-
-type DatasetCommandSuccessEnvelope = {
-  ok: true;
-  data?: unknown;
-};
-
-export type DatasetCommandCreateInput = {
-  table: DatasetCommandTable;
-  id: string;
-  jsonOrdered: unknown;
-  modelId?: string | null;
-  ruleVerification?: boolean | null;
-};
-
-export type DatasetCommandSaveDraftInput = DatasetCommandCreateInput & {
-  version: string;
-};
-
-export type DatasetCommandClient = {
-  create: (input: DatasetCommandCreateInput) => Promise<unknown>;
-  saveDraft: (input: DatasetCommandSaveDraftInput) => Promise<unknown>;
+export type DatasetCommandTransport = {
+  functionsBaseUrl: string;
+  publishableKey: string;
+  accessToken: string;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
 };
 
 function isRecord(value: unknown): value is JsonObject {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function trimToken(value: unknown): string {
-  return typeof value === 'string' ? value.trim() : '';
-}
-
-function command_endpoint(command: DatasetCommandName): string {
-  return command === 'create' ? 'app_dataset_create' : 'app_dataset_save_draft';
-}
-
-export function buildDatasetCommandUrl(apiBaseUrl: string, command: DatasetCommandName): string {
-  return `${deriveSupabaseFunctionsBaseUrl(apiBaseUrl)}/${command_endpoint(command)}`;
-}
-
-export function buildDatasetCommandHeaders(
-  region: string | null | undefined,
-): Record<string, string> {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-  };
-  const normalizedRegion = trimToken(region);
-  if (normalizedRegion) {
-    headers['x-region'] = normalizedRegion;
-  }
-  return headers;
-}
-
-export function buildDatasetCommandBody(
-  command: DatasetCommandName,
-  input: DatasetCommandCreateInput | DatasetCommandSaveDraftInput,
-): JsonObject {
-  const body: JsonObject = {
-    table: input.table,
-    id: input.id,
-    jsonOrdered: input.jsonOrdered,
-  };
-
-  if (command === 'save_draft') {
-    body.version = (input as DatasetCommandSaveDraftInput).version;
+function trimToken(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
   }
 
-  if ('modelId' in input && input.modelId !== undefined) {
-    body.modelId = input.modelId;
-  }
-
-  if ('ruleVerification' in input && input.ruleVerification !== undefined) {
-    body.ruleVerification = input.ruleVerification;
-  }
-
-  return body;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
 }
 
-function parseJsonText(rawText: string, url: string): unknown {
-  try {
-    return JSON.parse(rawText);
-  } catch (error) {
-    throw new CliError(`Remote response was not valid JSON for ${url}`, {
-      code: 'REMOTE_INVALID_JSON',
+function readOptionalRuleVerification(extraData?: JsonObject): boolean | null | undefined {
+  if (!extraData) {
+    return undefined;
+  }
+
+  if ('ruleVerification' in extraData) {
+    const value = extraData.ruleVerification;
+    if (typeof value === 'boolean' || value === null) {
+      return value;
+    }
+    return undefined;
+  }
+
+  if ('rule_verification' in extraData) {
+    const value = extraData.rule_verification;
+    if (typeof value === 'boolean' || value === null) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function readOptionalModelId(
+  extraData: JsonObject | undefined,
+  allowNull: boolean,
+): string | null | undefined {
+  if (!extraData) {
+    return undefined;
+  }
+
+  const value = extraData.modelId ?? extraData.model_id;
+  const trimmed = trimToken(value);
+  if (trimmed) {
+    return trimmed;
+  }
+
+  if (allowNull && value === null) {
+    return null;
+  }
+
+  return undefined;
+}
+
+function requireCommandSuccessPayload(payload: unknown, url: string): JsonObject {
+  const normalized = requireRemoteOkPayload(payload, url);
+  if (!isRecord(normalized) || normalized.ok !== true) {
+    throw new CliError(`Dataset command returned an unexpected payload for ${url}`, {
+      code: 'REMOTE_RESPONSE_INVALID',
       exitCode: 1,
-      details: String(error),
+      details: normalized,
     });
   }
+
+  return normalized;
 }
 
-function isDatasetCommandFailurePayload(value: unknown): value is DatasetCommandFailurePayload {
-  return (
-    isRecord(value) &&
-    value.ok === false &&
-    typeof value.code === 'string' &&
-    typeof value.message === 'string'
+async function invokeDatasetCommand(options: {
+  transport: DatasetCommandTransport;
+  commandName: 'app_dataset_create' | 'app_dataset_save_draft';
+  body: JsonObject;
+}): Promise<JsonObject> {
+  const url = `${options.transport.functionsBaseUrl}/${options.commandName}`;
+  return requireCommandSuccessPayload(
+    await postJson({
+      url,
+      headers: {
+        ...buildSupabaseAuthHeaders(
+          options.transport.publishableKey,
+          options.transport.accessToken,
+        ),
+        'Content-Type': 'application/json',
+      },
+      body: options.body,
+      timeoutMs: options.transport.timeoutMs,
+      fetchImpl: options.transport.fetchImpl,
+    }),
+    url,
   );
 }
 
-function unwrapDatasetCommandPayload(payload: unknown): unknown {
-  if (isDatasetCommandFailurePayload(payload)) {
-    throw new CliError(payload.message, {
-      code: 'REMOTE_REQUEST_FAILED',
-      exitCode: 1,
-      details: `${payload.code}: ${payload.message}`,
-    });
-  }
-
-  if (isRecord(payload) && payload.ok === true && 'data' in payload) {
-    return (payload as DatasetCommandSuccessEnvelope).data ?? null;
-  }
-
-  return payload;
+export function deriveSupabaseFunctionsBaseUrl(apiBaseUrl: string): string {
+  return `${deriveSupabaseProjectBaseUrl(apiBaseUrl)}/functions/v1`;
 }
 
-function parseDatasetCommandResponse(
-  response: ResponseLike,
-  url: string,
-  rawText: string,
-): unknown {
-  const contentType = response.headers.get('content-type') ?? '';
-  const parsed =
-    rawText.length === 0
-      ? null
-      : contentType.includes('application/json')
-        ? parseJsonText(rawText, url)
-        : rawText;
-
-  if (!response.ok) {
-    if (isDatasetCommandFailurePayload(parsed)) {
-      throw new CliError(`HTTP ${response.status} returned from ${url}`, {
-        code: 'REMOTE_REQUEST_FAILED',
-        exitCode: 1,
-        details: `${parsed.code}: ${parsed.message}`,
-      });
-    }
-
-    throw new CliError(`HTTP ${response.status} returned from ${url}`, {
-      code: 'REMOTE_REQUEST_FAILED',
-      exitCode: 1,
-      details: typeof parsed === 'string' ? parsed : rawText || undefined,
-    });
-  }
-
-  return unwrapDatasetCommandPayload(parsed);
-}
-
-async function executeDatasetCommand(
-  fetchWithAuth: typeof fetch,
-  url: string,
-  headers: Record<string, string>,
-  body: JsonObject,
-): Promise<unknown> {
-  const response = await fetchWithAuth(url, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(body),
-  });
-  return parseDatasetCommandResponse(response, url, await response.text());
-}
-
-export function createDatasetCommandClient(options: {
+export async function buildDatasetCommandTransport(options: {
   runtime: SupabaseDataRuntime;
-  fetchImpl: (input: string, init?: RequestInit) => Promise<ResponseLike>;
+  fetchImpl: FetchLike;
   timeoutMs: number;
-  region?: string | null;
-}): DatasetCommandClient {
-  const fetchWithAuth = createSupabaseFetch(options.fetchImpl, options.timeoutMs, options.runtime);
-  const headers = buildDatasetCommandHeaders(options.region);
-  const createUrl = buildDatasetCommandUrl(options.runtime.apiBaseUrl, 'create');
-  const saveDraftUrl = buildDatasetCommandUrl(options.runtime.apiBaseUrl, 'save_draft');
-
+}): Promise<DatasetCommandTransport> {
   return {
-    create: (input) =>
-      executeDatasetCommand(
-        fetchWithAuth,
-        createUrl,
-        headers,
-        buildDatasetCommandBody('create', input),
-      ),
-    saveDraft: (input) =>
-      executeDatasetCommand(
-        fetchWithAuth,
-        saveDraftUrl,
-        headers,
-        buildDatasetCommandBody('save_draft', input),
-      ),
+    functionsBaseUrl: deriveSupabaseFunctionsBaseUrl(options.runtime.apiBaseUrl),
+    publishableKey: options.runtime.publishableKey,
+    accessToken: await options.runtime.getAccessToken(),
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.timeoutMs,
   };
 }
 
+export async function resolveDatasetCommandTransport(options: {
+  env: NodeJS.ProcessEnv;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+}): Promise<DatasetCommandTransport> {
+  return buildDatasetCommandTransport({
+    runtime: createSupabaseDataRuntime({
+      runtime: requireSupabaseRestRuntime(options.env),
+      fetchImpl: options.fetchImpl,
+      timeoutMs: options.timeoutMs,
+    }),
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.timeoutMs,
+  });
+}
+
+export async function createDatasetRecord(options: {
+  transport: DatasetCommandTransport;
+  table: DatasetCommandTable;
+  id: string;
+  payload: JsonObject;
+  extraData?: JsonObject;
+}): Promise<JsonObject> {
+  const body: JsonObject = {
+    table: options.table,
+    id: options.id,
+    jsonOrdered: options.payload,
+  };
+  const modelId = readOptionalModelId(options.extraData, true);
+  if (modelId !== undefined) {
+    body.modelId = modelId;
+  }
+  const ruleVerification = readOptionalRuleVerification(options.extraData);
+  if (ruleVerification !== undefined) {
+    body.ruleVerification = ruleVerification;
+  }
+
+  return invokeDatasetCommand({
+    transport: options.transport,
+    commandName: 'app_dataset_create',
+    body,
+  });
+}
+
+export async function saveDraftDatasetRecord(options: {
+  transport: DatasetCommandTransport;
+  table: DatasetCommandTable;
+  id: string;
+  version: string;
+  payload: JsonObject;
+  extraData?: JsonObject;
+}): Promise<JsonObject> {
+  const body: JsonObject = {
+    table: options.table,
+    id: options.id,
+    version: options.version,
+    jsonOrdered: options.payload,
+  };
+  const modelId = readOptionalModelId(options.extraData, false);
+  if (modelId !== undefined) {
+    body.modelId = modelId;
+  }
+  const ruleVerification = readOptionalRuleVerification(options.extraData);
+  if (ruleVerification !== undefined) {
+    body.ruleVerification = ruleVerification;
+  }
+
+  return invokeDatasetCommand({
+    transport: options.transport,
+    commandName: 'app_dataset_save_draft',
+    body,
+  });
+}
+
 export const __testInternals = {
-  buildDatasetCommandBody,
-  buildDatasetCommandHeaders,
-  buildDatasetCommandUrl,
-  command_endpoint,
-  parseDatasetCommandResponse,
-  unwrapDatasetCommandPayload,
+  deriveSupabaseFunctionsBaseUrl,
+  readOptionalModelId,
+  readOptionalRuleVerification,
 };

--- a/src/lib/flow-publish-version.ts
+++ b/src/lib/flow-publish-version.ts
@@ -1,8 +1,12 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { writeJsonArtifact, writeJsonLinesArtifact } from './artifacts.js';
-import { createDatasetCommandClient, type DatasetCommandClient } from './dataset-command.js';
-import { readRuntimeEnv } from './env.js';
+import {
+  buildDatasetCommandTransport,
+  createDatasetRecord,
+  saveDraftDatasetRecord,
+  type DatasetCommandTransport,
+} from './dataset-command.js';
 import { CliError } from './errors.js';
 import {
   coerceText,
@@ -447,28 +451,30 @@ function build_error_reasons(stage: string, error: unknown): FlowPublishFailureR
 }
 
 async function insert_flow_version(options: {
-  commandClient: DatasetCommandClient;
+  transport: DatasetCommandTransport;
   rowId: string;
   payload: JsonRecord;
 }): Promise<void> {
-  await options.commandClient.create({
+  await createDatasetRecord({
+    transport: options.transport,
     table: 'flows',
     id: options.rowId,
-    jsonOrdered: options.payload,
+    payload: options.payload,
   });
 }
 
 async function update_flow_version(options: {
-  commandClient: DatasetCommandClient;
+  transport: DatasetCommandTransport;
   rowId: string;
   version: string;
   payload: JsonRecord;
 }): Promise<void> {
-  await options.commandClient.saveDraft({
+  await saveDraftDatasetRecord({
+    transport: options.transport,
     table: 'flows',
     id: options.rowId,
     version: options.version,
-    jsonOrdered: options.payload,
+    payload: options.payload,
   });
 }
 
@@ -476,8 +482,8 @@ async function sync_one_row(options: {
   row: JsonRecord;
   mode: FlowPublishMode;
   client: SupabaseDataClient;
-  commandClient: DatasetCommandClient;
   restBaseUrl: string;
+  commandTransport: DatasetCommandTransport;
   targetUserIdOverride: string | null;
 }): Promise<FlowPublishOutcome> {
   try {
@@ -533,7 +539,7 @@ async function sync_one_row(options: {
 
     if (ownBefore) {
       await update_flow_version({
-        commandClient: options.commandClient,
+        transport: options.commandTransport,
         rowId,
         version,
         payload,
@@ -560,7 +566,7 @@ async function sync_one_row(options: {
 
     try {
       await insert_flow_version({
-        commandClient: options.commandClient,
+        transport: options.commandTransport,
         rowId,
         payload,
       });
@@ -583,7 +589,7 @@ async function sync_one_row(options: {
       if (ownAfter) {
         try {
           await update_flow_version({
-            commandClient: options.commandClient,
+            transport: options.commandTransport,
             rowId,
             version,
             payload,
@@ -685,13 +691,12 @@ export async function runFlowPublishVersion(
     timeoutMs,
     now,
   });
-  const { client, restBaseUrl } = createSupabaseDataClient(runtime, fetchImpl, timeoutMs);
-  const commandClient = createDatasetCommandClient({
+  const commandTransport = await buildDatasetCommandTransport({
     runtime,
     fetchImpl,
     timeoutMs,
-    region: readRuntimeEnv(options.env ?? process.env).region,
   });
+  const { client, restBaseUrl } = createSupabaseDataClient(runtime, fetchImpl, timeoutMs);
   const targetUserIdOverride = normalize_token(options.targetUserId ?? null);
   const files = build_output_files(outDir);
 
@@ -711,8 +716,8 @@ export async function runFlowPublishVersion(
       row,
       mode,
       client,
-      commandClient,
       restBaseUrl,
+      commandTransport,
       targetUserIdOverride,
     }),
   );

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,5 +1,7 @@
 import { CliError } from './errors.js';
 
+type JsonObject = Record<string, unknown>;
+
 export type ResponseLike = {
   ok: boolean;
   status: number;
@@ -10,6 +12,10 @@ export type ResponseLike = {
 };
 
 export type FetchLike = (input: string, init?: RequestInit) => Promise<ResponseLike>;
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
 
 async function parseResponse(response: ResponseLike, url: string): Promise<unknown> {
   const rawText = await response.text();
@@ -36,6 +42,27 @@ async function parseResponse(response: ResponseLike, url: string): Promise<unkno
   }
 
   return rawText;
+}
+
+export function requireRemoteOkPayload(payload: unknown, url: string): unknown {
+  if (!isRecord(payload) || payload.ok !== false) {
+    return payload;
+  }
+
+  const code =
+    typeof payload.code === 'string' && payload.code.trim()
+      ? payload.code.trim()
+      : 'REMOTE_APPLICATION_ERROR';
+  const message =
+    typeof payload.message === 'string' && payload.message.trim()
+      ? payload.message.trim()
+      : `Remote application response returned ok:false for ${url}`;
+
+  throw new CliError(message, {
+    code,
+    exitCode: 1,
+    details: payload,
+  });
 }
 
 export async function postJson(options: {

--- a/src/lib/package-version.ts
+++ b/src/lib/package-version.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+
+const PACKAGE_JSON_CANDIDATES = ['../package.json', '../../package.json'] as const;
+
+type PackageVersionReader = (url: URL) => string;
+
+function parsePackageVersion(candidate: URL, readText: PackageVersionReader): string | null {
+  try {
+    const payload = JSON.parse(readText(candidate)) as { version?: unknown };
+    return typeof payload.version === 'string' && payload.version.length > 0
+      ? payload.version
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function loadCliPackageVersion(
+  importMetaUrl: string = import.meta.url,
+  readText: PackageVersionReader = (url) => readFileSync(url, 'utf8'),
+): string {
+  for (const relativePath of PACKAGE_JSON_CANDIDATES) {
+    const version = parsePackageVersion(new URL(relativePath, importMetaUrl), readText);
+    if (version) {
+      return version;
+    }
+  }
+
+  throw new Error('Could not resolve CLI package version from package.json.');
+}

--- a/src/lib/process-list.ts
+++ b/src/lib/process-list.ts
@@ -1,0 +1,491 @@
+import { CliError } from './errors.js';
+import { normalizeStateCodeList, normalizeTokenList } from './flow-read.js';
+import type { FetchLike } from './http.js';
+import { normalizeSupabaseProcessPayload, requireSupabaseRestRuntime } from './supabase-rest.js';
+import { createSupabaseDataClient, runSupabaseArrayQuery } from './supabase-client.js';
+import { createSupabaseDataRuntime } from './supabase-session.js';
+
+type JsonObject = Record<string, unknown>;
+
+const PROCESS_LIST_TIMEOUT_MS = 10_000;
+const DEFAULT_PROCESS_LIST_LIMIT = 100;
+const DEFAULT_PROCESS_LIST_PAGE_SIZE = 100;
+const DEFAULT_PROCESS_LIST_ORDER = 'id.asc,version.asc';
+const DEFAULT_PROCESS_LIST_MAX_ATTEMPTS = 3;
+
+type ProcessListQueryFilters = {
+  ids?: string[];
+  version?: string | null;
+  userId?: string | null;
+  stateCodes?: number[];
+  order?: string | null;
+  limit?: number | null;
+  offset?: number | null;
+};
+
+type SupabaseProcessListRow = {
+  id: string;
+  version: string;
+  user_id: string | null;
+  state_code: number | null;
+  modified_at: string | null;
+  json: unknown;
+};
+
+type QueryWithUrl = {
+  url: URL;
+  limit: (count: number) => QueryWithUrl;
+};
+
+export type RunProcessListOptions = {
+  ids?: string[];
+  version?: string | null;
+  userId?: string | null;
+  stateCodes?: number[];
+  limit?: number | null;
+  offset?: number | null;
+  all?: boolean;
+  pageSize?: number | null;
+  order?: string | null;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: FetchLike;
+  timeoutMs?: number;
+  now?: Date;
+  maxAttempts?: number | null;
+};
+
+export type ProcessListReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: 'listed_remote_processes';
+  filters: {
+    ids: string[];
+    requested_version: string | null;
+    requested_user_id: string | null;
+    requested_state_codes: number[];
+    order: string;
+    all: boolean;
+    limit: number | null;
+    offset: number;
+    page_size: number | null;
+  };
+  count: number;
+  source_urls: string[];
+  rows: Array<{
+    id: string;
+    version: string;
+    user_id: string | null;
+    state_code: number | null;
+    modified_at: string | null;
+    process: JsonObject;
+  }>;
+};
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeToken(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed;
+}
+
+function nowIso(now: Date = new Date()): string {
+  return now.toISOString();
+}
+
+function toPositiveInteger(value: number | null | undefined, label: string, code: string): number {
+  if (!Number.isInteger(value) || (value as number) <= 0) {
+    throw new CliError(`Expected ${label} to be a positive integer.`, {
+      code,
+      exitCode: 2,
+    });
+  }
+  return value as number;
+}
+
+function toNonNegativeInteger(
+  value: number | null | undefined,
+  label: string,
+  code: string,
+): number {
+  if (!Number.isInteger(value) || (value as number) < 0) {
+    throw new CliError(`Expected ${label} to be a non-negative integer.`, {
+      code,
+      exitCode: 2,
+    });
+  }
+  return value as number;
+}
+
+function optionalPositiveInteger(value: number | null | undefined): number | null {
+  return Number.isInteger(value) && (value as number) > 0 ? (value as number) : null;
+}
+
+function optionalNonNegativeInteger(value: number | null | undefined): number | null {
+  return Number.isInteger(value) && (value as number) >= 0 ? (value as number) : null;
+}
+
+function buildProcessListUrl(restBaseUrl: string, filters: ProcessListQueryFilters): string {
+  const url = new URL(`${restBaseUrl.replace(/\/+$/u, '')}/processes`);
+  url.searchParams.set('select', 'id,version,user_id,state_code,modified_at,json');
+
+  const ids = normalizeTokenList(filters.ids);
+  if (ids.length === 1) {
+    url.searchParams.set('id', `eq.${ids[0]}`);
+  } else if (ids.length > 1) {
+    url.searchParams.set('id', `in.(${ids.join(',')})`);
+  }
+
+  if (typeof filters.version === 'string' && filters.version.trim()) {
+    url.searchParams.set('version', `eq.${filters.version.trim()}`);
+  }
+
+  if (typeof filters.userId === 'string' && filters.userId.trim()) {
+    url.searchParams.set('user_id', `eq.${filters.userId.trim()}`);
+  }
+
+  const stateCodes = normalizeStateCodeList(filters.stateCodes);
+  if (stateCodes.length === 1) {
+    url.searchParams.set('state_code', `eq.${stateCodes[0]}`);
+  } else if (stateCodes.length > 1) {
+    url.searchParams.set('state_code', `in.(${stateCodes.join(',')})`);
+  }
+
+  if (typeof filters.order === 'string' && filters.order.trim()) {
+    url.searchParams.set('order', filters.order.trim());
+  }
+
+  if (Number.isInteger(filters.limit) && (filters.limit as number) > 0) {
+    url.searchParams.set('limit', String(filters.limit));
+  }
+
+  if (Number.isInteger(filters.offset) && (filters.offset as number) >= 0) {
+    url.searchParams.set('offset', String(filters.offset));
+  }
+
+  return url.toString();
+}
+
+function parseProcessRows(payload: unknown, url: string): SupabaseProcessListRow[] {
+  if (!Array.isArray(payload)) {
+    throw new CliError(`Supabase REST response was not a JSON array for ${url}`, {
+      code: 'SUPABASE_REST_RESPONSE_INVALID',
+      exitCode: 1,
+      details: payload,
+    });
+  }
+
+  return payload.map((item, index) => {
+    if (!isRecord(item)) {
+      throw new CliError(`Supabase REST row ${index} was not a JSON object for ${url}`, {
+        code: 'SUPABASE_REST_RESPONSE_INVALID',
+        exitCode: 1,
+        details: item,
+      });
+    }
+
+    return {
+      id: typeof item.id === 'string' ? item.id : '',
+      version: typeof item.version === 'string' ? item.version : '',
+      user_id: typeof item.user_id === 'string' ? item.user_id : null,
+      state_code: typeof item.state_code === 'number' ? item.state_code : null,
+      modified_at: typeof item.modified_at === 'string' ? item.modified_at : null,
+      json: item.json,
+    };
+  });
+}
+
+function applyOrder<Query extends { order: (column: string, options?: object) => Query }>(
+  query: Query,
+  orderValue: string | null | undefined,
+): Query {
+  const normalizedOrder = typeof orderValue === 'string' ? orderValue.trim() : '';
+  if (!normalizedOrder) {
+    return query;
+  }
+
+  let nextQuery = query;
+  for (const rawToken of normalizedOrder.split(',')) {
+    const token = rawToken.trim();
+    if (!token) {
+      continue;
+    }
+
+    const [column, direction, nulls] = token.split('.');
+    if (!column) {
+      continue;
+    }
+
+    nextQuery = nextQuery.order(column, {
+      ascending: direction !== 'desc',
+      nullsFirst: nulls === 'nullsfirst' ? true : nulls === 'nullslast' ? false : undefined,
+    });
+  }
+
+  return nextQuery;
+}
+
+async function listProcessRows(options: {
+  runtime: ReturnType<typeof createSupabaseDataRuntime>;
+  filters: ProcessListQueryFilters;
+  timeoutMs: number;
+  fetchImpl: FetchLike;
+}): Promise<{ rows: SupabaseProcessListRow[]; sourceUrl: string }> {
+  const { client, restBaseUrl } = createSupabaseDataClient(
+    options.runtime,
+    options.fetchImpl,
+    options.timeoutMs,
+  );
+  const sourceUrl = buildProcessListUrl(restBaseUrl, options.filters);
+  let query = client.from('processes').select('id,version,user_id,state_code,modified_at,json');
+
+  const ids = normalizeTokenList(options.filters.ids);
+  if (ids.length === 1) {
+    query = query.eq('id', ids[0] as string);
+  } else if (ids.length > 1) {
+    query = query.filter('id', 'in', `(${ids.join(',')})`);
+  }
+
+  if (typeof options.filters.version === 'string' && options.filters.version.trim()) {
+    query = query.eq('version', options.filters.version.trim());
+  }
+
+  if (typeof options.filters.userId === 'string' && options.filters.userId.trim()) {
+    query = query.eq('user_id', options.filters.userId.trim());
+  }
+
+  const stateCodes = normalizeStateCodeList(options.filters.stateCodes);
+  if (stateCodes.length === 1) {
+    query = query.eq('state_code', stateCodes[0] as number);
+  } else if (stateCodes.length > 1) {
+    query = query.filter('state_code', 'in', `(${stateCodes.join(',')})`);
+  }
+
+  query = applyOrder(query, options.filters.order);
+
+  const limit = optionalPositiveInteger(options.filters.limit);
+  const offset = optionalNonNegativeInteger(options.filters.offset);
+
+  if (limit !== null) {
+    query = query.limit(limit);
+    if (offset !== null) {
+      (query as unknown as QueryWithUrl).url.searchParams.set('offset', String(offset));
+    }
+  }
+
+  const payload = await runSupabaseArrayQuery(query, sourceUrl);
+  return {
+    rows: parseProcessRows(payload, sourceUrl),
+    sourceUrl,
+  };
+}
+
+function isRetryableError(error: unknown): boolean {
+  return !(error instanceof CliError && error.exitCode === 2);
+}
+
+async function listProcessRowsWithRetry(options: {
+  runtime: ReturnType<typeof createSupabaseDataRuntime>;
+  filters: ProcessListQueryFilters;
+  timeoutMs: number;
+  fetchImpl: FetchLike;
+  maxAttempts: number;
+}): Promise<{ rows: SupabaseProcessListRow[]; sourceUrl: string }> {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await listProcessRows(options);
+    } catch (error) {
+      if (attempt >= options.maxAttempts || !isRetryableError(error)) {
+        throw error;
+      }
+    }
+  }
+}
+
+export async function runProcessList(options: RunProcessListOptions): Promise<ProcessListReport> {
+  const ids = normalizeTokenList(options.ids);
+  const requestedVersion = normalizeToken(options.version ?? null);
+  const requestedUserId = normalizeToken(options.userId ?? null);
+  const requestedStateCodes = normalizeStateCodeList(options.stateCodes);
+  const all = Boolean(options.all);
+  const order = normalizeToken(options.order ?? null) ?? DEFAULT_PROCESS_LIST_ORDER;
+
+  if (all && options.limit !== null && options.limit !== undefined) {
+    throw new CliError('Cannot combine --all with --limit.', {
+      code: 'PROCESS_LIST_ALL_LIMIT_CONFLICT',
+      exitCode: 2,
+    });
+  }
+
+  if (all && options.offset !== null && options.offset !== undefined) {
+    throw new CliError('Cannot combine --all with --offset.', {
+      code: 'PROCESS_LIST_ALL_OFFSET_CONFLICT',
+      exitCode: 2,
+    });
+  }
+
+  if (
+    all &&
+    ids.length === 0 &&
+    requestedVersion === null &&
+    requestedUserId === null &&
+    requestedStateCodes.length === 0
+  ) {
+    throw new CliError('Refusing to run --all without at least one narrowing filter.', {
+      code: 'PROCESS_LIST_ALL_FILTER_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  const fetchImpl = options.fetchImpl ?? (fetch as FetchLike);
+  const timeoutMs = options.timeoutMs ?? PROCESS_LIST_TIMEOUT_MS;
+  const maxAttempts = toPositiveInteger(
+    options.maxAttempts ?? DEFAULT_PROCESS_LIST_MAX_ATTEMPTS,
+    'process list retry count',
+    'PROCESS_LIST_MAX_ATTEMPTS_INVALID',
+  );
+  const runtime = createSupabaseDataRuntime({
+    runtime: requireSupabaseRestRuntime(options.env ?? process.env),
+    fetchImpl,
+    timeoutMs,
+    now: options.now,
+  });
+  const sourceUrls: string[] = [];
+  const rows: ProcessListReport['rows'] = [];
+
+  if (all) {
+    const pageSizeValue = options.pageSize ?? DEFAULT_PROCESS_LIST_PAGE_SIZE;
+    const pageSize = toPositiveInteger(
+      pageSizeValue,
+      '--page-size',
+      'PROCESS_LIST_PAGE_SIZE_INVALID',
+    );
+    let currentOffset = 0;
+    while (true) {
+      const page = await listProcessRowsWithRetry({
+        runtime,
+        filters: {
+          ids,
+          version: requestedVersion,
+          userId: requestedUserId,
+          stateCodes: requestedStateCodes,
+          order,
+          limit: pageSize,
+          offset: currentOffset,
+        },
+        timeoutMs,
+        fetchImpl,
+        maxAttempts,
+      });
+      sourceUrls.push(page.sourceUrl);
+      rows.push(
+        ...page.rows.map((row) => ({
+          id: row.id,
+          version: row.version,
+          user_id: row.user_id,
+          state_code: row.state_code,
+          modified_at: row.modified_at,
+          process: normalizeSupabaseProcessPayload(row.json, `${row.id}@${row.version}`),
+        })),
+      );
+      if (page.rows.length < pageSize) {
+        break;
+      }
+      currentOffset += pageSize;
+    }
+
+    return {
+      schema_version: 1,
+      generated_at_utc: nowIso(options.now),
+      status: 'listed_remote_processes',
+      filters: {
+        ids,
+        requested_version: requestedVersion,
+        requested_user_id: requestedUserId,
+        requested_state_codes: requestedStateCodes,
+        order,
+        all: true,
+        limit: null,
+        offset: 0,
+        page_size: pageSize,
+      },
+      count: rows.length,
+      source_urls: sourceUrls,
+      rows,
+    };
+  }
+
+  const limit = toPositiveInteger(
+    options.limit ?? DEFAULT_PROCESS_LIST_LIMIT,
+    '--limit',
+    'PROCESS_LIST_LIMIT_INVALID',
+  );
+  const offset = toNonNegativeInteger(
+    options.offset ?? 0,
+    '--offset',
+    'PROCESS_LIST_OFFSET_INVALID',
+  );
+  const page = await listProcessRowsWithRetry({
+    runtime,
+    filters: {
+      ids,
+      version: requestedVersion,
+      userId: requestedUserId,
+      stateCodes: requestedStateCodes,
+      order,
+      limit,
+      offset,
+    },
+    timeoutMs,
+    fetchImpl,
+    maxAttempts,
+  });
+
+  return {
+    schema_version: 1,
+    generated_at_utc: nowIso(options.now),
+    status: 'listed_remote_processes',
+    filters: {
+      ids,
+      requested_version: requestedVersion,
+      requested_user_id: requestedUserId,
+      requested_state_codes: requestedStateCodes,
+      order,
+      all: false,
+      limit,
+      offset,
+      page_size: null,
+    },
+    count: page.rows.length,
+    source_urls: [page.sourceUrl],
+    rows: page.rows.map((row) => ({
+      id: row.id,
+      version: row.version,
+      user_id: row.user_id,
+      state_code: row.state_code,
+      modified_at: row.modified_at,
+      process: normalizeSupabaseProcessPayload(row.json, `${row.id}@${row.version}`),
+    })),
+  };
+}
+
+export const __testInternals = {
+  applyOrder,
+  buildProcessListUrl,
+  isRetryableError,
+  normalizeToken,
+  nowIso,
+  optionalNonNegativeInteger,
+  optionalPositiveInteger,
+  parseProcessRows,
+  toNonNegativeInteger,
+  toPositiveInteger,
+};

--- a/src/lib/process-save-draft-run.ts
+++ b/src/lib/process-save-draft-run.ts
@@ -1,0 +1,480 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { writeJsonArtifact, writeJsonLinesArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+import type { FetchLike } from './http.js';
+import { readJsonInput } from './io.js';
+import {
+  collectPublishInputs,
+  normalizePublishRequest,
+  type PublishCollectedDatasetEntry,
+  type PublishCollectedOrigin,
+} from './publish.js';
+import {
+  syncStateAwareProcessRecord,
+  type ProcessStateAwareWriteResult,
+} from './process-save-draft.js';
+import { buildRunId, resolveRunLayout } from './run.js';
+
+type JsonObject = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function first_non_empty(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+function resolve_path(baseDir: string, value: string): string {
+  return path.resolve(baseDir, value);
+}
+
+function serialize_error(error: unknown): { message: string } {
+  if (error instanceof Error) {
+    return { message: error.message };
+  }
+  return { message: String(error) };
+}
+
+function readJsonLinesInput(inputPath: string): JsonObject[] {
+  const resolved = path.resolve(inputPath);
+  if (!existsSync(resolved)) {
+    throw new CliError(`Input file not found: ${resolved}`, {
+      code: 'INPUT_NOT_FOUND',
+      exitCode: 2,
+    });
+  }
+
+  return readFileSync(resolved, 'utf8')
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line, index) => {
+      try {
+        const parsed = JSON.parse(line) as unknown;
+        if (!isRecord(parsed)) {
+          throw new CliError(
+            `Expected JSON object rows in JSONL input: ${resolved} (line ${index + 1})`,
+            {
+              code: 'INPUT_INVALID_JSONL_ROW',
+              exitCode: 2,
+            },
+          );
+        }
+        return parsed;
+      } catch (error) {
+        if (error instanceof CliError) {
+          throw error;
+        }
+        throw new CliError(`Input file contains invalid JSONL at line ${index + 1}: ${resolved}`, {
+          code: 'INPUT_INVALID_JSONL',
+          exitCode: 2,
+          details: String(error),
+        });
+      }
+    });
+}
+
+function readStructuredInput(inputPath: string): unknown {
+  return inputPath.toLowerCase().endsWith('.jsonl')
+    ? readJsonLinesInput(inputPath)
+    : readJsonInput(inputPath);
+}
+
+function looksLikePublishRequest(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    ('inputs' in value || 'publish' in value || 'out_dir' in value || 'output_dir' in value)
+  );
+}
+
+function loadProcessPayloadFromDatasetEntry(entry: unknown, baseDir: string): JsonObject {
+  if (isRecord(entry)) {
+    for (const key of ['json_ordered', 'jsonOrdered', 'payload'] as const) {
+      const candidate = entry[key];
+      if (isRecord(candidate)) {
+        return candidate;
+      }
+    }
+
+    const fileValue = first_non_empty(entry.file, entry.path);
+    if (fileValue) {
+      const filePath = resolve_path(baseDir, fileValue);
+      const loaded = readJsonInput(filePath);
+      if (!isRecord(loaded)) {
+        throw new CliError(`Expected JSON object input: ${filePath}`, {
+          code: 'PROCESS_SAVE_DRAFT_INPUT_NOT_OBJECT',
+          exitCode: 2,
+        });
+      }
+      return loaded;
+    }
+
+    return entry;
+  }
+
+  if (typeof entry === 'string' && entry.trim()) {
+    const filePath = resolve_path(baseDir, entry);
+    const loaded = readJsonInput(filePath);
+    if (!isRecord(loaded)) {
+      throw new CliError(`Expected JSON object input: ${filePath}`, {
+        code: 'PROCESS_SAVE_DRAFT_INPUT_NOT_OBJECT',
+        exitCode: 2,
+      });
+    }
+    return loaded;
+  }
+
+  throw new CliError('Unsupported process save-draft dataset entry.', {
+    code: 'PROCESS_SAVE_DRAFT_UNSUPPORTED_ENTRY',
+    exitCode: 2,
+    details: entry,
+  });
+}
+
+function extractProcessIdentity(payload: JsonObject): [string, string] {
+  const root = isRecord(payload.processDataSet) ? payload.processDataSet : payload;
+  const processInformation = isRecord(root.processInformation) ? root.processInformation : {};
+  const dataSetInformation = isRecord(processInformation.dataSetInformation)
+    ? processInformation.dataSetInformation
+    : {};
+  const administrativeInformation = isRecord(root.administrativeInformation)
+    ? root.administrativeInformation
+    : {};
+  const publicationAndOwnership = isRecord(administrativeInformation.publicationAndOwnership)
+    ? administrativeInformation.publicationAndOwnership
+    : {};
+  const datasetId = first_non_empty(dataSetInformation['common:UUID']);
+  const version = first_non_empty(publicationAndOwnership['common:dataSetVersion'], '01.01.000')!;
+
+  if (!datasetId) {
+    throw new CliError(
+      'Process payload missing processInformation.dataSetInformation.common:UUID.',
+      {
+        code: 'PUBLISH_PROCESS_ID_MISSING',
+        exitCode: 2,
+      },
+    );
+  }
+
+  return [datasetId, version];
+}
+
+function processPayloadFromRow(row: JsonObject): JsonObject {
+  if (isRecord(row.json_ordered)) {
+    return row.json_ordered;
+  }
+
+  if (isRecord(row.json)) {
+    return row.json;
+  }
+
+  return row;
+}
+
+export type ProcessSaveDraftSource = 'rows_file' | 'bundle' | 'input';
+
+export type ProcessSaveDraftCandidate = {
+  id: string | null;
+  version: string | null;
+  source: ProcessSaveDraftSource;
+  bundle_path: string | null;
+  payload: JsonObject;
+  error?: { message: string };
+};
+
+export type ProcessSaveDraftProcessReport = {
+  id: string | null;
+  version: string | null;
+  source: ProcessSaveDraftSource;
+  bundle_path: string | null;
+  status: 'prepared' | 'executed' | 'failed';
+  execution?: ProcessStateAwareWriteResult;
+  error?: { message: string };
+};
+
+export type ProcessSaveDraftReport = {
+  generated_at_utc: string;
+  input_path: string;
+  input_kind: 'rows_file' | 'publish_request';
+  out_dir: string;
+  commit: boolean;
+  mode: 'dry_run' | 'commit';
+  status: 'completed' | 'completed_with_failures';
+  counts: {
+    selected: number;
+    prepared: number;
+    executed: number;
+    failed: number;
+  };
+  files: {
+    normalized_input: string;
+    selected_processes: string;
+    progress_jsonl: string;
+    failures_jsonl: string;
+    summary_json: string;
+  };
+  processes: ProcessSaveDraftProcessReport[];
+};
+
+export type RunProcessSaveDraftOptions = {
+  inputPath: string;
+  outDir?: string | null;
+  commit?: boolean | null;
+  rawInput?: unknown;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: FetchLike;
+  timeoutMs?: number;
+  now?: Date;
+};
+
+type PreparedProcessSaveDraftInput = {
+  inputKind: 'rows_file' | 'publish_request';
+  normalizedInput: unknown;
+  processes: ProcessSaveDraftCandidate[];
+};
+
+function candidateFromPayload(
+  payload: JsonObject,
+  source: ProcessSaveDraftSource,
+  bundlePath: string | null,
+): ProcessSaveDraftCandidate {
+  try {
+    const [id, version] = extractProcessIdentity(payload);
+    return {
+      id,
+      version,
+      source,
+      bundle_path: bundlePath,
+      payload,
+    };
+  } catch (error) {
+    return {
+      id: first_non_empty(payload['@id'], payload.id),
+      version: first_non_empty(payload['@version'], payload.version, '01.01.000'),
+      source,
+      bundle_path: bundlePath,
+      payload,
+      error:
+        error instanceof CliError && error.code === 'PUBLISH_PROCESS_ID_MISSING'
+          ? {
+              message:
+                'Payload is not a canonical processDataSet wrapper; process save-draft only supports canonical process datasets.',
+            }
+          : serialize_error(error),
+    };
+  }
+}
+
+function sourceFromPublishOrigin(origin: PublishCollectedOrigin): ProcessSaveDraftSource {
+  return origin.source === 'bundle' ? 'bundle' : 'input';
+}
+
+function candidateFromPublishEntry(entry: PublishCollectedDatasetEntry): ProcessSaveDraftCandidate {
+  return candidateFromPayload(
+    loadProcessPayloadFromDatasetEntry(entry.entry, entry.origin.base_dir),
+    sourceFromPublishOrigin(entry.origin),
+    entry.origin.bundle_path,
+  );
+}
+
+function prepareRowsFileInput(inputPath: string, rawInput: unknown): PreparedProcessSaveDraftInput {
+  const rows = Array.isArray(rawInput) ? rawInput : [rawInput];
+  const normalizedRows = rows.map((row, index) => {
+    if (!isRecord(row)) {
+      throw new CliError(
+        `Expected JSON object rows in process save-draft input: ${inputPath} (index ${index})`,
+        {
+          code: 'PROCESS_SAVE_DRAFT_INVALID_ROW',
+          exitCode: 2,
+        },
+      );
+    }
+    return row;
+  });
+
+  return {
+    inputKind: 'rows_file',
+    normalizedInput: {
+      input_kind: 'rows_file',
+      input_path: inputPath,
+      row_count: normalizedRows.length,
+    },
+    processes: normalizedRows.map((row) =>
+      candidateFromPayload(processPayloadFromRow(row), 'rows_file', null),
+    ),
+  };
+}
+
+function preparePublishRequestInput(
+  inputPath: string,
+  rawInput: unknown,
+  commit: boolean,
+  now: Date,
+): PreparedProcessSaveDraftInput {
+  const normalized = normalizePublishRequest(rawInput, {
+    requestPath: inputPath,
+    commitOverride: commit,
+    now,
+  });
+  const collected = collectPublishInputs(normalized, path.dirname(inputPath));
+
+  return {
+    inputKind: 'publish_request',
+    normalizedInput: normalized,
+    processes: collected.processes.map(candidateFromPublishEntry),
+  };
+}
+
+function prepareProcessSaveDraftInput(
+  inputPath: string,
+  rawInput: unknown,
+  commit: boolean,
+  now: Date,
+): PreparedProcessSaveDraftInput {
+  return looksLikePublishRequest(rawInput)
+    ? preparePublishRequestInput(inputPath, rawInput, commit, now)
+    : prepareRowsFileInput(inputPath, rawInput);
+}
+
+function defaultOutDir(inputPath: string, commit: boolean, now: Date): string {
+  const runId = buildRunId({
+    namespace: 'process_save_draft',
+    operation: commit ? 'commit' : 'dry_run',
+    now,
+  });
+  return resolveRunLayout(
+    path.join(path.dirname(inputPath), 'artifacts'),
+    'process_save_draft',
+    runId,
+  ).runRoot;
+}
+
+function resolveOutDir(
+  inputPath: string,
+  outDir: string | null | undefined,
+  commit: boolean,
+  now: Date,
+): string {
+  return outDir ? path.resolve(outDir) : defaultOutDir(inputPath, commit, now);
+}
+
+function buildFiles(outDir: string): ProcessSaveDraftReport['files'] {
+  const outputDir = path.join(outDir, 'outputs', 'save-draft-rpc');
+  return {
+    normalized_input: path.join(outDir, 'inputs', 'normalized-input.json'),
+    selected_processes: path.join(outputDir, 'selected-processes.jsonl'),
+    progress_jsonl: path.join(outputDir, 'progress.jsonl'),
+    failures_jsonl: path.join(outputDir, 'failures.jsonl'),
+    summary_json: path.join(outputDir, 'summary.json'),
+  };
+}
+
+function compactCandidate(candidate: ProcessSaveDraftCandidate): JsonObject {
+  return {
+    id: candidate.id,
+    version: candidate.version,
+    source: candidate.source,
+    bundle_path: candidate.bundle_path,
+    payload: candidate.payload,
+    ...(candidate.error ? { error: candidate.error } : {}),
+  };
+}
+
+export async function runProcessSaveDraft(
+  options: RunProcessSaveDraftOptions,
+): Promise<ProcessSaveDraftReport> {
+  const now = options.now ?? new Date();
+  const inputPath = path.resolve(options.inputPath);
+  const commit = options.commit === true;
+  const rawInput = options.rawInput ?? readStructuredInput(inputPath);
+  const prepared = prepareProcessSaveDraftInput(inputPath, rawInput, commit, now);
+  const outDir = resolveOutDir(inputPath, options.outDir, commit, now);
+  const files = buildFiles(outDir);
+
+  if (commit && (!options.env || !options.fetchImpl)) {
+    throw new CliError('Process save-draft commit requires env and fetch runtime bindings.', {
+      code: 'PROCESS_SAVE_DRAFT_RUNTIME_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  writeJsonArtifact(files.normalized_input, prepared.normalizedInput);
+  writeJsonLinesArtifact(files.selected_processes, prepared.processes.map(compactCandidate));
+
+  const reports: ProcessSaveDraftProcessReport[] = [];
+  for (const candidate of prepared.processes) {
+    const report: ProcessSaveDraftProcessReport = {
+      id: candidate.id,
+      version: candidate.version,
+      source: candidate.source,
+      bundle_path: candidate.bundle_path,
+      status: 'prepared',
+    };
+
+    if (candidate.error) {
+      report.status = 'failed';
+      report.error = candidate.error;
+      reports.push(report);
+      continue;
+    }
+
+    if (!commit) {
+      reports.push(report);
+      continue;
+    }
+
+    try {
+      report.execution = await syncStateAwareProcessRecord({
+        id: candidate.id!,
+        version: candidate.version!,
+        payload: candidate.payload,
+        env: options.env!,
+        fetchImpl: options.fetchImpl!,
+        timeoutMs: options.timeoutMs,
+        audit: {
+          command: 'tiangong process save-draft',
+          source: candidate.source,
+          bundle_path: candidate.bundle_path,
+        },
+      });
+      report.status = 'executed';
+    } catch (error) {
+      report.status = 'failed';
+      report.error = serialize_error(error);
+    }
+
+    reports.push(report);
+  }
+
+  const failedReports = reports.filter((report) => report.status === 'failed');
+  writeJsonLinesArtifact(files.progress_jsonl, reports);
+  writeJsonLinesArtifact(files.failures_jsonl, failedReports);
+
+  const report: ProcessSaveDraftReport = {
+    generated_at_utc: now.toISOString(),
+    input_path: inputPath,
+    input_kind: prepared.inputKind,
+    out_dir: outDir,
+    commit,
+    mode: commit ? 'commit' : 'dry_run',
+    status: failedReports.length > 0 ? 'completed_with_failures' : 'completed',
+    counts: {
+      selected: prepared.processes.length,
+      prepared: reports.filter((entry) => entry.status === 'prepared').length,
+      executed: reports.filter((entry) => entry.status === 'executed').length,
+      failed: failedReports.length,
+    },
+    files,
+    processes: reports,
+  };
+
+  writeJsonArtifact(files.summary_json, report);
+  return report;
+}

--- a/src/lib/process-save-draft.ts
+++ b/src/lib/process-save-draft.ts
@@ -1,0 +1,271 @@
+import { CliError } from './errors.js';
+import type { FetchLike } from './http.js';
+import { postJson, requireRemoteOkPayload } from './http.js';
+import {
+  buildSupabaseAuthHeaders,
+  createSupabaseDataClient,
+  requireSupabaseRestRuntime,
+  runSupabaseArrayQuery,
+} from './supabase-client.js';
+import { createSupabaseDataRuntime } from './supabase-session.js';
+import {
+  syncSupabaseJsonOrderedRecord,
+  type SupabaseJsonOrderedWriteResult,
+} from './supabase-json-ordered-write.js';
+
+type JsonObject = Record<string, unknown>;
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function trimToken(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+export type VisibleProcessRow = {
+  id: string;
+  version: string;
+  user_id: string | null;
+  state_code: number | null;
+};
+
+export type ProcessSaveDraftRpcResult = {
+  ok: true;
+  [key: string]: unknown;
+};
+
+export type ProcessStateAwareWriteResult =
+  | SupabaseJsonOrderedWriteResult
+  | {
+      status: 'success';
+      operation: 'save_draft';
+      write_path: 'cmd_dataset_save_draft';
+      rpc_result: ProcessSaveDraftRpcResult;
+      visible_row: VisibleProcessRow;
+    };
+
+export type SyncStateAwareProcessRecordOptions = {
+  id: string;
+  version: string;
+  payload: JsonObject;
+  env: NodeJS.ProcessEnv;
+  fetchImpl: FetchLike;
+  timeoutMs?: number;
+  audit?: JsonObject;
+  modelId?: string | null;
+};
+
+function buildVisibleRowsUrl(restBaseUrl: string, id: string, version: string): string {
+  const url = new URL(`${restBaseUrl.replace(/\/+$/u, '')}/processes`);
+  url.searchParams.set('select', 'id,version,user_id,state_code');
+  url.searchParams.set('id', `eq.${id}`);
+  url.searchParams.set('version', `eq.${version}`);
+  return url.toString();
+}
+
+function parseVisibleRows(payload: unknown, url: string): VisibleProcessRow[] {
+  if (!Array.isArray(payload)) {
+    throw new CliError(`Supabase REST response was not a JSON array for ${url}`, {
+      code: 'SUPABASE_REST_RESPONSE_INVALID',
+      exitCode: 1,
+      details: payload,
+    });
+  }
+
+  return payload.map((item, index) => {
+    if (!isRecord(item)) {
+      throw new CliError(`Supabase REST row ${index} was not a JSON object for ${url}`, {
+        code: 'SUPABASE_REST_RESPONSE_INVALID',
+        exitCode: 1,
+        details: item,
+      });
+    }
+
+    return {
+      id: trimToken(item.id) ?? '',
+      version: trimToken(item.version) ?? '',
+      user_id: trimToken(item.user_id),
+      state_code: typeof item.state_code === 'number' ? item.state_code : null,
+    };
+  });
+}
+
+async function exactVisibleRows(options: {
+  id: string;
+  version: string;
+  env: NodeJS.ProcessEnv;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+}): Promise<{
+  rows: VisibleProcessRow[];
+  restBaseUrl: string;
+  accessToken: string;
+  publishableKey: string;
+}> {
+  const runtime = createSupabaseDataRuntime({
+    runtime: requireSupabaseRestRuntime(options.env),
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.timeoutMs,
+  });
+  const { client, restBaseUrl } = createSupabaseDataClient(
+    runtime,
+    options.fetchImpl,
+    options.timeoutMs,
+  );
+  const url = buildVisibleRowsUrl(restBaseUrl, options.id, options.version);
+  const payload = await runSupabaseArrayQuery(
+    client
+      .from('processes')
+      .select('id,version,user_id,state_code')
+      .eq('id', options.id)
+      .eq('version', options.version),
+    url,
+  );
+
+  return {
+    rows: parseVisibleRows(payload, url),
+    restBaseUrl,
+    accessToken: await runtime.getAccessToken(),
+    publishableKey: runtime.publishableKey,
+  };
+}
+
+function visibleDraftRow(rows: VisibleProcessRow[]): VisibleProcessRow | null {
+  return rows.find((row) => row.state_code === 0) ?? null;
+}
+
+function buildUnsupportedVisibleRowError(
+  id: string,
+  version: string,
+  rows: VisibleProcessRow[],
+): CliError {
+  const primaryRow = rows[0] ?? null;
+  const stateCode =
+    primaryRow?.state_code === null || primaryRow?.state_code === undefined
+      ? 'unknown'
+      : String(primaryRow.state_code);
+  const visibleOwner = primaryRow?.user_id ?? 'unknown';
+
+  return new CliError(
+    `Process ${id}@${version} is already visible but cannot use save-draft because the visible row is not a current-user draft (state_code=${stateCode}, visible_owner=${visibleOwner}).`,
+    {
+      code: 'PUBLISH_PROCESS_SAVE_DRAFT_UNSUPPORTED_VISIBLE_ROW',
+      exitCode: 1,
+      details: {
+        id,
+        version,
+        visible_rows: rows,
+      },
+    },
+  );
+}
+
+async function saveDraft(options: {
+  restBaseUrl: string;
+  publishableKey: string;
+  accessToken: string;
+  id: string;
+  version: string;
+  payload: JsonObject;
+  timeoutMs: number;
+  fetchImpl: FetchLike;
+  audit?: JsonObject;
+  modelId?: string | null;
+}): Promise<ProcessSaveDraftRpcResult> {
+  const url = `${options.restBaseUrl.replace(/\/+$/u, '')}/rpc/cmd_dataset_save_draft`;
+  const payload = requireRemoteOkPayload(
+    await postJson({
+      url,
+      headers: {
+        ...buildSupabaseAuthHeaders(options.publishableKey, options.accessToken),
+        'Content-Type': 'application/json',
+      },
+      body: {
+        p_table: 'processes',
+        p_id: options.id,
+        p_version: options.version,
+        p_json_ordered: options.payload,
+        p_model_id: options.modelId ?? null,
+        p_audit: options.audit ?? null,
+      },
+      timeoutMs: options.timeoutMs,
+      fetchImpl: options.fetchImpl,
+    }),
+    url,
+  );
+
+  if (!isRecord(payload) || payload.ok !== true) {
+    throw new CliError(`Process save-draft RPC returned an unexpected payload for ${url}`, {
+      code: 'REMOTE_RESPONSE_INVALID',
+      exitCode: 1,
+      details: payload,
+    });
+  }
+
+  return payload as ProcessSaveDraftRpcResult;
+}
+
+export async function syncStateAwareProcessRecord(
+  options: SyncStateAwareProcessRecordOptions,
+): Promise<ProcessStateAwareWriteResult> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const visible = await exactVisibleRows({
+    id: options.id,
+    version: options.version,
+    env: options.env,
+    fetchImpl: options.fetchImpl,
+    timeoutMs,
+  });
+  const draftRow = visibleDraftRow(visible.rows);
+
+  if (!draftRow) {
+    if (visible.rows.length > 0) {
+      throw buildUnsupportedVisibleRowError(options.id, options.version, visible.rows);
+    }
+
+    return syncSupabaseJsonOrderedRecord({
+      table: 'processes',
+      id: options.id,
+      version: options.version,
+      payload: options.payload,
+      writeMode: 'upsert_current_version',
+      env: options.env,
+      fetchImpl: options.fetchImpl,
+      timeoutMs,
+    });
+  }
+
+  return {
+    status: 'success',
+    operation: 'save_draft',
+    write_path: 'cmd_dataset_save_draft',
+    rpc_result: await saveDraft({
+      restBaseUrl: visible.restBaseUrl,
+      publishableKey: visible.publishableKey,
+      accessToken: visible.accessToken,
+      id: options.id,
+      version: options.version,
+      payload: options.payload,
+      timeoutMs,
+      fetchImpl: options.fetchImpl,
+      audit: options.audit,
+      modelId: options.modelId,
+    }),
+    visible_row: draftRow,
+  };
+}
+
+export const __testInternals = {
+  buildVisibleRowsUrl,
+  parseVisibleRows,
+  visibleDraftRow,
+  buildUnsupportedVisibleRowError,
+};

--- a/src/lib/publish.ts
+++ b/src/lib/publish.ts
@@ -3,6 +3,7 @@ import { CliError } from './errors.js';
 import { writeJsonArtifact } from './artifacts.js';
 import type { FetchLike } from './http.js';
 import { readJsonInput } from './io.js';
+import { syncStateAwareProcessRecord } from './process-save-draft.js';
 import { buildRunId, resolveRunLayout } from './run.js';
 import {
   hasSupabaseRestRuntime,
@@ -785,8 +786,24 @@ function build_default_dataset_executor(options: {
   fetchImpl: FetchLike;
   timeoutMs?: number;
 }) {
-  return async (args: DatasetPublishExecutorArgs): Promise<unknown> =>
-    syncSupabaseJsonOrderedRecord({
+  return async (args: DatasetPublishExecutorArgs): Promise<unknown> => {
+    if (options.table === 'processes') {
+      return syncStateAwareProcessRecord({
+        id: args.id,
+        version: args.version,
+        payload: args.payload,
+        env: options.env,
+        fetchImpl: options.fetchImpl,
+        timeoutMs: options.timeoutMs,
+        audit: {
+          command: 'tiangong publish run',
+          source: args.source,
+          bundle_path: args.bundle_path,
+        },
+      });
+    }
+
+    return syncSupabaseJsonOrderedRecord({
       table: options.table,
       id: args.id,
       version: args.version,
@@ -796,6 +813,7 @@ function build_default_dataset_executor(options: {
       fetchImpl: options.fetchImpl,
       timeoutMs: options.timeoutMs,
     });
+  };
 }
 
 function resolve_dataset_executors(options: RunPublishOptions): PublishExecutors {

--- a/src/lib/review-process.ts
+++ b/src/lib/review-process.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { writeJsonArtifact, writeTextArtifact } from './artifacts.js';
 import { CliError } from './errors.js';
@@ -151,11 +151,16 @@ export type ProcessReviewReport = {
   status: 'completed_local_process_review';
   run_id: string;
   run_root: string;
+  rows_file: string;
   out_dir: string;
+  input_mode: 'rows_file' | 'run_root';
+  effective_processes_dir: string;
   logic_version: string;
   process_count: number;
   totals: ProcessReviewTotals;
   files: {
+    review_input_summary: string;
+    materialization_summary: string | null;
     review_zh: string;
     review_en: string;
     timing: string;
@@ -167,8 +172,9 @@ export type ProcessReviewReport = {
 };
 
 export type RunProcessReviewOptions = {
-  runRoot: string;
-  runId: string;
+  rowsFile?: string;
+  runRoot?: string;
+  runId?: string;
   outDir: string;
   startTs?: string;
   endTs?: string;
@@ -479,6 +485,7 @@ function unwrapProcessPayload(value: unknown, filePath: string): JsonRecord {
   }
 
   const candidate =
+    (isRecord(value.process) && value.process) ||
     (isRecord(value.json_ordered) && value.json_ordered) ||
     (isRecord(value.jsonOrdered) && value.jsonOrdered) ||
     (isRecord(value.json) && value.json) ||
@@ -494,10 +501,202 @@ function unwrapProcessPayload(value: unknown, filePath: string): JsonRecord {
   return candidate;
 }
 
-function readProcessFiles(runRoot: string): string[] {
-  const processDir = path.join(runRoot, 'exports', 'processes');
+function extractProcessIdentity(value: JsonRecord, index: number): { id: string; version: string } {
+  const payload = unwrapProcessPayload(value, `row-${index + 1}`);
+  const root = payload.processDataSet as JsonRecord;
+  const processInformation = isRecord(root.processInformation) ? root.processInformation : {};
+  const dataSetInformation = isRecord(processInformation.dataSetInformation)
+    ? processInformation.dataSetInformation
+    : {};
+  const administrativeInformation = isRecord(root.administrativeInformation)
+    ? root.administrativeInformation
+    : {};
+  const publicationAndOwnership = isRecord(administrativeInformation.publicationAndOwnership)
+    ? administrativeInformation.publicationAndOwnership
+    : {};
+  const id =
+    String(dataSetInformation['common:UUID'] ?? value.id ?? '').trim() || `row-${index + 1}`;
+  const version =
+    String(publicationAndOwnership['common:dataSetVersion'] ?? value.version ?? '').trim() ||
+    '01.00.000';
+  return {
+    id,
+    version,
+  };
+}
+
+function loadReviewRows(rowsFile: string): JsonRecord[] {
+  const resolved = path.resolve(rowsFile);
+  const text = readFileSync(resolved, 'utf8');
+
+  if (resolved.endsWith('.jsonl')) {
+    return text
+      .split(/\r?\n/gu)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line, index) => {
+        try {
+          const parsed = JSON.parse(line) as unknown;
+          if (!isRecord(parsed)) {
+            throw new CliError(`Expected JSON object rows in JSONL file: ${resolved}`, {
+              code: 'PROCESS_REVIEW_ROWS_INVALID_JSONL_ROW',
+              exitCode: 2,
+            });
+          }
+          return parsed;
+        } catch (error) {
+          if (error instanceof CliError) {
+            throw error;
+          }
+          throw new CliError(
+            `Process review rows file contains invalid JSONL at line ${index + 1}.`,
+            {
+              code: 'PROCESS_REVIEW_ROWS_INVALID_JSONL',
+              exitCode: 2,
+              details: String(error),
+            },
+          );
+        }
+      });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text) as unknown;
+  } catch (error) {
+    throw new CliError(`Process review rows file is not valid JSON: ${resolved}`, {
+      code: 'PROCESS_REVIEW_ROWS_INVALID_JSON',
+      exitCode: 2,
+      details: String(error),
+    });
+  }
+  if (Array.isArray(parsed) && parsed.every(isRecord)) {
+    return parsed;
+  }
+
+  if (isRecord(parsed) && Array.isArray(parsed.rows) && parsed.rows.every(isRecord)) {
+    return parsed.rows;
+  }
+
+  throw new CliError(`Expected JSON array of objects or a report object with rows[]: ${resolved}`, {
+    code: 'PROCESS_REVIEW_ROWS_INVALID_JSON',
+    exitCode: 2,
+  });
+}
+
+function materializeRowsFile(
+  rowsFile: string,
+  outDir: string,
+): { processesDir: string; summaryPath: string } {
+  const rows = loadReviewRows(rowsFile);
+  const targetDir = path.join(outDir, 'review-input', 'processes');
+  mkdirSync(targetDir, { recursive: true });
+
+  const byKey: Record<string, JsonRecord> = {};
+  let duplicateCount = 0;
+  rows.forEach((row, index) => {
+    const payload = unwrapProcessPayload(row, `${rowsFile}#${index + 1}`);
+    const identity = extractProcessIdentity(row, index);
+    const key = `${identity.id}@${identity.version}`;
+    if (key in byKey) {
+      duplicateCount += 1;
+    }
+    byKey[key] = payload;
+  });
+
+  const items: Array<{ process_key: string; file: string }> = [];
+  Object.entries(byKey)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .forEach(([key, payload]) => {
+      const { id, version } = extractProcessIdentity(payload, 0);
+      const fileName = `${id}__${version}.json`;
+      const filePath = path.join(targetDir, fileName);
+      writeJsonArtifact(filePath, payload);
+      items.push({
+        process_key: key,
+        file: filePath,
+      });
+    });
+
+  const summaryPath = path.join(outDir, 'review-input', 'materialization-summary.json');
+  writeJsonArtifact(summaryPath, {
+    source_rows_file: path.resolve(rowsFile),
+    input_row_count: rows.length,
+    materialized_process_count: Object.keys(byKey).length,
+    duplicate_input_rows_collapsed: duplicateCount,
+    processes_dir: targetDir,
+    items,
+  });
+
+  return {
+    processesDir: targetDir,
+    summaryPath,
+  };
+}
+
+function resolveReviewInput(options: {
+  rowsFile?: string;
+  runRoot?: string;
+  runId?: string;
+  outDir: string;
+}): {
+  inputMode: 'rows_file' | 'run_root';
+  effectiveProcessesDir: string;
+  materializationSummaryPath: string | null;
+  runId: string;
+  runRoot: string;
+  rowsFile: string;
+  reviewInputSummary: JsonRecord;
+} {
+  const declaredModes = [Boolean(options.rowsFile), Boolean(options.runRoot)].filter(Boolean);
+  if (declaredModes.length !== 1) {
+    throw new CliError('Process review requires exactly one of --rows-file or --run-root.', {
+      code: 'PROCESS_REVIEW_INPUT_MODE_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  if (options.rowsFile) {
+    const materialized = materializeRowsFile(options.rowsFile, options.outDir);
+    return {
+      inputMode: 'rows_file',
+      effectiveProcessesDir: materialized.processesDir,
+      materializationSummaryPath: materialized.summaryPath,
+      runId: options.runId?.trim() || path.parse(options.rowsFile).name,
+      runRoot: '',
+      rowsFile: path.resolve(options.rowsFile),
+      reviewInputSummary: {
+        input_mode: 'rows_file',
+        rows_file: path.resolve(options.rowsFile),
+        run_root: '',
+        materialized_processes_dir: materialized.processesDir,
+        effective_processes_dir: materialized.processesDir,
+      },
+    };
+  }
+
+  const runRoot = path.resolve(options.runRoot!);
+  const effective = path.join(runRoot, 'exports', 'processes');
+  return {
+    inputMode: 'run_root',
+    effectiveProcessesDir: effective,
+    materializationSummaryPath: null,
+    runId: options.runId?.trim() || path.basename(runRoot),
+    runRoot,
+    rowsFile: '',
+    reviewInputSummary: {
+      input_mode: 'run_root',
+      rows_file: '',
+      run_root: runRoot,
+      materialized_processes_dir: '',
+      effective_processes_dir: effective,
+    },
+  };
+}
+
+function readProcessFiles(processDir: string): string[] {
   if (!existsSync(processDir) || !statSync(processDir).isDirectory()) {
-    throw new CliError(`Process review exports directory not found: ${processDir}`, {
+    throw new CliError(`Process review directory not found: ${processDir}`, {
       code: 'PROCESS_REVIEW_EXPORTS_NOT_FOUND',
       exitCode: 2,
     });
@@ -789,13 +988,16 @@ function renderUnitIssues(runId: string, unitIssues: UnitIssue[]): string {
 export async function runProcessReview(
   options: RunProcessReviewOptions,
 ): Promise<ProcessReviewReport> {
-  const runRoot = path.resolve(
-    requiredNonEmpty(options.runRoot, '--run-root', 'PROCESS_REVIEW_RUN_ROOT_REQUIRED'),
-  );
-  const runId = requiredNonEmpty(options.runId, '--run-id', 'PROCESS_REVIEW_RUN_ID_REQUIRED');
   const outDir = path.resolve(
     requiredNonEmpty(options.outDir, '--out-dir', 'PROCESS_REVIEW_OUT_DIR_REQUIRED'),
   );
+  const resolvedInput = resolveReviewInput({
+    rowsFile: options.rowsFile,
+    runRoot: options.runRoot,
+    runId: options.runId,
+    outDir,
+  });
+  const runId = requiredNonEmpty(resolvedInput.runId, '--run-id', 'PROCESS_REVIEW_RUN_ID_REQUIRED');
   const logicVersion = options.logicVersion?.trim() || 'v2.1';
   const fetchImpl = options.fetchImpl ?? (fetch as FetchLike);
   const env = options.env ?? process.env;
@@ -805,7 +1007,7 @@ export async function runProcessReview(
     options.llmMaxProcesses > 0
       ? options.llmMaxProcesses
       : 8;
-  const processFiles = readProcessFiles(runRoot);
+  const processFiles = readProcessFiles(resolvedInput.effectiveProcessesDir);
   const baseRows: Array<[string, BaseInfoCheck]> = [];
   const rows: ProcessReviewRow[] = [];
   const unitIssues: UnitIssue[] = [];
@@ -936,6 +1138,10 @@ export async function runProcessReview(
     totals,
     llm: llmResult,
   };
+  const reviewInputSummaryPath = writeJsonArtifact(
+    path.join(outDir, 'review-input-summary.json'),
+    resolvedInput.reviewInputSummary,
+  );
 
   const reviewZhPath = writeTextArtifact(
     path.join(outDir, 'one_flow_rerun_review_v2_1_zh.md'),
@@ -982,12 +1188,17 @@ export async function runProcessReview(
     generated_at_utc: (options.now ?? (() => new Date()))().toISOString(),
     status: 'completed_local_process_review',
     run_id: runId,
-    run_root: runRoot,
+    run_root: resolvedInput.runRoot,
+    rows_file: resolvedInput.rowsFile,
     out_dir: outDir,
+    input_mode: resolvedInput.inputMode,
+    effective_processes_dir: resolvedInput.effectiveProcessesDir,
     logic_version: logicVersion,
     process_count: processFiles.length,
     totals,
     files: {
+      review_input_summary: reviewInputSummaryPath,
+      materialization_summary: resolvedInput.materializationSummaryPath,
       review_zh: reviewZhPath,
       review_en: reviewEnPath,
       timing: timingPath,

--- a/src/lib/supabase-json-ordered-write.ts
+++ b/src/lib/supabase-json-ordered-write.ts
@@ -1,6 +1,10 @@
-import { createDatasetCommandClient, type DatasetCommandClient } from './dataset-command.js';
-import { readRuntimeEnv } from './env.js';
 import { CliError } from './errors.js';
+import {
+  buildDatasetCommandTransport,
+  createDatasetRecord,
+  saveDraftDatasetRecord,
+  type DatasetCommandTransport,
+} from './dataset-command.js';
 import type { FetchLike } from './http.js';
 import {
   createSupabaseDataClient,
@@ -113,34 +117,36 @@ async function exactVisibleRows(options: {
 }
 
 async function insertJsonOrderedRow(options: {
-  commandClient: DatasetCommandClient;
+  transport: DatasetCommandTransport;
   table: SupabaseJsonOrderedTable;
   id: string;
   payload: JsonObject;
   extraData?: JsonObject;
 }): Promise<void> {
-  await options.commandClient.create({
+  await createDatasetRecord({
+    transport: options.transport,
     table: options.table,
     id: options.id,
-    jsonOrdered: options.payload,
-    ...commandOptionsFromExtraData(options.extraData),
+    payload: options.payload,
+    extraData: options.extraData,
   });
 }
 
 async function updateJsonOrderedRow(options: {
-  commandClient: DatasetCommandClient;
+  transport: DatasetCommandTransport;
   table: SupabaseJsonOrderedTable;
   id: string;
   version: string;
   payload: JsonObject;
   extraData?: JsonObject;
 }): Promise<void> {
-  await options.commandClient.saveDraft({
+  await saveDraftDatasetRecord({
+    transport: options.transport,
     table: options.table,
     id: options.id,
     version: options.version,
-    jsonOrdered: options.payload,
-    ...commandOptionsFromExtraData(options.extraData),
+    payload: options.payload,
+    extraData: options.extraData,
   });
 }
 
@@ -153,34 +159,6 @@ function requireNonEmptyToken(value: string, label: string, code: string): strin
     });
   }
   return normalized;
-}
-
-function commandOptionsFromExtraData(extraData?: JsonObject): {
-  modelId?: string | null;
-  ruleVerification?: boolean | null;
-} {
-  if (!extraData) {
-    return {};
-  }
-
-  const result: {
-    modelId?: string | null;
-    ruleVerification?: boolean | null;
-  } = {};
-
-  if ('modelId' in extraData || 'model_id' in extraData) {
-    const modelIdValue = extraData.modelId ?? extraData.model_id;
-    result.modelId = modelIdValue === null ? null : trimToken(modelIdValue) || null;
-  }
-
-  if ('ruleVerification' in extraData || 'rule_verification' in extraData) {
-    const ruleVerificationValue = extraData.ruleVerification ?? extraData.rule_verification;
-    if (typeof ruleVerificationValue === 'boolean' || ruleVerificationValue === null) {
-      result.ruleVerification = ruleVerificationValue;
-    }
-  }
-
-  return result;
 }
 
 export function hasSupabaseRestRuntime(env: NodeJS.ProcessEnv | undefined): boolean {
@@ -218,13 +196,12 @@ export async function syncSupabaseJsonOrderedRecord(options: {
     fetchImpl: options.fetchImpl,
     timeoutMs,
   });
-  const { client, restBaseUrl } = createSupabaseDataClient(runtime, options.fetchImpl, timeoutMs);
-  const commandClient = createDatasetCommandClient({
+  const commandTransport = await buildDatasetCommandTransport({
     runtime,
     fetchImpl: options.fetchImpl,
     timeoutMs,
-    region: readRuntimeEnv(options.env).region,
   });
+  const { client, restBaseUrl } = createSupabaseDataClient(runtime, options.fetchImpl, timeoutMs);
 
   const visibleBefore = await exactVisibleRows({
     client,
@@ -243,7 +220,7 @@ export async function syncSupabaseJsonOrderedRecord(options: {
 
   if (visibleBefore.length > 0) {
     await updateJsonOrderedRow({
-      commandClient,
+      transport: commandTransport,
       table: options.table,
       id,
       version,
@@ -258,7 +235,7 @@ export async function syncSupabaseJsonOrderedRecord(options: {
 
   try {
     await insertJsonOrderedRow({
-      commandClient,
+      transport: commandTransport,
       table: options.table,
       id,
       payload: options.payload,
@@ -289,7 +266,7 @@ export async function syncSupabaseJsonOrderedRecord(options: {
     }
 
     await updateJsonOrderedRow({
-      commandClient,
+      transport: commandTransport,
       table: options.table,
       id,
       version,
@@ -308,7 +285,6 @@ export const __testInternals = {
   buildUpdateUrl,
   parseVisibleRows,
   exactVisibleRows,
-  commandOptionsFromExtraData,
   insertJsonOrderedRow,
   updateJsonOrderedRow,
   requireNonEmptyToken,

--- a/test/bin.test.ts
+++ b/test/bin.test.ts
@@ -1,5 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
 
 const maybeTest = process.env.TIANGONG_LCA_COVERAGE === '1' ? test.skip : test;
 
@@ -32,5 +36,65 @@ maybeTest('runFromBin executes when imported without direct auto-run', async () 
   } finally {
     process.stdout.write = originalStdoutWrite;
     process.stderr.write = originalStderrWrite;
+  }
+});
+
+maybeTest('packed tarball exposes non-empty help through installed bin and npm exec', () => {
+  const repoRoot = process.cwd();
+  const tempInstallDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-pack-install-'));
+  const tempExecDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-pack-exec-'));
+  const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const packResult = spawnSync(npmCommand, ['pack', '--silent'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+
+  assert.equal(packResult.status, 0, packResult.stderr);
+
+  const tarballName = packResult.stdout.trim().split('\n').at(-1);
+  assert.ok(tarballName);
+  const tarballPath = path.join(repoRoot, tarballName);
+  const installedBinPath = path.join(
+    tempInstallDir,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'tiangong.cmd' : 'tiangong',
+  );
+
+  try {
+    const initResult = spawnSync(npmCommand, ['init', '-y'], {
+      cwd: tempInstallDir,
+      encoding: 'utf8',
+    });
+    assert.equal(initResult.status, 0, initResult.stderr);
+
+    const installResult = spawnSync(npmCommand, ['install', '--silent', tarballPath], {
+      cwd: tempInstallDir,
+      encoding: 'utf8',
+    });
+    assert.equal(installResult.status, 0, installResult.stderr);
+
+    const binHelpResult = spawnSync(installedBinPath, ['--help'], {
+      cwd: tempInstallDir,
+      encoding: 'utf8',
+      shell: process.platform === 'win32',
+    });
+    assert.equal(binHelpResult.status, 0, binHelpResult.stderr);
+    assert.match(binHelpResult.stdout, /Unified TianGong command entrypoint/u);
+
+    const execHelpResult = spawnSync(
+      npmCommand,
+      ['exec', '--yes', `--package=${tarballPath}`, '--', 'tiangong', '--help'],
+      {
+        cwd: tempExecDir,
+        encoding: 'utf8',
+      },
+    );
+    assert.equal(execHelpResult.status, 0, execHelpResult.stderr);
+    assert.match(execHelpResult.stdout, /Unified TianGong command entrypoint/u);
+  } finally {
+    rmSync(tarballPath, { force: true });
+    rmSync(tempInstallDir, { recursive: true, force: true });
+    rmSync(tempExecDir, { recursive: true, force: true });
   }
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { executeCli } from '../src/cli.js';
@@ -58,7 +58,7 @@ test('executeCli prints main help when no command is given', async () => {
   assert.match(result.stdout, /Unified TianGong command entrypoint/u);
   assert.match(result.stdout, /Implemented Commands:/u);
   assert.match(result.stdout, /Planned Surface \(not implemented yet\):/u);
-  assert.match(result.stdout, /process\s+get \| auto-build/u);
+  assert.match(result.stdout, /process\s+get \| list \| auto-build/u);
   assert.match(result.stdout, /process\s+auto-build/u);
   assert.match(result.stdout, /lifecyclemodel auto-build/u);
   assert.match(result.stdout, /lifecyclemodel auto-build \| validate-build \| publish-build/u);
@@ -85,7 +85,12 @@ test('executeCli main help reports loaded dotenv metadata when available', async
 test('executeCli prints version', async () => {
   const result = await executeCli(['--version'], makeDeps());
   assert.equal(result.exitCode, 0);
-  assert.equal(result.stdout, '0.0.1\n');
+  const packageJson = JSON.parse(
+    readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+  ) as {
+    version: string;
+  };
+  assert.equal(result.stdout, `${packageJson.version}\n`);
 });
 
 test('executeCli returns doctor text and success status', async () => {
@@ -177,6 +182,10 @@ test('executeCli returns help for publish and validation subcommands', async () 
   const publishHelp = await executeCli(['publish', 'run', '--help'], makeDeps());
   assert.equal(publishHelp.exitCode, 0);
   assert.match(publishHelp.stdout, /--out-dir/u);
+  assert.match(
+    publishHelp.stdout,
+    /Relative out_dir values from the request body or --out-dir resolve from the request file directory\./u,
+  );
 
   const validationHelp = await executeCli(['validation', 'run', '--help'], makeDeps());
   assert.equal(validationHelp.exitCode, 0);
@@ -184,10 +193,12 @@ test('executeCli returns help for publish and validation subcommands', async () 
 
   const reviewHelp = await executeCli(['review', 'process', '--help'], makeDeps());
   assert.equal(reviewHelp.exitCode, 0);
-  assert.match(
-    reviewHelp.stdout,
-    /tiangong review process --run-root <dir> --run-id <id> --out-dir <dir>/u,
+  assert.ok(
+    reviewHelp.stdout.includes(
+      'tiangong review process (--rows-file <file> | --run-root <dir>) --out-dir <dir>',
+    ),
   );
+  assert.match(reviewHelp.stdout, /full process list reports with rows\[\] are also accepted/u);
   assert.match(reviewHelp.stdout, /--enable-llm/u);
 
   const reviewFlowHelp = await executeCli(['review', 'flow', '--help'], makeDeps());
@@ -969,9 +980,11 @@ test('executeCli returns help for the process namespace and implemented subcomma
   assert.equal(processHelp.exitCode, 0);
   assert.match(processHelp.stdout, /tiangong process <subcommand>/u);
   assert.match(processHelp.stdout, /get/u);
+  assert.match(processHelp.stdout, /list/u);
   assert.match(processHelp.stdout, /auto-build/u);
   assert.match(processHelp.stdout, /resume-build/u);
   assert.match(processHelp.stdout, /publish-build/u);
+  assert.match(processHelp.stdout, /save-draft/u);
   assert.match(processHelp.stdout, /batch-build/u);
 
   const getHelp = await executeCli(['process', 'get', '--help'], makeDeps());
@@ -980,6 +993,13 @@ test('executeCli returns help for the process namespace and implemented subcomma
   assert.match(getHelp.stdout, /TIANGONG_LCA_API_BASE_URL/u);
   assert.match(getHelp.stdout, /TIANGONG_LCA_API_KEY/u);
   assert.doesNotMatch(getHelp.stdout, /Planned command/u);
+
+  const listHelp = await executeCli(['process', 'list', '--help'], makeDeps());
+  assert.equal(listHelp.exitCode, 0);
+  assert.match(listHelp.stdout, /tiangong process list \[options\]/u);
+  assert.match(listHelp.stdout, /--page-size/u);
+  assert.match(listHelp.stdout, /TIANGONG_LCA_API_BASE_URL/u);
+  assert.doesNotMatch(listHelp.stdout, /Planned command/u);
 
   const autoBuildHelp = await executeCli(['process', 'auto-build', '--help'], makeDeps());
   assert.equal(autoBuildHelp.exitCode, 0);
@@ -1004,6 +1024,13 @@ test('executeCli returns help for the process namespace and implemented subcomma
   );
   assert.match(publishBuildHelp.stdout, /--run-dir/u);
   assert.doesNotMatch(publishBuildHelp.stdout, /Planned command/u);
+
+  const saveDraftHelp = await executeCli(['process', 'save-draft', '--help'], makeDeps());
+  assert.equal(saveDraftHelp.exitCode, 0);
+  assert.match(saveDraftHelp.stdout, /tiangong process save-draft --input <file>/u);
+  assert.match(saveDraftHelp.stdout, /--commit/u);
+  assert.match(saveDraftHelp.stdout, /outputs\/save-draft-rpc\/summary\.json/u);
+  assert.doesNotMatch(saveDraftHelp.stdout, /Planned command/u);
 
   const batchBuildHelp = await executeCli(['process', 'batch-build', '--help'], makeDeps());
   assert.equal(batchBuildHelp.exitCode, 0);
@@ -1107,6 +1134,116 @@ test('executeCli executes process get with injected implementation', async () =>
   assert.equal(result.exitCode, 0);
   assert.match(result.stdout, /"status": "resolved_remote_process"/u);
   assert.equal(result.stderr, '');
+});
+
+test('executeCli executes process list with injected implementation', async () => {
+  const deps = makeDeps({
+    TIANGONG_LCA_API_BASE_URL: 'https://supabase.example/functions/v1',
+    TIANGONG_LCA_API_KEY: 'supabase-api-key',
+  });
+
+  const result = await executeCli(
+    [
+      'process',
+      'list',
+      '--id',
+      'proc-1',
+      '--version',
+      '00.00.001',
+      '--user-id',
+      'user-1',
+      '--state-code',
+      '100',
+      '--all',
+      '--page-size',
+      '50',
+      '--order',
+      'version.desc',
+    ],
+    {
+      ...deps,
+      runProcessListImpl: async (options) => {
+        assert.deepEqual(options.ids, ['proc-1']);
+        assert.equal(options.version, '00.00.001');
+        assert.equal(options.userId, 'user-1');
+        assert.deepEqual(options.stateCodes, [100]);
+        assert.equal(options.all, true);
+        assert.equal(options.pageSize, 50);
+        assert.equal(options.order, 'version.desc');
+        assert.equal(options.env, deps.env);
+        assert.equal(options.fetchImpl, deps.fetchImpl);
+        return {
+          schema_version: 1,
+          generated_at_utc: '2026-03-30T00:00:00.000Z',
+          status: 'listed_remote_processes',
+          filters: {
+            ids: ['proc-1'],
+            requested_version: '00.00.001',
+            requested_user_id: 'user-1',
+            requested_state_codes: [100],
+            order: 'version.desc',
+            all: true,
+            limit: null,
+            offset: 0,
+            page_size: 50,
+          },
+          count: 1,
+          source_urls: ['https://supabase.example/rest/v1/processes?id=eq.proc-1'],
+          rows: [
+            {
+              id: 'proc-1',
+              version: '00.00.001',
+              user_id: 'user-1',
+              state_code: 100,
+              modified_at: null,
+              process: { processDataSet: { id: 'proc-1' } },
+            },
+          ],
+        };
+      },
+    },
+  );
+
+  assert.equal(result.exitCode, 0);
+  assert.match(result.stdout, /"status": "listed_remote_processes"/u);
+  assert.equal(result.stderr, '');
+});
+
+test('executeCli parses non-all process list pagination flags', async () => {
+  const deps = makeDeps({
+    TIANGONG_LCA_API_BASE_URL: 'https://supabase.example/functions/v1',
+    TIANGONG_LCA_API_KEY: 'supabase-api-key',
+  });
+
+  const result = await executeCli(['process', 'list', '--limit', '5', '--offset', '3'], {
+    ...deps,
+    runProcessListImpl: async (options) => {
+      assert.equal(options.limit, 5);
+      assert.equal(options.offset, 3);
+      return {
+        schema_version: 1,
+        generated_at_utc: '2026-03-30T00:00:00.000Z',
+        status: 'listed_remote_processes',
+        filters: {
+          ids: [],
+          requested_version: null,
+          requested_user_id: null,
+          requested_state_codes: [],
+          order: 'id.asc,version.asc',
+          all: false,
+          limit: 5,
+          offset: 3,
+          page_size: null,
+        },
+        count: 0,
+        source_urls: ['https://supabase.example/rest/v1/processes?limit=5&offset=3'],
+        rows: [],
+      };
+    },
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.match(result.stdout, /"offset": 3/u);
 });
 
 test('executeCli executes flow get with injected implementation', async () => {
@@ -1696,6 +1833,185 @@ test('executeCli executes process publish-build with run-dir only', async () => 
   }
 });
 
+test('executeCli executes process save-draft with injected implementation', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-save-draft-cli-'));
+  const inputPath = path.join(dir, 'patched-processes.jsonl');
+  writeFileSync(inputPath, '{"id":"proc-1"}\n', 'utf8');
+
+  try {
+    const result = await executeCli(
+      [
+        'process',
+        'save-draft',
+        '--json',
+        '--input',
+        inputPath,
+        '--out-dir',
+        './save-root',
+        '--commit',
+      ],
+      {
+        ...makeDeps(),
+        runProcessSaveDraftImpl: async (options) => {
+          assert.equal(options.inputPath, inputPath);
+          assert.equal(options.outDir, './save-root');
+          assert.equal(options.commit, true);
+          return {
+            generated_at_utc: '2026-04-14T12:00:00.000Z',
+            input_path: inputPath,
+            input_kind: 'rows_file',
+            out_dir: path.join(dir, 'save-root'),
+            commit: true,
+            mode: 'commit',
+            status: 'completed',
+            counts: {
+              selected: 1,
+              prepared: 0,
+              executed: 1,
+              failed: 0,
+            },
+            files: {
+              normalized_input: path.join(dir, 'save-root', 'inputs', 'normalized-input.json'),
+              selected_processes: path.join(
+                dir,
+                'save-root',
+                'outputs',
+                'save-draft-rpc',
+                'selected-processes.jsonl',
+              ),
+              progress_jsonl: path.join(
+                dir,
+                'save-root',
+                'outputs',
+                'save-draft-rpc',
+                'progress.jsonl',
+              ),
+              failures_jsonl: path.join(
+                dir,
+                'save-root',
+                'outputs',
+                'save-draft-rpc',
+                'failures.jsonl',
+              ),
+              summary_json: path.join(
+                dir,
+                'save-root',
+                'outputs',
+                'save-draft-rpc',
+                'summary.json',
+              ),
+            },
+            processes: [
+              {
+                id: 'proc-1',
+                version: '01.01.000',
+                source: 'rows_file',
+                bundle_path: null,
+                status: 'executed',
+                execution: {
+                  status: 'success',
+                  operation: 'save_draft',
+                  write_path: 'cmd_dataset_save_draft',
+                  rpc_result: { ok: true },
+                  visible_row: {
+                    id: 'proc-1',
+                    version: '01.01.000',
+                    user_id: 'user-1',
+                    state_code: 0,
+                  },
+                },
+              },
+            ],
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /"status":"completed"/u);
+    assert.match(result.stdout, /"write_path":"cmd_dataset_save_draft"/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli maps process save-draft failures to exit code 1', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-save-draft-cli-failure-'));
+  const inputPath = path.join(dir, 'patched-processes.jsonl');
+  writeFileSync(inputPath, '{"id":"proc-1"}\n', 'utf8');
+
+  try {
+    const result = await executeCli(['process', 'save-draft', '--input', inputPath], {
+      ...makeDeps(),
+      runProcessSaveDraftImpl: async () => ({
+        generated_at_utc: '2026-04-14T12:05:00.000Z',
+        input_path: inputPath,
+        input_kind: 'rows_file',
+        out_dir: path.join(dir, 'save-root'),
+        commit: false,
+        mode: 'dry_run',
+        status: 'completed_with_failures',
+        counts: {
+          selected: 1,
+          prepared: 0,
+          executed: 0,
+          failed: 1,
+        },
+        files: {
+          normalized_input: path.join(dir, 'save-root', 'inputs', 'normalized-input.json'),
+          selected_processes: path.join(
+            dir,
+            'save-root',
+            'outputs',
+            'save-draft-rpc',
+            'selected-processes.jsonl',
+          ),
+          progress_jsonl: path.join(
+            dir,
+            'save-root',
+            'outputs',
+            'save-draft-rpc',
+            'progress.jsonl',
+          ),
+          failures_jsonl: path.join(
+            dir,
+            'save-root',
+            'outputs',
+            'save-draft-rpc',
+            'failures.jsonl',
+          ),
+          summary_json: path.join(dir, 'save-root', 'outputs', 'save-draft-rpc', 'summary.json'),
+        },
+        processes: [
+          {
+            id: 'proc-1',
+            version: '01.01.000',
+            source: 'rows_file',
+            bundle_path: null,
+            status: 'failed',
+            error: { message: 'owner required' },
+          },
+        ],
+      }),
+    });
+
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stdout, /owner required/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli rejects conflicting process save-draft mode flags', async () => {
+  const result = await executeCli(
+    ['process', 'save-draft', '--input', './rows.jsonl', '--commit', '--dry-run'],
+    makeDeps(),
+  );
+
+  assert.equal(result.exitCode, 2);
+  assert.match(result.stderr, /INVALID_PROCESS_SAVE_DRAFT_MODE/u);
+});
+
 test('executeCli executes process batch-build with injected implementation', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-batch-build-cli-'));
   const inputPath = path.join(dir, 'batch-request.json');
@@ -2219,6 +2535,33 @@ test('executeCli returns parsing errors for invalid lifecyclemodel, process, and
   assert.equal(processGetResult.stdout, '');
   assert.match(processGetResult.stderr, /INVALID_ARGS/u);
 
+  const processListResult = await executeCli(['process', 'list', '--bad-flag'], makeDeps());
+  assert.equal(processListResult.exitCode, 2);
+  assert.equal(processListResult.stdout, '');
+  assert.match(processListResult.stderr, /INVALID_ARGS/u);
+
+  const processListPageSizeResult = await executeCli(
+    ['process', 'list', '--page-size', '10'],
+    makeDeps(),
+  );
+  assert.equal(processListPageSizeResult.exitCode, 2);
+  assert.match(processListPageSizeResult.stderr, /PROCESS_LIST_PAGE_SIZE_REQUIRES_ALL/u);
+
+  const processListStateCodeResult = await executeCli(
+    ['process', 'list', '--state-code=-1'],
+    makeDeps(),
+  );
+  assert.equal(processListStateCodeResult.exitCode, 2);
+  assert.match(processListStateCodeResult.stderr, /INVALID_PROCESS_LIST_STATE_CODE/u);
+
+  const processListLimitResult = await executeCli(['process', 'list', '--limit=0'], makeDeps());
+  assert.equal(processListLimitResult.exitCode, 2);
+  assert.match(processListLimitResult.stderr, /INVALID_PROCESS_LIST_LIMIT/u);
+
+  const processListOffsetResult = await executeCli(['process', 'list', '--offset=-1'], makeDeps());
+  assert.equal(processListOffsetResult.exitCode, 2);
+  assert.match(processListOffsetResult.stderr, /INVALID_PROCESS_LIST_OFFSET/u);
+
   const processResult = await executeCli(['process', 'auto-build', '--bad-flag'], makeDeps());
   assert.equal(processResult.exitCode, 2);
   assert.equal(processResult.stdout, '');
@@ -2239,6 +2582,14 @@ test('executeCli returns parsing errors for invalid lifecyclemodel, process, and
   assert.equal(processPublishResult.exitCode, 2);
   assert.equal(processPublishResult.stdout, '');
   assert.match(processPublishResult.stderr, /INVALID_ARGS/u);
+
+  const processSaveDraftResult = await executeCli(
+    ['process', 'save-draft', '--bad-flag'],
+    makeDeps(),
+  );
+  assert.equal(processSaveDraftResult.exitCode, 2);
+  assert.equal(processSaveDraftResult.stdout, '');
+  assert.match(processSaveDraftResult.stderr, /INVALID_ARGS/u);
 
   const processBatchResult = await executeCli(['process', 'batch-build', '--bad-flag'], makeDeps());
   assert.equal(processBatchResult.exitCode, 2);
@@ -2323,6 +2674,9 @@ test('executeCli executes review process with injected implementation', async ()
       {
         ...makeDeps(),
         runProcessReviewImpl: async (options) => {
+          assert.equal(options.rowsFile, undefined);
+          assert.equal(options.runRoot, path.join(dir, 'run-root'));
+          assert.equal(options.runId, 'run-001');
           assert.equal(options.startTs, '2026-03-30T00:00:00.000Z');
           assert.equal(options.endTs, '2026-03-30T00:05:00.000Z');
           assert.equal(options.logicVersion, 'v2.2');
@@ -2332,9 +2686,12 @@ test('executeCli executes review process with injected implementation', async ()
             schema_version: 1,
             generated_at_utc: '2026-03-30T00:00:00.000Z',
             status: 'completed_local_process_review',
-            run_id: options.runId,
-            run_root: options.runRoot,
+            run_id: options.runId ?? 'run-001',
+            run_root: options.runRoot ?? '',
+            rows_file: options.rowsFile ?? '',
             out_dir: options.outDir,
+            input_mode: 'run_root',
+            effective_processes_dir: path.join(dir, 'run-root', 'exports', 'processes'),
             logic_version: options.logicVersion ?? 'v2.1',
             process_count: 1,
             totals: {
@@ -2345,6 +2702,8 @@ test('executeCli executes review process with injected implementation', async ()
               energy_excluded: 0,
             },
             files: {
+              review_input_summary: path.join(dir, 'review', 'review-input-summary.json'),
+              materialization_summary: null,
               review_zh: path.join(dir, 'review', 'zh.md'),
               review_en: path.join(dir, 'review', 'en.md'),
               timing: path.join(dir, 'review', 'timing.md'),
@@ -2373,6 +2732,69 @@ test('executeCli executes review process with injected implementation', async ()
   }
 });
 
+test('executeCli passes rows-file review process input through to the implementation', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-cli-rows-'));
+  const rowsFile = path.join(dir, 'process-list-report.json');
+
+  try {
+    const result = await executeCli(
+      ['review', 'process', '--rows-file', rowsFile, '--out-dir', path.join(dir, 'review')],
+      {
+        ...makeDeps(),
+        runProcessReviewImpl: async (options) => {
+          assert.equal(options.rowsFile, rowsFile);
+          assert.equal(options.runRoot, undefined);
+          assert.equal(options.runId, undefined);
+          return {
+            schema_version: 1,
+            generated_at_utc: '2026-03-30T00:00:00.000Z',
+            status: 'completed_local_process_review',
+            run_id: 'process-list-report',
+            run_root: '',
+            rows_file: rowsFile,
+            out_dir: options.outDir,
+            input_mode: 'rows_file',
+            effective_processes_dir: path.join(dir, 'review', 'review-input', 'processes'),
+            logic_version: 'v2.1',
+            process_count: 1,
+            totals: {
+              raw_input: 1,
+              product_plus_byproduct_plus_waste: 1,
+              delta: 0,
+              relative_deviation: 0,
+              energy_excluded: 0,
+            },
+            files: {
+              review_input_summary: path.join(dir, 'review', 'review-input-summary.json'),
+              materialization_summary: path.join(
+                dir,
+                'review',
+                'review-input',
+                'materialization-summary.json',
+              ),
+              review_zh: path.join(dir, 'review', 'zh.md'),
+              review_en: path.join(dir, 'review', 'en.md'),
+              timing: path.join(dir, 'review', 'timing.md'),
+              unit_issue_log: path.join(dir, 'review', 'unit.md'),
+              summary: path.join(dir, 'review', 'summary.json'),
+              report: path.join(dir, 'review', 'report.json'),
+            },
+            llm: {
+              enabled: false,
+              reason: 'disabled',
+            },
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /"input_mode": "rows_file"/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('executeCli executes review process with only required flags', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-cli-required-'));
 
@@ -2391,6 +2813,9 @@ test('executeCli executes review process with only required flags', async () => 
       {
         ...makeDeps(),
         runProcessReviewImpl: async (options) => {
+          assert.equal(options.rowsFile, undefined);
+          assert.equal(options.runRoot, path.join(dir, 'run-root'));
+          assert.equal(options.runId, 'run-required');
           assert.equal(options.startTs, undefined);
           assert.equal(options.endTs, undefined);
           assert.equal(options.logicVersion, undefined);
@@ -2401,9 +2826,12 @@ test('executeCli executes review process with only required flags', async () => 
             schema_version: 1,
             generated_at_utc: '2026-03-30T00:00:00.000Z',
             status: 'completed_local_process_review',
-            run_id: options.runId,
-            run_root: options.runRoot,
+            run_id: options.runId ?? 'run-required',
+            run_root: options.runRoot ?? '',
+            rows_file: options.rowsFile ?? '',
             out_dir: options.outDir,
+            input_mode: 'run_root',
+            effective_processes_dir: path.join(dir, 'run-root', 'exports', 'processes'),
             logic_version: 'v2.1',
             process_count: 0,
             totals: {
@@ -2414,6 +2842,8 @@ test('executeCli executes review process with only required flags', async () => 
               energy_excluded: 0,
             },
             files: {
+              review_input_summary: path.join(dir, 'review', 'review-input-summary.json'),
+              materialization_summary: null,
               review_zh: path.join(dir, 'review', 'zh.md'),
               review_en: path.join(dir, 'review', 'en.md'),
               timing: path.join(dir, 'review', 'timing.md'),
@@ -3875,10 +4305,10 @@ test('executeCli supports alternate review flow input modes and validates numeri
 });
 
 test('executeCli returns planned command message for other unimplemented process subcommands', async () => {
-  const result = await executeCli(['process', 'list'], makeDeps());
+  const result = await executeCli(['process', 'delete'], makeDeps());
   assert.equal(result.exitCode, 2);
   assert.equal(result.stdout, '');
-  assert.match(result.stderr, /Command 'process list'/u);
+  assert.match(result.stderr, /Command 'process delete'/u);
 
   const flowRegenHelp = await executeCli(['flow', 'regen-product', '--help'], makeDeps());
   assert.equal(flowRegenHelp.exitCode, 0);

--- a/test/dataset-command.test.ts
+++ b/test/dataset-command.test.ts
@@ -1,7 +1,18 @@
-import test from 'node:test';
 import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  __testInternals,
+  createDatasetRecord,
+  resolveDatasetCommandTransport,
+  saveDraftDatasetRecord,
+} from '../src/lib/dataset-command.js';
 import { CliError } from '../src/lib/errors.js';
-import { createDatasetCommandClient, __testInternals } from '../src/lib/dataset-command.js';
+import type { FetchLike } from '../src/lib/http.js';
+import {
+  buildSupabaseTestEnv,
+  isSupabaseAuthTokenUrl,
+  makeSupabaseAuthResponse,
+} from './helpers/supabase-auth.js';
 
 function makeResponse(options: {
   ok: boolean;
@@ -25,264 +36,178 @@ function makeResponse(options: {
   };
 }
 
-const runtime = {
-  apiBaseUrl: 'https://example.supabase.co/rest/v1',
-  publishableKey: 'sb-publishable-key',
-  getAccessToken: async () => 'access-token',
-  refreshAccessToken: async () => 'refreshed-access-token',
-};
+function withSupabaseAuthBootstrap(fetchImpl: FetchLike): FetchLike {
+  return async (url, init) => {
+    if (isSupabaseAuthTokenUrl(String(url))) {
+      return makeSupabaseAuthResponse();
+    }
 
-test('dataset command helpers derive URLs, headers, bodies, and unwrap success envelopes', () => {
-  assert.equal(__testInternals.command_endpoint('create'), 'app_dataset_create');
-  assert.equal(__testInternals.command_endpoint('save_draft'), 'app_dataset_save_draft');
-  assert.equal(
-    __testInternals.buildDatasetCommandUrl('https://example.supabase.co', 'create'),
-    'https://example.supabase.co/functions/v1/app_dataset_create',
-  );
-  assert.equal(
-    __testInternals.buildDatasetCommandUrl('https://example.supabase.co/rest/v1', 'save_draft'),
-    'https://example.supabase.co/functions/v1/app_dataset_save_draft',
-  );
-  assert.deepEqual(__testInternals.buildDatasetCommandHeaders('us-east-1'), {
-    'Content-Type': 'application/json',
-    'x-region': 'us-east-1',
-  });
-  assert.deepEqual(__testInternals.buildDatasetCommandHeaders('  '), {
-    'Content-Type': 'application/json',
-  });
-  assert.deepEqual(
-    __testInternals.buildDatasetCommandBody('create', {
-      table: 'flows',
-      id: 'flow-1',
-      jsonOrdered: { flowDataSet: {} },
-      ruleVerification: false,
-    }),
-    {
-      table: 'flows',
-      id: 'flow-1',
-      jsonOrdered: { flowDataSet: {} },
-      ruleVerification: false,
-    },
-  );
-  assert.deepEqual(
-    __testInternals.buildDatasetCommandBody('save_draft', {
-      table: 'processes',
-      id: 'proc-1',
-      version: '01.00.001',
-      jsonOrdered: { processDataSet: {} },
-      modelId: 'model-1',
-    }),
-    {
-      table: 'processes',
-      id: 'proc-1',
-      version: '01.00.001',
-      jsonOrdered: { processDataSet: {} },
-      modelId: 'model-1',
-    },
-  );
-  assert.deepEqual(
-    __testInternals.unwrapDatasetCommandPayload({
-      ok: true,
-      data: { id: 'flow-1', version: '01.00.001' },
-    }),
-    { id: 'flow-1', version: '01.00.001' },
-  );
-  assert.equal(
-    __testInternals.unwrapDatasetCommandPayload({
-      ok: true,
-      data: null,
-    }),
-    null,
-  );
-  assert.equal(__testInternals.unwrapDatasetCommandPayload('plain-text'), 'plain-text');
+    return fetchImpl(String(url), init);
+  };
+}
 
-  assert.throws(
-    () =>
-      __testInternals.unwrapDatasetCommandPayload({
-        ok: false,
-        code: 'DATASET_OWNER_REQUIRED',
-        message: 'Only the dataset owner can save draft changes',
-      }),
-    (error) =>
-      error instanceof CliError &&
-      error.code === 'REMOTE_REQUEST_FAILED' &&
-      error.details === 'DATASET_OWNER_REQUIRED: Only the dataset owner can save draft changes',
+test('dataset command helper derives functions base URLs from supported API base shapes', () => {
+  assert.equal(
+    __testInternals.deriveSupabaseFunctionsBaseUrl('https://example.supabase.co'),
+    'https://example.supabase.co/functions/v1',
+  );
+  assert.equal(
+    __testInternals.deriveSupabaseFunctionsBaseUrl('https://example.supabase.co/rest/v1'),
+    'https://example.supabase.co/functions/v1',
+  );
+  assert.equal(
+    __testInternals.deriveSupabaseFunctionsBaseUrl('https://example.supabase.co/functions/v1'),
+    'https://example.supabase.co/functions/v1',
   );
 });
 
-test('dataset command client posts create and save-draft requests to edge-function endpoints', async () => {
-  const observed: Array<{ url: string; method: string; headers: Headers; body: string }> = [];
-  let callCount = 0;
-  const client = createDatasetCommandClient({
-    runtime,
-    fetchImpl: async (url, init) => {
+test('dataset command helper posts create and save-draft payloads with normalized field names', async () => {
+  const observed: Array<{ url: string; method: string; body?: string }> = [];
+  const transport = await resolveDatasetCommandTransport({
+    env: buildSupabaseTestEnv({
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/rest/v1',
+      TIANGONG_LCA_API_KEY: 'key',
+    }),
+    fetchImpl: withSupabaseAuthBootstrap(async (url, init) => {
       observed.push({
-        url,
-        method: String(init?.method ?? ''),
-        headers: new Headers(init?.headers),
-        body: typeof init?.body === 'string' ? init.body : '',
+        url: String(url),
+        method: String(init?.method ?? 'GET'),
+        body: typeof init?.body === 'string' ? init.body : undefined,
       });
-      callCount += 1;
+
       return makeResponse({
         ok: true,
         status: 200,
-        body: JSON.stringify({
-          ok: true,
-          command: callCount === 1 ? 'dataset_create' : 'dataset_save_draft',
-          data: callCount === 1 ? { id: 'flow-1' } : { id: 'flow-1', version: '01.00.001' },
-        }),
+        body: '{"ok":true,"data":{"id":"ok"}}',
       });
+    }),
+    timeoutMs: 10,
+  });
+
+  await createDatasetRecord({
+    transport,
+    table: 'flows',
+    id: '11111111-1111-1111-1111-111111111111',
+    payload: { flowDataSet: {} },
+    extraData: {
+      model_id: null,
+      rule_verification: false,
     },
-    timeoutMs: 25,
-    region: 'us-east-1',
+  });
+  await saveDraftDatasetRecord({
+    transport,
+    table: 'processes',
+    id: '22222222-2222-2222-2222-222222222222',
+    version: '01.00.001',
+    payload: { processDataSet: {} },
+    extraData: {
+      modelId: '33333333-3333-3333-3333-333333333333',
+      ruleVerification: null,
+    },
   });
 
   assert.deepEqual(
-    await client.create({
-      table: 'flows',
-      id: 'flow-1',
-      jsonOrdered: { flowDataSet: {} },
-      ruleVerification: null,
-    }),
-    { id: 'flow-1' },
+    observed.map((entry) => entry.method),
+    ['POST', 'POST'],
   );
-  assert.deepEqual(
-    await client.saveDraft({
-      table: 'processes',
-      id: 'proc-1',
-      version: '01.00.001',
-      jsonOrdered: { processDataSet: {} },
-      modelId: 'model-1',
-    }),
-    { id: 'flow-1', version: '01.00.001' },
-  );
-
-  assert.deepEqual(
-    observed.map((entry) => [entry.method, entry.url]),
-    [
-      ['POST', 'https://example.supabase.co/functions/v1/app_dataset_create'],
-      ['POST', 'https://example.supabase.co/functions/v1/app_dataset_save_draft'],
-    ],
-  );
-  assert.equal(observed[0]?.headers.get('Authorization'), 'Bearer access-token');
-  assert.equal(observed[0]?.headers.get('apikey'), 'sb-publishable-key');
-  assert.equal(observed[0]?.headers.get('x-region'), 'us-east-1');
+  assert.match(observed[0]?.url ?? '', /\/functions\/v1\/app_dataset_create$/u);
+  assert.match(observed[1]?.url ?? '', /\/functions\/v1\/app_dataset_save_draft$/u);
   assert.deepEqual(JSON.parse(observed[0]?.body ?? '{}'), {
     table: 'flows',
-    id: 'flow-1',
-    jsonOrdered: { flowDataSet: {} },
-    ruleVerification: null,
+    id: '11111111-1111-1111-1111-111111111111',
+    jsonOrdered: {
+      flowDataSet: {},
+    },
+    modelId: null,
+    ruleVerification: false,
   });
   assert.deepEqual(JSON.parse(observed[1]?.body ?? '{}'), {
     table: 'processes',
-    id: 'proc-1',
+    id: '22222222-2222-2222-2222-222222222222',
     version: '01.00.001',
-    jsonOrdered: { processDataSet: {} },
-    modelId: 'model-1',
+    jsonOrdered: {
+      processDataSet: {},
+    },
+    modelId: '33333333-3333-3333-3333-333333333333',
+    ruleVerification: null,
   });
 });
 
-test('dataset command client maps structured command failures to CliError', async () => {
-  const client = createDatasetCommandClient({
-    runtime,
-    fetchImpl: async () =>
+test('dataset command helper rejects ok:false application payloads', async () => {
+  const transport = await resolveDatasetCommandTransport({
+    env: buildSupabaseTestEnv({
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+      TIANGONG_LCA_API_KEY: 'key',
+    }),
+    fetchImpl: withSupabaseAuthBootstrap(async () =>
       makeResponse({
-        ok: false,
-        status: 403,
-        body: JSON.stringify({
-          ok: false,
-          code: 'DATASET_OWNER_REQUIRED',
-          message: 'Only the dataset owner can save draft changes',
-        }),
+        ok: true,
+        status: 200,
+        body: '{"ok":false,"code":"OWNERSHIP_REQUIRED","message":"blocked"}',
       }),
-    timeoutMs: 25,
-    region: null,
+    ),
+    timeoutMs: 10,
   });
 
   await assert.rejects(
     () =>
-      client.saveDraft({
-        table: 'sources',
-        id: 'src-1',
-        version: '01.00.001',
-        jsonOrdered: { sourceDataSet: {} },
+      createDatasetRecord({
+        transport,
+        table: 'flows',
+        id: '44444444-4444-4444-4444-444444444444',
+        payload: { flowDataSet: {} },
       }),
-    (error) =>
-      error instanceof CliError &&
-      error.code === 'REMOTE_REQUEST_FAILED' &&
-      error.details === 'DATASET_OWNER_REQUIRED: Only the dataset owner can save draft changes',
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'OWNERSHIP_REQUIRED');
+      return true;
+    },
   );
 });
 
-test('dataset command response parsing handles plain text and invalid JSON branches', async () => {
+test('dataset command helper normalizes optional metadata helpers and rejects malformed success payloads', async () => {
+  assert.equal(__testInternals.readOptionalRuleVerification(undefined), undefined);
   assert.equal(
-    __testInternals.parseDatasetCommandResponse(
+    __testInternals.readOptionalRuleVerification({ ruleVerification: 'bad' }),
+    undefined,
+  );
+  assert.equal(
+    __testInternals.readOptionalRuleVerification({ rule_verification: 'bad' }),
+    undefined,
+  );
+  assert.equal(__testInternals.readOptionalRuleVerification({ rule_verification: null }), null);
+  assert.equal(__testInternals.readOptionalModelId({ modelId: '  model-1  ' }, false), 'model-1');
+  assert.equal(__testInternals.readOptionalModelId({ modelId: '   ' }, false), undefined);
+  assert.equal(__testInternals.readOptionalModelId({ model_id: null }, true), null);
+  assert.equal(__testInternals.readOptionalModelId({ model_id: null }, false), undefined);
+
+  const transport = await resolveDatasetCommandTransport({
+    env: buildSupabaseTestEnv({
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+      TIANGONG_LCA_API_KEY: 'key',
+    }),
+    fetchImpl: withSupabaseAuthBootstrap(async () =>
       makeResponse({
         ok: true,
         status: 200,
-        contentType: 'text/plain',
-        body: 'created',
+        body: '[]',
       }),
-      'https://example.supabase.co/functions/v1/app_dataset_create',
-      'created',
     ),
-    'created',
-  );
+    timeoutMs: 10,
+  });
 
-  assert.throws(
+  await assert.rejects(
     () =>
-      __testInternals.parseDatasetCommandResponse(
-        makeResponse({
-          ok: true,
-          status: 200,
-          contentType: 'application/json',
-          body: '{broken-json',
-        }),
-        'https://example.supabase.co/functions/v1/app_dataset_create',
-        '{broken-json',
-      ),
-    (error) => error instanceof CliError && error.code === 'REMOTE_INVALID_JSON',
-  );
-
-  assert.throws(
-    () =>
-      __testInternals.parseDatasetCommandResponse(
-        makeResponse({
-          ok: false,
-          status: 500,
-          contentType: 'text/plain',
-          body: 'upstream unavailable',
-        }),
-        'https://example.supabase.co/functions/v1/app_dataset_save_draft',
-        'upstream unavailable',
-      ),
-    (error) =>
-      error instanceof CliError &&
-      error.code === 'REMOTE_REQUEST_FAILED' &&
-      error.details === 'upstream unavailable',
-  );
-
-  assert.throws(
-    () =>
-      __testInternals.parseDatasetCommandResponse(
-        {
-          ok: false,
-          status: 500,
-          headers: {
-            get() {
-              return null;
-            },
-          },
-          async text() {
-            return '';
-          },
-        },
-        'https://example.supabase.co/functions/v1/app_dataset_save_draft',
-        '',
-      ),
-    (error) =>
-      error instanceof CliError &&
-      error.code === 'REMOTE_REQUEST_FAILED' &&
-      error.details === undefined,
+      createDatasetRecord({
+        transport,
+        table: 'flows',
+        id: '55555555-5555-5555-5555-555555555555',
+        payload: { flowDataSet: {} },
+      }),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'REMOTE_RESPONSE_INVALID');
+      return true;
+    },
   );
 });

--- a/test/flow-publish-reviewed-data.test.ts
+++ b/test/flow-publish-reviewed-data.test.ts
@@ -597,7 +597,7 @@ test('flow publish reviewed data process helpers unwrap root payloads and map up
           },
         },
         async text() {
-          return '[{"id":"proc-updated"}]';
+          return '{"ok":true,"command":"dataset_save_draft","data":{"id":"proc-updated"}}';
         },
       };
     }),
@@ -745,11 +745,11 @@ test('runFlowReviewedPublishData can use the default flow publish-version implem
 
     return {
       ok: true,
-      status: 201,
+      status: 200,
       headers: {
         get: () => 'application/json',
       },
-      text: async () => '',
+      text: async () => '{"ok":true,"command":"dataset_create","data":{"id":"flow-default"}}',
     };
   }) as unknown as FetchLike;
 
@@ -889,7 +889,7 @@ test('runFlowReviewedPublishData prepares process rows locally, rewrites flow re
   }
 });
 
-test('runFlowReviewedPublishData commits prepared process rows through Supabase REST when process publish is requested', async () => {
+test('runFlowReviewedPublishData commits prepared process rows through dataset commands when process publish is requested', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-publish-reviewed-process-commit-'));
   const processRowsFile = path.join(dir, 'reviewed-processes.json');
   const outDir = path.join(dir, 'publish-reviewed');
@@ -952,6 +952,7 @@ test('runFlowReviewedPublishData commits prepared process rows through Supabase 
       observed.map((entry) => entry.method),
       ['GET', 'POST'],
     );
+    assert.match(observed[1]?.url ?? '', /\/functions\/v1\/app_dataset_create$/u);
     assert.match(observed[1]?.body ?? '', /"jsonOrdered"/u);
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -1575,14 +1576,14 @@ test('flow publish-reviewed-data helper internals cover validation, compatibilit
 
         return {
           ok: true,
-          status: 201,
+          status: 200,
           headers: {
             get() {
               return 'application/json';
             },
           },
           async text() {
-            return '[{"id":"proc-commit-plan"}]';
+            return '{"ok":true,"command":"dataset_create","data":{"id":"proc-commit-plan"}}';
           },
         };
       }),

--- a/test/flow-publish-version.test.ts
+++ b/test/flow-publish-version.test.ts
@@ -256,34 +256,20 @@ test('runFlowPublishVersion commit executes update, insert, fallback update, and
           {
             body: [{ id: 'flow-1', version: '01.00.001', user_id: 'user-1', state_code: 100 }],
           },
-          {
-            body: { ok: true, command: 'dataset_save_draft', data: { id: 'flow-1' } },
-          },
+          { body: { ok: true, command: 'dataset_save_draft', data: { id: 'flow-1' } } },
           { body: [] },
-          {
-            body: { ok: true, command: 'dataset_create', data: { id: 'flow-2' } },
-          },
+          { body: { ok: true, command: 'dataset_create', data: { id: 'flow-2' } } },
           { body: [] },
-          {
-            ok: false,
-            status: 409,
-            body: { ok: false, code: 'DUPLICATE_VERSION', message: 'duplicate' },
-          },
+          { ok: false, status: 409, contentType: 'text/plain', rawText: 'duplicate' },
           {
             body: [{ id: 'flow-3', version: '01.00.001', user_id: 'user-3', state_code: 100 }],
           },
-          {
-            body: { ok: true, command: 'dataset_save_draft', data: { id: 'flow-3' } },
-          },
+          { body: { ok: true, command: 'dataset_save_draft', data: { id: 'flow-3' } } },
           {
             body: [{ id: 'flow-4', version: '01.00.001', user_id: 'other-user', state_code: 40 }],
           },
           { body: [] },
-          {
-            ok: false,
-            status: 500,
-            body: { ok: false, code: 'INTERNAL_ERROR', message: 'boom' },
-          },
+          { ok: false, status: 500, contentType: 'application/json', body: { message: 'boom' } },
           { body: [] },
         ],
         observed,
@@ -331,6 +317,7 @@ test('runFlowPublishVersion commit executes update, insert, fallback update, and
     );
     assert.match(observed[1]?.url ?? '', /\/functions\/v1\/app_dataset_save_draft$/u);
     assert.match(observed[3]?.url ?? '', /\/functions\/v1\/app_dataset_create$/u);
+    assert.match(observed[1]?.body ?? '', /"version":"01\.00\.001"/u);
     assert.match(observed[1]?.body ?? '', /"jsonOrdered"/u);
     assert.match(observed[3]?.body ?? '', /"id":"flow-2"/u);
   } finally {
@@ -574,19 +561,11 @@ test('runFlowPublishVersion surfaces update-after-insert-error failures when fal
       fetchImpl: makeFetchQueue(
         [
           { body: [] },
-          {
-            ok: false,
-            status: 409,
-            body: { ok: false, code: 'DUPLICATE_VERSION', message: 'duplicate' },
-          },
+          { ok: false, status: 409, contentType: 'text/plain', rawText: 'duplicate' },
           {
             body: [{ id: 'flow-1', version: '01.00.001', user_id: 'user-1', state_code: 100 }],
           },
-          {
-            ok: false,
-            status: 500,
-            body: { ok: false, code: 'SAVE_DRAFT_FAILED', message: 'patch failed' },
-          },
+          { ok: false, status: 500, contentType: 'text/plain', rawText: 'save draft failed' },
         ],
         observed,
       ),

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { getJson, postJson } from '../src/lib/http.js';
+import { CliError } from '../src/lib/errors.js';
+import { getJson, postJson, requireRemoteOkPayload } from '../src/lib/http.js';
 
 test('postJson returns parsed JSON payloads', async () => {
   const payload = await postJson({
@@ -125,4 +126,24 @@ test('getJson sends GET requests and returns parsed JSON payloads', async () => 
   assert.equal(observedMethod, 'GET');
   assert.equal(observedBody, undefined);
   assert.deepEqual(payload, { hello: 'world' });
+});
+
+test('requireRemoteOkPayload normalizes blank application error fields', () => {
+  assert.throws(
+    () =>
+      requireRemoteOkPayload(
+        {
+          ok: false,
+          code: '   ',
+          message: '   ',
+        },
+        'https://example.com/rpc',
+      ),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'REMOTE_APPLICATION_ERROR');
+      assert.match(error.message, /ok:false/u);
+      return true;
+    },
+  );
 });

--- a/test/package-version.test.ts
+++ b/test/package-version.test.ts
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { loadCliPackageVersion } from '../src/lib/package-version.js';
+
+test('loadCliPackageVersion resolves package.json relative to source modules', () => {
+  const version = loadCliPackageVersion('file:///repo/src/cli.ts', (url) => {
+    assert.equal(url.href, 'file:///repo/package.json');
+    return JSON.stringify({ version: '1.2.3' });
+  });
+
+  assert.equal(version, '1.2.3');
+});
+
+test('loadCliPackageVersion falls back to the dist-relative package.json candidate', () => {
+  const version = loadCliPackageVersion('file:///repo/dist/src/cli.js', (url) => {
+    if (url.href === 'file:///repo/dist/package.json') {
+      throw new Error('missing dist package');
+    }
+
+    assert.equal(url.href, 'file:///repo/package.json');
+    return JSON.stringify({ version: '2.3.4' });
+  });
+
+  assert.equal(version, '2.3.4');
+});
+
+test('loadCliPackageVersion rejects empty or missing versions after exhausting candidates', () => {
+  assert.throws(
+    () =>
+      loadCliPackageVersion('file:///repo/src/cli.ts', (url) => {
+        if (url.href === 'file:///repo/package.json') {
+          return JSON.stringify({ version: '' });
+        }
+
+        throw new Error(`unexpected candidate: ${url.href}`);
+      }),
+    /Could not resolve CLI package version from package\.json\./u,
+  );
+});

--- a/test/process-list.test.ts
+++ b/test/process-list.test.ts
@@ -1,0 +1,437 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { CliError } from '../src/lib/errors.js';
+import type { FetchLike } from '../src/lib/http.js';
+import { __testInternals, runProcessList } from '../src/lib/process-list.js';
+import {
+  buildSupabaseTestEnv,
+  isSupabaseAuthTokenUrl,
+  makeSupabaseAuthResponse,
+} from './helpers/supabase-auth.js';
+
+function jsonFetch(responses: Array<unknown | Error>, observedUrls: string[] = []): FetchLike {
+  let index = 0;
+  return (async (input) => {
+    if (isSupabaseAuthTokenUrl(String(input))) {
+      return makeSupabaseAuthResponse();
+    }
+
+    observedUrls.push(String(input));
+    const next = responses[Math.min(index, responses.length - 1)];
+    index += 1;
+    if (next instanceof Error) {
+      throw next;
+    }
+    return {
+      ok: true,
+      status: 200,
+      headers: {
+        get: () => 'application/json',
+      },
+      text: async () => JSON.stringify(next),
+    };
+  }) as FetchLike;
+}
+
+test('runProcessList returns one deterministic page of process rows', async () => {
+  const observedUrls: string[] = [];
+  const report = await runProcessList({
+    ids: [' proc-2 ', 'proc-1', 'proc-2'],
+    version: '01.00.001',
+    userId: ' user-1 ',
+    stateCodes: [100, 0, 100],
+    limit: 5,
+    offset: 2,
+    order: 'version.desc,id.asc',
+    now: new Date('2026-03-30T00:00:00.000Z'),
+    env: buildSupabaseTestEnv({
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
+    }),
+    fetchImpl: jsonFetch(
+      [
+        [
+          {
+            id: 'proc-1',
+            version: '01.00.001',
+            user_id: 'user-1',
+            state_code: 100,
+            modified_at: '2026-03-29T00:00:00.000Z',
+            json: '{"processDataSet":{"id":"proc-1"}}',
+          },
+        ],
+      ],
+      observedUrls,
+    ),
+  });
+
+  assert.deepEqual(report, {
+    schema_version: 1,
+    generated_at_utc: '2026-03-30T00:00:00.000Z',
+    status: 'listed_remote_processes',
+    filters: {
+      ids: ['proc-2', 'proc-1'],
+      requested_version: '01.00.001',
+      requested_user_id: 'user-1',
+      requested_state_codes: [100, 0],
+      order: 'version.desc,id.asc',
+      all: false,
+      limit: 5,
+      offset: 2,
+      page_size: null,
+    },
+    count: 1,
+    source_urls: [
+      'https://example.supabase.co/rest/v1/processes?select=id%2Cversion%2Cuser_id%2Cstate_code%2Cmodified_at%2Cjson&id=in.%28proc-2%2Cproc-1%29&version=eq.01.00.001&user_id=eq.user-1&state_code=in.%28100%2C0%29&order=version.desc%2Cid.asc&limit=5&offset=2',
+    ],
+    rows: [
+      {
+        id: 'proc-1',
+        version: '01.00.001',
+        user_id: 'user-1',
+        state_code: 100,
+        modified_at: '2026-03-29T00:00:00.000Z',
+        process: { processDataSet: { id: 'proc-1' } },
+      },
+    ],
+  });
+  assert.deepEqual(observedUrls, report.source_urls);
+});
+
+test('runProcessList auto-pages when --all is enabled and retries transient page failures', async () => {
+  const observedUrls: string[] = [];
+  const report = await runProcessList({
+    ids: ['proc-1'],
+    all: true,
+    pageSize: 2,
+    env: buildSupabaseTestEnv({
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/rest/v1',
+    }),
+    fetchImpl: jsonFetch(
+      [
+        new Error('statement timeout'),
+        [
+          {
+            id: 'proc-1',
+            version: '01.00.003',
+            user_id: 'user-1',
+            state_code: 100,
+            modified_at: null,
+            json: { processDataSet: { id: 'proc-1', page: 1 } },
+          },
+          {
+            id: 'proc-1',
+            version: '01.00.002',
+            user_id: 'user-1',
+            state_code: 100,
+            modified_at: null,
+            json: { processDataSet: { id: 'proc-1', page: 1 } },
+          },
+        ],
+        [
+          {
+            id: 'proc-1',
+            version: '01.00.001',
+            user_id: 'user-1',
+            state_code: 100,
+            modified_at: null,
+            json: { processDataSet: { id: 'proc-1', page: 2 } },
+          },
+        ],
+      ],
+      observedUrls,
+    ),
+  });
+
+  assert.equal(report.filters.all, true);
+  assert.equal(report.filters.limit, null);
+  assert.equal(report.filters.page_size, 2);
+  assert.equal(report.count, 3);
+  assert.equal(report.rows.length, 3);
+  assert.equal(report.source_urls.length, 2);
+  assert.equal(observedUrls.filter((url) => url.includes('offset=0')).length, 2);
+  assert.match(report.source_urls[0] as string, /limit=2/u);
+  assert.match(report.source_urls[1] as string, /offset=2/u);
+});
+
+test('runProcessList uses the default page size when --all omits pageSize', async () => {
+  const report = await runProcessList({
+    ids: ['proc-1'],
+    all: true,
+    env: buildSupabaseTestEnv({
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/rest/v1',
+    }),
+    fetchImpl: jsonFetch([[]]),
+  });
+
+  assert.equal(report.filters.page_size, 100);
+  assert.equal(report.count, 0);
+});
+
+test('runProcessList can fall back to process.env and global fetch', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalBaseUrl = process.env.TIANGONG_LCA_API_BASE_URL;
+  const originalApiKey = process.env.TIANGONG_LCA_API_KEY;
+  const originalPublishableKey = process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
+  const testEnv = buildSupabaseTestEnv({
+    TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+    TIANGONG_LCA_API_KEY: 'secret-token',
+  });
+
+  process.env.TIANGONG_LCA_API_BASE_URL = testEnv.TIANGONG_LCA_API_BASE_URL;
+  process.env.TIANGONG_LCA_API_KEY = testEnv.TIANGONG_LCA_API_KEY;
+  process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY = testEnv.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    if (isSupabaseAuthTokenUrl(String(input))) {
+      return makeSupabaseAuthResponse();
+    }
+
+    return {
+      ok: true,
+      status: 200,
+      headers: {
+        get: () => 'application/json',
+      },
+      text: async () =>
+        JSON.stringify([
+          {
+            id: 'proc-1',
+            version: '01.00.001',
+            user_id: null,
+            state_code: null,
+            modified_at: null,
+            json: { processDataSet: { id: 'proc-1' } },
+          },
+        ]),
+    };
+  }) as unknown as typeof fetch;
+
+  try {
+    const report = await runProcessList({});
+    assert.equal(report.count, 1);
+    assert.equal(report.filters.limit, 100);
+    assert.equal(report.filters.offset, 0);
+    assert.equal(report.filters.order, 'id.asc,version.asc');
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalBaseUrl === undefined) {
+      delete process.env.TIANGONG_LCA_API_BASE_URL;
+    } else {
+      process.env.TIANGONG_LCA_API_BASE_URL = originalBaseUrl;
+    }
+    if (originalApiKey === undefined) {
+      delete process.env.TIANGONG_LCA_API_KEY;
+    } else {
+      process.env.TIANGONG_LCA_API_KEY = originalApiKey;
+    }
+    if (originalPublishableKey === undefined) {
+      delete process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
+    } else {
+      process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY = originalPublishableKey;
+    }
+  }
+});
+
+test('runProcessList rejects conflicting and invalid pagination controls', async () => {
+  const env = buildSupabaseTestEnv({
+    TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+  });
+
+  await assert.rejects(
+    () =>
+      runProcessList({
+        ids: ['proc-1'],
+        all: true,
+        limit: 1,
+        env,
+        fetchImpl: jsonFetch([[]]),
+      }),
+    (error) => error instanceof CliError && error.code === 'PROCESS_LIST_ALL_LIMIT_CONFLICT',
+  );
+
+  await assert.rejects(
+    () =>
+      runProcessList({
+        ids: ['proc-1'],
+        all: true,
+        offset: 1,
+        env,
+        fetchImpl: jsonFetch([[]]),
+      }),
+    (error) => error instanceof CliError && error.code === 'PROCESS_LIST_ALL_OFFSET_CONFLICT',
+  );
+
+  await assert.rejects(
+    () =>
+      runProcessList({
+        all: true,
+        env,
+        fetchImpl: jsonFetch([[]]),
+      }),
+    (error) => error instanceof CliError && error.code === 'PROCESS_LIST_ALL_FILTER_REQUIRED',
+  );
+
+  await assert.rejects(
+    () =>
+      runProcessList({
+        ids: ['proc-1'],
+        limit: 0,
+        env,
+        fetchImpl: jsonFetch([[]]),
+      }),
+    (error) => error instanceof CliError && error.code === 'PROCESS_LIST_LIMIT_INVALID',
+  );
+
+  await assert.rejects(
+    () =>
+      runProcessList({
+        ids: ['proc-1'],
+        offset: -1,
+        env,
+        fetchImpl: jsonFetch([[]]),
+      }),
+    (error) => error instanceof CliError && error.code === 'PROCESS_LIST_OFFSET_INVALID',
+  );
+
+  await assert.rejects(
+    () =>
+      runProcessList({
+        ids: ['proc-1'],
+        maxAttempts: 0,
+        env,
+        fetchImpl: jsonFetch([[]]),
+      }),
+    (error) => error instanceof CliError && error.code === 'PROCESS_LIST_MAX_ATTEMPTS_INVALID',
+  );
+});
+
+test('runProcessList rejects malformed remote payloads and honors retry boundaries', async () => {
+  const env = buildSupabaseTestEnv({
+    TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+  });
+
+  await assert.rejects(
+    () =>
+      runProcessList({
+        ids: ['proc-1'],
+        stateCodes: [0],
+        env,
+        fetchImpl: jsonFetch([{}]),
+      }),
+    (error) => error instanceof CliError && error.code === 'SUPABASE_REST_RESPONSE_INVALID',
+  );
+
+  await assert.rejects(
+    () =>
+      runProcessList({
+        ids: ['proc-1'],
+        env,
+        fetchImpl: jsonFetch([[0]]),
+      }),
+    (error) => error instanceof CliError && error.code === 'SUPABASE_REST_RESPONSE_INVALID',
+  );
+
+  await assert.rejects(
+    () =>
+      runProcessList({
+        ids: ['proc-1'],
+        env,
+        maxAttempts: 1,
+        fetchImpl: jsonFetch([new Error('statement timeout')]),
+      }),
+    (error) => error instanceof CliError && error.code === 'REMOTE_REQUEST_FAILED',
+  );
+});
+
+test('process-list helper internals normalize tokens and apply sparse order clauses', () => {
+  assert.equal(__testInternals.normalizeToken('   '), null);
+  assert.equal(__testInternals.normalizeToken(' version-1 '), 'version-1');
+
+  assert.equal(
+    __testInternals.buildProcessListUrl('https://example.supabase.co/rest/v1', {
+      ids: [' proc-1 '],
+      stateCodes: [0],
+      order: 'id.asc',
+      limit: 5,
+    }),
+    'https://example.supabase.co/rest/v1/processes?select=id%2Cversion%2Cuser_id%2Cstate_code%2Cmodified_at%2Cjson&id=eq.proc-1&state_code=eq.0&order=id.asc&limit=5',
+  );
+
+  const orderCalls: Array<{ column: string; options: object | undefined }> = [];
+  const query = {
+    order(column: string, options?: object) {
+      orderCalls.push({ column, options });
+      return this;
+    },
+  };
+  assert.equal(__testInternals.applyOrder(query, undefined), query);
+  assert.equal(__testInternals.applyOrder(query, '   '), query);
+  assert.equal(
+    __testInternals.applyOrder(query, 'id.asc,,.desc,version.desc.nullslast,state.asc.nullsfirst'),
+    query,
+  );
+  assert.deepEqual(orderCalls, [
+    {
+      column: 'id',
+      options: {
+        ascending: true,
+        nullsFirst: undefined,
+      },
+    },
+    {
+      column: 'version',
+      options: {
+        ascending: false,
+        nullsFirst: false,
+      },
+    },
+    {
+      column: 'state',
+      options: {
+        ascending: true,
+        nullsFirst: true,
+      },
+    },
+  ]);
+
+  assert.equal(__testInternals.isRetryableError(new Error('retry')), true);
+  assert.equal(
+    __testInternals.isRetryableError(
+      new CliError('bad args', {
+        code: 'INVALID_ARGS',
+        exitCode: 2,
+      }),
+    ),
+    false,
+  );
+  assert.equal(__testInternals.optionalPositiveInteger(undefined), null);
+  assert.equal(__testInternals.optionalPositiveInteger(0), null);
+  assert.equal(__testInternals.optionalPositiveInteger(5), 5);
+  assert.equal(__testInternals.optionalNonNegativeInteger(undefined), null);
+  assert.equal(__testInternals.optionalNonNegativeInteger(-1), null);
+  assert.equal(__testInternals.optionalNonNegativeInteger(3), 3);
+  assert.deepEqual(
+    __testInternals.parseProcessRows(
+      [
+        {
+          id: 1,
+          version: 2,
+          user_id: null,
+          state_code: 0,
+          modified_at: null,
+          json: {},
+        },
+      ],
+      'https://example.com/processes',
+    ),
+    [
+      {
+        id: '',
+        version: '',
+        user_id: null,
+        state_code: 0,
+        modified_at: null,
+        json: {},
+      },
+    ],
+  );
+});

--- a/test/process-save-draft-run.test.ts
+++ b/test/process-save-draft-run.test.ts
@@ -1,0 +1,534 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { CliError } from '../src/lib/errors.js';
+import { runProcessSaveDraft } from '../src/lib/process-save-draft-run.js';
+import type { FetchLike } from '../src/lib/http.js';
+import {
+  buildSupabaseTestEnv,
+  isSupabaseAuthTokenUrl,
+  makeSupabaseAuthResponse,
+} from './helpers/supabase-auth.js';
+
+function writeJson(filePath: string, value: unknown): void {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function writeJsonl(filePath: string, rows: unknown[]): void {
+  writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`, 'utf8');
+}
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+function readJsonl(filePath: string): unknown[] {
+  return readFileSync(filePath, 'utf8')
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function makeCanonicalProcess(id: string): Record<string, unknown> {
+  return {
+    processDataSet: {
+      processInformation: {
+        dataSetInformation: {
+          'common:UUID': id,
+        },
+      },
+      administrativeInformation: {
+        publicationAndOwnership: {
+          'common:dataSetVersion': '01.01.000',
+        },
+      },
+    },
+  };
+}
+
+function makeResponse(options: {
+  ok: boolean;
+  status: number;
+  contentType?: string;
+  body?: string;
+}) {
+  return {
+    ok: options.ok,
+    status: options.status,
+    headers: {
+      get(name: string): string | null {
+        return name.toLowerCase() === 'content-type'
+          ? (options.contentType ?? 'application/json')
+          : null;
+      },
+    },
+    async text(): Promise<string> {
+      return options.body ?? '';
+    },
+  };
+}
+
+function withSupabaseAuthBootstrap(fetchImpl: FetchLike): FetchLike {
+  return async (url, init) => {
+    if (isSupabaseAuthTokenUrl(String(url))) {
+      return makeSupabaseAuthResponse();
+    }
+
+    return fetchImpl(String(url), init);
+  };
+}
+
+test('runProcessSaveDraft produces dry-run artifacts from a rows file', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-save-draft-rows-'));
+  const inputPath = path.join(dir, 'patched-processes.jsonl');
+
+  writeJsonl(inputPath, [
+    makeCanonicalProcess('proc-row-1'),
+    {
+      id: 'db-row-2',
+      version: '01.01.000',
+      json_ordered: makeCanonicalProcess('proc-row-2'),
+    },
+    {
+      id: 'db-row-3',
+      version: '01.01.000',
+      json: makeCanonicalProcess('proc-row-3'),
+    },
+  ]);
+
+  try {
+    const report = await runProcessSaveDraft({
+      inputPath,
+      now: new Date('2026-04-14T00:00:00.000Z'),
+    });
+
+    assert.equal(report.commit, false);
+    assert.equal(report.mode, 'dry_run');
+    assert.equal(report.input_kind, 'rows_file');
+    assert.equal(report.status, 'completed');
+    assert.deepEqual(report.counts, {
+      selected: 3,
+      prepared: 3,
+      executed: 0,
+      failed: 0,
+    });
+    assert.equal(existsSync(report.files.summary_json), true);
+    assert.deepEqual(readJson(report.files.summary_json), report);
+    assert.deepEqual(
+      (readJsonl(report.files.progress_jsonl) as Array<{ status: string }>).map(
+        (row) => row.status,
+      ),
+      ['prepared', 'prepared', 'prepared'],
+    );
+    assert.equal(readJsonl(report.files.selected_processes).length, 3);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessSaveDraft extracts processes from publish-request inputs', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-save-draft-request-'));
+  const requestPath = path.join(dir, 'publish-request.json');
+  const bundlePath = path.join(dir, 'bundle.json');
+  const processPath = path.join(dir, 'proc.json');
+  const sourcePath = path.join(dir, 'source.json');
+
+  writeJson(bundlePath, {
+    processes: [makeCanonicalProcess('proc-bundle')],
+  });
+  writeJson(processPath, makeCanonicalProcess('proc-input'));
+  writeJson(sourcePath, {
+    sourceDataSet: {
+      sourceInformation: {
+        dataSetInformation: {
+          'common:UUID': 'src-ignored',
+        },
+      },
+    },
+  });
+  writeJson(requestPath, {
+    inputs: {
+      bundle_paths: ['./bundle.json'],
+      processes: [{ file: './proc.json' }],
+      sources: [{ file: './source.json' }],
+    },
+  });
+
+  try {
+    const report = await runProcessSaveDraft({
+      inputPath: requestPath,
+      now: new Date('2026-04-14T00:10:00.000Z'),
+    });
+    const normalizedInput = readJson(report.files.normalized_input) as {
+      inputs: {
+        bundle_paths: string[];
+        processes: Array<{ file: string }>;
+        sources: Array<{ file: string }>;
+      };
+      publish: { commit: boolean };
+      out_dir: string;
+    };
+
+    assert.equal(report.input_kind, 'publish_request');
+    assert.equal(report.status, 'completed');
+    assert.deepEqual(report.counts, {
+      selected: 2,
+      prepared: 2,
+      executed: 0,
+      failed: 0,
+    });
+    assert.deepEqual(
+      report.processes.map((entry) => entry.source),
+      ['bundle', 'input'],
+    );
+    assert.deepEqual(normalizedInput.inputs.bundle_paths, [bundlePath]);
+    assert.deepEqual(normalizedInput.inputs.processes, [{ file: './proc.json' }]);
+    assert.deepEqual(normalizedInput.inputs.sources, [{ file: './source.json' }]);
+    assert.equal(normalizedInput.publish.commit, false);
+    assert.equal(path.isAbsolute(normalizedInput.out_dir), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessSaveDraft executes state-aware save-draft writes on commit', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-save-draft-commit-'));
+  const inputPath = path.join(dir, 'patched-processes.jsonl');
+  const observed: Array<{ method: string; url: string; body?: string }> = [];
+
+  writeJsonl(inputPath, [makeCanonicalProcess('proc-commit-1')]);
+
+  try {
+    const report = await runProcessSaveDraft({
+      inputPath,
+      commit: true,
+      env: buildSupabaseTestEnv({
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+        TIANGONG_LCA_API_KEY: 'key',
+      }),
+      fetchImpl: withSupabaseAuthBootstrap(async (url, init) => {
+        observed.push({
+          method: String(init?.method ?? 'GET'),
+          url: String(url),
+          body: typeof init?.body === 'string' ? init.body : undefined,
+        });
+
+        if (String(init?.method ?? 'GET') === 'GET') {
+          return makeResponse({
+            ok: true,
+            status: 200,
+            body: '[{"id":"proc-commit-1","version":"01.01.000","user_id":"user-1","state_code":0}]',
+          });
+        }
+
+        return makeResponse({
+          ok: true,
+          status: 200,
+          body: '{"ok":true,"data":{"id":"proc-commit-1"}}',
+        });
+      }),
+      now: new Date('2026-04-14T00:20:00.000Z'),
+    });
+
+    assert.deepEqual(
+      observed.map((entry) => entry.method),
+      ['GET', 'POST'],
+    );
+    assert.equal(report.status, 'completed');
+    assert.deepEqual(report.counts, {
+      selected: 1,
+      prepared: 0,
+      executed: 1,
+      failed: 0,
+    });
+    assert.equal(report.processes[0]?.status, 'executed');
+    assert.deepEqual(report.processes[0]?.execution, {
+      status: 'success',
+      operation: 'save_draft',
+      write_path: 'cmd_dataset_save_draft',
+      rpc_result: { ok: true, data: { id: 'proc-commit-1' } },
+      visible_row: {
+        id: 'proc-commit-1',
+        version: '01.01.000',
+        user_id: 'user-1',
+        state_code: 0,
+      },
+    });
+    assert.deepEqual(
+      (readJsonl(report.files.progress_jsonl) as Array<{ status: string }>).map(
+        (row) => row.status,
+      ),
+      ['executed'],
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessSaveDraft records non-canonical payloads as failed entries', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-save-draft-invalid-'));
+  const inputPath = path.join(dir, 'patched-processes.jsonl');
+
+  writeJsonl(inputPath, [{ '@id': 'projection-only', '@version': '01.01.000' }]);
+
+  try {
+    const report = await runProcessSaveDraft({
+      inputPath,
+      now: new Date('2026-04-14T00:30:00.000Z'),
+    });
+
+    assert.equal(report.status, 'completed_with_failures');
+    assert.deepEqual(report.counts, {
+      selected: 1,
+      prepared: 0,
+      executed: 0,
+      failed: 1,
+    });
+    assert.equal(report.processes[0]?.status, 'failed');
+    assert.match(report.processes[0]?.error?.message ?? '', /canonical process datasets/u);
+    assert.equal(readJsonl(report.files.failures_jsonl).length, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessSaveDraft validates JSONL inputs before processing', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-save-draft-jsonl-errors-'));
+  const missingPath = path.join(dir, 'missing.jsonl');
+  const invalidJsonlPath = path.join(dir, 'invalid.jsonl');
+  const invalidRowPath = path.join(dir, 'invalid-row.jsonl');
+
+  writeFileSync(invalidJsonlPath, '{"bad"\n', 'utf8');
+  writeFileSync(invalidRowPath, '7\n', 'utf8');
+
+  try {
+    await assert.rejects(
+      () => runProcessSaveDraft({ inputPath: missingPath }),
+      (error) => error instanceof CliError && error.code === 'INPUT_NOT_FOUND',
+    );
+
+    await assert.rejects(
+      () => runProcessSaveDraft({ inputPath: invalidJsonlPath }),
+      (error) => error instanceof CliError && error.code === 'INPUT_INVALID_JSONL',
+    );
+
+    await assert.rejects(
+      () => runProcessSaveDraft({ inputPath: invalidRowPath }),
+      (error) => error instanceof CliError && error.code === 'INPUT_INVALID_JSONL_ROW',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessSaveDraft supports publish-request entry variants and validates publish entry files', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-save-draft-publish-variants-'));
+  const requestPath = path.join(dir, 'publish-request.json');
+  const processPath = path.join(dir, 'proc.json');
+  const scalarPath = path.join(dir, 'scalar.json');
+
+  writeJson(processPath, makeCanonicalProcess('proc-string-path'));
+  writeJson(scalarPath, 7);
+
+  try {
+    const report = await runProcessSaveDraft({
+      inputPath: requestPath,
+      rawInput: {
+        inputs: {
+          processes: [
+            './proc.json',
+            {
+              payload: makeCanonicalProcess('proc-inline-payload'),
+            },
+          ],
+        },
+      },
+      now: new Date('2026-04-14T00:40:00.000Z'),
+    });
+
+    assert.equal(report.input_kind, 'publish_request');
+    assert.deepEqual(report.counts, {
+      selected: 2,
+      prepared: 2,
+      executed: 0,
+      failed: 0,
+    });
+    assert.deepEqual(
+      report.processes.map((entry) => entry.id),
+      ['proc-string-path', 'proc-inline-payload'],
+    );
+
+    await assert.rejects(
+      () =>
+        runProcessSaveDraft({
+          inputPath: requestPath,
+          rawInput: {
+            inputs: {
+              processes: [
+                {
+                  file: './scalar.json',
+                },
+              ],
+            },
+          },
+        }),
+      (error) => error instanceof CliError && error.code === 'PROCESS_SAVE_DRAFT_INPUT_NOT_OBJECT',
+    );
+
+    await assert.rejects(
+      () =>
+        runProcessSaveDraft({
+          inputPath: requestPath,
+          rawInput: {
+            inputs: {
+              processes: ['./scalar.json'],
+            },
+          },
+        }),
+      (error) => error instanceof CliError && error.code === 'PROCESS_SAVE_DRAFT_INPUT_NOT_OBJECT',
+    );
+
+    await assert.rejects(
+      () =>
+        runProcessSaveDraft({
+          inputPath: requestPath,
+          rawInput: {
+            inputs: {
+              processes: [7],
+            },
+          },
+        }),
+      (error) => error instanceof CliError && error.code === 'PROCESS_SAVE_DRAFT_UNSUPPORTED_ENTRY',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessSaveDraft accepts single-row raw input and explicit output overrides', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-save-draft-single-row-'));
+  const inputPath = path.join(dir, 'single-row.json');
+  const explicitOutDir = path.join(dir, 'explicit-out');
+
+  try {
+    const singleRowReport = await runProcessSaveDraft({
+      inputPath,
+      rawInput: makeCanonicalProcess('proc-single-row'),
+      now: new Date('2026-04-14T00:45:00.000Z'),
+    });
+
+    assert.equal(singleRowReport.input_kind, 'rows_file');
+    assert.deepEqual(singleRowReport.counts, {
+      selected: 1,
+      prepared: 1,
+      executed: 0,
+      failed: 0,
+    });
+
+    const publishHintReport = await runProcessSaveDraft({
+      inputPath: path.join(dir, 'publish-hint.json'),
+      rawInput: {
+        output_dir: './hinted-out',
+      },
+      outDir: explicitOutDir,
+      now: new Date('2026-04-14T00:46:00.000Z'),
+    });
+
+    assert.equal(publishHintReport.input_kind, 'publish_request');
+    assert.equal(publishHintReport.out_dir, explicitOutDir);
+    assert.deepEqual(publishHintReport.counts, {
+      selected: 0,
+      prepared: 0,
+      executed: 0,
+      failed: 0,
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessSaveDraft rejects invalid prepared rows and missing commit runtime bindings', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-save-draft-invalid-rows-'));
+  const inputPath = path.join(dir, 'rows.json');
+
+  writeJson(inputPath, makeCanonicalProcess('proc-runtime-check'));
+
+  try {
+    await assert.rejects(
+      () =>
+        runProcessSaveDraft({
+          inputPath,
+          rawInput: [1],
+        }),
+      (error) => error instanceof CliError && error.code === 'PROCESS_SAVE_DRAFT_INVALID_ROW',
+    );
+
+    await assert.rejects(
+      () =>
+        runProcessSaveDraft({
+          inputPath,
+          commit: true,
+          rawInput: [makeCanonicalProcess('proc-runtime-check')],
+        }),
+      (error) => error instanceof CliError && error.code === 'PROCESS_SAVE_DRAFT_RUNTIME_REQUIRED',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessSaveDraft records execution failures and non-canonical extraction failures', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-save-draft-runtime-failure-'));
+  const inputPath = path.join(dir, 'rows.jsonl');
+
+  writeJsonl(inputPath, [makeCanonicalProcess('proc-runtime-failure')]);
+
+  const getterExplodes = {} as Record<string, unknown>;
+  Object.defineProperty(getterExplodes, 'processDataSet', {
+    enumerable: false,
+    get() {
+      throw new Error('getter exploded');
+    },
+  });
+
+  try {
+    const failureReport = await runProcessSaveDraft({
+      inputPath,
+      commit: true,
+      env: buildSupabaseTestEnv({
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+        TIANGONG_LCA_API_KEY: 'key',
+      }),
+      fetchImpl: withSupabaseAuthBootstrap(async (_url, init) => {
+        if (String(init?.method ?? 'GET') === 'GET') {
+          return makeResponse({
+            ok: true,
+            status: 200,
+            body: '[{"id":"proc-runtime-failure","version":"01.01.000","user_id":"user-1","state_code":0}]',
+          });
+        }
+        throw 'rpc exploded';
+      }),
+      now: new Date('2026-04-14T00:50:00.000Z'),
+    });
+
+    assert.equal(failureReport.status, 'completed_with_failures');
+    assert.equal(failureReport.processes[0]?.status, 'failed');
+    assert.deepEqual(failureReport.processes[0]?.error, { message: 'rpc exploded' });
+
+    const getterReport = await runProcessSaveDraft({
+      inputPath: path.join(dir, 'getter.json'),
+      rawInput: [getterExplodes],
+      now: new Date('2026-04-14T01:00:00.000Z'),
+    });
+
+    assert.equal(getterReport.status, 'completed_with_failures');
+    assert.equal(getterReport.processes[0]?.status, 'failed');
+    assert.match(getterReport.processes[0]?.error?.message ?? '', /getter exploded/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/process-save-draft.test.ts
+++ b/test/process-save-draft.test.ts
@@ -1,0 +1,308 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { CliError } from '../src/lib/errors.js';
+import { syncStateAwareProcessRecord, __testInternals } from '../src/lib/process-save-draft.js';
+import type { FetchLike } from '../src/lib/http.js';
+import {
+  buildSupabaseTestEnv,
+  isSupabaseAuthTokenUrl,
+  makeSupabaseAuthResponse,
+} from './helpers/supabase-auth.js';
+
+function makeResponse(options: {
+  ok: boolean;
+  status: number;
+  contentType?: string;
+  body?: string;
+}) {
+  return {
+    ok: options.ok,
+    status: options.status,
+    headers: {
+      get(name: string): string | null {
+        return name.toLowerCase() === 'content-type'
+          ? (options.contentType ?? 'application/json')
+          : null;
+      },
+    },
+    async text(): Promise<string> {
+      return options.body ?? '';
+    },
+  };
+}
+
+function withSupabaseAuthBootstrap(fetchImpl: FetchLike): FetchLike {
+  return async (url, init) => {
+    if (isSupabaseAuthTokenUrl(String(url))) {
+      return makeSupabaseAuthResponse();
+    }
+
+    return fetchImpl(String(url), init);
+  };
+}
+
+test('state-aware process write routes visible drafts through cmd_dataset_save_draft', async () => {
+  const observed: Array<{ method: string; url: string; body?: string }> = [];
+  const result = await syncStateAwareProcessRecord({
+    id: 'proc-draft',
+    version: '01.00.001',
+    payload: { processDataSet: {} },
+    env: buildSupabaseTestEnv({
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+      TIANGONG_LCA_API_KEY: 'key',
+    }),
+    fetchImpl: withSupabaseAuthBootstrap(async (url, init) => {
+      observed.push({
+        method: String(init?.method ?? 'GET'),
+        url: String(url),
+        body: typeof init?.body === 'string' ? init.body : undefined,
+      });
+
+      if (observed.length === 1) {
+        return makeResponse({
+          ok: true,
+          status: 200,
+          body: '[{"id":"proc-draft","version":"01.00.001","user_id":"user-1","state_code":0}]',
+        });
+      }
+
+      return makeResponse({
+        ok: true,
+        status: 200,
+        body: '{"ok":true,"data":{"id":"proc-draft"}}',
+      });
+    }),
+  });
+
+  assert.deepEqual(
+    observed.map((entry) => entry.method),
+    ['GET', 'POST'],
+  );
+  assert.match(observed[1]?.url ?? '', /\/rest\/v1\/rpc\/cmd_dataset_save_draft$/u);
+  assert.match(observed[1]?.body ?? '', /"p_table":"processes"/u);
+  assert.deepEqual(result, {
+    status: 'success',
+    operation: 'save_draft',
+    write_path: 'cmd_dataset_save_draft',
+    rpc_result: { ok: true, data: { id: 'proc-draft' } },
+    visible_row: {
+      id: 'proc-draft',
+      version: '01.00.001',
+      user_id: 'user-1',
+      state_code: 0,
+    },
+  });
+});
+
+test('state-aware process write rejects visible non-draft rows before raw table updates', async () => {
+  await assert.rejects(
+    () =>
+      syncStateAwareProcessRecord({
+        id: 'proc-public',
+        version: '01.00.001',
+        payload: { processDataSet: {} },
+        env: buildSupabaseTestEnv({
+          TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+          TIANGONG_LCA_API_KEY: 'key',
+        }),
+        fetchImpl: withSupabaseAuthBootstrap(async () =>
+          makeResponse({
+            ok: true,
+            status: 200,
+            body: '[{"id":"proc-public","version":"01.00.001","user_id":"other-user","state_code":100}]',
+          }),
+        ),
+      }),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'PUBLISH_PROCESS_SAVE_DRAFT_UNSUPPORTED_VISIBLE_ROW');
+      assert.match(error.message, /state_code=100/u);
+      return true;
+    },
+  );
+});
+
+test('state-aware process write treats HTTP 200 ok:false RPC payloads as failures', async () => {
+  await assert.rejects(
+    () =>
+      syncStateAwareProcessRecord({
+        id: 'proc-owner-blocked',
+        version: '01.00.001',
+        payload: { processDataSet: {} },
+        env: buildSupabaseTestEnv({
+          TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+          TIANGONG_LCA_API_KEY: 'key',
+        }),
+        fetchImpl: withSupabaseAuthBootstrap(async (_url, init) => {
+          if (String(init?.method ?? 'GET') === 'GET') {
+            return makeResponse({
+              ok: true,
+              status: 200,
+              body: '[{"id":"proc-owner-blocked","version":"01.00.001","user_id":"other-user","state_code":0}]',
+            });
+          }
+
+          return makeResponse({
+            ok: true,
+            status: 200,
+            body: '{"ok":false,"code":"DATASET_OWNER_REQUIRED","status":403,"message":"Only the dataset owner can save draft changes"}',
+          });
+        }),
+      }),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'DATASET_OWNER_REQUIRED');
+      assert.match(error.message, /Only the dataset owner can save draft changes/u);
+      return true;
+    },
+  );
+});
+
+test('state-aware process write falls back to dataset create when no exact visible row exists', async () => {
+  const observed: Array<{ method: string; url: string; body?: string }> = [];
+  const result = await syncStateAwareProcessRecord({
+    id: 'proc-new',
+    version: '01.00.001',
+    payload: { processDataSet: {} },
+    env: buildSupabaseTestEnv({
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+      TIANGONG_LCA_API_KEY: 'key',
+    }),
+    fetchImpl: withSupabaseAuthBootstrap(async (_url, init) => {
+      observed.push({
+        method: String(init?.method ?? 'GET'),
+        url: String(_url),
+        body: typeof init?.body === 'string' ? init.body : undefined,
+      });
+      if (observed.length <= 2) {
+        return makeResponse({
+          ok: true,
+          status: 200,
+          body: '[]',
+        });
+      }
+
+      return makeResponse({
+        ok: true,
+        status: 200,
+        body: '{"ok":true,"data":{"id":"proc-new"}}',
+      });
+    }),
+  });
+
+  assert.deepEqual(
+    observed.map((entry) => entry.method),
+    ['GET', 'GET', 'POST'],
+  );
+  assert.match(observed[2]?.url ?? '', /\/functions\/v1\/app_dataset_create$/u);
+  assert.deepEqual(JSON.parse(observed[2]?.body ?? '{}'), {
+    table: 'processes',
+    id: 'proc-new',
+    jsonOrdered: {
+      processDataSet: {},
+    },
+  });
+  assert.deepEqual(result, {
+    status: 'success',
+    operation: 'insert',
+  });
+});
+
+test('state-aware process write helpers normalize edge-case visible rows', () => {
+  assert.equal(
+    __testInternals.buildVisibleRowsUrl(
+      'https://example.supabase.co/rest/v1',
+      'proc-1',
+      '01.00.001',
+    ),
+    'https://example.supabase.co/rest/v1/processes?select=id%2Cversion%2Cuser_id%2Cstate_code&id=eq.proc-1&version=eq.01.00.001',
+  );
+  assert.deepEqual(
+    __testInternals.parseVisibleRows(
+      [{ id: 'proc-1', version: '01.00.001', user_id: 'user-1', state_code: 0 }],
+      'https://example.com',
+    ),
+    [{ id: 'proc-1', version: '01.00.001', user_id: 'user-1', state_code: 0 }],
+  );
+  assert.deepEqual(
+    __testInternals.parseVisibleRows(
+      [{ id: 7, version: null, user_id: { bad: true }, state_code: 'oops' }],
+      'https://example.com',
+    ),
+    [{ id: '', version: '', user_id: null, state_code: null }],
+  );
+  assert.deepEqual(
+    __testInternals.parseVisibleRows(
+      [{ id: '   ', version: '   ', user_id: '   ', state_code: 0 }],
+      'https://example.com',
+    ),
+    [{ id: '', version: '', user_id: null, state_code: 0 }],
+  );
+  assert.deepEqual(
+    __testInternals.visibleDraftRow([
+      { id: 'proc-1', version: '01.00.001', user_id: 'user-1', state_code: 100 },
+      { id: 'proc-1', version: '01.00.001', user_id: 'user-2', state_code: 0 },
+    ]),
+    { id: 'proc-1', version: '01.00.001', user_id: 'user-2', state_code: 0 },
+  );
+  assert.throws(
+    () => __testInternals.parseVisibleRows([0], 'https://example.com'),
+    /row 0 was not a JSON object/u,
+  );
+  assert.throws(
+    () => __testInternals.parseVisibleRows('bad', 'https://example.com'),
+    /was not a JSON array/u,
+  );
+  assert.match(
+    __testInternals.buildUnsupportedVisibleRowError('proc-1', '01.00.001', [
+      { id: 'proc-1', version: '01.00.001', user_id: 'user-9', state_code: 100 },
+    ]).message,
+    /visible_owner=user-9/u,
+  );
+  assert.match(
+    __testInternals.buildUnsupportedVisibleRowError('proc-1', '01.00.001', [
+      { id: 'proc-1', version: '01.00.001', user_id: null, state_code: null },
+    ]).message,
+    /state_code=unknown/u,
+  );
+  assert.match(
+    __testInternals.buildUnsupportedVisibleRowError('proc-1', '01.00.001', []).message,
+    /visible_owner=unknown/u,
+  );
+});
+
+test('state-aware process write rejects unexpected RPC payloads even on HTTP 200', async () => {
+  await assert.rejects(
+    () =>
+      syncStateAwareProcessRecord({
+        id: 'proc-draft-invalid',
+        version: '01.00.001',
+        payload: { processDataSet: {} },
+        env: buildSupabaseTestEnv({
+          TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+          TIANGONG_LCA_API_KEY: 'key',
+        }),
+        fetchImpl: withSupabaseAuthBootstrap(async (_url, init) => {
+          if (String(init?.method ?? 'GET') === 'GET') {
+            return makeResponse({
+              ok: true,
+              status: 200,
+              body: '[{"id":"proc-draft-invalid","version":"01.00.001","user_id":"user-1","state_code":0}]',
+            });
+          }
+
+          return makeResponse({
+            ok: true,
+            status: 200,
+            body: '[]',
+          });
+        }),
+      }),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'REMOTE_RESPONSE_INVALID');
+      assert.match(error.message, /unexpected payload/u);
+      return true;
+    },
+  );
+});

--- a/test/publish.test.ts
+++ b/test/publish.test.ts
@@ -105,6 +105,22 @@ test('normalizePublishRequest resolves paths relative to the request file and ap
   assert.equal(normalized.publish.retry_delay_seconds, 2);
 });
 
+test('normalizePublishRequest resolves outDirOverride relative to the request file', () => {
+  const requestPath = path.join(path.sep, 'tmp', 'tg-cli-publish', 'nested', 'request.json');
+  const requestDir = path.dirname(requestPath);
+  const normalized = normalizePublishRequest(
+    {
+      out_dir: './request-out',
+    },
+    {
+      requestPath,
+      outDirOverride: './override-out',
+    },
+  );
+
+  assert.equal(normalized.out_dir, path.resolve(requestDir, 'override-out'));
+});
+
 test('normalizePublishRequest rejects unsupported relation modes and invalid integer settings', () => {
   assert.throws(
     () =>
@@ -436,8 +452,8 @@ test('runPublish honors commit override, defers missing executors, and rejects i
   }
 });
 
-test('runPublish uses default Supabase dataset command executors when runtime env and fetch are provided', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-publish-default-dataset-command-'));
+test('runPublish uses state-aware process draft writes and generic source updates by default', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-publish-default-rest-'));
   const requestPath = path.join(dir, 'request.json');
   const observed: Array<{ method: string; url: string; body?: string }> = [];
 
@@ -469,7 +485,7 @@ test('runPublish uses default Supabase dataset command executors when runtime en
           return makeResponse({
             ok: true,
             status: 200,
-            body: '[]',
+            body: '[{"id":"proc-default-rest","version":"01.01.000","user_id":"user-1","state_code":0}]',
           });
         }
 
@@ -478,6 +494,22 @@ test('runPublish uses default Supabase dataset command executors when runtime en
             ok: true,
             status: 200,
             body: '[{"id":"src-default-rest","version":"01.01.000","state_code":0}]',
+          });
+        }
+
+        if (String(url).includes('/functions/v1/app_dataset_save_draft')) {
+          return makeResponse({
+            ok: true,
+            status: 200,
+            body: '{"ok":true,"command":"dataset_save_draft","data":{"id":"ok"}}',
+          });
+        }
+
+        if (String(url).includes('/rpc/cmd_dataset_save_draft')) {
+          return makeResponse({
+            ok: true,
+            status: 200,
+            body: '{"ok":true,"id":"ok"}',
           });
         }
 
@@ -494,7 +526,18 @@ test('runPublish uses default Supabase dataset command executors when runtime en
     assert.equal(report.sources[0].status, 'executed');
     assert.deepEqual(report.processes[0].execution, {
       status: 'success',
-      operation: 'insert',
+      operation: 'save_draft',
+      write_path: 'cmd_dataset_save_draft',
+      rpc_result: {
+        id: 'ok',
+        ok: true,
+      },
+      visible_row: {
+        id: 'proc-default-rest',
+        state_code: 0,
+        user_id: 'user-1',
+        version: '01.01.000',
+      },
     });
     assert.deepEqual(report.sources[0].execution, {
       status: 'success',
@@ -504,22 +547,53 @@ test('runPublish uses default Supabase dataset command executors when runtime en
       observed.map((entry) => entry.method),
       ['GET', 'POST', 'GET', 'POST'],
     );
-    assert.match(observed[0].url, /\/rest\/v1\/processes\?select=/u);
-    assert.match(observed[1].url, /\/functions\/v1\/app_dataset_create$/u);
-    assert.match(observed[2].url, /\/rest\/v1\/sources\?select=/u);
-    assert.match(observed[3].url, /\/functions\/v1\/app_dataset_save_draft$/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
-    assert.deepEqual(JSON.parse(observed[1].body ?? '{}'), {
-      table: 'processes',
-      id: 'proc-default-rest',
-      jsonOrdered: makeCanonicalProcess('proc-default-rest'),
+test('runPublish fails truthfully when a visible process row cannot use the draft save path', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-publish-owner-blocked-'));
+  const requestPath = path.join(dir, 'request.json');
+
+  writeJson(requestPath, {
+    inputs: {
+      processes: [makeCanonicalProcess('proc-owner-blocked')],
+    },
+    publish: {
+      commit: true,
+    },
+  });
+
+  try {
+    const report = await runPublish({
+      inputPath: requestPath,
+      env: buildSupabaseTestEnv({
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+        TIANGONG_LCA_API_KEY: 'key',
+      }),
+      fetchImpl: withSupabaseAuth(async (url) => {
+        if (String(url).includes('/processes?select=')) {
+          return makeResponse({
+            ok: true,
+            status: 200,
+            body: '[{"id":"proc-owner-blocked","version":"01.01.000","user_id":"other-user","state_code":100}]',
+          });
+        }
+
+        return makeResponse({
+          ok: true,
+          status: 200,
+          body: '[{"id":"unexpected"}]',
+        });
+      }),
+      now: new Date('2026-03-28T00:00:00Z'),
     });
-    assert.deepEqual(JSON.parse(observed[3].body ?? '{}'), {
-      table: 'sources',
-      id: 'src-default-rest',
-      version: '01.01.000',
-      jsonOrdered: makeSource('src-default-rest'),
-    });
+
+    assert.equal(report.status, 'completed_with_failures');
+    assert.equal(report.processes[0].status, 'failed');
+    assert.match(report.processes[0].error?.message ?? '', /cannot use save-draft/u);
+    assert.match(report.processes[0].error?.message ?? '', /state_code=100/u);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/review-process.test.ts
+++ b/test/review-process.test.ts
@@ -171,13 +171,17 @@ test('runProcessReview writes artifact-first local review outputs without LLM', 
   try {
     const report = await runProcessReview({
       runRoot,
-      runId: 'run-001',
       outDir,
       logicVersion: 'v2.1',
       now: () => new Date('2026-03-30T00:00:00.000Z'),
     });
 
     assert.equal(report.status, 'completed_local_process_review');
+    assert.equal(report.run_id, 'run-root');
+    assert.equal(report.run_root, runRoot);
+    assert.equal(report.rows_file, '');
+    assert.equal(report.input_mode, 'run_root');
+    assert.equal(report.effective_processes_dir, processDir);
     assert.equal(report.process_count, 1);
     assert.equal(report.logic_version, 'v2.1');
     assert.equal(report.llm.enabled, false);
@@ -191,8 +195,10 @@ test('runProcessReview writes artifact-first local review outputs without LLM', 
     assert.ok(existsSync(report.files.review_en));
     assert.ok(existsSync(report.files.timing));
     assert.ok(existsSync(report.files.unit_issue_log));
+    assert.ok(existsSync(report.files.review_input_summary));
     assert.ok(existsSync(report.files.summary));
     assert.ok(existsSync(report.files.report));
+    assert.equal(report.files.materialization_summary, null);
 
     const summary = JSON.parse(readFileSync(report.files.summary, 'utf8')) as JsonRecord;
     assert.equal(summary.process_count, 1);
@@ -205,6 +211,125 @@ test('runProcessReview writes artifact-first local review outputs without LLM', 
     const unitLog = readFileSync(report.files.unit_issue_log, 'utf8');
     assert.match(unitLog, /flow-electric/u);
     assert.match(unitLog, /kWh/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessReview materializes rows-file and full process-list reports before reviewing', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-process-rows-'));
+  const rowsFile = path.join(dir, 'process-list-report.json');
+  const outDir = path.join(dir, 'review');
+
+  writeJson(rowsFile, {
+    rows: [
+      {
+        id: 'proc-a',
+        version: '01.00.001',
+        process: createProcessPayload(),
+      },
+      {
+        id: 'proc-a',
+        version: '01.00.001',
+        process: createProcessPayload(),
+      },
+    ],
+  });
+
+  try {
+    const report = await runProcessReview({
+      rowsFile,
+      outDir,
+      now: () => new Date('2026-03-30T00:00:00.000Z'),
+    });
+
+    assert.equal(report.input_mode, 'rows_file');
+    assert.equal(report.run_root, '');
+    assert.equal(report.rows_file, rowsFile);
+    assert.equal(report.run_id, 'process-list-report');
+    assert.equal(report.process_count, 1);
+    assert.ok(report.files.materialization_summary);
+    assert.ok(existsSync(report.files.review_input_summary));
+    assert.ok(existsSync(report.files.materialization_summary as string));
+
+    const materialization = JSON.parse(
+      readFileSync(report.files.materialization_summary as string, 'utf8'),
+    ) as JsonRecord;
+    assert.equal(materialization.input_row_count, 2);
+    assert.equal(materialization.materialized_process_count, 1);
+    assert.equal(materialization.duplicate_input_rows_collapsed, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessReview accepts direct rows arrays and falls back to row identity defaults', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-process-array-'));
+  const rowsFile = path.join(dir, 'rows.json');
+  const outDir = path.join(dir, 'review');
+
+  writeJson(rowsFile, [
+    {
+      id: 'proc-fallback-id',
+      process: {
+        processDataSet: {
+          exchanges: {
+            exchange: [],
+          },
+        },
+      },
+    },
+  ]);
+
+  try {
+    const report = await runProcessReview({
+      rowsFile,
+      outDir,
+      now: () => new Date('2026-03-30T00:05:00.000Z'),
+    });
+
+    assert.equal(report.input_mode, 'rows_file');
+    assert.equal(report.process_count, 1);
+    assert.ok(report.files.materialization_summary);
+
+    const materialization = JSON.parse(
+      readFileSync(report.files.materialization_summary as string, 'utf8'),
+    ) as {
+      items: Array<{ process_key: string; file: string }>;
+    };
+    assert.equal(materialization.items[0]?.process_key, 'proc-fallback-id@01.00.000');
+    assert.match(materialization.items[0]?.file ?? '', /row-1__01\.00\.000\.json$/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessReview accepts JSONL rows-file inputs and trims explicit run ids', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-process-jsonl-'));
+  const rowsFile = path.join(dir, 'rows.jsonl');
+  const outDir = path.join(dir, 'review');
+
+  writeFileSync(
+    rowsFile,
+    `${JSON.stringify({
+      id: 'proc-jsonl',
+      version: '01.00.123',
+      process: createProcessPayload(),
+    })}\n`,
+    'utf8',
+  );
+
+  try {
+    const report = await runProcessReview({
+      rowsFile,
+      runId: '  explicit-run-id  ',
+      outDir,
+      now: () => new Date('2026-03-30T00:06:00.000Z'),
+    });
+
+    assert.equal(report.input_mode, 'rows_file');
+    assert.equal(report.run_id, 'explicit-run-id');
+    assert.equal(report.process_count, 1);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -313,6 +438,84 @@ test('runProcessReview records non-fatal LLM runtime failures and validates time
       (error) => {
         assert.ok(error instanceof CliError);
         assert.equal(error.code, 'PROCESS_REVIEW_EXPORTS_NOT_FOUND');
+        return true;
+      },
+    );
+
+    await assert.rejects(
+      runProcessReview({
+        outDir: path.join(dir, 'review-missing-input'),
+      }),
+      (error) => {
+        assert.ok(error instanceof CliError);
+        assert.equal(error.code, 'PROCESS_REVIEW_INPUT_MODE_REQUIRED');
+        return true;
+      },
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessReview validates malformed rows-file inputs', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-process-invalid-rows-'));
+  const invalidJsonlPath = path.join(dir, 'rows.jsonl');
+  const invalidJsonlRowPath = path.join(dir, 'rows-scalar.jsonl');
+  const invalidJsonPath = path.join(dir, 'rows.json');
+  const invalidShapePath = path.join(dir, 'rows-shape.json');
+
+  writeFileSync(invalidJsonlPath, '{"bad"\n', 'utf8');
+  writeFileSync(invalidJsonlRowPath, '7\n', 'utf8');
+  writeFileSync(invalidJsonPath, '{bad', 'utf8');
+  writeJson(invalidShapePath, { ok: true });
+
+  try {
+    await assert.rejects(
+      runProcessReview({
+        rowsFile: invalidJsonlPath,
+        outDir: path.join(dir, 'review-jsonl'),
+      }),
+      (error) => {
+        assert.ok(error instanceof CliError);
+        assert.equal(error.code, 'PROCESS_REVIEW_ROWS_INVALID_JSONL');
+        return true;
+      },
+    );
+
+    await assert.rejects(
+      runProcessReview({
+        rowsFile: invalidJsonlRowPath,
+        outDir: path.join(dir, 'review-jsonl-row'),
+      }),
+      (error) => {
+        assert.ok(error instanceof CliError);
+        assert.equal(error.code, 'PROCESS_REVIEW_ROWS_INVALID_JSONL_ROW');
+        return true;
+      },
+    );
+
+    await assert.rejects(
+      runProcessReview({
+        rowsFile: invalidJsonPath,
+        outDir: path.join(dir, 'review-json'),
+      }),
+      (error) => {
+        assert.ok(error instanceof CliError);
+        assert.equal(error.code, 'PROCESS_REVIEW_ROWS_INVALID_JSON');
+        assert.match(error.message, /not valid JSON/u);
+        return true;
+      },
+    );
+
+    await assert.rejects(
+      runProcessReview({
+        rowsFile: invalidShapePath,
+        outDir: path.join(dir, 'review-shape'),
+      }),
+      (error) => {
+        assert.ok(error instanceof CliError);
+        assert.equal(error.code, 'PROCESS_REVIEW_ROWS_INVALID_JSON');
+        assert.match(error.message, /rows\[\]/u);
         return true;
       },
     );
@@ -633,6 +836,15 @@ test('review-process internals cover helper branches and rendering fallbacks', a
   assert.equal(minimalBase.name_zh_en_ok, false);
   assert.equal(minimalBase.completeness_score, 0);
 
+  assert.equal(
+    __testInternals.unwrapProcessPayload(
+      {
+        process: createProcessPayload(),
+      },
+      '/tmp/proc.json',
+    ).processDataSet !== undefined,
+    true,
+  );
   assert.equal(
     __testInternals.unwrapProcessPayload(
       {

--- a/test/supabase-json-ordered-write.test.ts
+++ b/test/supabase-json-ordered-write.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { resolveDatasetCommandTransport } from '../src/lib/dataset-command.js';
 import { CliError } from '../src/lib/errors.js';
 import type { FetchLike } from '../src/lib/http.js';
 import {
@@ -108,6 +109,7 @@ test('supabase json_ordered write inserts when no exact row exists', async () =>
     /\/rest\/v1\/processes\?select=id%2Cversion%2Cstate_code&id=eq\.proc-1&version=eq\.01\.00\.001/u,
   );
   assert.match(observed[1]?.url ?? '', /\/functions\/v1\/app_dataset_create$/u);
+  assert.match(observed[1]?.body ?? '', /"table":"processes"/u);
   assert.match(observed[1]?.body ?? '', /"jsonOrdered"/u);
 });
 
@@ -266,58 +268,50 @@ test('append-only insert skips existing rows and validates helper branches', asy
 });
 
 test('supabase json_ordered helpers handle empty/text success payloads and invalid visible-row shapes', async () => {
+  const observed: Array<{ method: string; url: string; body?: string }> = [];
+  const fetchImpl = withSupabaseAuthBootstrap(async (url, init) => {
+    observed.push({
+      method: String(init?.method ?? 'GET'),
+      url: String(url),
+      body: typeof init?.body === 'string' ? init.body : undefined,
+    });
+
+    return makeResponse({
+      ok: true,
+      status: 200,
+      body: '{"ok":true,"data":{"id":"ok"}}',
+    });
+  });
+  const transport = await resolveDatasetCommandTransport({
+    env: buildSupabaseTestEnv({
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+      TIANGONG_LCA_API_KEY: 'key',
+    }),
+    fetchImpl,
+    timeoutMs: 10,
+  });
+
   await __testInternals.insertJsonOrderedRow({
-    commandClient: {
-      create: async () => 'created',
-      saveDraft: async () => null,
-    },
+    transport,
     table: 'processes',
     id: 'proc-text',
     payload: { processDataSet: {} },
   });
 
   await __testInternals.updateJsonOrderedRow({
-    commandClient: {
-      create: async () => null,
-      saveDraft: async () => null,
-    },
+    transport,
     table: 'processes',
     id: 'proc-empty',
     version: '01.00.001',
     payload: { processDataSet: {} },
   });
 
-  assert.deepEqual(__testInternals.commandOptionsFromExtraData({ model_id: 'model-1' }), {
-    modelId: 'model-1',
-  });
   assert.deepEqual(
-    __testInternals.commandOptionsFromExtraData({
-      modelId: 'model-2',
-      rule_verification: false,
-    }),
-    {
-      modelId: 'model-2',
-      ruleVerification: false,
-    },
+    observed.map((item) => item.method),
+    ['POST', 'POST'],
   );
-  assert.deepEqual(
-    __testInternals.commandOptionsFromExtraData({
-      model_id: null,
-      rule_verification: null,
-    }),
-    {
-      modelId: null,
-      ruleVerification: null,
-    },
-  );
-  assert.deepEqual(
-    __testInternals.commandOptionsFromExtraData({
-      model_id: '   ',
-    }),
-    {
-      modelId: null,
-    },
-  );
+  assert.match(observed[0]?.url ?? '', /\/functions\/v1\/app_dataset_create$/u);
+  assert.match(observed[1]?.url ?? '', /\/functions\/v1\/app_dataset_save_draft$/u);
 
   assert.throws(
     () => __testInternals.parseVisibleRows('not-an-array', 'https://example.com/select'),


### PR DESCRIPTION
Closes #68

## Summary
- source CLI --version from package metadata instead of a hardcoded string
- document and test the request-file-relative publish out_dir contract instead of leaving it ambiguous
- add stable process list / rows-file review / save-draft primitives so remote workflows stop depending on case-local bridges

## Key Decisions
- keep publish run out_dir request-relative and make that rule explicit in help, docs, and tests
- route owned draft process maintenance through the state-aware save-draft path instead of direct table updates
- ignore repo-local artifacts/ output so local review runs stop showing up as source changes

## Validation
- npm run lint && npm run test:coverage && npm run test:coverage:assert-full

## Workspace Integration
- Requires a later lca-workspace submodule bump after the cli repo PR merges.