### PR TITLE
refactor: require explicit artifact roots for local build commands

### DIFF
--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -160,19 +160,19 @@ npm exec tiangong -- doctor
 npm exec tiangong -- doctor --json
 npm exec tiangong -- search flow --input ./request.json --dry-run
 npm exec tiangong -- process get --id <process-id> --version <version> --json
-npm exec tiangong -- process auto-build --input ./examples/process-auto-build.request.json --json
-npm exec tiangong -- process resume-build --run-id <run-id> --json
-npm exec tiangong -- process publish-build --run-id <run-id> --json
-npm exec tiangong -- process batch-build --input ./examples/process-batch-build.request.json --json
-npm exec tiangong -- lifecyclemodel auto-build --input ./examples/lifecyclemodel-auto-build.request.json --json
-npm exec tiangong -- lifecyclemodel validate-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --json
-npm exec tiangong -- lifecyclemodel publish-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --json
-npm exec tiangong -- lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir ./artifacts/lifecyclemodel_recursive/<run_id> --json
+npm exec tiangong -- process auto-build --input ./examples/process-auto-build.request.json --out-dir /abs/path/to/process-run --json
+npm exec tiangong -- process resume-build --run-dir /abs/path/to/process-run --json
+npm exec tiangong -- process publish-build --run-dir /abs/path/to/process-run --json
+npm exec tiangong -- process batch-build --input ./examples/process-batch-build.request.json --out-dir /abs/path/to/process-batch --json
+npm exec tiangong -- lifecyclemodel auto-build --input ./examples/lifecyclemodel-auto-build.request.json --out-dir /abs/path/to/lifecyclemodel-run --json
+npm exec tiangong -- lifecyclemodel validate-build --run-dir /abs/path/to/lifecyclemodel-run --json
+npm exec tiangong -- lifecyclemodel publish-build --run-dir /abs/path/to/lifecyclemodel-run --json
+npm exec tiangong -- lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir /abs/path/to/lifecyclemodel-recursive-run --json
 npm exec tiangong -- lifecyclemodel build-resulting-process --input ./request.json --json
 npm exec tiangong -- lifecyclemodel publish-resulting-process --run-dir ./runs/example --publish-processes --publish-relations --json
-npm exec tiangong -- review process --run-root ./artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir ./review --json
+npm exec tiangong -- review process --run-root /abs/path/to/process-run --run-id <run_id> --out-dir ./review --json
 npm exec tiangong -- review flow --rows-file ./flows.json --out-dir ./flow-review --json
-npm exec tiangong -- review lifecyclemodel --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --out-dir ./lifecyclemodel-review --json
+npm exec tiangong -- review lifecyclemodel --run-dir /abs/path/to/lifecyclemodel-run --out-dir ./lifecyclemodel-review --json
 npm exec tiangong -- flow get --id <flow-id> --version <version> --json
 npm exec tiangong -- flow list --id <flow-id> --state-code 100 --limit 20 --json
 npm exec tiangong -- flow remediate --input-file ./invalid-flows.jsonl --out-dir ./flow-remediation --json
@@ -205,7 +205,7 @@ npm exec tiangong -- admin embedding-run --input ./jobs.json --dry-run
 - 读取单个 process-from-flow request
 - 解析 `flow_file` 指向的 ILCD flow JSON
 - 生成兼容旧工作流的 `run_id`
-- 创建本地 `artifacts/process_from_flow/<run_id>/` 运行骨架
+- 通过 `--out-dir` 或 request `workspace_run_root` 指定显式 run root，并在其中创建运行骨架
 - 预写 `cache/process_from_flow_state.json`
 - 预写 `cache/agent_handoff_summary.json`
 - 产出 request / flow / assembly / lineage / invocation / run manifest / report
@@ -214,7 +214,7 @@ npm exec tiangong -- admin embedding-run --input ./jobs.json --dry-run
 
 `tiangong process resume-build` 现在也已经进入可执行状态，负责：
 
-- 从 `--run-id` 或 `--run-dir` 重开一个现有 process build run
+- 从 `--run-dir` 重开一个现有 process build run；可选 `--run-id` 只做 basename 一致性校验
 - 校验 `process_from_flow_state.json`、`agent_handoff_summary.json`、`run-manifest.json` 等关键产物
 - 复用本地 state lock，避免并发写入同一个 run
 - 清理持久化的 `stop_after` checkpoint，并把状态推进到 `resume_prepared`
@@ -226,7 +226,7 @@ npm exec tiangong -- admin embedding-run --input ./jobs.json --dry-run
 
 `tiangong process publish-build` 现在也已经进入可执行状态，负责：
 
-- 从 `--run-id` 或 `--run-dir` 读取一个现有 process build run
+- 从 `--run-dir` 读取一个现有 process build run；可选 `--run-id` 只做 basename 一致性校验
 - 校验 `process_from_flow_state.json`、`agent_handoff_summary.json`、`run-manifest.json`、`invocation-index.json`
 - 优先从 `exports/processes`、`exports/sources` 收集 canonical 数据，缺失时回退到 state 中的 `process_datasets`、`source_datasets`
 - 生成 `stage_outputs/10_publish/publish-bundle.json`
@@ -240,7 +240,7 @@ npm exec tiangong -- admin embedding-run --input ./jobs.json --dry-run
 `tiangong process batch-build` 现在也已经进入可执行状态，负责：
 
 - 读取单个 batch manifest
-- 创建自包含的 batch root 和聚合 report 路径
+- 通过 `--out-dir` 或 request `out_dir` 指定显式 batch root，并创建聚合 report 路径
 - 顺序复用 CLI 的 `process auto-build` 契约执行多个 item
 - 为每个 item 生成稳定的本地 run 目录
 - 在 batch report 中记录 per-item prepared / failed / skipped 结果

--- a/README.md
+++ b/README.md
@@ -185,19 +185,19 @@ npm exec tiangong -- doctor
 npm exec tiangong -- doctor --json
 npm exec tiangong -- search flow --input ./request.json --dry-run
 npm exec tiangong -- process get --id <process-id> --version <version> --json
-npm exec tiangong -- process auto-build --input ./examples/process-auto-build.request.json --json
-npm exec tiangong -- process resume-build --run-id <run-id> --json
-npm exec tiangong -- process publish-build --run-id <run-id> --json
-npm exec tiangong -- process batch-build --input ./examples/process-batch-build.request.json --json
-npm exec tiangong -- lifecyclemodel auto-build --input ./examples/lifecyclemodel-auto-build.request.json --json
-npm exec tiangong -- lifecyclemodel validate-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --json
-npm exec tiangong -- lifecyclemodel publish-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --json
-npm exec tiangong -- lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir ./artifacts/lifecyclemodel_recursive/<run_id> --json
+npm exec tiangong -- process auto-build --input ./examples/process-auto-build.request.json --out-dir /abs/path/to/process-run --json
+npm exec tiangong -- process resume-build --run-dir /abs/path/to/process-run --json
+npm exec tiangong -- process publish-build --run-dir /abs/path/to/process-run --json
+npm exec tiangong -- process batch-build --input ./examples/process-batch-build.request.json --out-dir /abs/path/to/process-batch --json
+npm exec tiangong -- lifecyclemodel auto-build --input ./examples/lifecyclemodel-auto-build.request.json --out-dir /abs/path/to/lifecyclemodel-run --json
+npm exec tiangong -- lifecyclemodel validate-build --run-dir /abs/path/to/lifecyclemodel-run --json
+npm exec tiangong -- lifecyclemodel publish-build --run-dir /abs/path/to/lifecyclemodel-run --json
+npm exec tiangong -- lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir /abs/path/to/lifecyclemodel-recursive-run --json
 npm exec tiangong -- lifecyclemodel build-resulting-process --input ./request.json --json
 npm exec tiangong -- lifecyclemodel publish-resulting-process --run-dir ./runs/example --publish-processes --publish-relations --json
