### PR TITLE
chore: release cli 0.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/cli",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.101.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Unified TianGong LCA CLI with direct REST adapters and low-entropy command surface.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #81

## Summary
- Bump @tiangong-lca/cli from 0.0.5 to 0.0.6.
- Ship the merged lifecyclemodel publish alignment from PR #80 through the repository's normal tag-and-publish workflow.

## Key Decisions
- Keep release mechanics on the existing main -> cli-vX.Y.Z tag -> npm publish workflow instead of doing an ad hoc local publish.

## Validation
- npm run prepush:gate
- node ./scripts/ci/release-version.cjs assert-unpublished --version 0.0.6
- npm pack --dry-run >/dev/null

## Follow-ups
- After merge, verify Tag Release From Merge creates cli-v0.0.6 and Publish Package publishes npm latest=0.0.6.

## Workspace Integration
- After the release is published successfully, bump the CLI submodule in lca-workspace if delivery needs the new revision.