### PR TITLE
docs: add AI doc contracts for issue #85

### DIFF
--- a/.github/scripts/ai-doc-lint.mjs
+++ b/.github/scripts/ai-doc-lint.mjs
@@ -1,0 +1,426 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const MARKDOWN_METADATA_KEYS = [
+  'docType',
+  'scope',
+  'status',
+  'authoritative',
+  'owner',
+  'language',
+  'whenToUse',
+  'whenToUpdate',
+  'checkPaths',
+  'lastReviewedAt',
+  'lastReviewedCommit',
+];
+
+const YAML_METADATA_KEYS = ['lastReviewedAt', 'lastReviewedCommit'];
+
+export function normalizePath(value) {
+  return value.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+/g, '/');
+}
+
+export function escapeRegex(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+export function globToRegExp(pattern) {
+  const normalized = normalizePath(pattern);
+  let output = '^';
+
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index];
+    const next = normalized[index + 1];
+
+    if (char === '*') {
+      if (next === '*') {
+        output += '.*';
+        index += 1;
+      } else {
+        output += '[^/]*';
+      }
+      continue;
+    }
+
+    if (char === '?') {
+      output += '[^/]';
+      continue;
+    }
+
+    output += escapeRegex(char);
+  }
+
+  output += '$';
+  return new RegExp(output);
+}
+
+export function matchesPattern(filePath, pattern) {
+  return globToRegExp(pattern).test(normalizePath(filePath));
+}
+
+export function parseJsonCompatibleYaml(text, sourceLabel) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `${sourceLabel} is not valid JSON-compatible YAML. Phase 1 contract files must use JSON-compatible YAML syntax. ${error.message}`,
+    );
+  }
+}
+
+export function loadJsonCompatibleYaml(absPath, sourceLabel = absPath) {
+  return parseJsonCompatibleYaml(readFileSync(absPath, 'utf8'), sourceLabel);
+}
+
+export function parseFrontmatterKeys(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) {
+    return new Set();
+  }
+
+  return new Set(
+    Array.from(match[1].matchAll(/^([A-Za-z][A-Za-z0-9]*)\s*:/gm), (result) => result[1]),
+  );
+}
+
+export function missingMarkdownMetadata(text) {
+  const keys = parseFrontmatterKeys(text);
+  return MARKDOWN_METADATA_KEYS.filter((key) => !keys.has(key));
+}
+
+export function missingYamlMetadata(text, sourceLabel) {
+  const parsed = parseJsonCompatibleYaml(text, sourceLabel);
+  return YAML_METADATA_KEYS.filter((key) => !(key in parsed));
+}
+
+export function isKeyMarkdownDoc(relPath) {
+  const normalized = normalizePath(relPath);
+  return (
+    path.posix.basename(normalized) === 'AGENTS.md' ||
+    ((normalized.startsWith('ai/') || normalized.includes('/ai/')) && normalized.endsWith('.md'))
+  );
+}
+
+export function isKeyYamlContract(relPath) {
+  const normalized = normalizePath(relPath);
+  return normalized.endsWith('.yaml') && (normalized.startsWith('ai/') || normalized.includes('/ai/'));
+}
+
+export function detectImpactLayout(rootDir) {
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact-map.yaml'))) {
+    return 'workspace';
+  }
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact.yaml'))) {
+    return 'repo';
+  }
+  return 'none';
+}
+
+export function listImpactFiles(rootDir) {
+  const layout = detectImpactLayout(rootDir);
+
+  if (layout === 'repo') {
+    return [
+      {
+        absPath: path.join(rootDir, 'ai', 'doc-impact.yaml'),
+        relPath: 'ai/doc-impact.yaml',
+        baseDir: '',
+      },
+    ];
+  }
+
+  if (layout !== 'workspace') {
+    return [];
+  }
+
+  const rootImpact = path.join(rootDir, 'ai', 'doc-impact-map.yaml');
+  const results = [
+    {
+      absPath: rootImpact,
+      relPath: 'ai/doc-impact-map.yaml',
+      baseDir: '',
+    },
+  ];
+
+  for (const entry of readdirSync(rootDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+
+    const repoImpact = path.join(rootDir, entry.name, 'ai', 'doc-impact.yaml');
+    if (!existsSync(repoImpact)) {
+      continue;
+    }
+
+    results.push({
+      absPath: repoImpact,
+      relPath: normalizePath(path.join(entry.name, 'ai', 'doc-impact.yaml')),
+      baseDir: entry.name,
+    });
+  }
+
+  return results;
+}
+
+export function loadImpactFiles(rootDir) {
+  return listImpactFiles(rootDir).flatMap(({ absPath, relPath, baseDir }) => {
+    const parsed = loadJsonCompatibleYaml(absPath, relPath);
+    const rules = Array.isArray(parsed.rules) ? parsed.rules : [];
+
+    return rules.map((rule) => ({
+      source: relPath,
+      baseDir,
+      rule,
+    }));
+  });
+}
+
+export function resolveRulePath(baseDir, relPattern) {
+  if (!baseDir) {
+    return normalizePath(relPattern);
+  }
+  return normalizePath(path.posix.join(baseDir, relPattern));
+}
+
+export function matchRules(changedPaths, loadedRules) {
+  const matches = [];
+
+  for (const changedPath of changedPaths) {
+    for (const loaded of loadedRules) {
+      const triggers = Array.isArray(loaded.rule.triggers) ? loaded.rule.triggers : [];
+      if (
+        triggers.some((trigger) =>
+          matchesPattern(changedPath, resolveRulePath(loaded.baseDir, trigger.path)),
+        )
+      ) {
+        matches.push({
+          changedPath,
+          source: loaded.source,
+          rule: loaded.rule,
+          baseDir: loaded.baseDir,
+        });
+      }
+    }
+  }
+
+  return matches;
+}
+
+export function collectExpectedDocs(matches) {
+  const expected = new Map();
+
+  for (const match of matches) {
+    const requiredDocs = Array.isArray(match.rule.requiredDocs) ? match.rule.requiredDocs : [];
+    for (const doc of requiredDocs) {
+      const fullPath = resolveRulePath(match.baseDir, doc.path);
+      if (!expected.has(fullPath)) {
+        expected.set(fullPath, {
+          path: fullPath,
+          rules: new Set(),
+          changedPaths: new Set(),
+          modes: new Set(),
+        });
+      }
+
+      const entry = expected.get(fullPath);
+      entry.rules.add(match.rule.id);
+      entry.changedPaths.add(match.changedPath);
+      entry.modes.add(doc.mode);
+    }
+  }
+
+  return expected;
+}
+
+export function parseArgs(argv) {
+  const options = {
+    rootDir: process.cwd(),
+    mode: 'warn',
+    files: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--root') {
+      options.rootDir = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--mode') {
+      options.mode = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--base') {
+      options.base = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--head') {
+      options.head = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--files') {
+      options.files = argv[index + 1]
+        .split(',')
+        .map((value) => normalizePath(value.trim()))
+        .filter(Boolean);
+      index += 1;
+      continue;
+    }
+    if (arg === '--help') {
+      options.help = true;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+export function getChangedPaths({ rootDir, base, head, files }) {
+  if (files.length > 0) {
+    return [...new Set(files)];
+  }
+
+  if (!base || !head) {
+    throw new Error('Pass either --files or both --base and --head.');
+  }
+
+  const output = execFileSync('git', ['diff', '--name-only', `${base}...${head}`], {
+    cwd: rootDir,
+    encoding: 'utf8',
+  });
+
+  return [...new Set(output.split(/\r?\n/).map((value) => normalizePath(value.trim())).filter(Boolean))];
+}
+
+export function buildDocProblems({ rootDir, changedPaths }) {
+  const problems = [];
+
+  for (const relPath of changedPaths) {
+    const absPath = path.join(rootDir, relPath);
+    if (!existsSync(absPath)) {
+      continue;
+    }
+
+    if (isKeyMarkdownDoc(relPath)) {
+      const missing = missingMarkdownMetadata(readFileSync(absPath, 'utf8'));
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing Markdown metadata keys: ${missing.join(', ')}`,
+        });
+      }
+      continue;
+    }
+
+    if (isKeyYamlContract(relPath)) {
+      const missing = missingYamlMetadata(readFileSync(absPath, 'utf8'), relPath);
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing YAML metadata keys: ${missing.join(', ')}`,
+        });
+      }
+    }
+  }
+
+  return problems;
+}
+
+export function buildMissingDocProblems({ changedPaths, expectedDocs }) {
+  const changed = new Set(changedPaths);
+  const problems = [];
+
+  for (const entry of expectedDocs.values()) {
+    if (changed.has(entry.path)) {
+      continue;
+    }
+
+    problems.push({
+      type: 'missing-review',
+      path: entry.path,
+      message: `Expected reviewed doc was not touched. Triggered by ${Array.from(entry.changedPaths).join(', ')} via rule(s): ${Array.from(entry.rules).join(', ')}`,
+    });
+  }
+
+  return problems;
+}
+
+export function formatProblem(problem) {
+  return `- [${problem.type}] ${problem.path}: ${problem.message}`;
+}
+
+export function emitProblems(problems, mode) {
+  if (problems.length === 0) {
+    console.log('AI doc lint: no problems found.');
+    return;
+  }
+
+  const heading =
+    mode === 'enforce' ? 'AI doc lint found blocking problems:' : 'AI doc lint found warnings:';
+  const annotationLevel = mode === 'enforce' ? 'error' : 'warning';
+  console.log(heading);
+  for (const problem of problems) {
+    console.log(formatProblem(problem));
+    if (process.env.GITHUB_ACTIONS) {
+      console.log(`::${annotationLevel} file=${problem.path}::${problem.message}`);
+    }
+  }
+}
+
+export function run(options) {
+  const changedPaths = getChangedPaths(options);
+  if (changedPaths.length === 0) {
+    console.log('AI doc lint: no changed paths to inspect.');
+    return { problems: [], changedPaths, matchedRules: [] };
+  }
+
+  const loadedRules = loadImpactFiles(options.rootDir);
+  const matchedRules = matchRules(changedPaths, loadedRules);
+  const expectedDocs = collectExpectedDocs(matchedRules);
+  const problems = [
+    ...buildMissingDocProblems({ changedPaths, expectedDocs }),
+    ...buildDocProblems({ rootDir: options.rootDir, changedPaths }),
+  ];
+
+  emitProblems(problems, options.mode);
+
+  if (options.mode === 'enforce' && problems.length > 0) {
+    process.exitCode = 1;
+  }
+
+  return { problems, changedPaths, matchedRules };
+}
+
+function printHelp() {
+  console.log(`Usage: node .github/scripts/ai-doc-lint.mjs [--mode warn|enforce] [--base <sha> --head <sha> | --files <csv>] [--root <dir>]`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      printHelp();
+      process.exit(0);
+    }
+    run(options);
+  } catch (error) {
+    console.error(`AI doc lint error: ${error.message}`);
+    process.exit(2);
+  }
+}