-npm exec tiangong -- review process --run-root ./artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir ./review --json
+npm exec tiangong -- review process --run-root /abs/path/to/process-run --run-id <run_id> --out-dir ./review --json
 npm exec tiangong -- review flow --rows-file ./flows.json --out-dir ./flow-review --json
-npm exec tiangong -- review lifecyclemodel --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --out-dir ./lifecyclemodel-review --json
+npm exec tiangong -- review lifecyclemodel --run-dir /abs/path/to/lifecyclemodel-run --out-dir ./lifecyclemodel-review --json
 npm exec tiangong -- flow get --id <flow-id> --version <version> --json
 npm exec tiangong -- flow list --id <flow-id> --state-code 100 --limit 20 --json
 npm exec tiangong -- flow remediate --input-file ./invalid-flows.jsonl --out-dir ./flow-remediation --json
@@ -218,19 +218,19 @@ npm exec tiangong -- admin embedding-run --input ./jobs.json --dry-run
 
 `tiangong process get` is the CLI-owned read-only process detail surface. It derives a deterministic Supabase read target from `TIANGONG_LCA_API_BASE_URL`, executes through the native `@supabase/supabase-js` client, resolves one process row by `id/version` with a latest-version fallback, and returns one structured JSON payload without reintroducing MCP, Python, or a generic transport layer.
 
-`tiangong process auto-build` is the first migrated `process_from_flow` slice. It reads one request JSON from `--input`, loads the referenced ILCD flow dataset from `flow_file`, preserves the old run id contract (`pfw_<flow_code>_<flow_uuid8>_<operation>_<UTC_TIMESTAMP>`), and writes a local run scaffold under `artifacts/process_from_flow/<run_id>/` or `--out-dir`.
+`tiangong process auto-build` is the first migrated `process_from_flow` slice. It reads one request JSON from `--input`, loads the referenced ILCD flow dataset from `flow_file`, preserves the old run id contract (`pfw_<flow_code>_<flow_uuid8>_<operation>_<UTC_TIMESTAMP>`), and requires one explicit caller-managed run root from `--out-dir` or `request.workspace_run_root`. The CLI does not invent a repo-local `./artifacts/...` fallback.
 
-The command keeps the legacy per-run layout that later stages still expect, including `input/`, `exports/processes/`, `exports/sources/`, `cache/process_from_flow_state.json`, and `cache/agent_handoff_summary.json`. It also adds CLI-owned manifests such as the normalized request snapshot, flow summary, assembly plan, lineage manifest, invocation index, run manifest, and a compact report artifact.
+The command keeps the legacy per-run layout that later stages still expect inside that provided run root, including `input/`, `exports/processes/`, `exports/sources/`, `cache/process_from_flow_state.json`, and `cache/agent_handoff_summary.json`. It also adds CLI-owned manifests such as the normalized request snapshot, flow summary, assembly plan, lineage manifest, invocation index, run manifest, and a compact report artifact.
 
-`tiangong process resume-build` is the second migrated `process_from_flow` slice. It reopens one existing local run by `--run-id` or `--run-dir`, validates the required run artifacts, takes the local state lock, clears any persisted `stop_after` checkpoint, records `resume-metadata.json` and `resume-history.jsonl`, updates `invocation-index.json`, rewrites `agent_handoff_summary.json`, and emits `process-resume-build-report.json`.
+`tiangong process resume-build` is the second migrated `process_from_flow` slice. It reopens one existing local run by `--run-dir`, optionally checks `--run-id` against the run-dir basename, validates the required run artifacts, takes the local state lock, clears any persisted `stop_after` checkpoint, records `resume-metadata.json` and `resume-history.jsonl`, updates `invocation-index.json`, rewrites `agent_handoff_summary.json`, and emits `process-resume-build-report.json`.
 
-`tiangong process publish-build` is the third migrated `process_from_flow` slice. It reopens one existing local run by `--run-id` or `--run-dir`, validates `process_from_flow_state.json`, `agent_handoff_summary.json`, `run-manifest.json`, and `invocation-index.json`, collects canonical process/source datasets from `exports/` or state fallbacks, writes `stage_outputs/10_publish/publish-bundle.json`, `publish-request.json`, `publish-intent.json`, rewrites `agent_handoff_summary.json`, updates the run state and invocation index, and emits `process-publish-build-report.json`.
+`tiangong process publish-build` is the third migrated `process_from_flow` slice. It reopens one existing local run by `--run-dir`, optionally checks `--run-id` against the run-dir basename, validates `process_from_flow_state.json`, `agent_handoff_summary.json`, `run-manifest.json`, and `invocation-index.json`, collects canonical process/source datasets from `exports/` or state fallbacks, writes `stage_outputs/10_publish/publish-bundle.json`, `publish-request.json`, `publish-intent.json`, rewrites `agent_handoff_summary.json`, updates the run state and invocation index, and emits `process-publish-build-report.json`.
 
-`tiangong process batch-build` is the fourth migrated `process_from_flow` slice. It reads one batch manifest, prepares a self-contained batch root, fans out multiple local `process auto-build` runs through the CLI-owned contract, writes a structured per-item aggregate report, and preserves deterministic item-level artifact paths for downstream `resume-build` or `publish-build` steps.
+`tiangong process batch-build` is the fourth migrated `process_from_flow` slice. It reads one batch manifest, requires one explicit caller-managed batch root from `--out-dir` or `request.out_dir`, prepares a self-contained batch root, fans out multiple local `process auto-build` runs through the CLI-owned contract, writes a structured per-item aggregate report, and preserves deterministic item-level artifact paths for downstream `resume-build` or `publish-build` steps.
 
 `resume-build`, `publish-build`, and `batch-build` all still stop at local handoff boundaries. They do not execute remote publish CRUD or commit mode themselves; that boundary remains in `tiangong publish run`.
 
