### PR TITLE
chore: release cli 0.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/cli",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.101.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Unified TianGong LCA CLI with direct REST adapters and low-entropy command surface.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #77

## Summary
- bump @tiangong-lca/cli from 0.0.4 to 0.0.5
- ship the merged fixes from PRs #72, #74, and #76 through the repository's normal trusted-publishing path

## Key Decisions
- keep release mechanics on the existing main -> cli-vX.Y.Z tag -> npm publish workflow instead of running an ad hoc local publish

## Validation
- npm run prepush:gate
- node ./scripts/ci/release-version.cjs assert-unpublished

## Follow-ups
- after merge, verify Tag Release From Merge creates cli-v0.0.5 and Publish Package publishes npm latest=0.0.5