### PR TITLE
fix: align lifecyclemodel publish with bundle save

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -962,6 +962,7 @@ This command:
   - collects native lifecyclemodel json_ordered payloads from one local build run
   - writes publish-bundle.json, publish-request.json, and publish-intent.json
   - keeps actual dry-run / commit execution in tiangong publish run
+  - routes lifecyclemodel commit through save_lifecycle_model_bundle internally
 `.trim();
 }
 

--- a/src/lib/lifecyclemodel-bundle-save.ts
+++ b/src/lib/lifecyclemodel-bundle-save.ts
@@ -1,0 +1,625 @@
+import { CliError } from './errors.js';
+import type { FetchLike } from './http.js';
+import {
+  buildSupabaseAuthHeaders,
+  createSupabaseDataClient,
+  deriveSupabaseFunctionsBaseUrl,
+  requireSupabaseRestRuntime,
+  runSupabaseArrayQuery,
+} from './supabase-client.js';
+import { createSupabaseDataRuntime } from './supabase-session.js';
+
+type JsonObject = Record<string, unknown>;
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_NODE_WIDTH = 350;
+const DEFAULT_NODE_HEIGHT = 120;
+const DEFAULT_NODE_GAP_X = 420;
+const DEFAULT_NODE_GAP_Y = 180;
+
+export type LifecyclemodelPublishMetadata = {
+  json_tg?: JsonObject;
+  processMutations?: JsonObject[];
+  ruleVerification?: boolean;
+};
+
+type LifecyclemodelVisibleRow = {
+  id: string;
+  version: string;
+};
+
+type LifecyclemodelBundlePlan = {
+  mode: 'create' | 'update';
+  modelId: string;
+  version?: string;
+  parent: {
+    jsonOrdered: JsonObject;
+    jsonTg: JsonObject;
+    ruleVerification?: boolean;
+  };
+  processMutations: JsonObject[];
+};
+
+export type LifecyclemodelBundleWriteResult = {
+  status: 'success';
+  operation: 'create' | 'update' | 'update_after_create_conflict';
+  mode: 'create' | 'update';
+  transport: 'save_lifecycle_model_bundle';
+  response: JsonObject;
+};
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function ensureList<T = unknown>(value: unknown): T[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  return Array.isArray(value) ? (value as T[]) : ([value] as T[]);
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function trimToken(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function firstNonEmpty(...values: unknown[]): string | null {
+  for (const value of values) {
+    const trimmed = trimToken(value);
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return null;
+}
+
+function lifecyclemodelRoot(payload: JsonObject): JsonObject {
+  return isRecord(payload.lifeCycleModelDataSet) ? payload.lifeCycleModelDataSet : payload;
+}
+
+function dataSetInformation(root: JsonObject): JsonObject {
+  const info = isRecord(root.lifeCycleModelInformation) ? root.lifeCycleModelInformation : {};
+  return isRecord(info.dataSetInformation) ? info.dataSetInformation : {};
+}
+
+function technology(root: JsonObject): JsonObject {
+  const info = isRecord(root.lifeCycleModelInformation) ? root.lifeCycleModelInformation : {};
+  return isRecord(info.technology) ? info.technology : {};
+}
+
+function processesBlock(root: JsonObject): JsonObject {
+  const tech = technology(root);
+  return isRecord(tech.processes) ? tech.processes : {};
+}
+
+function extractProcessInstances(payload: JsonObject): JsonObject[] {
+  return ensureList<JsonObject>(processesBlock(lifecyclemodelRoot(payload)).processInstance).filter(
+    isRecord,
+  );
+}
+
+function outputConnections(instance: JsonObject): JsonObject[] {
+  const connections = isRecord(instance.connections) ? instance.connections : {};
+  return ensureList<JsonObject>(connections.outputExchange).filter(isRecord);
+}
+
+function matchingResultingProcessType(
+  instance: JsonObject,
+  payload: JsonObject,
+): 'primary' | 'secondary' {
+  const ref = isRecord(instance.referenceToProcess) ? instance.referenceToProcess : {};
+  const resulting = isRecord(
+    dataSetInformation(lifecyclemodelRoot(payload)).referenceToResultingProcess,
+  )
+    ? (dataSetInformation(lifecyclemodelRoot(payload)).referenceToResultingProcess as JsonObject)
+    : {};
+  const processId = trimToken(ref['@refObjectId']);
+  const processVersion = trimToken(ref['@version']);
+  const resultingId = trimToken(resulting['@refObjectId']);
+  const resultingVersion = trimToken(resulting['@version']);
+
+  if (
+    processId &&
+    processId === resultingId &&
+    (!resultingVersion || processVersion === resultingVersion)
+  ) {
+    return 'primary';
+  }
+
+  return 'secondary';
+}
+
+function displayName(reference: JsonObject): unknown {
+  if (reference.name !== undefined) {
+    return cloneJson(reference.name);
+  }
+
+  if (reference['common:shortDescription'] !== undefined) {
+    return cloneJson(reference['common:shortDescription']);
+  }
+
+  return undefined;
+}
+
+function deriveSubmodels(payload: JsonObject): JsonObject[] {
+  const submodels: Array<JsonObject | null> = extractProcessInstances(payload).map(
+    (instance, index) => {
+      const reference = isRecord(instance.referenceToProcess) ? instance.referenceToProcess : {};
+      const id = trimToken(reference['@refObjectId']);
+      if (!id) {
+        return null;
+      }
+
+      const version = trimToken(reference['@version']);
+      return {
+        id,
+        ...(version ? { version } : {}),
+        type: matchingResultingProcessType(instance, payload),
+        ...(displayName(reference) !== undefined ? { name: displayName(reference) } : {}),
+        instanceId: firstNonEmpty(instance['@dataSetInternalID'], `instance-${index + 1}`),
+      };
+    },
+  );
+
+  return submodels.filter((value): value is JsonObject => value !== null);
+}
+
+function buildNodeLabel(reference: JsonObject, fallback: string): unknown {
+  return displayName(reference) ?? fallback;
+}
+
+function deriveXflowNodes(payload: JsonObject): JsonObject[] {
+  const instances = extractProcessInstances(payload);
+  const columnCount = Math.max(1, Math.ceil(Math.sqrt(Math.max(instances.length, 1))));
+
+  return instances.map((instance, index) => {
+    const reference = isRecord(instance.referenceToProcess) ? instance.referenceToProcess : {};
+    const internalId = firstNonEmpty(instance['@dataSetInternalID'], `node-${index + 1}`)!;
+    const processId = firstNonEmpty(reference['@refObjectId'], `process-${index + 1}`)!;
+    const version = trimToken(reference['@version']);
+    const x = (index % columnCount) * DEFAULT_NODE_GAP_X;
+    const y = Math.floor(index / columnCount) * DEFAULT_NODE_GAP_Y;
+
+    return {
+      id: internalId,
+      x,
+      y,
+      width: DEFAULT_NODE_WIDTH,
+      height: DEFAULT_NODE_HEIGHT,
+      data: {
+        id: processId,
+        ...(version ? { version } : {}),
+        label: buildNodeLabel(reference, processId),
+        shortDescription: cloneJson(reference['common:shortDescription'] ?? []),
+      },
+    };
+  });
+}
+
+function deriveXflowEdges(payload: JsonObject): JsonObject[] {
+  const instances = extractProcessInstances(payload);
+  const nodeByInternalId = new Map<string, { processId: string; version: string | null }>(
+    instances.map((instance, index) => {
+      const reference = isRecord(instance.referenceToProcess) ? instance.referenceToProcess : {};
+      return [
+        firstNonEmpty(instance['@dataSetInternalID'], `node-${index + 1}`)!,
+        {
+          processId: firstNonEmpty(reference['@refObjectId'], `process-${index + 1}`)!,
+          version: trimToken(reference['@version']),
+        },
+      ];
+    }),
+  );
+
+  let edgeIndex = 0;
+  const edges: JsonObject[] = [];
+
+  instances.forEach((instance, index) => {
+    const sourceCell = firstNonEmpty(instance['@dataSetInternalID'], `node-${index + 1}`)!;
+    const sourceNode = nodeByInternalId.get(sourceCell)!;
+
+    outputConnections(instance).forEach((outputExchange) => {
+      const flowUuid = trimToken(outputExchange['@flowUUID']);
+      const downstreamProcesses = ensureList<JsonObject>(outputExchange.downstreamProcess).filter(
+        isRecord,
+      );
+
+      downstreamProcesses.forEach((downstreamProcess) => {
+        const targetCell = trimToken(downstreamProcess['@id']);
+        if (!targetCell) {
+          return;
+        }
+
+        const targetNode = nodeByInternalId.get(targetCell) ?? { processId: null, version: null };
+        edgeIndex += 1;
+        edges.push({
+          id: [sourceCell, targetCell, flowUuid ?? `edge-${edgeIndex}`].join(':'),
+          source: {
+            cell: sourceCell,
+          },
+          target: {
+            cell: targetCell,
+          },
+          labels: [],
+          data: {
+            connection: {
+              outputExchange: {
+                ...(flowUuid ? { '@flowUUID': flowUuid } : {}),
+                downstreamProcess: cloneJson(downstreamProcess),
+              },
+            },
+            node: {
+              sourceNodeID: sourceCell,
+              targetNodeID: targetCell,
+              sourceProcessId: sourceNode.processId,
+              ...(sourceNode.version ? { sourceProcessVersion: sourceNode.version } : {}),
+              ...(targetNode.processId ? { targetProcessId: targetNode.processId } : {}),
+              ...(targetNode.version ? { targetProcessVersion: targetNode.version } : {}),
+            },
+          },
+        });
+      });
+    });
+  });
+
+  return edges;
+}
+
+export function deriveLifecyclemodelJsonTg(payload: JsonObject): JsonObject {
+  return {
+    xflow: {
+      nodes: deriveXflowNodes(payload),
+      edges: deriveXflowEdges(payload),
+    },
+    submodels: deriveSubmodels(payload),
+  };
+}
+
+function mergeLifecyclemodelJsonTg(explicit: JsonObject | null, derived: JsonObject): JsonObject {
+  if (!explicit) {
+    return derived;
+  }
+
+  const derivedXflow = isRecord(derived.xflow) ? derived.xflow : {};
+  const explicitXflow = isRecord(explicit.xflow) ? explicit.xflow : null;
+
+  return {
+    ...derived,
+    ...cloneJson(explicit),
+    xflow: explicitXflow
+      ? {
+          ...cloneJson(derivedXflow),
+          ...cloneJson(explicitXflow),
+          nodes: Array.isArray(explicitXflow.nodes)
+            ? cloneJson(explicitXflow.nodes)
+            : derivedXflow.nodes,
+          edges: Array.isArray(explicitXflow.edges)
+            ? cloneJson(explicitXflow.edges)
+            : derivedXflow.edges,
+        }
+      : derived.xflow,
+    submodels: Array.isArray(explicit.submodels)
+      ? cloneJson(explicit.submodels)
+      : derived.submodels,
+  };
+}
+
+function normalizeProcessMutations(value: unknown): JsonObject[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+
+  const mutations = ensureList<JsonObject>(value);
+  if (!mutations.every(isRecord)) {
+    throw new CliError(
+      'Lifecyclemodel publish metadata expected processMutations to contain JSON objects.',
+      {
+        code: 'LIFECYCLEMODEL_PROCESS_MUTATIONS_INVALID',
+        exitCode: 2,
+        details: value,
+      },
+    );
+  }
+
+  return cloneJson(mutations);
+}
+
+export function buildLifecyclemodelBundlePlan(options: {
+  id: string;
+  version: string;
+  payload: JsonObject;
+  metadata?: LifecyclemodelPublishMetadata | null;
+  mode: 'create' | 'update';
+}): LifecyclemodelBundlePlan {
+  const explicitJsonTg = isRecord(options.metadata?.json_tg) ? options.metadata?.json_tg : null;
+  const derivedJsonTg = deriveLifecyclemodelJsonTg(options.payload);
+
+  return {
+    mode: options.mode,
+    modelId: options.id,
+    ...(options.mode === 'update' ? { version: options.version } : {}),
+    parent: {
+      jsonOrdered: cloneJson(options.payload),
+      jsonTg: mergeLifecyclemodelJsonTg(explicitJsonTg, derivedJsonTg),
+      ...(typeof options.metadata?.ruleVerification === 'boolean'
+        ? { ruleVerification: options.metadata.ruleVerification }
+        : {}),
+    },
+    processMutations: normalizeProcessMutations(options.metadata?.processMutations),
+  };
+}
+
+function buildVisibleRowsUrl(restBaseUrl: string, id: string, version: string): string {
+  const url = new URL(`${restBaseUrl.replace(/\/+$/u, '')}/lifecyclemodels`);
+  url.searchParams.set('select', 'id,version');
+  url.searchParams.set('id', `eq.${id}`);
+  url.searchParams.set('version', `eq.${version}`);
+  return url.toString();
+}
+
+function parseVisibleRows(payload: unknown, url: string): LifecyclemodelVisibleRow[] {
+  if (!Array.isArray(payload)) {
+    throw new CliError(`Supabase REST response was not a JSON array for ${url}`, {
+      code: 'SUPABASE_REST_RESPONSE_INVALID',
+      exitCode: 1,
+      details: payload,
+    });
+  }
+
+  return payload.map((item, index) => {
+    if (!isRecord(item)) {
+      throw new CliError(`Supabase REST row ${index} was not a JSON object for ${url}`, {
+        code: 'SUPABASE_REST_RESPONSE_INVALID',
+        exitCode: 1,
+        details: item,
+      });
+    }
+
+    return {
+      id: trimToken(item.id) ?? '',
+      version: trimToken(item.version) ?? '',
+    };
+  });
+}
+
+async function exactVisibleRows(options: {
+  id: string;
+  version: string;
+  env: NodeJS.ProcessEnv;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+}): Promise<LifecyclemodelVisibleRow[]> {
+  const runtime = createSupabaseDataRuntime({
+    runtime: requireSupabaseRestRuntime(options.env),
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.timeoutMs,
+  });
+  const { client, restBaseUrl } = createSupabaseDataClient(
+    runtime,
+    options.fetchImpl,
+    options.timeoutMs,
+  );
+  const url = buildVisibleRowsUrl(restBaseUrl, options.id, options.version);
+  const payload = await runSupabaseArrayQuery(
+    client
+      .from('lifecyclemodels')
+      .select('id,version')
+      .eq('id', options.id)
+      .eq('version', options.version),
+    url,
+  );
+
+  return parseVisibleRows(payload, url);
+}
+
+function parseLifecyclemodelBundleJson(rawText: string, url: string): unknown {
+  try {
+    return JSON.parse(rawText);
+  } catch (error) {
+    throw new CliError(`Remote response was not valid JSON for ${url}`, {
+      code: 'REMOTE_INVALID_JSON',
+      exitCode: 1,
+      details: String(error),
+    });
+  }
+}
+
+function requireLifecyclemodelBundleResponse(payload: unknown, url: string): JsonObject {
+  if (!isRecord(payload)) {
+    throw new CliError(`Lifecyclemodel bundle endpoint returned an unexpected payload for ${url}`, {
+      code: 'REMOTE_RESPONSE_INVALID',
+      exitCode: 1,
+      details: payload,
+    });
+  }
+
+  if (payload.ok === false) {
+    const code = trimToken(payload.code) ?? 'REMOTE_APPLICATION_ERROR';
+    const message =
+      trimToken(payload.message) ?? `Remote application response returned ok:false for ${url}`;
+    throw new CliError(message, {
+      code,
+      exitCode: 1,
+      details: payload.details ?? payload,
+    });
+  }
+
+  return payload;
+}
+
+function throwLifecyclemodelBundleHttpError(
+  status: number,
+  payload: unknown,
+  rawText: string,
+  url: string,
+): never {
+  if (isRecord(payload)) {
+    const code = trimToken(payload.code);
+    const message = trimToken(payload.message);
+    if (code && message) {
+      throw new CliError(message, {
+        code,
+        exitCode: 1,
+        details: payload.details ?? payload,
+      });
+    }
+  }
+
+  throw new CliError(`HTTP ${status} returned from ${url}`, {
+    code: 'REMOTE_REQUEST_FAILED',
+    exitCode: 1,
+    details: rawText,
+  });
+}
+
+async function invokeSaveLifecyclemodelBundle(options: {
+  plan: LifecyclemodelBundlePlan;
+  env: NodeJS.ProcessEnv;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+}): Promise<JsonObject> {
+  const runtime = createSupabaseDataRuntime({
+    runtime: requireSupabaseRestRuntime(options.env),
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.timeoutMs,
+  });
+  const accessToken = await runtime.getAccessToken();
+  const url = `${deriveSupabaseFunctionsBaseUrl(runtime.apiBaseUrl)}/save_lifecycle_model_bundle`;
+  const response = await options.fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      ...buildSupabaseAuthHeaders(runtime.publishableKey, accessToken),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(options.plan),
+    signal: AbortSignal.timeout(options.timeoutMs),
+  });
+  const rawText = await response.text();
+  const contentType = response.headers.get('content-type') ?? '';
+  const payload =
+    contentType.includes('application/json') && rawText.length > 0
+      ? parseLifecyclemodelBundleJson(rawText, url)
+      : rawText;
+
+  if (!response.ok) {
+    throwLifecyclemodelBundleHttpError(response.status, payload, rawText, url);
+  }
+
+  return requireLifecyclemodelBundleResponse(payload, url);
+}
+
+export async function syncLifecyclemodelBundleRecord(options: {
+  id: string;
+  version: string;
+  payload: JsonObject;
+  metadata?: LifecyclemodelPublishMetadata | null;
+  env: NodeJS.ProcessEnv;
+  fetchImpl: FetchLike;
+  timeoutMs?: number;
+}): Promise<LifecyclemodelBundleWriteResult> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const visibleRows = await exactVisibleRows({
+    id: options.id,
+    version: options.version,
+    env: options.env,
+    fetchImpl: options.fetchImpl,
+    timeoutMs,
+  });
+
+  if (visibleRows.length > 0) {
+    return {
+      status: 'success',
+      operation: 'update',
+      mode: 'update',
+      transport: 'save_lifecycle_model_bundle',
+      response: await invokeSaveLifecyclemodelBundle({
+        plan: buildLifecyclemodelBundlePlan({
+          id: options.id,
+          version: options.version,
+          payload: options.payload,
+          metadata: options.metadata,
+          mode: 'update',
+        }),
+        env: options.env,
+        fetchImpl: options.fetchImpl,
+        timeoutMs,
+      }),
+    };
+  }
+
+  try {
+    return {
+      status: 'success',
+      operation: 'create',
+      mode: 'create',
+      transport: 'save_lifecycle_model_bundle',
+      response: await invokeSaveLifecyclemodelBundle({
+        plan: buildLifecyclemodelBundlePlan({
+          id: options.id,
+          version: options.version,
+          payload: options.payload,
+          metadata: options.metadata,
+          mode: 'create',
+        }),
+        env: options.env,
+        fetchImpl: options.fetchImpl,
+        timeoutMs,
+      }),
+    };
+  } catch (error) {
+    if (!(error instanceof CliError) || error.code !== 'VERSION_CONFLICT') {
+      throw error;
+    }
+
+    const visibleAfterConflict = await exactVisibleRows({
+      id: options.id,
+      version: options.version,
+      env: options.env,
+      fetchImpl: options.fetchImpl,
+      timeoutMs,
+    });
+    if (visibleAfterConflict.length === 0) {
+      throw error;
+    }
+
+    return {
+      status: 'success',
+      operation: 'update_after_create_conflict',
+      mode: 'update',
+      transport: 'save_lifecycle_model_bundle',
+      response: await invokeSaveLifecyclemodelBundle({
+        plan: buildLifecyclemodelBundlePlan({
+          id: options.id,
+          version: options.version,
+          payload: options.payload,
+          metadata: options.metadata,
+          mode: 'update',
+        }),
+        env: options.env,
+        fetchImpl: options.fetchImpl,
+        timeoutMs,
+      }),
+    };
+  }
+}
+
+export const __testInternals = {
+  buildLifecyclemodelBundlePlan,
+  deriveLifecyclemodelJsonTg,
+  exactVisibleRows,
+  firstNonEmpty,
+  matchingResultingProcessType,
+  mergeLifecyclemodelJsonTg,
+  parseVisibleRows,
+  requireLifecyclemodelBundleResponse,
+  trimToken,
+};

--- a/src/lib/lifecyclemodel-publish-build.ts
+++ b/src/lib/lifecyclemodel-publish-build.ts
@@ -314,6 +314,7 @@ function buildPublishIntent(
   return {
     ok: true,
     command: 'publish run',
+    lifecyclemodel_transport: 'save_lifecycle_model_bundle',
     input_path: layout.publishRequestPath,
     run_id: layout.runId,
     run_root: layout.runRoot,
@@ -355,7 +356,7 @@ function buildNextActions(layout: LifecyclemodelPublishBuildLayout): string[] {
   return [
     `inspect: ${layout.publishBundlePath}`,
     `inspect: ${layout.publishRequestPath}`,
-    `run: tiangong publish run --input ${layout.publishRequestPath}`,
+    `run: tiangong publish run --input ${layout.publishRequestPath}  # lifecyclemodels commit through save_lifecycle_model_bundle`,
   ];
 }
 