-`tiangong lifecyclemodel auto-build` is the first migrated `lifecyclemodel_automated_builder` slice. It reads one local-run manifest from `--input`, resolves one or more `process-automated-builder` run directories, infers the process graph from shared flow UUIDs, chooses one reference process, computes `@multiplicationFactor`, writes native `json_ordered` lifecyclemodel datasets plus `run-plan.json`, `resolved-manifest.json`, `selection/selection-brief.md`, `discovery/reference-model-summary.json`, `models/**/summary.json`, `connections.json`, and `process-catalog.json`, and keeps the run local-only and read-only.
+`tiangong lifecyclemodel auto-build` is the first migrated `lifecyclemodel_automated_builder` slice. It reads one local-run manifest from `--input`, requires one explicit caller-managed run root from `--out-dir` or `request.out_dir`, resolves one or more `process-automated-builder` run directories, infers the process graph from shared flow UUIDs, chooses one reference process, computes `@multiplicationFactor`, writes native `json_ordered` lifecyclemodel datasets plus `run-plan.json`, `resolved-manifest.json`, `selection/selection-brief.md`, `discovery/reference-model-summary.json`, `models/**/summary.json`, `connections.json`, and `process-catalog.json`, and keeps the run local-only and read-only.
 
 The canonical `tiangong-lca-skills/lifecyclemodel-automated-builder` entrypoint now uses a native Node `.mjs` wrapper that delegates directly to `tiangong lifecyclemodel auto-build`. The canonical build path no longer routes through Bash, Python, or MCP.
 
@@ -305,14 +305,14 @@ node ./bin/tiangong.js flow scan-process-flow-refs --processes-file ./processes.
 node ./bin/tiangong.js flow plan-process-flow-repairs --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --scan-findings ./flow-scan/scan-findings.json --out-dir ./flow-repair-plan --json
 node ./bin/tiangong.js flow apply-process-flow-repairs --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --scan-findings ./flow-scan/scan-findings.json --out-dir ./flow-repair-apply --json
 node ./bin/tiangong.js flow regen-product --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-regen --apply --json
-node ./bin/tiangong.js process auto-build --input ./examples/process-auto-build.request.json --json
-node ./bin/tiangong.js process resume-build --run-id <run-id> --json
-node ./bin/tiangong.js process publish-build --run-id <run-id> --json
-node ./bin/tiangong.js process batch-build --input ./examples/process-batch-build.request.json --json
-node ./bin/tiangong.js lifecyclemodel auto-build --input ./examples/lifecyclemodel-auto-build.request.json --json
-node ./bin/tiangong.js lifecyclemodel validate-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --json
-node ./bin/tiangong.js lifecyclemodel publish-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --json
-node ./bin/tiangong.js lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir ./artifacts/lifecyclemodel_recursive/<run_id> --json
+node ./bin/tiangong.js process auto-build --input ./examples/process-auto-build.request.json --out-dir /abs/path/to/process-run --json
+node ./bin/tiangong.js process resume-build --run-dir /abs/path/to/process-run --json
+node ./bin/tiangong.js process publish-build --run-dir /abs/path/to/process-run --json
+node ./bin/tiangong.js process batch-build --input ./examples/process-batch-build.request.json --out-dir /abs/path/to/process-batch --json
+node ./bin/tiangong.js lifecyclemodel auto-build --input ./examples/lifecyclemodel-auto-build.request.json --out-dir /abs/path/to/lifecyclemodel-run --json
+node ./bin/tiangong.js lifecyclemodel validate-build --run-dir /abs/path/to/lifecyclemodel-run --json
+node ./bin/tiangong.js lifecyclemodel publish-build --run-dir /abs/path/to/lifecyclemodel-run --json
+node ./bin/tiangong.js lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir /abs/path/to/lifecyclemodel-recursive-run --json
 node ./bin/tiangong.js flow publish-version --input-file ./ready-flows.jsonl --out-dir ./flow-publish --dry-run --json
 node ./bin/tiangong.js publish run --input ./examples/publish-run.request.json --dry-run --json
 node ./bin/tiangong.js validation run --input-dir ./package --engine auto --json

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -149,13 +149,13 @@ tiangong
 注意：
 
 - `process get` 当前固定为 CLI 内部共享的 deterministic direct-read 面，内部执行已收口到原生 `@supabase/supabase-js`，供 lifecyclemodel resulting-process 和后续 review/governance 迁移复用
-- 已实现的 `process auto-build` 保留了旧 `artifacts/process_from_flow/<run_id>/`、`cache/process_from_flow_state.json`、`cache/agent_handoff_summary.json` 等运行布局
+- 已实现的 `process auto-build` 在调用方显式提供的 run root 内保留旧 `cache/process_from_flow_state.json`、`cache/agent_handoff_summary.json` 等运行布局，不再推断 repo 本地 `./artifacts/...` 默认路径
 - `process auto-build` 当前只负责本地 request intake、flow 归一化、run scaffold 和 manifest/report 预写，不继续执行后续阶段
 - 已实现的 `process resume-build` 保留同一套 run 布局，并把本地 state-lock、run-manifest 校验、resume metadata/history、invocation index 更新统一收口到 CLI
 - `process resume-build` 当前只负责本地 resume handoff，不直接执行 route / split / exchange / QA / publish 阶段
 - 已实现的 `process publish-build` 继续保留同一套 run 布局，并把本地 publish-bundle/request/intent、state/invocation/handoff 更新统一收口到 CLI
 - `process publish-build` 当前只负责本地 publish handoff，不直接执行远端 publish commit 或数据库写入
-- 已实现的 `process batch-build` 继续走本地优先、artifact-first 路径，并把批量 item 编排、聚合 report、默认 run_dir 分配统一收口到 CLI
+- 已实现的 `process batch-build` 继续走本地优先、artifact-first 路径，并把批量 item 编排、聚合 report、显式 batch root 下的 item run_dir 分配统一收口到 CLI
 - `process batch-build` 当前只负责本地 batch orchestration，不直接串接 resume / publish 或远端执行器
 - 已实现的 `lifecyclemodel auto-build` 走本地只读、artifact-first 路径，输入固定为 local run manifest，不依赖 Python、MCP、KB、LLM 或远端 CRUD
 - `lifecyclemodel auto-build` 当前负责 graph 推断、reference process 选择、`@multiplicationFactor` 计算与 `json_ordered` lifecyclemodel 产物输出，并保留 `run-plan.json`、`resolved-manifest.json`、`selection/selection-brief.md`、`discovery/reference-model-summary.json`、`connections.json`、`process-catalog.json` 等 CLI 契约

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -240,14 +240,14 @@ Examples:
   tiangong search flow --input ./request.json
   tiangong search process --input ./request.json --dry-run
   tiangong process get --id <process-id>
-  tiangong process auto-build --input ./pff-request.json
-  tiangong process resume-build --run-id <id>
-  tiangong process publish-build --run-id <id>
-  tiangong process batch-build --input ./batch-request.json
-  tiangong lifecyclemodel auto-build --input ./lifecyclemodel-auto-build.request.json
-  tiangong lifecyclemodel validate-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id>
-  tiangong lifecyclemodel publish-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id>
-  tiangong lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir ./artifacts/lifecyclemodel_recursive/run-001
+  tiangong process auto-build --input ./pff-request.json --out-dir /abs/path/to/process-run
+  tiangong process resume-build --run-dir /abs/path/to/process-run
+  tiangong process publish-build --run-dir /abs/path/to/process-run
+  tiangong process batch-build --input ./batch-request.json --out-dir /abs/path/to/process-batch
+  tiangong lifecyclemodel auto-build --input ./lifecyclemodel-auto-build.request.json --out-dir /abs/path/to/lifecyclemodel-run
+  tiangong lifecyclemodel validate-build --run-dir /abs/path/to/lifecyclemodel-run
+  tiangong lifecyclemodel publish-build --run-dir /abs/path/to/lifecyclemodel-run
+  tiangong lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir /abs/path/to/lifecyclemodel-recursive-run
   tiangong flow get --id <flow-id> --version <version>
   tiangong flow list --id <flow-id> --state-code 100 --limit 20
   tiangong flow remediate --input-file ./invalid-flows.jsonl --out-dir ./flow-remediation