--- a/.github/scripts/ai-doc-lint.test.mjs
+++ b/.github/scripts/ai-doc-lint.test.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  collectExpectedDocs,
+  detectImpactLayout,
+  globToRegExp,
+  isKeyMarkdownDoc,
+  loadImpactFiles,
+  matchRules,
+  missingMarkdownMetadata,
+  missingYamlMetadata,
+  normalizePath,
+} from './ai-doc-lint.mjs';
+
+test('normalizePath and globToRegExp support repo-relative matching', () => {
+  assert.equal(normalizePath('.\\tiangong-lca-next\\config\\routes.ts'), 'tiangong-lca-next/config/routes.ts');
+  assert.equal(globToRegExp('tiangong-lca-next/**').test('tiangong-lca-next/config/routes.ts'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/quality-rubric.md'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/nested/file.md'), false);
+});
+
+test('detectImpactLayout distinguishes workspace and repo roots', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-layout-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  assert.equal(detectImpactLayout(tempDir), 'none');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'repo');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact-map.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'workspace');
+});
+
+test('isKeyMarkdownDoc excludes YAML contract files', () => {
+  assert.equal(isKeyMarkdownDoc('ai/quality-rubric.md'), true);
+  assert.equal(isKeyMarkdownDoc('AGENTS.md'), true);
+  assert.equal(isKeyMarkdownDoc('ai/workspace.yaml'), false);
+});
+
+test('missingMarkdownMetadata detects absent frontmatter keys', () => {
+  const text = `---
+title: Example
+docType: contract
+scope: workspace
+status: draft
+authoritative: false
+owner: lca-workspace
+language: en
+whenToUse:
+  - x
+whenToUpdate:
+  - y
+checkPaths:
+  - ai/**
+lastReviewedAt: 2026-04-18
+---
+
+# Example
+`;
+
+  assert.deepEqual(missingMarkdownMetadata(text), ['lastReviewedCommit']);
+});
+
+test('missingYamlMetadata detects absent top-level review fields', () => {
+  const text = JSON.stringify({ version: 1, lastReviewedAt: '2026-04-18' });
+  assert.deepEqual(missingYamlMetadata(text, 'ai/example.yaml'), ['lastReviewedCommit']);
+});
+
+test('loadImpactFiles, matchRules, and collectExpectedDocs resolve repo-local paths', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+  mkdirSync(path.join(tempDir, 'subrepo', 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact-map.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'root-rule',
+            scope: 'workspace',
+            repo: 'lca-workspace',
+            triggers: [{ path: 'AGENTS.md', kind: 'doc-contract' }],
+            requiredDocs: [{ path: 'ai/workspace.yaml', mode: 'review_or_update' }],
+            reason: 'root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  writeFileSync(
+    path.join(tempDir, 'subrepo', 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'subrepo',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/task-router.md', mode: 'review_or_update' }],
+            reason: 'repo',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['AGENTS.md', 'subrepo/src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 2);
+  assert.equal(matches.length, 2);
+  assert.deepEqual([...expectedDocs.keys()].sort(), ['ai/workspace.yaml', 'subrepo/ai/task-router.md']);
+});
+
+test('loadImpactFiles supports repo-root mode', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-repo-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'example',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/validation.md', mode: 'review_or_update' }],
+            reason: 'repo-root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 1);
+  assert.equal(matches.length, 1);
+  assert.deepEqual([...expectedDocs.keys()], ['ai/validation.md']);
+});

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,0 +1,32 @@
+name: ai-doc-lint
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ai-doc-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Run ai-doc-lint unit tests
+        run: node --test .github/scripts/ai-doc-lint.test.mjs
+
+      - name: Run ai-doc-lint
+        run: |
+          node .github/scripts/ai-doc-lint.mjs \
+            --mode enforce \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ Route those tasks to:
 
 ## Runtime Facts
 
+- Repo-local AI-doc maintenance is enforced by `.github/workflows/ai-doc-lint.yml` using the vendored `.github/scripts/ai-doc-lint.*` files.
 - Package manager: `npm`
 - Node baseline: `>=24 <25`
 - Runtime style: TypeScript source, Node-native CLI, direct REST and Edge Function access only

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,73 +1,108 @@
-# AGENTS – TianGong CLI
+---
+title: cli AI Working Guide
+docType: contract
+scope: repo
+status: active
+authoritative: true
+owner: cli
+language: en
+whenToUse:
+  - when a task may change the public `tiangong` command surface, CLI runtime behavior, session handling, or release gating
+  - when routing work from the workspace root into tiangong-lca-cli
+  - when deciding whether a change belongs here, in tiangong-lca-skills, in tiangong-lca-mcp, or in a remote runtime repo
+whenToUpdate:
+  - when command ownership or repo boundaries change
+  - when validation, packaging, or coverage rules change
+  - when the repo-local AI bootstrap docs under ai/ change
+checkPaths:
+  - AGENTS.md
+  - README.md
+  - DEV_CN.md
+  - docs/IMPLEMENTATION_GUIDE_CN.md
+  - ai/**/*.md
+  - ai/**/*.yaml
+  - package.json
+  - .nvmrc
+  - bin/**
+  - src/**
+  - test/**
+  - scripts/**
+  - .github/workflows/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 8a2184bd17dd796a7f13704a085ffe538605f0fe
+related:
+  - ai/repo.yaml
+  - ai/task-router.md
+  - ai/validation.md
+  - ai/architecture.md
+  - README.md
+  - docs/IMPLEMENTATION_GUIDE_CN.md
+---
 
-Use this file as the local entry point for coding agents working in `tiangong-lca-cli`.
+## Repo Contract
 
-## Why This File Exists
+`tiangong-lca-cli` owns the checked-in public `tiangong` CLI contract: command nouns and verbs, launcher behavior, local artifact workflow, remote session/auth handling, and the repo-level release gate. Start here when the task may change what the CLI does or how it is validated.
 
-- keep repo-specific rules close to the CLI implementation
-- reduce agent drift across docs, testing, and delivery
-- preserve the current low-entropy command-surface direction
+## AI Load Order
 
-## Runtime Baseline
+Load docs in this order:
 
-- Node.js `>= 24 < 25` via `.nvmrc`
-- TypeScript source, Node-native runtime first
-- direct REST / Edge Function access only; no MCP inside the CLI
-- do not add orchestration frameworks such as LangGraph unless a human explicitly approves it
-- do not add npm dependencies unless a human explicitly approves it
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. `ai/task-router.md`
+4. `ai/validation.md`
+5. `ai/architecture.md`
+6. `README.md` only for user-facing invocation examples
+7. `docs/IMPLEMENTATION_GUIDE_CN.md` only when you need deeper historical maintainer notes
 
-## Core Commands
+Do not start with scattered subcommands or tests before you know which command family owns the task.
 
-```bash
-npm install
-npm start -- --help
-npm run dev -- --help
-npm run lint
-npm run prettier
-npm test
-npm run test:coverage
-npm run test:coverage:assert-full
-npm run prepush:gate
-npm run build
-```
+## Repo Ownership
 
-Notes:
+This repo owns:
 
-- `npm run lint` is the required local gate: `eslint + deprecated diagnostics + coverage-ignore guard + prettier --check + tsc`.
-- `npm run prettier` is the write-mode formatter.
-- `npm run test:coverage` enforces `100%` coverage for `src/**/*.ts`.
-- `npm run test:coverage:assert-full` verifies the latest coverage artifact without rerunning coverage.
-- `npm run prepush:gate` is the full local push gate: `lint + full coverage + strict 100% assertion`.
+- `bin/tiangong.js` as the stable launcher entrypoint
+- `src/cli.ts` and `src/main.ts` for command dispatch, process entry, help, and exit behavior
+- `src/lib/**` for reusable CLI command logic, session handling, artifacts, and remote adapters
+- `test/**` and `scripts/assert-full-coverage.ts` for the hard validation gate
+- package metadata, build output contract, and tag/release checks in `package.json` and `scripts/ci/**`
 
-## Repo Landmarks
+This repo does not own:
 
-- `bin/tiangong.js`: thin launcher for the stable `tiangong` entrypoint
-- `src/cli.ts`: command dispatch, argument parsing, help text, exit semantics
-- `src/main.ts`: process entry, `.env` loading, stdout / stderr handling
-- `src/lib/**`: reusable CLI helpers
-- `test/**`: unit coverage plus launcher smoke tests
-- `scripts/assert-full-coverage.ts`: hard coverage gate
+- skill packaging and skill wrapper metadata
+- MCP transport or inspector surfaces
+- remote product or Edge Function business logic
+- workspace integration state after merge
 
-## Delivery Contract
+Route those tasks to:
 
-- Investigate first with `rg` and nearby files before editing.
-- Keep the CLI low-entropy:
-  - stable command nouns
-  - file-first input
-  - structured JSON output
-  - no generic “do anything” command layer
-- Every modification must be followed by at least `npm run lint`.
-- If behavior changed, run the relevant tests in the same working session.
-- Before push, the repo must pass `npm run prepush:gate`.
-- Keep `src/**/*.ts` at `100%` statements / branches / functions / lines.
-- Do not use `c8 ignore`, `istanbul ignore`, or similar coverage pragmas to bypass missing tests; cover edge cases in the test suite instead.
-- Keep launcher smoke tests in the normal `npm test` suite; do not weaken them to make coverage easier.
-- Keep diffs scoped; do not mix unrelated refactors into command-surface changes.
+- `tiangong-lca-skills` for skill wrappers and `SKILL.md` packages
+- `tiangong-lca-mcp` for MCP transports and tool registration
+- the owning runtime repo for API, schema, or product behavior
+- `lca-workspace` for root integration after merge
 
-## Documentation Maintenance
+## Runtime Facts
 
-- If commands, workflows, or quality gates change, update the docs in the same change.
-- At minimum, keep these files aligned when relevant:
-  - `README.md`
-  - `DEV_CN.md`
-  - `docs/IMPLEMENTATION_GUIDE_CN.md`
+- Package manager: `npm`
+- Node baseline: `>=24 <25`
+- Runtime style: TypeScript source, Node-native CLI, direct REST and Edge Function access only
+- The canonical minimum validation command is `npm run lint`
+- The authoritative full gate is `npm run prepush:gate`
+- Coverage for `src/**/*.ts` is expected to stay at `100%` statements, branches, functions, and lines
+
+## Hard Boundaries
+
+- Do not add orchestration frameworks or new npm dependencies without explicit approval
+- Do not move business logic into skill wrappers when the native `tiangong` CLI should own it
+- Do not weaken the coverage gate with ignore pragmas; cover the branch or remove dead code
+- Do not treat a merged repo PR here as workspace-delivery complete if the root repo still needs a submodule bump
+
+## Workspace Integration
+
+A merged PR in `tiangong-lca-cli` is repo-complete, not delivery-complete.
+
+If the change must ship through the workspace:
+
+1. merge the child PR into `tiangong-lca-cli`
+2. update the `lca-workspace` submodule pointer deliberately
+3. complete any later workspace-level validation that depends on the updated CLI snapshot

--- a/ai/architecture.md
+++ b/ai/architecture.md
@@ -1,0 +1,112 @@
+---
+title: cli Architecture Notes
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: cli
+language: en
+whenToUse:
+  - when you need a compact mental model of the CLI before editing command routing, helper modules, or release gates
+  - when deciding which file family owns a behavior change
+  - when launcher, session, review, publish, or artifact hotspots are mentioned without exact paths
+whenToUpdate:
+  - when major repo paths or command families change
+  - when session or artifact architecture moves
+  - when coverage or release gating becomes materially different
+checkPaths:
+  - ai/architecture.md
+  - ai/repo.yaml
+  - package.json
+  - bin/**
+  - src/**
+  - test/**
+  - scripts/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 8a2184bd17dd796a7f13704a085ffe538605f0fe
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./task-router.md
+  - ./validation.md
+  - ../README.md
+---
+
+## Repo Shape
+
+This repo is organized around one stable launcher plus a library-style `src/lib/**` tree that implements command families and shared helpers.
+
+## Stable Path Map
+
+| Path group | Role |
+| --- | --- |
+| `bin/tiangong.js` | stable launcher entrypoint exposed as the public `tiangong` executable |
+| `src/main.ts` | process entry, dotenv loading, stdout and stderr wiring |
+| `src/cli.ts` | top-level command dispatch, parsing, and help routing |
+| `src/lib/**` | command-family implementations plus shared auth, IO, artifact, and remote helpers |
+| `test/**` | unit and launcher tests that back the coverage gate |
+| `scripts/assert-full-coverage.ts` | strict coverage enforcement |
+| `scripts/ci/**` | release-tag and package publication checks |
+
+## Current Architectural Clusters
+
+### Launcher and entry contract
+
+The public `tiangong` surface starts in:
+
+- `bin/tiangong.js`
+- `src/main.ts`
+- `src/cli.ts`
+
+If a task changes help output, exit behavior, or how subcommands are registered, start here.
+
+### Session and remote access layer
+
+The CLI talks to remote services directly through helper modules such as:
+
+- `src/lib/env.ts`
+- `src/lib/dotenv.ts`
+- `src/lib/user-api-key.ts`
+- `src/lib/supabase-session.ts`
+- `src/lib/supabase-client.ts`
+- `src/lib/supabase-rest.ts`
+- `src/lib/remote.ts`
+- `src/lib/http.ts`
+
+This is where the CLI-owned remote access contract lives.
+
+### Workflow command families
+
+The widest feature families currently live in:
+
+- `src/lib/flow-*.ts`
+- `src/lib/review-*.ts`
+- `src/lib/process-*.ts`
+- `src/lib/lifecyclemodel-*.ts`
+- `src/lib/publish.ts`
+- `src/lib/run.ts`
+
+These files own the public CLI semantics for those workflows.
+
+### Artifact and filesystem behavior
+
+Artifact materialization and local state handling cluster around:
+
+- `src/lib/artifacts.ts`
+- `src/lib/io.ts`
+- `src/lib/state-lock.ts`
+
+If a task changes output layout, locking, or local run roots, inspect these first.
+
+## Cross-Repo Boundaries
+
+- `tiangong-lca-skills` wraps CLI commands but does not own the native command contract
+- `tiangong-lca-mcp` owns MCP transports and tool exposure, not the CLI executable
+- runtime API, schema, or product behavior still belong in their owning repos
+- `lca-workspace` owns root delivery completion after a child PR merges
+
+## Common Misreads
+
+- a skill wrapper is not the source of truth for a missing command
+- the CLI should not absorb MCP transport behavior
+- a merged child PR does not finish workspace delivery

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -117,7 +117,15 @@
           "kind": "release-gate"
         },
         {
-          "path": ".github/workflows/**",
+          "path": ".github/workflows/quality-gate.yml",
+          "kind": "ci"
+        },
+        {
+          "path": ".github/workflows/publish.yml",
+          "kind": "ci"
+        },
+        {
+          "path": ".github/workflows/tag-release-from-merge.yml",
           "kind": "ci"
         }
       ],
@@ -140,6 +148,44 @@
         }
       ],
       "reason": "Runtime, coverage, and release-gate changes alter how future CLI work is validated and shipped."
+    },
+    {
+      "id": "cli-ai-doc-maintenance-contract",
+      "scope": "repo",
+      "repo": "cli",
+      "triggers": [
+        {
+          "path": ".github/workflows/ai-doc-lint.yml",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.mjs",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.test.mjs",
+          "kind": "automation"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/doc-impact.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Repo-local AI doc maintenance automation changes alter the maintenance gate and should refresh the AI contract docs."
     }
   ]
 }

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -1,0 +1,145 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "8a2184bd17dd796a7f13704a085ffe538605f0fe",
+  "rules": [
+    {
+      "id": "cli-bootstrap-contract",
+      "scope": "repo",
+      "repo": "cli",
+      "triggers": [
+        {
+          "path": "AGENTS.md",
+          "kind": "doc-contract"
+        },
+        {
+          "path": "README.md",
+          "kind": "doc-entry"
+        },
+        {
+          "path": "DEV_CN.md",
+          "kind": "doc-maintainer"
+        },
+        {
+          "path": "docs/IMPLEMENTATION_GUIDE_CN.md",
+          "kind": "doc-maintainer"
+        },
+        {
+          "path": "ai/**",
+          "kind": "doc-ai-layer"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Entry guidance, repo facts, and routing docs must stay aligned."
+    },
+    {
+      "id": "cli-command-surface-contract",
+      "scope": "repo",
+      "repo": "cli",
+      "triggers": [
+        {
+          "path": "bin/**",
+          "kind": "launcher"
+        },
+        {
+          "path": "src/cli.ts",
+          "kind": "command-router"
+        },
+        {
+          "path": "src/main.ts",
+          "kind": "process-entry"
+        },
+        {
+          "path": "src/lib/**",
+          "kind": "command-logic"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Launcher and command implementation changes alter the public CLI contract and should refresh the AI bootstrap docs."
+    },
+    {
+      "id": "cli-validation-and-release-contract",
+      "scope": "repo",
+      "repo": "cli",
+      "triggers": [
+        {
+          "path": "package.json",
+          "kind": "runtime-config"
+        },
+        {
+          "path": ".nvmrc",
+          "kind": "runtime-config"
+        },
+        {
+          "path": "test/**",
+          "kind": "repo-test"
+        },
+        {
+          "path": "scripts/assert-full-coverage.ts",
+          "kind": "coverage-gate"
+        },
+        {
+          "path": "scripts/ci/**",
+          "kind": "release-gate"
+        },
+        {
+          "path": ".github/workflows/**",
+          "kind": "ci"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Runtime, coverage, and release-gate changes alter how future CLI work is validated and shipped."
+    }
+  ]
+}

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -160,7 +160,7 @@
       "notes": [
         "npm run test:coverage and npm run test:coverage:assert-full are the coverage-specific proofs when code or test behavior changes.",
         "Use npm run test:ci -- <jest-args> for focused suites with extra Jest flags.",
-        "AI-doc changes should still run the root warning-only ai-doc-lint."
+        "AI-doc changes should still run the repo-local ai-doc-lint workflow or the equivalent local node command."
       ]
     }
   }

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -1,0 +1,167 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "8a2184bd17dd796a7f13704a085ffe538605f0fe",
+  "repo": {
+    "id": "cli",
+    "path": "tiangong-lca-cli",
+    "canonicalRepo": "tiangong-lca/tiangong-cli",
+    "purpose": "Unified TianGong LCA CLI with a low-entropy public command surface and direct remote adapters.",
+    "entryDoc": "AGENTS.md",
+    "taskRouterDoc": "ai/task-router.md",
+    "validationDoc": "ai/validation.md",
+    "architectureDoc": "ai/architecture.md",
+    "readmeDoc": "README.md",
+    "defaultBranch": "main",
+    "dailyTrunk": "main",
+    "routinePrBase": "main",
+    "branchModel": "M1",
+    "workspaceIntegrationRequired": true,
+    "rootIntegrationRule": "lca-workspace/main may bump merged main-branch CLI snapshots when the workspace intends to ship the updated command surface.",
+    "trackedBy": {
+      "workspaceParentIssue": "https://github.com/tiangong-lca/workspace/issues/73",
+      "repoIssue": "https://github.com/tiangong-lca/tiangong-cli/issues/85"
+    },
+    "runtime": {
+      "packageManager": "npm",
+      "nodeVersion": ">=24 <25",
+      "moduleSystem": "ESM",
+      "publicExecutable": "tiangong",
+      "launcher": "bin/tiangong.js",
+      "entrypoints": [
+        "src/main.ts",
+        "src/cli.ts"
+      ],
+      "baselineValidationCommands": [
+        "npm run lint",
+        "npm test",
+        "npm run build"
+      ],
+      "fullGateCommand": "npm run prepush:gate"
+    },
+    "sourceOfTruth": {
+      "stableManualEditPaths": [
+        {
+          "path": "bin/tiangong.js",
+          "role": "stable launcher entrypoint"
+        },
+        {
+          "path": "src/cli.ts",
+          "role": "command dispatch, argument parsing, help, and exit semantics"
+        },
+        {
+          "path": "src/main.ts",
+          "role": "process entry, dotenv loading, stdout and stderr handling"
+        },
+        {
+          "path": "src/lib/**",
+          "role": "command-family implementations, auth/session helpers, remote adapters, and artifact logic"
+        },
+        {
+          "path": "test/**",
+          "role": "coverage-enforced unit and launcher tests"
+        },
+        {
+          "path": "scripts/assert-full-coverage.ts",
+          "role": "strict coverage gate enforcement"
+        },
+        {
+          "path": "scripts/ci/**",
+          "role": "release tag and publication sanity checks"
+        },
+        {
+          "path": "README.md",
+          "role": "user-facing invocation contract and examples"
+        },
+        {
+          "path": "DEV_CN.md",
+          "role": "Chinese maintainer notes"
+        },
+        {
+          "path": "docs/IMPLEMENTATION_GUIDE_CN.md",
+          "role": "deeper historical implementation notes"
+        }
+      ],
+      "nonOwnerBoundaries": [
+        {
+          "repo": "skills",
+          "doesNotOwn": [
+            "skill package metadata",
+            "skill wrapper installation layout"
+          ]
+        },
+        {
+          "repo": "mcp",
+          "doesNotOwn": [
+            "MCP transports",
+            "inspector or HTTP MCP serving surfaces"
+          ]
+        },
+        {
+          "repo": "lca-workspace",
+          "doesNotOwn": [
+            "root integration state",
+            "submodule pointer updates"
+          ]
+        }
+      ]
+    },
+    "taskHotspots": [
+      {
+        "topic": "launcher, help, and command-surface routing",
+        "paths": [
+          "bin/tiangong.js",
+          "src/main.ts",
+          "src/cli.ts"
+        ]
+      },
+      {
+        "topic": "remote session, auth, and REST or Edge adapters",
+        "paths": [
+          "src/lib/env.ts",
+          "src/lib/dotenv.ts",
+          "src/lib/user-api-key.ts",
+          "src/lib/supabase-session.ts",
+          "src/lib/supabase-client.ts",
+          "src/lib/supabase-rest.ts",
+          "src/lib/remote.ts",
+          "src/lib/http.ts"
+        ]
+      },
+      {
+        "topic": "workflow command families and artifact materialization",
+        "paths": [
+          "src/lib/flow-*.ts",
+          "src/lib/review-*.ts",
+          "src/lib/process-*.ts",
+          "src/lib/lifecyclemodel-*.ts",
+          "src/lib/publish.ts",
+          "src/lib/run.ts",
+          "src/lib/artifacts.ts"
+        ]
+      },
+      {
+        "topic": "coverage and release gating",
+        "paths": [
+          "test/**",
+          "scripts/assert-full-coverage.ts",
+          "scripts/ci/**",
+          "package.json"
+        ]
+      }
+    ],
+    "validation": {
+      "baselineLocalCommands": [
+        "npm run lint",
+        "npm test",
+        "npm run build"
+      ],
+      "fullGateCommand": "npm run prepush:gate",
+      "notes": [
+        "npm run test:coverage and npm run test:coverage:assert-full are the coverage-specific proofs when code or test behavior changes.",
+        "Use npm run test:ci -- <jest-args> for focused suites with extra Jest flags.",
+        "AI-doc changes should still run the root warning-only ai-doc-lint."
+      ]
+    }
+  }
+}

--- a/ai/task-router.md
+++ b/ai/task-router.md
@@ -1,0 +1,94 @@
+---
+title: cli Task Router
+docType: router
+scope: repo
+status: active
+authoritative: false
+owner: cli
+language: en
+whenToUse:
+  - when you already know the task belongs in tiangong-lca-cli but need the right next file or next doc
+  - when deciding whether a change belongs in the launcher, one command family, session helpers, release gates, or another repo
+  - when routing between CLI work and handoffs to skills, MCP, or runtime repos
+whenToUpdate:
+  - when new high-frequency command families appear
+  - when repo boundaries or deep-doc links change
+  - when validation routing becomes misleading
+checkPaths:
+  - AGENTS.md
+  - ai/repo.yaml
+  - ai/task-router.md
+  - ai/validation.md
+  - ai/architecture.md
+  - package.json
+  - bin/**
+  - src/**
+  - test/**
+  - scripts/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 8a2184bd17dd796a7f13704a085ffe538605f0fe
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./validation.md
+  - ./architecture.md
+  - ../README.md
+  - ../docs/IMPLEMENTATION_GUIDE_CN.md
+---
+
+## Repo Load Order
+
+When working inside `tiangong-lca-cli`, load docs in this order:
+
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. this file
+4. `ai/validation.md` or `ai/architecture.md`
+5. `README.md` only for public invocation examples
+6. `docs/IMPLEMENTATION_GUIDE_CN.md` only for deeper historical maintainer context
+
+## High-Frequency Task Routing
+
+| Task intent | First code paths to inspect | Next docs to load | Notes |
+| --- | --- | --- | --- |
+| Change launcher behavior, `--help`, exit codes, or top-level command routing | `bin/tiangong.js`, `src/main.ts`, `src/cli.ts` | `ai/validation.md`, `ai/architecture.md` | This is the core public command surface. |
+| Change env loading, session caching, or user API key exchange | `src/lib/dotenv.ts`, `src/lib/env.ts`, `src/lib/user-api-key.ts`, `src/lib/supabase-session.ts`, `src/lib/supabase-client.ts` | `ai/validation.md`, `ai/architecture.md` | Remote auth and session behavior belong here, not in skill wrappers. |
+| Change generic REST or Edge request behavior | `src/lib/http.ts`, `src/lib/remote.ts`, `src/lib/supabase-rest.ts` | `ai/validation.md`, `ai/architecture.md` | If the remote API contract itself changes, coordinate with the owning runtime repo. |
+| Change flow governance, dedupe, or reviewed-data commands | `src/lib/flow-*.ts` | `ai/validation.md`, `ai/architecture.md` | Keep public command semantics and artifact outputs aligned. |
+| Change process review or process build flows | `src/lib/process-*.ts`, `src/lib/review-process.ts` | `ai/validation.md`, `ai/architecture.md` | Use focused tests for the affected process command family. |
+| Change lifecycle model automation or publish flows | `src/lib/lifecyclemodel-*.ts`, `src/lib/publish.ts`, `src/lib/run.ts` | `ai/validation.md`, `ai/architecture.md` | These commands often touch artifact layout and remote orchestration together. |
+| Change local artifact, lockfile, or output path behavior | `src/lib/artifacts.ts`, `src/lib/io.ts`, `src/lib/state-lock.ts` | `ai/validation.md`, `ai/architecture.md` | Preserve file-first usage and deterministic output layout. |
+| Change TIDAS SDK validation inside the CLI | `src/lib/tidas-sdk-package-validator.ts` | `ai/validation.md`, `ai/architecture.md` | If the SDK package contract itself changes, coordinate with `tidas-sdk`. |
+| Change coverage, release tag checks, or protected-branch gates | `scripts/assert-full-coverage.ts`, `scripts/ci/**`, `package.json`, `test/**` | `ai/validation.md` | `npm run prepush:gate` remains the full protected-branch contract. |
+| Add a capability that only exists today in skills wrappers | `tiangong-lca-cli`, then `tiangong-lca-skills` | root `ai/task-router.md` | Add the native CLI command first, then update the skill wrapper repo. |
+| Change MCP transport or inspector behavior | `tiangong-lca-mcp`, not this repo | root `ai/task-router.md` | CLI and MCP are separate surfaces. |
+| Decide whether work is delivery-complete after merge | root workspace docs, not repo code paths | root `AGENTS.md`, `_docs/workspace-branch-policy-contract.md` | Root integration remains a separate phase. |
+
+## Wrong Turns To Avoid
+
+### Implementing command semantics in skills first
+
+If the public command does not exist yet, add it here first. Skills are wrappers, not the primary CLI truth.
+
+### Weakening the coverage gate to land a feature
+
+Do not bypass `npm run prepush:gate` with coverage ignores. Either test the branch or remove dead code.
+
+### Treating remote runtime drift as a CLI-only problem
+
+If the CLI behavior is wrong because the remote API or schema changed, coordinate with the owning runtime repo instead of inventing a local-only contract.
+
+## Cross-Repo Handoffs
+
+Use these handoffs when work crosses boundaries:
+
+1. new native command needed by skills
+   - start here
+   - then update `tiangong-lca-skills`
+2. CLI bug caused by MCP transport behavior
+   - route to `tiangong-lca-mcp`
+3. CLI bug caused by remote API or schema truth
+   - route to the owning runtime repo
+4. merged repo PR still needs to ship through the workspace
+   - return to `lca-workspace`
+   - do the submodule pointer bump there

--- a/ai/task-router.md
+++ b/ai/task-router.md
@@ -62,6 +62,7 @@ When working inside `tiangong-lca-cli`, load docs in this order:
 | Change coverage, release tag checks, or protected-branch gates | `scripts/assert-full-coverage.ts`, `scripts/ci/**`, `package.json`, `test/**` | `ai/validation.md` | `npm run prepush:gate` remains the full protected-branch contract. |
 | Add a capability that only exists today in skills wrappers | `tiangong-lca-cli`, then `tiangong-lca-skills` | root `ai/task-router.md` | Add the native CLI command first, then update the skill wrapper repo. |
 | Change MCP transport or inspector behavior | `tiangong-lca-mcp`, not this repo | root `ai/task-router.md` | CLI and MCP are separate surfaces. |
+| Change repo-local AI-doc maintenance only | `AGENTS.md`, `ai/**`, `.github/workflows/ai-doc-lint.yml`, `.github/scripts/ai-doc-lint.*` | `ai/validation.md` when present, otherwise `ai/repo.yaml` | Keep the repo-local maintenance gate aligned with root `ai/ci-lint-spec.md` and `ai/review-matrix.md`. |
 | Decide whether work is delivery-complete after merge | root workspace docs, not repo code paths | root `AGENTS.md`, `_docs/workspace-branch-policy-contract.md` | Root integration remains a separate phase. |
 
 ## Wrong Turns To Avoid

--- a/ai/validation.md
+++ b/ai/validation.md
@@ -1,0 +1,80 @@
+---
+title: cli Validation Guide
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: cli
+language: en
+whenToUse:
+  - when a tiangong-lca-cli change is ready for local validation
+  - when deciding the minimum proof required for command, session, artifact, test, or release-gate changes
+  - when writing PR validation notes for tiangong-lca-cli work
+whenToUpdate:
+  - when the repo gains a new canonical validation command or wrapper
+  - when change categories require different minimum proof
+  - when the protected-branch or coverage contract changes
+checkPaths:
+  - ai/validation.md
+  - ai/task-router.md
+  - package.json
+  - bin/**
+  - src/**
+  - test/**
+  - scripts/**
+  - .github/workflows/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 8a2184bd17dd796a7f13704a085ffe538605f0fe
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./task-router.md
+  - ./architecture.md
+  - ../README.md
+---
+
+## Default Baseline
+
+Unless the change is doc-only, the minimum local baseline is:
+
+```bash
+npm run lint
+npm test
+npm run build
+```
+
+For protected-branch parity, the authoritative full gate is:
+
+```bash
+npm run prepush:gate
+```
+
+## Validation Matrix
+
+| Change type | Minimum local proof | Additional proof when risk is higher | Notes |
+| --- | --- | --- | --- |
+| `bin/**`, `src/main.ts`, or `src/cli.ts` | `npm run lint`; `npm test`; `npm run build` | run the relevant `tiangong --help` or subcommand help path after build | Launcher and dispatch changes affect the public command surface directly. |
+| session, auth, env, or remote adapter helpers under `src/lib/{dotenv,env,user-api-key,supabase-*,remote,http}*` | `npm run lint`; `npm test`; `npm run build` | run focused tests for the touched helper plus one command that exercises the changed path | Record any required live env assumptions in the PR note. |
+| flow, process, lifecyclemodel, review, publish, or run command families | `npm run lint`; `npm test`; `npm run build` | run focused tests for the touched command family; run `npm run test:coverage:assert-full` if the change touched uncovered branches | Preserve the low-entropy command contract and structured artifact outputs. |
+| artifact, IO, or state-lock behavior | `npm run lint`; `npm test`; `npm run build` | run one representative command path that writes the changed artifact layout, if safe | Path and file layout regressions matter for downstream automation. |
+| `test/**` or coverage gate scripts | `npm run lint`; `npm test`; `npm run test:coverage`; `npm run test:coverage:assert-full` | run `npm run prepush:gate` when the change affects the protected-branch gate directly | Coverage for `src/**/*.ts` is expected to remain at `100%`. |
+| `package.json`, `.nvmrc`, or `scripts/ci/**` | `npm run lint`; `npm test`; `npm run build` | run `npm run prepush:gate` when the change affects release or protected-branch checks | Release-tag checks and dependency baselines change the repo contract. |
+| AI docs only | run the root warning-only `ai-doc-lint` against touched files | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
+
+## Coverage Notes
+
+Facts that matter:
+
+- `npm run test:coverage` is the full coverage proof
+- `npm run test:coverage:assert-full` verifies the latest coverage artifact without rerunning coverage
+- `npm run prepush:gate` is the exact protected-branch gate
+
+If the task changes control flow, add or update tests instead of using coverage-ignore pragmas.
+
+## Minimum PR Note Quality
+
+A good PR note for this repo should say:
+
+1. which commands ran
+2. which focused tests or help paths were exercised when the change touched one command family
+3. whether the full protected-branch gate was run or deferred

--- a/ai/validation.md
+++ b/ai/validation.md
@@ -59,7 +59,7 @@ npm run prepush:gate
 | artifact, IO, or state-lock behavior | `npm run lint`; `npm test`; `npm run build` | run one representative command path that writes the changed artifact layout, if safe | Path and file layout regressions matter for downstream automation. |
 | `test/**` or coverage gate scripts | `npm run lint`; `npm test`; `npm run test:coverage`; `npm run test:coverage:assert-full` | run `npm run prepush:gate` when the change affects the protected-branch gate directly | Coverage for `src/**/*.ts` is expected to remain at `100%`. |
 | `package.json`, `.nvmrc`, or `scripts/ci/**` | `npm run lint`; `npm test`; `npm run build` | run `npm run prepush:gate` when the change affects release or protected-branch checks | Release-tag checks and dependency baselines change the repo contract. |
-| AI docs only | run the root warning-only `ai-doc-lint` against touched files | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
+| AI docs only | run repo-local `ai-doc-lint` against touched files or the equivalent local PR check | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
 
 ## Coverage Notes
 


### PR DESCRIPTION
Closes tiangong-lca/tiangong-cli#85

## Summary
- Add a checked-in AI contract layer with AGENTS.md and repo-local ai/*.md docs.
- Document command-surface ownership, validation gates, and repo boundaries for low-token CLI routing.

## Validation
- npm run lint
- npm run build
- npm test

## Workspace Integration
- If the merged doc change needs to ship in the workspace snapshot, bump the submodule in lca-workspace after merge.