@@ -379,6 +380,7 @@ export async function runLifecyclemodelPublishBuild(
     run_id: layout.runId,
     run_root: layout.runRoot,
     status: 'prepared_local_lifecyclemodel_publish_bundle' as const,
+    lifecyclemodel_transport: 'save_lifecycle_model_bundle' as const,
     source_run: {
       run_manifest: copyJson(runManifest),
     },

--- a/src/lib/publish.ts
+++ b/src/lib/publish.ts
@@ -3,6 +3,10 @@ import { CliError } from './errors.js';
 import { writeJsonArtifact } from './artifacts.js';
 import type { FetchLike } from './http.js';
 import { readJsonInput } from './io.js';
+import {
+  syncLifecyclemodelBundleRecord,
+  type LifecyclemodelPublishMetadata,
+} from './lifecyclemodel-bundle-save.js';
 import { syncStateAwareProcessRecord } from './process-save-draft.js';
 import { buildRunId, resolveRunLayout } from './run.js';
 import {
@@ -188,6 +192,7 @@ export type DatasetPublishExecutorArgs = {
   id: string;
   version: string;
   payload: JsonObject;
+  metadata?: LifecyclemodelPublishMetadata | null;
   source: 'bundle' | 'input';
   bundle_path: string | null;
   publish: PublishRequest['publish'];
@@ -307,6 +312,11 @@ type PublishRequestOptions = {
   publish: PublishRequest['publish'];
 };
 
+type LoadedLifecyclemodelPublishEntry = {
+  payload: JsonObject;
+  metadata: LifecyclemodelPublishMetadata | null;
+};
+
 function extract_lifecyclemodel_identity(payload: JsonObject): [string, string] {
   const root = isRecord(payload.lifeCycleModelDataSet) ? payload.lifeCycleModelDataSet : payload;
   const lifeCycleModelInformation = isRecord(root.lifeCycleModelInformation)
@@ -393,13 +403,21 @@ function extract_source_identity(payload: JsonObject): [string, string] {
 }
 
 function load_dataset_entry(entry: PublishDatasetEntry, baseDir: string): JsonObject {
-  if (isRecord(entry)) {
+  const source = load_dataset_entry_source(entry, baseDir);
+  if (isRecord(source)) {
     for (const key of ['json_ordered', 'jsonOrdered', 'payload'] as const) {
-      const candidate = entry[key];
+      const candidate = source[key];
       if (isRecord(candidate)) {
         return candidate;
       }
     }
+  }
+
+  return source;
+}
+
+function load_dataset_entry_source(entry: PublishDatasetEntry, baseDir: string): JsonObject {
+  if (isRecord(entry)) {
     const fileValue = first_non_empty(entry.file, entry.path);
     if (fileValue) {
       return load_json_object(resolve_path(baseDir, fileValue));
@@ -416,6 +434,43 @@ function load_dataset_entry(entry: PublishDatasetEntry, baseDir: string): JsonOb
     exitCode: 2,
     details: entry,
   });
+}
+
+function load_lifecyclemodel_publish_entry(
+  entry: PublishDatasetEntry,
+  baseDir: string,
+): LoadedLifecyclemodelPublishEntry {
+  const source = load_dataset_entry_source(entry, baseDir);
+  const payload = load_dataset_entry(entry, baseDir);
+  const metadata: LifecyclemodelPublishMetadata = {};
+  const jsonTg = isRecord(source.json_tg)
+    ? source.json_tg
+    : isRecord(source.jsonTg)
+      ? source.jsonTg
+      : null;
+  if (jsonTg) {
+    metadata.json_tg = jsonTg;
+  }
+
+  const processMutations = source.processMutations ?? source.process_mutations;
+  if (Array.isArray(processMutations)) {
+    metadata.processMutations = processMutations as JsonObject[];
+  }
+
+  const ruleVerification =
+    typeof source.ruleVerification === 'boolean'
+      ? source.ruleVerification
+      : typeof source.rule_verification === 'boolean'
+        ? source.rule_verification
+        : undefined;
+  if (typeof ruleVerification === 'boolean') {
+    metadata.ruleVerification = ruleVerification;
+  }
+
+  return {
+    payload,
+    metadata: Object.keys(metadata).length > 0 ? metadata : null,
+  };
 }
 
 function push_collected_entries<T>(
@@ -576,6 +631,7 @@ async function maybe_execute_dataset(
   payload: JsonObject,
   options: PublishRequestOptions & {
     table: 'lifecyclemodels' | 'processes' | 'sources';
+    metadata?: LifecyclemodelPublishMetadata | null;
   },
 ): Promise<PublishDatasetReport> {
   if (!options.commit) {
@@ -593,6 +649,7 @@ async function maybe_execute_dataset(
       id: report.id,
       version: report.version,
       payload,
+      metadata: options.metadata,
       source: report.source,
       bundle_path: report.bundle_path,
       publish: options.publish,
@@ -612,7 +669,8 @@ async function publish_lifecyclemodels(
 ): Promise<PublishDatasetReport[]> {
   const reports: PublishDatasetReport[] = [];
   for (const item of entries) {
-    const payload = load_dataset_entry(item.entry, item.origin.base_dir);
+    const loaded = load_lifecyclemodel_publish_entry(item.entry, item.origin.base_dir);
+    const payload = loaded.payload;
     const [datasetId, version] = extract_lifecyclemodel_identity(payload);
     const report: PreparedPublishDatasetReport = {
       table: 'lifecyclemodels',
@@ -627,6 +685,7 @@ async function publish_lifecyclemodels(
         ...options,
         table: 'lifecyclemodels',
         executor: options.executor,
+        metadata: loaded.metadata,
       }),
     );
   }
@@ -800,6 +859,18 @@ function build_default_dataset_executor(options: {
           source: args.source,
           bundle_path: args.bundle_path,
         },
+      });
+    }
+
+    if (options.table === 'lifecyclemodels') {
+      return syncLifecyclemodelBundleRecord({
+        id: args.id,
+        version: args.version,
+        payload: args.payload,
+        metadata: args.metadata ?? null,
+        env: options.env,
+        fetchImpl: options.fetchImpl,
+        timeoutMs: options.timeoutMs,
       });
     }
 

--- a/test/lifecyclemodel-bundle-save.test.ts
+++ b/test/lifecyclemodel-bundle-save.test.ts
@@ -1,0 +1,960 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { CliError } from '../src/lib/errors.js';
+import type { FetchLike } from '../src/lib/http.js';
+import {
+  __testInternals,
+  syncLifecyclemodelBundleRecord,
+} from '../src/lib/lifecyclemodel-bundle-save.js';
+import {
+  buildSupabaseTestEnv,
+  isSupabaseAuthTokenUrl,
+  makeSupabaseAuthResponse,
+} from './helpers/supabase-auth.js';
+
+function makeResponse(options: {
+  ok: boolean;
+  status: number;
+  contentType?: string;
+  body?: string;
+}) {
+  return {
+    ok: options.ok,
+    status: options.status,
+    headers: {
+      get(name: string): string | null {
+        return name.toLowerCase() === 'content-type'
+          ? (options.contentType ?? 'application/json')
+          : null;
+      },
+    },
+    async text(): Promise<string> {
+      return options.body ?? '';
+    },
+  };
+}
+
+function withSupabaseAuthBootstrap(fetchImpl: FetchLike): FetchLike {
+  return async (url, init) => {
+    if (isSupabaseAuthTokenUrl(String(url))) {
+      return makeSupabaseAuthResponse();
+    }
+
+    return fetchImpl(String(url), init);
+  };
+}
+
+function createLifecyclemodelPayload(): Record<string, unknown> {
+  return {
+    lifeCycleModelDataSet: {
+      lifeCycleModelInformation: {
+        dataSetInformation: {
+          'common:UUID': 'lm-1',
+          referenceToResultingProcess: {
+            '@refObjectId': 'proc-primary',
+            '@version': '01.01.000',
+          },
+        },
+        technology: {
+          processes: {
+            processInstance: [
+              {
+                '@dataSetInternalID': '1',
+                referenceToProcess: {
+                  '@refObjectId': 'proc-primary',
+                  '@version': '01.01.000',
+                  name: {
+                    baseName: [{ '#text': 'Primary process' }],
+                  },
+                },
+                connections: {
+                  outputExchange: {
+                    '@flowUUID': 'flow-1',
+                    downstreamProcess: {
+                      '@id': '2',
+                      '@flowUUID': 'flow-1',
+                    },
+                  },
+                },
+              },
+              {
+                '@dataSetInternalID': '2',
+                referenceToProcess: {
+                  '@refObjectId': 'proc-secondary',
+                  '@version': '01.01.000',
+                  'common:shortDescription': [{ '#text': 'Secondary process' }],
+                },
+              },
+            ],
+          },
+        },
+      },
+      administrativeInformation: {
+        publicationAndOwnership: {
+          'common:dataSetVersion': '01.01.000',
+        },
+      },
+    },
+  };
+}
+
+test('deriveLifecyclemodelJsonTg builds xflow and submodels from json_ordered payloads', () => {
+  const jsonTg = __testInternals.deriveLifecyclemodelJsonTg(createLifecyclemodelPayload());
+
+  assert.equal((jsonTg.submodels as Array<Record<string, unknown>>).length, 2);
+  assert.deepEqual((jsonTg.submodels as Array<Record<string, unknown>>)[0], {
+    id: 'proc-primary',
+    version: '01.01.000',
+    type: 'primary',
+    name: {
+      baseName: [{ '#text': 'Primary process' }],
+    },
+    instanceId: '1',
+  });
+  assert.equal((jsonTg.xflow as Record<string, unknown>).nodes instanceof Array, true);
+  assert.equal(((jsonTg.xflow as Record<string, unknown>).nodes as unknown[]).length, 2);
+  assert.deepEqual(
+    ((jsonTg.xflow as Record<string, unknown>).edges as Array<Record<string, unknown>>)[0],
+    {
+      id: '1:2:flow-1',
+      source: {
+        cell: '1',
+      },
+      target: {
+        cell: '2',
+      },
+      labels: [],
+      data: {
+        connection: {
+          outputExchange: {
+            '@flowUUID': 'flow-1',
+            downstreamProcess: {
+              '@id': '2',
+              '@flowUUID': 'flow-1',
+            },
+          },
+        },
+        node: {
+          sourceNodeID: '1',
+          targetNodeID: '2',
+          sourceProcessId: 'proc-primary',
+          sourceProcessVersion: '01.01.000',
+          targetProcessId: 'proc-secondary',
+          targetProcessVersion: '01.01.000',
+        },
+      },
+    },
+  );
+});
+
+test('deriveLifecyclemodelJsonTg skips invalid submodels and dangling downstream references', () => {
+  const payload = createLifecyclemodelPayload();
+  const processInstances = (
+    (payload.lifeCycleModelDataSet as Record<string, unknown>).lifeCycleModelInformation as Record<
+      string,
+      unknown
+    >
+  ).technology as Record<string, unknown>;
+  (
+    (
+      (processInstances.processes as Record<string, unknown>).processInstance as Record<
+        string,
+        unknown
+      >[]
+    )[0].connections as Record<string, unknown>
+  ).outputExchange = {
+    '@flowUUID': 'flow-dangling',
+    downstreamProcess: {
+      '@flowUUID': 'flow-dangling',
+    },
+  };
+  (
+    (processInstances.processes as Record<string, unknown>).processInstance as Record<
+      string,
+      unknown
+    >[]
+  ).push({
+    '@dataSetInternalID': '3',
+    referenceToProcess: {},
+  });
+
+  const jsonTg = __testInternals.deriveLifecyclemodelJsonTg(payload);
+  assert.equal((jsonTg.submodels as Array<Record<string, unknown>>).length, 2);
+  assert.equal(((jsonTg.xflow as Record<string, unknown>).edges as unknown[]).length, 0);
+});
+
+test('buildLifecyclemodelBundlePlan merges explicit metadata and validates processMutations', () => {
+  const payload = createLifecyclemodelPayload();
+  const plan = __testInternals.buildLifecyclemodelBundlePlan({
+    id: 'lm-1',
+    version: '01.01.000',
+    payload,
+    metadata: {
+      json_tg: {
+        xflow: {
+          nodes: [{ id: 'explicit-node' }],
+        },
+        preserved: true,
+      },
+      processMutations: [
+        {
+          op: 'create',
+          id: '11111111-1111-1111-1111-111111111111',
+          modelId: 'lm-1',
+          jsonOrdered: {
+            processDataSet: {},
+          },
+        },
+      ],
+      ruleVerification: false,
+    },
+    mode: 'update',
+  });
+
+  assert.equal(plan.mode, 'update');
+  assert.equal(plan.version, '01.01.000');
+  assert.equal(plan.parent.ruleVerification, false);
+  assert.deepEqual(plan.parent.jsonTg, {
+    xflow: {
+      nodes: [{ id: 'explicit-node' }],
+      edges: [
+        {
+          id: '1:2:flow-1',
+          source: {
+            cell: '1',
+          },
+          target: {
+            cell: '2',
+          },
+          labels: [],
+          data: {
+            connection: {
+              outputExchange: {
+                '@flowUUID': 'flow-1',
+                downstreamProcess: {
+                  '@id': '2',
+                  '@flowUUID': 'flow-1',
+                },
+              },
+            },
+            node: {
+              sourceNodeID: '1',
+              targetNodeID: '2',
+              sourceProcessId: 'proc-primary',
+              sourceProcessVersion: '01.01.000',
+              targetProcessId: 'proc-secondary',
+              targetProcessVersion: '01.01.000',
+            },
+          },
+        },
+      ],
+    },
+    submodels: [
+      {
+        id: 'proc-primary',
+        version: '01.01.000',
+        type: 'primary',
+        name: {
+          baseName: [{ '#text': 'Primary process' }],
+        },
+        instanceId: '1',
+      },
+      {
+        id: 'proc-secondary',
+        version: '01.01.000',
+        type: 'secondary',
+        name: [{ '#text': 'Secondary process' }],
+        instanceId: '2',
+      },
+    ],
+    preserved: true,
+  });
+  assert.equal(plan.processMutations.length, 1);
+
+  assert.throws(
+    () =>
+      __testInternals.buildLifecyclemodelBundlePlan({
+        id: 'lm-1',
+        version: '01.01.000',
+        payload,
+        metadata: {
+          processMutations: [0 as unknown as Record<string, unknown>],
+        },
+        mode: 'create',
+      }),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'LIFECYCLEMODEL_PROCESS_MUTATIONS_INVALID');
+      return true;
+    },
+  );
+});
+
+test('lifecyclemodel bundle helpers validate visible rows and function payloads', () => {
+  assert.throws(
+    () => __testInternals.parseVisibleRows({}, 'https://example.test/rest/v1/lifecyclemodels'),
+    /JSON array/u,
+  );
+  assert.throws(
+    () =>
+      __testInternals.parseVisibleRows(
+        [0],
+        'https://example.test/rest/v1/lifecyclemodels?id=eq.lm-1',
+      ),
+    /JSON object/u,
+  );
+  assert.throws(
+    () => __testInternals.requireLifecyclemodelBundleResponse([], 'https://example.test/function'),
+    /unexpected payload/u,
+  );
+  assert.throws(
+    () =>
+      __testInternals.requireLifecyclemodelBundleResponse(
+        {
+          ok: false,
+          code: 'INVALID_PAYLOAD',
+          message: 'bad request',
+        },
+        'https://example.test/function',
+      ),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'INVALID_PAYLOAD');
+      assert.match(error.message, /bad request/u);
+      return true;
+    },
+  );
+  assert.deepEqual(
+    __testInternals.mergeLifecyclemodelJsonTg(null, {
+      xflow: {
+        nodes: [],
+        edges: [],
+      },
+      submodels: [],
+    }),
+    {
+      xflow: {
+        nodes: [],
+        edges: [],
+      },
+      submodels: [],
+    },
+  );
+  assert.deepEqual(
+    __testInternals.mergeLifecyclemodelJsonTg(
+      {
+        submodels: [{ id: 'explicit-submodel' }],
+      },
+      {
+        xflow: {
+          nodes: [{ id: 'derived-node' }],
+          edges: [{ id: 'derived-edge' }],
+        },
+        submodels: [{ id: 'derived-submodel' }],
+      },
+    ),
+    {
+      xflow: {
+        nodes: [{ id: 'derived-node' }],
+        edges: [{ id: 'derived-edge' }],
+      },
+      submodels: [{ id: 'explicit-submodel' }],
+    },
+  );
+  assert.deepEqual(
+    __testInternals.mergeLifecyclemodelJsonTg(
+      {
+        xflow: {},
+      },
+      {
+        xflow: {
+          nodes: [{ id: 'derived-node' }],
+          edges: [{ id: 'derived-edge' }],
+        },
+        submodels: [],
+      },
+    ),
+    {
+      xflow: {
+        nodes: [{ id: 'derived-node' }],
+        edges: [{ id: 'derived-edge' }],
+      },
+      submodels: [],
+    },
+  );
+  assert.deepEqual(
+    __testInternals.mergeLifecyclemodelJsonTg(
+      {
+        xflow: {
+          nodes: 'ignored',
+          edges: [{ id: 'explicit-edge' }],
+        },
+      },
+      {
+        xflow: {
+          nodes: [{ id: 'derived-node' }],
+          edges: [{ id: 'derived-edge' }],
+        },
+        submodels: [],
+      },
+    ),
+    {
+      xflow: {
+        nodes: [{ id: 'derived-node' }],
+        edges: [{ id: 'explicit-edge' }],
+      },
+      submodels: [],
+    },
+  );
+  assert.deepEqual(
+    __testInternals.mergeLifecyclemodelJsonTg(
+      {
+        xflow: {
+          nodes: [{ id: 'explicit-node' }],
+          edges: [{ id: 'explicit-edge' }],
+        },
+      },
+      {
+        xflow: 'invalid' as unknown as Record<string, unknown>,
+        submodels: [],
+      },
+    ),
+    {
+      xflow: {
+        nodes: [{ id: 'explicit-node' }],
+        edges: [{ id: 'explicit-edge' }],
+      },
+      submodels: [],
+    },
+  );
+  assert.deepEqual(
+    __testInternals.parseVisibleRows(
+      [
+        {
+          id: '  ',
+          version: null,
+        },
+      ],
+      'https://example.test/rest/v1/lifecyclemodels?id=eq.lm-1',
+    ),
+    [
+      {
+        id: '',
+        version: '',
+      },
+    ],
+  );
+  assert.throws(
+    () =>
+      __testInternals.requireLifecyclemodelBundleResponse(
+        {
+          ok: false,
+        },
+        'https://example.test/function',
+      ),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'REMOTE_APPLICATION_ERROR');
+      assert.match(error.message, /ok:false/u);
+      return true;
+    },
+  );
+});
+
+test('lifecyclemodel bundle helpers fall back cleanly for sparse payloads', () => {
+  assert.deepEqual(__testInternals.deriveLifecyclemodelJsonTg({}), {
+    xflow: {
+      nodes: [],
+      edges: [],
+    },
+    submodels: [],
+  });
+
+  const sparsePayload = {
+    lifeCycleModelInformation: {
+      dataSetInformation: {
+        referenceToResultingProcess: 'not-a-record',
+      },
+      technology: {
+        processes: {
+          processInstance: [
+            {
+              '@dataSetInternalID': ' ',
+              referenceToProcess: 0,
+              connections: {
+                outputExchange: {
+                  '@flowUUID': ' ',
+                  downstreamProcess: {
+                    '@id': 'missing-node',
+                  },
+                },
+              },
+            },
+            {
+              referenceToProcess: {
+                '@refObjectId': 'proc-2',
+                '@version': ' ',
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+
+  const jsonTg = __testInternals.deriveLifecyclemodelJsonTg(sparsePayload);
+  assert.deepEqual(jsonTg.submodels, [
+    {
+      id: 'proc-2',
+      type: 'secondary',
+      instanceId: 'instance-2',
+    },
+  ]);
+  assert.deepEqual((jsonTg.xflow as Record<string, unknown>).nodes, [
+    {
+      id: 'node-1',
+      x: 0,
+      y: 0,
+      width: 350,
+      height: 120,
+      data: {
+        id: 'process-1',
+        label: 'process-1',
+        shortDescription: [],
+      },
+    },
+    {
+      id: 'node-2',
+      x: 420,
+      y: 0,
+      width: 350,
+      height: 120,
+      data: {
+        id: 'proc-2',
+        label: 'proc-2',
+        shortDescription: [],
+      },
+    },
+  ]);
+  assert.deepEqual((jsonTg.xflow as Record<string, unknown>).edges, [
+    {
+      id: 'node-1:missing-node:edge-1',
+      source: {
+        cell: 'node-1',
+      },
+      target: {
+        cell: 'missing-node',
+      },
+      labels: [],
+      data: {
+        connection: {
+          outputExchange: {
+            downstreamProcess: {
+              '@id': 'missing-node',
+            },
+          },
+        },
+        node: {
+          sourceNodeID: 'node-1',
+          targetNodeID: 'missing-node',
+          sourceProcessId: 'process-1',
+        },
+      },
+    },
+  ]);
+});
+
+test('lifecyclemodel bundle token and process matching helpers cover empty inputs', () => {
+  assert.equal(__testInternals.trimToken('  '), null);
+  assert.equal(__testInternals.firstNonEmpty(undefined, ' ', '\n'), null);
+  assert.equal(
+    __testInternals.matchingResultingProcessType(
+      {
+        referenceToProcess: 0 as unknown as Record<string, unknown>,
+      },
+      {},
+    ),
+    'secondary',
+  );
+  assert.equal(
+    __testInternals.matchingResultingProcessType(
+      {
+        referenceToProcess: 0 as unknown as Record<string, unknown>,
+      },
+      {
+        lifeCycleModelInformation: {
+          dataSetInformation: {
+            referenceToResultingProcess: {},
+          },
+        },
+      },
+    ),
+    'secondary',
+  );
+  assert.equal(
+    __testInternals.matchingResultingProcessType(
+      {
+        referenceToProcess: {
+          '@refObjectId': 'proc-primary',
+          '@version': '02.00.000',
+        },
+      },
+      {
+        lifeCycleModelInformation: {
+          dataSetInformation: {
+            referenceToResultingProcess: {
+              '@refObjectId': 'proc-primary',
+            },
+          },
+        },
+      },
+    ),
+    'primary',
+  );
+  assert.equal(
+    __testInternals.matchingResultingProcessType(
+      {
+        referenceToProcess: {
+          '@refObjectId': 'proc-secondary',
+        },
+      },
+      {
+        lifeCycleModelInformation: {
+          dataSetInformation: 0 as unknown as Record<string, unknown>,
+        },
+      },
+    ),
+    'secondary',
+  );
+});
+
+test('syncLifecyclemodelBundleRecord creates lifecyclemodels through save_lifecycle_model_bundle', async () => {
+  const observed: Array<{ method: string; url: string; body?: string }> = [];
+  const fetchImpl = withSupabaseAuthBootstrap(async (url, init) => {
+    observed.push({
+      method: String(init?.method ?? 'GET'),
+      url: String(url),
+      body: typeof init?.body === 'string' ? init.body : undefined,
+    });
+
+    if (observed.length === 1) {
+      return makeResponse({
+        ok: true,
+        status: 200,
+        body: '[]',
+      });
+    }
+
+    return makeResponse({
+      ok: true,
+      status: 200,
+      body: '{"ok":true,"modelId":"lm-1","version":"01.01.000"}',
+    });
+  });
+
+  const result = await syncLifecyclemodelBundleRecord({
+    id: 'lm-1',
+    version: '01.01.000',
+    payload: createLifecyclemodelPayload(),
+    env: buildSupabaseTestEnv({
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
+      TIANGONG_LCA_API_KEY: 'key',
+    }),
+    fetchImpl,
+  });
+
+  assert.equal(result.operation, 'create');
+  assert.equal(result.mode, 'create');
+  assert.equal(result.transport, 'save_lifecycle_model_bundle');
+  assert.deepEqual(
+    observed.map((item) => item.method),
+    ['GET', 'POST'],
+  );
+  assert.match(observed[0]?.url ?? '', /\/rest\/v1\/lifecyclemodels\?select=id%2Cversion/u);
+  assert.match(observed[1]?.url ?? '', /\/functions\/v1\/save_lifecycle_model_bundle$/u);
+  assert.match(observed[1]?.body ?? '', /"mode":"create"/u);
+  assert.match(observed[1]?.body ?? '', /"processMutations":\[\]/u);
+  assert.match(observed[1]?.body ?? '', /"jsonTg"/u);
+});
+
+test('syncLifecyclemodelBundleRecord updates existing lifecyclemodels and retries after VERSION_CONFLICT', async () => {
+  const updateObserved: Array<{ method: string; body?: string }> = [];
+  const updateFetch = withSupabaseAuthBootstrap(async (_url, init) => {
+    updateObserved.push({
+      method: String(init?.method ?? 'GET'),
+      body: typeof init?.body === 'string' ? init.body : undefined,
+    });
+
+    if (updateObserved.length === 1) {
+      return makeResponse({
+        ok: true,
+        status: 200,
+        body: '[{"id":"lm-1","version":"01.01.000"}]',
+      });
+    }
+
+    return makeResponse({
+      ok: true,
+      status: 200,
+      body: '{"ok":true,"modelId":"lm-1","version":"01.01.000"}',
+    });
+  });
+
+  const updateResult = await syncLifecyclemodelBundleRecord({
+    id: 'lm-1',
+    version: '01.01.000',
+    payload: createLifecyclemodelPayload(),
+    env: buildSupabaseTestEnv({
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+      TIANGONG_LCA_API_KEY: 'key',
+    }),
+    fetchImpl: updateFetch,
+  });
+
+  assert.equal(updateResult.operation, 'update');
+  assert.match(updateObserved[1]?.body ?? '', /"mode":"update"/u);
+  assert.match(updateObserved[1]?.body ?? '', /"version":"01.01.000"/u);
+
+  const conflictObserved: Array<{ method: string; body?: string }> = [];
+  const conflictFetch = withSupabaseAuthBootstrap(async (_url, init) => {
+    conflictObserved.push({
+      method: String(init?.method ?? 'GET'),
+      body: typeof init?.body === 'string' ? init.body : undefined,
+    });
+
+    if (conflictObserved.length === 1) {
+      return makeResponse({
+        ok: true,
+        status: 200,
+        body: '[]',
+      });
+    }
+
+    if (conflictObserved.length === 2) {
+      return makeResponse({
+        ok: false,
+        status: 409,
+        body: '{"code":"VERSION_CONFLICT","message":"duplicate version"}',
+      });
+    }
+
+    if (conflictObserved.length === 3) {
+      return makeResponse({
+        ok: true,
+        status: 200,
+        body: '[{"id":"lm-1","version":"01.01.000"}]',
+      });
+    }
+
+    return makeResponse({
+      ok: true,
+      status: 200,
+      body: '{"ok":true,"modelId":"lm-1","version":"01.01.000"}',
+    });
+  });
+
+  const conflictResult = await syncLifecyclemodelBundleRecord({
+    id: 'lm-1',
+    version: '01.01.000',
+    payload: createLifecyclemodelPayload(),
+    env: buildSupabaseTestEnv({
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/rest/v1',
+      TIANGONG_LCA_API_KEY: 'key',
+    }),
+    fetchImpl: conflictFetch,
+  });
+
+  assert.equal(conflictResult.operation, 'update_after_create_conflict');
+  assert.deepEqual(
+    conflictObserved.map((item) => item.method),
+    ['GET', 'POST', 'GET', 'POST'],
+  );
+  assert.match(conflictObserved[3]?.body ?? '', /"mode":"update"/u);
+});
+
+test('syncLifecyclemodelBundleRecord preserves structured errors and generic HTTP failures', async () => {
+  const structuredFetch = withSupabaseAuthBootstrap(async (_url) => {
+    if (_url.includes('/rest/v1/lifecyclemodels')) {
+      return makeResponse({
+        ok: true,
+        status: 200,
+        body: '[]',
+      });
+    }
+
+    return makeResponse({
+      ok: false,
+      status: 400,
+      body: '{"code":"FORBIDDEN","message":"not allowed","details":{"reason":"policy"}}',
+    });
+  });
+
+  await assert.rejects(
+    () =>
+      syncLifecyclemodelBundleRecord({
+        id: 'lm-1',
+        version: '01.01.000',
+        payload: createLifecyclemodelPayload(),
+        env: buildSupabaseTestEnv({
+          TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+          TIANGONG_LCA_API_KEY: 'key',
+        }),
+        fetchImpl: structuredFetch,
+      }),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'FORBIDDEN');
+      assert.equal(error.message, 'not allowed');
+      return true;
+    },
+  );
+
+  const textErrorFetch = withSupabaseAuthBootstrap(async (_url) => {
+    if (_url.includes('/rest/v1/lifecyclemodels')) {
+      return makeResponse({
+        ok: true,
+        status: 200,
+        body: '[]',
+      });
+    }
+
+    return makeResponse({
+      ok: false,
+      status: 500,
+      contentType: 'text/plain',
+      body: 'boom',
+    });
+  });
+
+  await assert.rejects(
+    () =>
+      syncLifecyclemodelBundleRecord({
+        id: 'lm-1',
+        version: '01.01.000',
+        payload: createLifecyclemodelPayload(),
+        env: buildSupabaseTestEnv({
+          TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+          TIANGONG_LCA_API_KEY: 'key',
+        }),
+        fetchImpl: textErrorFetch,
+      }),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'REMOTE_REQUEST_FAILED');
+      assert.match(error.message, /HTTP 500/u);
+      return true;
+    },
+  );
+
+  const conflictWithoutVisibleRowFetch = withSupabaseAuthBootstrap(async (_url) => {
+    if (_url.includes('/rest/v1/lifecyclemodels')) {
+      return makeResponse({
+        ok: true,
+        status: 200,
+        body: '[]',
+      });
+    }
+
+    return makeResponse({
+      ok: false,
+      status: 409,
+      body: '{"code":"VERSION_CONFLICT","message":"duplicate version"}',
+    });
+  });
+
+  await assert.rejects(
+    () =>
+      syncLifecyclemodelBundleRecord({
+        id: 'lm-1',
+        version: '01.01.000',
+        payload: createLifecyclemodelPayload(),
+        env: buildSupabaseTestEnv({
+          TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+          TIANGONG_LCA_API_KEY: 'key',
+        }),
+        fetchImpl: conflictWithoutVisibleRowFetch,
+      }),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'VERSION_CONFLICT');
+      return true;
+    },
+  );
+
+  const invalidJsonFetch = withSupabaseAuthBootstrap(async (_url) => {
+    if (_url.includes('/rest/v1/lifecyclemodels')) {
+      return makeResponse({
+        ok: true,
+        status: 200,
+        body: '[]',
+      });
+    }
+
+    return makeResponse({
+      ok: true,
+      status: 200,
+      body: '{',
+    });
+  });
+
+  await assert.rejects(
+    () =>
+      syncLifecyclemodelBundleRecord({
+        id: 'lm-1',
+        version: '01.01.000',
+        payload: createLifecyclemodelPayload(),
+        env: buildSupabaseTestEnv({
+          TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+          TIANGONG_LCA_API_KEY: 'key',
+        }),
+        fetchImpl: invalidJsonFetch,
+      }),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'REMOTE_INVALID_JSON');
+      return true;
+    },
+  );
+
+  const missingContentTypeFetch = withSupabaseAuthBootstrap(async (_url) => {
+    if (_url.includes('/rest/v1/lifecyclemodels')) {
+      return makeResponse({
+        ok: true,
+        status: 200,
+        body: '[]',
+      });
+    }
+
+    return {
+      ok: true,
+      status: 200,
+      headers: {
+        get(): string | null {
+          return null;
+        },
+      },
+      async text(): Promise<string> {
+        return 'plain-text-payload';
+      },
+    };
+  });
+
+  await assert.rejects(
+    () =>
+      syncLifecyclemodelBundleRecord({
+        id: 'lm-1',
+        version: '01.01.000',
+        payload: createLifecyclemodelPayload(),
+        env: buildSupabaseTestEnv({
+          TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+          TIANGONG_LCA_API_KEY: 'key',
+        }),
+        fetchImpl: missingContentTypeFetch,
+      }),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'REMOTE_RESPONSE_INVALID');
+      return true;
+    },
+  );
+});