@@ -259,9 +259,9 @@ Examples:
   tiangong flow apply-process-flow-repairs --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-repair-apply
   tiangong flow regen-product --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-regeneration --apply
   tiangong flow validate-processes --original-processes-file ./before.jsonl --patched-processes-file ./after.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-validation
-  tiangong review process --run-root ./artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir ./review
+  tiangong review process --run-root /abs/path/to/process-run --run-id <run_id> --out-dir ./review
   tiangong review flow --rows-file ./flows.json --out-dir ./review
-  tiangong review lifecyclemodel --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --out-dir ./lifecyclemodel-review
+  tiangong review lifecyclemodel --run-dir /abs/path/to/lifecyclemodel-run --out-dir ./lifecyclemodel-review
   tiangong publish run --input ./publish-request.json --dry-run
   tiangong validation run --input-dir ./package --engine auto
   tiangong admin embedding-run --input ./jobs.json
@@ -801,7 +801,7 @@ function renderLifecyclemodelAutoBuildHelp(): string {
 
 Options:
   --input <file>     JSON request file
-  --out-dir <dir>    Override the default lifecyclemodel build run root
+  --out-dir <dir>    Explicit run root; otherwise request.out_dir is required
   --json             Print compact JSON
   -h, --help
 
@@ -811,6 +811,7 @@ Minimal request contract:
   }
 
 This first CLI slice is local-only and read-only:
+  - applies no implicit repo-local ./artifacts fallback; callers must provide a run root
   - loads local process build run directories
   - infers the process graph from shared flow UUIDs
   - emits native lifecyclemodel json_ordered artifacts
@@ -857,9 +858,11 @@ function renderProcessAutoBuildHelp(): string {
 
 Options:
   --input <file>     JSON request file
-  --out-dir <dir>    Override the default run root directory
+  --out-dir <dir>    Explicit run root; otherwise request.workspace_run_root is required
   --json             Print compact JSON
   -h, --help
+
+This command applies no implicit repo-local ./artifacts fallback.
 `.trim();
 }
 
@@ -884,11 +887,11 @@ Runtime note:
 
 function renderProcessResumeBuildHelp(): string {
   return `Usage:
-  tiangong process resume-build [--run-id <id>] [--run-dir <dir>] [options]
+  tiangong process resume-build --run-dir <dir> [options]
 
 Options:
-  --run-id <id>      Existing process build run id
   --run-dir <dir>    Existing process build run directory
+  --run-id <id>      Optional run id consistency check
   --json             Print compact JSON
   -h, --help
 `.trim();
@@ -896,11 +899,11 @@ Options:
 
 function renderProcessPublishBuildHelp(): string {
   return `Usage:
-  tiangong process publish-build [--run-id <id>] [--run-dir <dir>] [options]
+  tiangong process publish-build --run-dir <dir> [options]
 
 Options:
-  --run-id <id>      Existing process build run id
   --run-dir <dir>    Existing process build run directory
+  --run-id <id>      Optional run id consistency check
   --json             Print compact JSON
   -h, --help
 `.trim();
@@ -912,9 +915,11 @@ function renderProcessBatchBuildHelp(): string {
 
 Options:
   --input <file>     JSON batch manifest file
-  --out-dir <dir>    Override the batch artifact output directory
+  --out-dir <dir>    Explicit batch root; otherwise request.out_dir is required
   --json             Print compact JSON
   -h, --help
+
+This command applies no implicit repo-local ./artifacts fallback.
 `.trim();
 }
 
@@ -933,8 +938,8 @@ Examples:
   tiangong process --help
   tiangong process get --id <process-id>
   tiangong process auto-build --help
