### PR TITLE
test: isolate remote env session state in windows CI

### DIFF
--- a/test/flow-get.test.ts
+++ b/test/flow-get.test.ts
@@ -84,6 +84,7 @@ test('runFlowGet can fall back to process.env and global fetch', async () => {
   const originalBaseUrl = process.env.TIANGONG_LCA_API_BASE_URL;
   const originalApiKey = process.env.TIANGONG_LCA_API_KEY;
   const originalPublishableKey = process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
+  const originalSessionMemoryOnly = process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY;
   const testEnv = buildSupabaseTestEnv({
     TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
     TIANGONG_LCA_API_KEY: 'secret-token',
@@ -92,6 +93,7 @@ test('runFlowGet can fall back to process.env and global fetch', async () => {
   process.env.TIANGONG_LCA_API_BASE_URL = testEnv.TIANGONG_LCA_API_BASE_URL;
   process.env.TIANGONG_LCA_API_KEY = testEnv.TIANGONG_LCA_API_KEY;
   process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY = testEnv.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
+  process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY = testEnv.TIANGONG_LCA_SESSION_MEMORY_ONLY;
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     if (isSupabaseAuthTokenUrl(String(input))) {
       return makeSupabaseAuthResponse();
@@ -142,6 +144,11 @@ test('runFlowGet can fall back to process.env and global fetch', async () => {
       delete process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
     } else {
       process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY = originalPublishableKey;
+    }
+    if (originalSessionMemoryOnly === undefined) {
+      delete process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY;
+    } else {
+      process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY = originalSessionMemoryOnly;
     }
   }
 });

--- a/test/flow-list.test.ts
+++ b/test/flow-list.test.ts
@@ -171,6 +171,7 @@ test('runFlowList can fall back to process.env and global fetch', async () => {
   const originalBaseUrl = process.env.TIANGONG_LCA_API_BASE_URL;
   const originalApiKey = process.env.TIANGONG_LCA_API_KEY;
   const originalPublishableKey = process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
+  const originalSessionMemoryOnly = process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY;
   const testEnv = buildSupabaseTestEnv({
     TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
     TIANGONG_LCA_API_KEY: 'secret-token',
@@ -179,6 +180,7 @@ test('runFlowList can fall back to process.env and global fetch', async () => {
   process.env.TIANGONG_LCA_API_BASE_URL = testEnv.TIANGONG_LCA_API_BASE_URL;
   process.env.TIANGONG_LCA_API_KEY = testEnv.TIANGONG_LCA_API_KEY;
   process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY = testEnv.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
+  process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY = testEnv.TIANGONG_LCA_SESSION_MEMORY_ONLY;
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     if (isSupabaseAuthTokenUrl(String(input))) {
       return makeSupabaseAuthResponse();
@@ -226,6 +228,11 @@ test('runFlowList can fall back to process.env and global fetch', async () => {
       delete process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
     } else {
       process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY = originalPublishableKey;
+    }
+    if (originalSessionMemoryOnly === undefined) {
+      delete process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY;
+    } else {
+      process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY = originalSessionMemoryOnly;
     }
   }
 });

--- a/test/flow-publish-version.test.ts
+++ b/test/flow-publish-version.test.ts
@@ -391,6 +391,7 @@ test('runFlowPublishVersion can fall back to process.env and global fetch and re
   const originalBaseUrl = process.env.TIANGONG_LCA_API_BASE_URL;
   const originalApiKey = process.env.TIANGONG_LCA_API_KEY;
   const originalPublishableKey = process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
+  const originalSessionMemoryOnly = process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY;
   const testEnv = buildSupabaseTestEnv({
     TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
     TIANGONG_LCA_API_KEY: 'secret-token',
@@ -404,6 +405,7 @@ test('runFlowPublishVersion can fall back to process.env and global fetch and re
   process.env.TIANGONG_LCA_API_BASE_URL = testEnv.TIANGONG_LCA_API_BASE_URL;
   process.env.TIANGONG_LCA_API_KEY = testEnv.TIANGONG_LCA_API_KEY;
   process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY = testEnv.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
+  process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY = testEnv.TIANGONG_LCA_SESSION_MEMORY_ONLY;
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     if (isSupabaseAuthTokenUrl(String(input))) {
       return makeSupabaseAuthResponse();
@@ -445,6 +447,11 @@ test('runFlowPublishVersion can fall back to process.env and global fetch and re
       delete process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
     } else {
       process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY = originalPublishableKey;
+    }
+    if (originalSessionMemoryOnly === undefined) {
+      delete process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY;
+    } else {
+      process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY = originalSessionMemoryOnly;
     }
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/helpers/supabase-auth.ts
+++ b/test/helpers/supabase-auth.ts
@@ -33,6 +33,7 @@ export function buildSupabaseTestEnv(
   return {
     TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
     TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY: 'sb-publishable-key',
+    TIANGONG_LCA_SESSION_MEMORY_ONLY: '1',
     ...overrides,
     TIANGONG_LCA_API_KEY: resolvedApiKey,
   } as NodeJS.ProcessEnv;

--- a/test/lifecyclemodel-resulting-process.test.ts
+++ b/test/lifecyclemodel-resulting-process.test.ts
@@ -1346,6 +1346,7 @@ test('runLifecyclemodelBuildResultingProcess can use process.env and global fetc
   const originalBaseUrl = process.env.TIANGONG_LCA_API_BASE_URL;
   const originalApiKey = process.env.TIANGONG_LCA_API_KEY;
   const originalPublishableKey = process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
+  const originalSessionMemoryOnly = process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY;
   const testEnv = buildSupabaseTestEnv({
     TIANGONG_LCA_API_BASE_URL: 'https://supabase.example/functions/v1',
     TIANGONG_LCA_API_KEY: 'supabase-api-key',
@@ -1376,6 +1377,7 @@ test('runLifecyclemodelBuildResultingProcess can use process.env and global fetc
   process.env.TIANGONG_LCA_API_BASE_URL = testEnv.TIANGONG_LCA_API_BASE_URL;
   process.env.TIANGONG_LCA_API_KEY = testEnv.TIANGONG_LCA_API_KEY;
   process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY = testEnv.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
+  process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY = testEnv.TIANGONG_LCA_SESSION_MEMORY_ONLY;
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     if (isSupabaseAuthTokenUrl(String(input))) {
       return makeSupabaseAuthResponse();
@@ -1441,6 +1443,11 @@ test('runLifecyclemodelBuildResultingProcess can use process.env and global fetc
       delete process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
     } else {
       process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY = originalPublishableKey;
+    }
+    if (originalSessionMemoryOnly === undefined) {
+      delete process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY;
+    } else {
+      process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY = originalSessionMemoryOnly;
     }
     rmSync(dir, { recursive: true, force: true });
   }
@@ -2490,6 +2497,7 @@ test('buildProjectionBundle can fall back to process.env and global fetch for re
   const originalBaseUrl = process.env.TIANGONG_LCA_API_BASE_URL;
   const originalApiKey = process.env.TIANGONG_LCA_API_KEY;
   const originalPublishableKey = process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
+  const originalSessionMemoryOnly = process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY;
   const testEnv = buildSupabaseTestEnv({
     TIANGONG_LCA_API_BASE_URL: 'https://supabase.example/functions/v1',
     TIANGONG_LCA_API_KEY: 'supabase-api-key',
@@ -2498,6 +2506,7 @@ test('buildProjectionBundle can fall back to process.env and global fetch for re
   process.env.TIANGONG_LCA_API_BASE_URL = testEnv.TIANGONG_LCA_API_BASE_URL;
   process.env.TIANGONG_LCA_API_KEY = testEnv.TIANGONG_LCA_API_KEY;
   process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY = testEnv.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
+  process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY = testEnv.TIANGONG_LCA_SESSION_MEMORY_ONLY;
   globalThis.fetch = createJsonFetch(
     [
       [
@@ -2600,6 +2609,11 @@ test('buildProjectionBundle can fall back to process.env and global fetch for re
       delete process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
     } else {
       process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY = originalPublishableKey;
+    }
+    if (originalSessionMemoryOnly === undefined) {
+      delete process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY;
+    } else {
+      process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY = originalSessionMemoryOnly;
     }
   }
 });

--- a/test/process-get.test.ts
+++ b/test/process-get.test.ts
@@ -78,6 +78,7 @@ test('runProcessGet can fall back to process.env and global fetch', async () => 
   const originalBaseUrl = process.env.TIANGONG_LCA_API_BASE_URL;
   const originalApiKey = process.env.TIANGONG_LCA_API_KEY;
   const originalPublishableKey = process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
+  const originalSessionMemoryOnly = process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY;
   const testEnv = buildSupabaseTestEnv({
     TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
     TIANGONG_LCA_API_KEY: 'secret-token',
@@ -86,6 +87,7 @@ test('runProcessGet can fall back to process.env and global fetch', async () => 
   process.env.TIANGONG_LCA_API_BASE_URL = testEnv.TIANGONG_LCA_API_BASE_URL;
   process.env.TIANGONG_LCA_API_KEY = testEnv.TIANGONG_LCA_API_KEY;
   process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY = testEnv.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
+  process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY = testEnv.TIANGONG_LCA_SESSION_MEMORY_ONLY;
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     if (isSupabaseAuthTokenUrl(String(input))) {
       return makeSupabaseAuthResponse();
@@ -135,6 +137,11 @@ test('runProcessGet can fall back to process.env and global fetch', async () => 
       delete process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
     } else {
       process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY = originalPublishableKey;
+    }
+    if (originalSessionMemoryOnly === undefined) {
+      delete process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY;
+    } else {
+      process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY = originalSessionMemoryOnly;
     }
   }
 });

--- a/test/process-list.test.ts
+++ b/test/process-list.test.ts
@@ -172,6 +172,7 @@ test('runProcessList can fall back to process.env and global fetch', async () =>
   const originalBaseUrl = process.env.TIANGONG_LCA_API_BASE_URL;
   const originalApiKey = process.env.TIANGONG_LCA_API_KEY;
   const originalPublishableKey = process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
+  const originalSessionMemoryOnly = process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY;
   const testEnv = buildSupabaseTestEnv({
     TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
     TIANGONG_LCA_API_KEY: 'secret-token',
@@ -180,6 +181,7 @@ test('runProcessList can fall back to process.env and global fetch', async () =>
   process.env.TIANGONG_LCA_API_BASE_URL = testEnv.TIANGONG_LCA_API_BASE_URL;
   process.env.TIANGONG_LCA_API_KEY = testEnv.TIANGONG_LCA_API_KEY;
   process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY = testEnv.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
+  process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY = testEnv.TIANGONG_LCA_SESSION_MEMORY_ONLY;
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     if (isSupabaseAuthTokenUrl(String(input))) {
       return makeSupabaseAuthResponse();
@@ -227,6 +229,11 @@ test('runProcessList can fall back to process.env and global fetch', async () =>
       delete process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY;
     } else {
       process.env.TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY = originalPublishableKey;
+    }
+    if (originalSessionMemoryOnly === undefined) {
+      delete process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY;
+    } else {
+      process.env.TIANGONG_LCA_SESSION_MEMORY_ONLY = originalSessionMemoryOnly;
     }
   }
 });


### PR DESCRIPTION
Closes #75

## Summary
- default buildSupabaseTestEnv to memory-only sessions so remote fallback tests stop writing shared session cache files in CI
- propagate TIANGONG_LCA_SESSION_MEMORY_ONLY into the tests that mirror remote env vars onto process.env directly

## Key Decisions
- keep the fix test-only; do not change CLI runtime session persistence defaults

## Validation
- npm test -- --test test/flow-get.test.ts test/flow-list.test.ts test/process-get.test.ts test/process-list.test.ts test/flow-publish-version.test.ts test/lifecyclemodel-resulting-process.test.ts
- npm run lint && npm run test:coverage && npm run test:coverage:assert-full

## Workspace Integration
- No extra lca-workspace integration step is needed beyond the later root submodule bump for the already merged CLI work.