--- a/test/lifecyclemodel-publish-build.test.ts
+++ b/test/lifecyclemodel-publish-build.test.ts
@@ -123,13 +123,16 @@ test('runLifecyclemodelPublishBuild writes lifecyclemodel publish handoff artifa
     const publishBundle = readJson<JsonRecord>(report.files.publish_bundle);
     assert.equal((publishBundle.lifecyclemodels as JsonRecord[]).length, 2);
     assert.equal((publishBundle.relations as JsonRecord[]).length, 0);
+    assert.equal(publishBundle.lifecyclemodel_transport, 'save_lifecycle_model_bundle');
     assert.equal((publishBundle.source_run as JsonRecord).run_manifest instanceof Object, true);
 
     const publishRequest = readJson<JsonRecord>(report.files.publish_request);
     assert.deepEqual((publishRequest.inputs as JsonRecord).bundle_paths, ['./publish-bundle.json']);
     const publishIntent = readJson<JsonRecord>(report.files.publish_intent);
     assert.equal(publishIntent.command, 'publish run');
+    assert.equal(publishIntent.lifecyclemodel_transport, 'save_lifecycle_model_bundle');
     assert.match(report.next_actions[2], /tiangong publish run/u);
+    assert.match(report.next_actions[2], /save_lifecycle_model_bundle/u);
 
     const invocationIndex = readJson<{ invocations: Array<Record<string, unknown>> }>(
       report.files.invocation_index,

--- a/test/publish.test.ts
+++ b/test/publish.test.ts
@@ -49,6 +49,38 @@ function makeSource(id: string): Record<string, unknown> {
   };
 }
 
+function makeLifecyclemodel(id: string): Record<string, unknown> {
+  return {
+    lifeCycleModelDataSet: {
+      lifeCycleModelInformation: {
+        dataSetInformation: {
+          'common:UUID': id,
+          referenceToResultingProcess: {
+            '@refObjectId': 'proc-result',
+            '@version': '01.01.000',
+          },
+        },
+        technology: {
+          processes: {
+            processInstance: {
+              '@dataSetInternalID': '1',
+              referenceToProcess: {
+                '@refObjectId': 'proc-result',
+                '@version': '01.01.000',
+              },
+            },
+          },
+        },
+      },
+      administrativeInformation: {
+        publicationAndOwnership: {
+          'common:dataSetVersion': '01.01.000',
+        },
+      },
+    },
+  };
+}
+
 function makeResponse(options: {
   ok: boolean;
   status: number;
@@ -547,6 +579,219 @@ test('runPublish uses state-aware process draft writes and generic source update
       observed.map((entry) => entry.method),
       ['GET', 'POST', 'GET', 'POST'],
     );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runPublish uses save_lifecycle_model_bundle for lifecyclemodels by default', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-publish-lifecyclemodel-default-'));
+  const requestPath = path.join(dir, 'request.json');
+  const observed: Array<{ method: string; url: string; body?: string }> = [];
+
+  writeJson(requestPath, {
+    inputs: {
+      lifecyclemodels: [
+        {
+          json_ordered: makeLifecyclemodel('lm-default-rest'),
+          json_tg: {
+            xflow: {
+              nodes: [{ id: 'explicit-node' }],
+              edges: [],
+            },
+          },
+          rule_verification: false,
+        },
+      ],
+    },
+    publish: {
+      commit: true,
+    },
+  });
+
+  try {
+    const report = await runPublish({
+      inputPath: requestPath,
+      env: buildSupabaseTestEnv({
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+        TIANGONG_LCA_API_KEY: 'key',
+      }),
+      fetchImpl: withSupabaseAuth(async (url, init) => {
+        observed.push({
+          method: String(init?.method ?? 'GET'),
+          url: String(url),
+          body: typeof init?.body === 'string' ? init.body : undefined,
+        });
+
+        if (String(url).includes('/lifecyclemodels?select=')) {
+          return makeResponse({
+            ok: true,
+            status: 200,
+            body: '[]',
+          });
+        }
+
+        if (String(url).includes('/functions/v1/save_lifecycle_model_bundle')) {
+          return makeResponse({
+            ok: true,
+            status: 200,
+            body: '{"ok":true,"modelId":"lm-default-rest","version":"01.01.000"}',
+          });
+        }
+
+        return makeResponse({
+          ok: true,
+          status: 200,
+          body: '[{"id":"unexpected"}]',
+        });
+      }),
+      now: new Date('2026-03-28T00:00:00Z'),
+    });
+
+    assert.equal(report.lifecyclemodels[0].status, 'executed');
+    assert.deepEqual(report.lifecyclemodels[0].execution, {
+      status: 'success',
+      operation: 'create',
+      mode: 'create',
+      transport: 'save_lifecycle_model_bundle',
+      response: {
+        ok: true,
+        modelId: 'lm-default-rest',
+        version: '01.01.000',
+      },
+    });
+    assert.deepEqual(
+      observed.map((entry) => entry.method),
+      ['GET', 'POST'],
+    );
+    assert.match(observed[1]?.url ?? '', /\/functions\/v1\/save_lifecycle_model_bundle$/u);
+    assert.match(observed[1]?.body ?? '', /"explicit-node"/u);
+    assert.match(observed[1]?.body ?? '', /"ruleVerification":false/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runPublish preserves lifecyclemodel metadata aliases from wrapper entries', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-publish-lifecyclemodel-metadata-'));
+  const requestPath = path.join(dir, 'request.json');
+  let observedArgs: { metadata?: unknown } | null = null;
+
+  writeJson(requestPath, {
+    inputs: {
+      lifecyclemodels: [
+        {
+          jsonOrdered: makeLifecyclemodel('lm-metadata'),
+          jsonTg: {
+            xflow: {
+              nodes: [{ id: 'camel-node' }],
+              edges: [],
+            },
+          },
+          process_mutations: [
+            {
+              op: 'create',
+              id: '11111111-1111-1111-1111-111111111111',
+              modelId: 'lm-metadata',
+              jsonOrdered: {
+                processDataSet: {},
+              },
+            },
+          ],
+          ruleVerification: true,
+        },
+      ],
+    },
+    publish: {
+      commit: true,
+    },
+  });
+
+  try {
+    const report = await runPublish({
+      inputPath: requestPath,
+      executors: {
+        lifecyclemodels: async (args) => {
+          observedArgs = args as Record<string, unknown>;
+          return {
+            inserted: true,
+          };
+        },
+      },
+      now: new Date('2026-03-28T00:00:00Z'),
+    });
+
+    assert.equal(report.lifecyclemodels[0].status, 'executed');
+    const observedMetadata =
+      ((observedArgs as { metadata?: unknown } | null)?.metadata as
+        | Record<string, unknown>
+        | undefined) ?? {};
+    assert.deepEqual(observedMetadata, {
+      json_tg: {
+        xflow: {
+          nodes: [{ id: 'camel-node' }],
+          edges: [],
+        },
+      },
+      processMutations: [
+        {
+          op: 'create',
+          id: '11111111-1111-1111-1111-111111111111',
+          modelId: 'lm-metadata',
+          jsonOrdered: {
+            processDataSet: {},
+          },
+        },
+      ],
+      ruleVerification: true,
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runPublish passes null lifecyclemodel metadata to the default executor when no wrapper metadata exists', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-publish-lifecyclemodel-null-metadata-'));
+  const requestPath = path.join(dir, 'request.json');
+  let observedBody = '';
+
+  writeJson(requestPath, {
+    inputs: {
+      lifecyclemodels: [makeLifecyclemodel('lm-null-metadata')],
+    },
+    publish: {
+      commit: true,
+    },
+  });
+
+  try {
+    const report = await runPublish({
+      inputPath: requestPath,
+      env: buildSupabaseTestEnv({
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+        TIANGONG_LCA_API_KEY: 'key',
+      }),
+      fetchImpl: withSupabaseAuth(async (url, init) => {
+        if (String(url).includes('/lifecyclemodels?select=')) {
+          return makeResponse({
+            ok: true,
+            status: 200,
+            body: '[]',
+          });
+        }
+
+        observedBody = typeof init?.body === 'string' ? init.body : '';
+        return makeResponse({
+          ok: true,
+          status: 200,
+          body: '{"ok":true,"modelId":"lm-null-metadata","version":"01.01.000"}',
+        });
+      }),
+      now: new Date('2026-03-28T00:00:00Z'),
+    });
+
+    assert.equal(report.lifecyclemodels[0].status, 'executed');
+    assert.doesNotMatch(observedBody, /"ruleVerification"/u);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #79

## Summary
- Route lifecyclemodel commits in `tiangong publish run` through the platform `save_lifecycle_model_bundle` contract instead of the generic dataset writer.
- Add a CLI-side lifecyclemodel bundle executor with visible-row detection, bundle payload derivation, metadata normalization, structured error surfacing, and create-to-update conflict retry.
- Update lifecyclemodel publish-build artifacts and help text to declare the bundle-save transport while keeping the external command surface unchanged.

## Key Decisions
- Keep `tiangong publish run` as the user-facing entrypoint and special-case only lifecyclemodels for now so flow/process publish behavior stays unchanged.
- Derive fallback `jsonTg` from lifecyclemodel `json_ordered` when wrapper metadata does not provide it, matching the platform expectation for `xflow` and `submodels`.

## Validation
- `npm run prepush:gate`

## Risks / Rollback
- Low-to-moderate risk: lifecyclemodel commit transport changed, but the change is isolated to the lifecyclemodel publish path and is covered by regression tests plus full repo coverage gates.

## Follow-ups
- After merge, bump the CLI submodule in `lca-workspace` where this newer publish path is required.

## Workspace Integration
- Workspace integration is still required after merge if the pinned CLI revision needs to advance for delivery use.