-  tiangong process resume-build --run-id <id> --help
-  tiangong process publish-build --run-id <id> --help
+  tiangong process resume-build --run-dir /abs/path/to/process-run --help
+  tiangong process publish-build --run-dir /abs/path/to/process-run --help
   tiangong process batch-build --input ./batch-request.json --help
 `.trim();
 }

--- a/src/lib/lifecyclemodel-auto-build.ts
+++ b/src/lib/lifecyclemodel-auto-build.ts
@@ -477,7 +477,6 @@ function normalizeLocalRuns(value: unknown, requestDir: string): string[] {
 
 function resolveRunRoot(
   requestDir: string,
-  runId: string,
   outDirOverride: string | null | undefined,
   requestOutDir: unknown,
 ): string {
@@ -491,7 +490,13 @@ function resolveRunRoot(
     return path.resolve(requestDir, requestValue);
   }
 
-  return path.join(requestDir, 'artifacts', 'lifecyclemodel_auto_build', runId);
+  throw new CliError(
+    'Missing required lifecyclemodel auto-build run root. Provide --out-dir or request.out_dir.',
+    {
+      code: 'LIFECYCLEMODEL_AUTO_BUILD_RUN_ROOT_REQUIRED',
+      exitCode: 2,
+    },
+  );
 }
 
 function buildLayout(runRoot: string, runId: string): LifecyclemodelAutoBuildLayout {
@@ -594,7 +599,7 @@ export function normalizeLifecyclemodelAutoBuildRequest(
     schema_version: 1,
     request_path: requestPath,
     run_id: runId,
-    run_root: resolveRunRoot(requestDir, runId, options.outDir, request.out_dir),
+    run_root: resolveRunRoot(requestDir, options.outDir, request.out_dir),
     manifest: mergedManifest,
     local_runs: normalizeLocalRuns(mergedManifest.local_runs, requestDir),
   };

--- a/src/lib/process-auto-build.ts
+++ b/src/lib/process-auto-build.ts
@@ -470,7 +470,6 @@ function buildProcessAutoBuildRunId(
 
 function resolveRunRoot(
   requestDir: string,
-  runId: string,
   outDirOverride: string | null | undefined,
   requestRunRoot: unknown,
 ): string {
@@ -484,7 +483,13 @@ function resolveRunRoot(
     return path.resolve(requestDir, requestValue);
   }
 
-  return path.join(requestDir, 'artifacts', 'process_from_flow', runId);
+  throw new CliError(
+    'Missing required process auto-build run root. Provide --out-dir or request.workspace_run_root.',
+    {
+      code: 'PROCESS_AUTO_BUILD_RUN_ROOT_REQUIRED',
+      exitCode: 2,
+    },
+  );
 }
 
 function normalizeSourceInputType(value: unknown): ProcessAutoBuildSourceInputType {
@@ -786,16 +791,13 @@ function buildInitialState(
   };
 }
 
-function buildNextActions(
-  layout: ProcessAutoBuildLayout,
-  normalized: NormalizedProcessAutoBuildRequest,
-): string[] {
+function buildNextActions(layout: ProcessAutoBuildLayout): string[] {
   return [
     `inspect: ${layout.normalizedRequestPath}`,
     `inspect: ${layout.statePath}`,
     `inspect: ${layout.assemblyPlanPath}`,
-    `future: tiangong process resume-build --run-id ${normalized.run_id}`,
-    `future: tiangong process publish-build --run-id ${normalized.run_id}`,
+    `future: tiangong process resume-build --run-dir ${layout.runRoot}`,
+    `future: tiangong process publish-build --run-dir ${layout.runRoot}`,
   ];
 }
 
@@ -832,7 +834,7 @@ function buildAgentHandoffSummary(
       assembly_plan: layout.assemblyPlanPath,
       flow_copy: flowArtifactPath,
     },
-    next_actions: buildNextActions(layout, normalized),
+    next_actions: buildNextActions(layout),
     extra: {
       status: 'prepared_local_process_auto_build_run',
       request_id: normalized.request_id,
@@ -880,7 +882,7 @@ function buildReport(
       handoff_summary: layout.handoffSummaryPath,
       report: layout.reportPath,
     },
-    next_actions: buildNextActions(layout, normalized),
+    next_actions: buildNextActions(layout),
   };
 }
 
@@ -905,7 +907,7 @@ export function normalizeProcessAutoBuildRequest(
     nonEmptyString(options.runIdOverride) ??
     nonEmptyString(request.run_id) ??
     buildProcessAutoBuildRunId(flowFile, operation, flowSummary, options.now);
-  const runRoot = resolveRunRoot(requestDir, runId, options.outDir, request.workspace_run_root);
+  const runRoot = resolveRunRoot(requestDir, options.outDir, request.workspace_run_root);
   const layout = buildLayout(runRoot, runId);
 
   return {

--- a/src/lib/process-batch-build.ts
+++ b/src/lib/process-batch-build.ts
@@ -128,7 +128,6 @@ function requiredRequestObject(input: unknown): JsonRecord {
 
 function resolveBatchRoot(
   manifestDir: string,
-  batchId: string,
   outDirOverride: string | null | undefined,
   requestOutDir: unknown,
 ): string {
@@ -142,7 +141,13 @@ function resolveBatchRoot(
     return path.resolve(manifestDir, requestValue);
   }
 
-  return path.join(manifestDir, 'artifacts', 'process_batch', batchId);
+  throw new CliError(
+    'Missing required process batch-build root. Provide --out-dir or request.out_dir.',
+    {
+      code: 'PROCESS_BATCH_BUILD_ROOT_REQUIRED',
+      exitCode: 2,
+    },
+  );
 }
 
 function buildLayout(batchRoot: string, batchId: string): ProcessBatchBuildLayout {
@@ -316,7 +321,7 @@ export function normalizeProcessBatchBuildRequest(
   const manifestDir = path.dirname(manifestPath);
   const now = options.now ?? new Date();
   const batchId = normalizeBatchId(manifestPath, request, now);
-  const batchRoot = resolveBatchRoot(manifestDir, batchId, options.outDir, request.out_dir);
+  const batchRoot = resolveBatchRoot(manifestDir, options.outDir, request.out_dir);
 
   return {
     schema_version: 1,

--- a/src/lib/process-publish-build.ts
+++ b/src/lib/process-publish-build.ts
@@ -148,16 +148,14 @@ function resolveLayout(options: RunProcessPublishBuildOptions): ProcessPublishBu
   const runId = nonEmptyString(options.runId);
   const runDir = nonEmptyString(options.runDir);
 
-  if (!runId && !runDir) {
-    throw new CliError('Missing required --run-id or --run-dir for process publish-build.', {
+  if (!runDir) {
+    throw new CliError('Missing required --run-dir for process publish-build.', {
       code: 'PROCESS_PUBLISH_RUN_REQUIRED',
       exitCode: 2,
     });
   }
 
-  const runRoot = runDir
-    ? path.resolve(runDir)
-    : path.resolve('artifacts', 'process_from_flow', runId as string);
+  const runRoot = path.resolve(runDir);
   const derivedRunId = path.basename(runRoot);
 
   if (runDir && runId && derivedRunId !== runId) {

--- a/src/lib/process-resume-build.ts
+++ b/src/lib/process-resume-build.ts
@@ -131,16 +131,14 @@ function resolveLayout(options: RunProcessResumeBuildOptions): ProcessResumeBuil
   const runId = nonEmptyString(options.runId);
   const runDir = nonEmptyString(options.runDir);
 
-  if (!runId && !runDir) {
-    throw new CliError('Missing required --run-id or --run-dir for process resume-build.', {
+  if (!runDir) {
+    throw new CliError('Missing required --run-dir for process resume-build.', {
       code: 'PROCESS_RESUME_RUN_REQUIRED',
       exitCode: 2,
     });
   }
 
-  const runRoot = runDir
-    ? path.resolve(runDir)
-    : path.resolve('artifacts', 'process_from_flow', runId as string);
+  const runRoot = path.resolve(runDir);
   const derivedRunId = path.basename(runRoot);
 
   if (runDir && runId && derivedRunId !== runId) {
@@ -400,7 +398,7 @@ function buildNextActions(
     summary.next_stage
       ? `future: migrate CLI stage executor for ${summary.next_stage}`
       : `future: inspect completed run state for ${layout.runId}`,
-    `future: tiangong process publish-build --run-id ${layout.runId}`,
+    `future: tiangong process publish-build --run-dir ${layout.runRoot}`,
   ];
 }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -286,6 +286,7 @@ test('executeCli returns help for the lifecyclemodel namespace and implemented s
   const autoBuildHelp = await executeCli(['lifecyclemodel', 'auto-build', '--help'], makeDeps());
   assert.equal(autoBuildHelp.exitCode, 0);
   assert.match(autoBuildHelp.stdout, /tiangong lifecyclemodel auto-build --input <file>/u);
+  assert.match(autoBuildHelp.stdout, /request\.out_dir is required/u);
   assert.match(autoBuildHelp.stdout, /"local_runs": \["\/abs\/path\/to\/process-build-run"\]/u);
   assert.match(
     autoBuildHelp.stdout,
@@ -788,30 +789,26 @@ test('executeCli returns help for the process namespace and implemented subcomma
   const autoBuildHelp = await executeCli(['process', 'auto-build', '--help'], makeDeps());
   assert.equal(autoBuildHelp.exitCode, 0);
   assert.match(autoBuildHelp.stdout, /tiangong process auto-build --input <file>/u);
+  assert.match(autoBuildHelp.stdout, /request\.workspace_run_root is required/u);
   assert.match(autoBuildHelp.stdout, /--out-dir/u);
   assert.doesNotMatch(autoBuildHelp.stdout, /Planned command/u);
 
   const resumeBuildHelp = await executeCli(['process', 'resume-build', '--help'], makeDeps());
   assert.equal(resumeBuildHelp.exitCode, 0);
-  assert.match(
-    resumeBuildHelp.stdout,
-    /tiangong process resume-build \[--run-id <id>\] \[--run-dir <dir>\]/u,
-  );
+  assert.match(resumeBuildHelp.stdout, /tiangong process resume-build --run-dir <dir>/u);
   assert.match(resumeBuildHelp.stdout, /--run-dir/u);
   assert.doesNotMatch(resumeBuildHelp.stdout, /Planned command/u);
 
   const publishBuildHelp = await executeCli(['process', 'publish-build', '--help'], makeDeps());
   assert.equal(publishBuildHelp.exitCode, 0);
-  assert.match(
-    publishBuildHelp.stdout,
-    /tiangong process publish-build \[--run-id <id>\] \[--run-dir <dir>\]/u,
-  );
+  assert.match(publishBuildHelp.stdout, /tiangong process publish-build --run-dir <dir>/u);
   assert.match(publishBuildHelp.stdout, /--run-dir/u);
   assert.doesNotMatch(publishBuildHelp.stdout, /Planned command/u);
 
   const batchBuildHelp = await executeCli(['process', 'batch-build', '--help'], makeDeps());
   assert.equal(batchBuildHelp.exitCode, 0);
   assert.match(batchBuildHelp.stdout, /tiangong process batch-build --input <file>/u);
+  assert.match(batchBuildHelp.stdout, /request\.out_dir is required/u);
   assert.match(batchBuildHelp.stdout, /--out-dir/u);
   assert.doesNotMatch(batchBuildHelp.stdout, /Planned command/u);
 });

--- a/test/lifecyclemodel-auto-build.test.ts
+++ b/test/lifecyclemodel-auto-build.test.ts
@@ -268,6 +268,7 @@ test('normalizeLifecyclemodelAutoBuildRequest resolves defaults, run roots, and 
   const requestPath = path.join(dir, 'request.json');
   writeJson(requestPath, {
     run_label: 'demo-local-build',
+    out_dir: './normalized-run-root',
     local_runs: ['./run-1'],
   });
 
@@ -279,10 +280,7 @@ test('normalizeLifecyclemodelAutoBuildRequest resolves defaults, run roots, and 
     });
 
     assert.equal(normalized.run_id, 'lm-run-1');
-    assert.equal(
-      normalized.run_root,
-      path.join(dir, 'artifacts', 'lifecyclemodel_auto_build', 'lm-run-1'),
-    );
+    assert.equal(normalized.run_root, path.join(dir, 'normalized-run-root'));
     assert.deepEqual(normalized.local_runs, [runDir]);
     assert.equal(normalized.manifest.run_label, 'demo-local-build');
     assert.equal((normalized.manifest.selection as JsonRecord).mode, 'graph_first_local_build');
@@ -290,6 +288,7 @@ test('normalizeLifecyclemodelAutoBuildRequest resolves defaults, run roots, and 
     const fallbackRequestPath = path.join(dir, 'fallback-request.json');
     writeJson(fallbackRequestPath, {
       run_label: '',
+      out_dir: './fallback-run-root',
       local_runs: ['./run-1'],
     });
     const fallbackNormalized = normalizeLifecyclemodelAutoBuildRequest(
@@ -302,9 +301,19 @@ test('normalizeLifecyclemodelAutoBuildRequest resolves defaults, run roots, and 
       fallbackNormalized.run_id,
       /^lifecyclemodel_auto_build_fallback_request_build_\d{8}T\d{6}Z_[a-z0-9_]+$/u,
     );
-    assert.equal(
-      fallbackNormalized.run_root,
-      path.join(dir, 'artifacts', 'lifecyclemodel_auto_build', fallbackNormalized.run_id),
+    assert.equal(fallbackNormalized.run_root, path.join(dir, 'fallback-run-root'));
+
+    assert.throws(
+      () =>
+        normalizeLifecyclemodelAutoBuildRequest(
+          {
+            local_runs: ['./run-1'],
+          },
+          {
+            inputPath: requestPath,
+          },
+        ),
+      /Provide --out-dir or request\.out_dir/u,
     );
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -1777,6 +1786,7 @@ test('runLifecyclemodelAutoBuild rejects invalid manifests and broken local runs
     );
 
     writeJson(requestPath, {
+      out_dir: './missing-state-root',
       local_runs: ['./missing-run'],
     });
     await assert.rejects(
@@ -1794,6 +1804,7 @@ test('runLifecyclemodelAutoBuild rejects invalid manifests and broken local runs
       flow_dataset: {},
     });
     writeJson(requestPath, {
+      out_dir: './no-exports-root',
       local_runs: ['./no-exports-run'],
     });
     await assert.rejects(
@@ -1812,6 +1823,7 @@ test('runLifecyclemodelAutoBuild rejects invalid manifests and broken local runs
       flow_dataset: {},
     });
     writeJson(requestPath, {
+      out_dir: './empty-run-root',
       local_runs: ['./empty-run'],
     });
     await assert.rejects(
@@ -1826,6 +1838,7 @@ test('runLifecyclemodelAutoBuild rejects invalid manifests and broken local runs
       badProcess: 'missing_reference_exchange',
     });
     writeJson(requestPath, {
+      out_dir: './bad-reference-root',
       local_runs: ['./bad-reference-run'],
     });
     await assert.rejects(
@@ -1840,6 +1853,7 @@ test('runLifecyclemodelAutoBuild rejects invalid manifests and broken local runs
       badProcess: 'missing_uuid',
     });
     writeJson(requestPath, {
+      out_dir: './bad-uuid-root',
       local_runs: ['./bad-uuid-run'],
     });
     await assert.rejects(
@@ -1871,6 +1885,7 @@ test('runLifecyclemodelAutoBuild rejects invalid manifests and broken local runs
       }),
     );
     writeJson(requestPath, {
+      out_dir: './invalid-state-root',
       local_runs: ['./invalid-state-run'],
     });
     await assert.rejects(

--- a/test/process-auto-build.test.ts
+++ b/test/process-auto-build.test.ts
@@ -52,6 +52,7 @@ test('normalizeProcessAutoBuildRequest resolves defaults, flow summaries, and so
   writeFileSync(sourcePath, 'paper-data', 'utf8');
   writeJson(requestPath, {
     flow_file: `./${path.basename(flowPath)}`,
+    workspace_run_root: './workspace-run-root',
     source_inputs: [
       {
         source_id: 'paper-1',
@@ -70,10 +71,7 @@ test('normalizeProcessAutoBuildRequest resolves defaults, flow summaries, and so
 
     assert.equal(normalized.request_id, 'pff-pfw_01211_3a8d74d8_produce_20260329T000000Z');
     assert.equal(normalized.run_id, 'pfw_01211_3a8d74d8_produce_20260329T000000Z');
-    assert.equal(
-      normalized.run_root,
-      path.join(dir, 'artifacts', 'process_from_flow', normalized.run_id),
-    );
+    assert.equal(normalized.run_root, path.join(dir, 'workspace-run-root'));
     assert.equal(normalized.flow_file, flowPath);
     assert.equal(normalized.flow_summary.wrapper, 'flowDataSet');
     assert.equal(normalized.flow_summary.uuid, '4d8a3345-51fd-44ac-87e0-59bc8d3b0fdc');
@@ -86,15 +84,7 @@ test('normalizeProcessAutoBuildRequest resolves defaults, flow summaries, and so
     ]);
     assert.equal(
       normalized.source_inputs[0]?.artifact_path,
-      path.join(
-        dir,
-        'artifacts',
-        'process_from_flow',
-        normalized.run_id,
-        'evidence',
-        'incoming',
-        '01_paper_1.pdf',
-      ),
+      path.join(dir, 'workspace-run-root', 'evidence', 'incoming', '01_paper_1.pdf'),
     );
     assert.deepEqual(normalized.source_policy.step1_route.preferred, ['user_bundle', 'kb_bundle']);
     assert.equal(normalized.source_policy.step3b_exchange_values.allow_estimation, true);
@@ -204,10 +194,24 @@ test('normalizeProcessAutoBuildRequest rejects invalid request and source input 
         normalizeProcessAutoBuildRequest(
           {
             flow_file: './01211_3a8d74d8_reference-flow.json',
+          },
+          {
+            inputPath: requestPath,
+          },
+        ),
+      /Provide --out-dir or request\.workspace_run_root/u,
+    );
+
+    assert.throws(
+      () =>
+        normalizeProcessAutoBuildRequest(
+          {
+            flow_file: './01211_3a8d74d8_reference-flow.json',
             source_inputs: {},
           },
           {
             inputPath: requestPath,
+            outDir: './test-run-root',
           },
         ),
       /source_inputs must be an array/u,
@@ -222,6 +226,7 @@ test('normalizeProcessAutoBuildRequest rejects invalid request and source input 
           },
           {
             inputPath: requestPath,
+            outDir: './test-run-root',
           },
         ),
       /entries must be objects/u,
@@ -242,6 +247,7 @@ test('normalizeProcessAutoBuildRequest rejects invalid request and source input 
           },
           {
             inputPath: requestPath,
+            outDir: './test-run-root',
           },
         ),
       /type must be 'local_file' or 'local_text'/u,
@@ -262,6 +268,7 @@ test('normalizeProcessAutoBuildRequest rejects invalid request and source input 
           },
           {
             inputPath: requestPath,
+            outDir: './test-run-root',
           },
         ),
       /source input not found/u,
@@ -287,6 +294,7 @@ test('normalizeProcessAutoBuildRequest rejects invalid request and source input 
           },
           {
             inputPath: requestPath,
+            outDir: './test-run-root',
           },
         ),
       /Duplicate process auto-build source_id/u,
@@ -461,6 +469,7 @@ test('runProcessAutoBuild writes the local artifact scaffold, state, and handoff
   const requestPath = path.join(dir, 'request.json');
   writeJson(requestPath, {
     flow_file: `./${path.basename(flowPath)}`,
+    workspace_run_root: './process-run',
   });
 
   try {
@@ -471,7 +480,7 @@ test('runProcessAutoBuild writes the local artifact scaffold, state, and handoff
     });
 
     assert.equal(report.status, 'prepared_local_process_auto_build_run');
-    assert.equal(report.run_root, path.join(dir, 'artifacts', 'process_from_flow', report.run_id));
+    assert.equal(report.run_root, path.join(dir, 'process-run'));
     assert.equal(existsSync(report.files.state), true);
     assert.equal(existsSync(report.files.handoff_summary), true);
     assert.equal(existsSync(report.files.run_manifest), true);
@@ -601,6 +610,7 @@ test('runProcessAutoBuild rejects invalid flow payloads, non-empty run roots, an
   const sourceDirRequestPath = path.join(dir, 'source-dir-request.json');
   writeJson(sourceDirRequestPath, {
     flow_file: './valid-flow.json',
+    workspace_run_root: './source-dir-run',
     source_inputs: [
       {
         source_id: 'source-dir',
@@ -608,6 +618,10 @@ test('runProcessAutoBuild rejects invalid flow payloads, non-empty run roots, an
         path: './source-dir',
       },
     ],
+  });
+  const missingRootRequestPath = path.join(dir, 'missing-root-request.json');
+  writeJson(missingRootRequestPath, {
+    flow_file: './valid-flow.json',
   });
 
   try {
@@ -633,6 +647,14 @@ test('runProcessAutoBuild rejects invalid flow payloads, non-empty run roots, an
           inputPath: sourceDirRequestPath,
         }),
       /Failed to copy artifact file/u,
+    );
+
+    await assert.rejects(
+      () =>
+        runProcessAutoBuild({
+          inputPath: missingRootRequestPath,
+        }),
+      /Provide --out-dir or request\.workspace_run_root/u,
     );
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/test/process-batch-build.test.ts
+++ b/test/process-batch-build.test.ts
@@ -151,6 +151,7 @@ test('runProcessBatchBuild supports partial failures when continue_on_error is t
   const manifestPath = path.join(dir, 'batch-request.json');
   writeJson(manifestPath, {
     batch_id: 'batch-continue',
+    out_dir: './batch-continue-root',
     items: ['./request-a.json', './missing.json', './request-b.json'],
   });
 
@@ -191,6 +192,7 @@ test('runProcessBatchBuild stops after the first failure when continue_on_error 
   writeJson(manifestPath, {
     batch_id: 'batch-stop',
     continue_on_error: false,
+    out_dir: './batch-stop-root',
     items: ['./request-a.json', './missing.json', './request-c.json'],
   });
 
@@ -297,14 +299,26 @@ test('runProcessBatchBuild rejects invalid manifests and duplicate runtime ident
     );
 
     const missingItemsPath = path.join(dir, 'missing-items.json');
-    writeJson(missingItemsPath, {});
+    writeJson(missingItemsPath, {
+      out_dir: './missing-items-root',
+    });
     await assert.rejects(
       () => runProcessBatchBuild({ inputPath: missingItemsPath }),
       /items must be an array/u,
     );
 
+    const missingRootPath = path.join(dir, 'missing-root.json');
+    writeJson(missingRootPath, {
+      items: ['./request-a.json'],
+    });
+    await assert.rejects(
+      () => runProcessBatchBuild({ inputPath: missingRootPath }),
+      /Provide --out-dir or request\.out_dir/u,
+    );
+
     const emptyItemsPath = path.join(dir, 'empty-items.json');
     writeJson(emptyItemsPath, {
+      out_dir: './empty-items-root',
       items: [],
     });
     await assert.rejects(
@@ -314,6 +328,7 @@ test('runProcessBatchBuild rejects invalid manifests and duplicate runtime ident
 
     const badItemPath = path.join(dir, 'bad-item.json');
     writeJson(badItemPath, {
+      out_dir: './bad-item-root',
       items: [true],
     });
     await assert.rejects(
@@ -323,6 +338,7 @@ test('runProcessBatchBuild rejects invalid manifests and duplicate runtime ident
 
     const missingInputPath = path.join(dir, 'missing-input.json');
     writeJson(missingInputPath, {
+      out_dir: './missing-input-root',
       items: [{}],
     });
     await assert.rejects(
@@ -332,6 +348,7 @@ test('runProcessBatchBuild rejects invalid manifests and duplicate runtime ident
 
     const duplicateItemIdPath = path.join(dir, 'duplicate-item-id.json');
     writeJson(duplicateItemIdPath, {
+      out_dir: './duplicate-item-root',
       items: [
         { input_path: './request-a.json', item_id: 'same' },
         { input_path: './request-b.json', item_id: 'same' },
@@ -345,6 +362,7 @@ test('runProcessBatchBuild rejects invalid manifests and duplicate runtime ident
     const duplicateRunIdPath = path.join(dir, 'duplicate-run-id.json');
     writeJson(duplicateRunIdPath, {
       batch_id: 'batch-duplicate-runid',
+      out_dir: './duplicate-run-id-root',
       items: ['./request-a.json', './request-b.json'],
     });
     const duplicateRunIdReport = await runProcessBatchBuild({
@@ -388,16 +406,20 @@ test('process batch-build internals cover layout, normalization, and helper fall
   );
 
   assert.equal(
-    __testInternals.resolveBatchRoot('/tmp/work', 'batch-1', './override', null),
+    __testInternals.resolveBatchRoot('/tmp/work', './override', null),
     path.resolve('/tmp/work', './override'),
   );
   assert.equal(
-    __testInternals.resolveBatchRoot('/tmp/work', 'batch-1', null, './request-root'),
+    __testInternals.resolveBatchRoot('/tmp/work', null, './request-root'),
     path.resolve('/tmp/work', './request-root'),
   );
   assert.equal(
-    __testInternals.resolveBatchRoot('/tmp/work', 'batch-1', '   ', './request-root'),
+    __testInternals.resolveBatchRoot('/tmp/work', '   ', './request-root'),
     path.resolve('/tmp/work', './request-root'),
+  );
+  assert.throws(
+    () => __testInternals.resolveBatchRoot('/tmp/work', undefined, undefined),
+    /Provide --out-dir or request\.out_dir/u,
   );
 
   const normalized = __testInternals.normalizeProcessBatchBuildRequest(
@@ -420,6 +442,7 @@ test('process batch-build internals cover layout, normalization, and helper fall
   const normalizedWithoutNow = __testInternals.normalizeProcessBatchBuildRequest(
     {
       batch_id: 'batch-inline-default-now',
+      out_dir: './batch-root-default-now',
       items: ['./request-a.json'],
     },
     {
@@ -431,6 +454,7 @@ test('process batch-build internals cover layout, normalization, and helper fall
   const normalizedWithOccupiedSuffix = __testInternals.normalizeProcessBatchBuildRequest(
     {
       batch_id: 'batch-inline-loop',
+      out_dir: './batch-root-loop',
       items: [
         './request-a.json',
         {

--- a/test/process-publish-build.test.ts
+++ b/test/process-publish-build.test.ts
@@ -78,6 +78,8 @@ async function createPreparedRun(dir: string): Promise<{
   const flowPath = writeFlowFixture(dir);
   const requestPath = path.join(dir, 'request.json');
   writeJson(requestPath, {
+    run_id: 'prepared-run',
+    workspace_run_root: './prepared-run',
     flow_file: `./${path.basename(flowPath)}`,
   });
 
@@ -93,7 +95,7 @@ async function createPreparedRun(dir: string): Promise<{
   };
 }
 
-test('runProcessPublishBuild writes local publish handoff artifacts from run-id using export datasets', async () => {
+test('runProcessPublishBuild writes local publish handoff artifacts from run-dir using export datasets', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-publish-build-runid-'));
   const originalCwd = process.cwd();
 
@@ -132,6 +134,7 @@ test('runProcessPublishBuild writes local publish handoff artifacts from run-id 
     process.chdir(dir);
     const publishReport = await runProcessPublishBuild({
       runId: autoReport.run_id,
+      runDir: autoReport.run_root,
       now: new Date('2026-03-29T03:00:00Z'),
       cwd: '/tmp/process-publish-build-runid',
     });
@@ -219,6 +222,8 @@ test('runProcessPublishBuild writes local publish handoff artifacts from run-id 
       'publish-build',
       '--run-id',
       autoReport.run_id,
+      '--run-dir',
+      autoReport.run_root,
     ]);
     assert.equal(invocationIndex.invocations[1]?.cwd, '/tmp/process-publish-build-runid');
 
@@ -347,7 +352,11 @@ test('runProcessPublishBuild recreates a missing invocation index for older runs
 });
 
 test('runProcessPublishBuild rejects invalid inputs and corrupted publish-build artifacts', async () => {
-  await assert.rejects(() => runProcessPublishBuild({}), /Missing required --run-id or --run-dir/u);
+  await assert.rejects(() => runProcessPublishBuild({}), /Missing required --run-dir/u);
+  await assert.rejects(
+    () => runProcessPublishBuild({ runId: 'run-only' }),
+    /Missing required --run-dir/u,
+  );
 
   const mismatchDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-publish-build-mismatch-'));
   try {

--- a/test/process-resume-build.test.ts
+++ b/test/process-resume-build.test.ts
@@ -43,6 +43,8 @@ async function createPreparedRun(dir: string): Promise<{
   const flowPath = writeFlowFixture(dir);
   const requestPath = path.join(dir, 'request.json');
   writeJson(requestPath, {
+    run_id: 'prepared-run',
+    workspace_run_root: './prepared-run',
     flow_file: `./${path.basename(flowPath)}`,
   });
 
@@ -58,7 +60,7 @@ async function createPreparedRun(dir: string): Promise<{
   };
 }
 
-test('runProcessResumeBuild clears stop_after and writes resume artifacts from run-id', async () => {
+test('runProcessResumeBuild clears stop_after and writes resume artifacts from run-dir', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-resume-build-runid-'));
   const originalCwd = process.cwd();
 
@@ -77,6 +79,7 @@ test('runProcessResumeBuild clears stop_after and writes resume artifacts from r
     process.chdir(dir);
     const resumeReport = await runProcessResumeBuild({
       runId: autoReport.run_id,
+      runDir: autoReport.run_root,
       now: new Date('2026-03-29T03:00:00Z'),
       cwd: '/tmp/process-resume-build-resume',
     });
@@ -123,6 +126,8 @@ test('runProcessResumeBuild clears stop_after and writes resume artifacts from r
       'resume-build',
       '--run-id',
       autoReport.run_id,
+      '--run-dir',
+      autoReport.run_root,
     ]);
     assert.equal(invocationIndex.invocations[1]?.cwd, '/tmp/process-resume-build-resume');
 
@@ -232,7 +237,11 @@ test('runProcessResumeBuild rebuilds invocation history when invocation index om
 });
 
 test('runProcessResumeBuild rejects invalid inputs and corrupted process run artifacts', async () => {
-  await assert.rejects(() => runProcessResumeBuild({}), /Missing required --run-id or --run-dir/u);
+  await assert.rejects(() => runProcessResumeBuild({}), /Missing required --run-dir/u);
+  await assert.rejects(
+    () => runProcessResumeBuild({ runId: 'run-only' }),
+    /Missing required --run-dir/u,
+  );
 
   const mismatchDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-resume-build-mismatch-'));
   try {


### PR DESCRIPTION
## Summary
- require explicit caller-managed artifact roots for `process auto-build`, `process batch-build`, and `lifecyclemodel auto-build`
- require `--run-dir` for `process resume-build` and `process publish-build`, keeping `--run-id` only as an optional basename consistency check
- update CLI help text, README/docs, and tests to match the explicit artifact-path contract

## Testing
- npm run prepush:gate