### PR TITLE
Fix CLI quality gates for process commands

### DIFF
--- a/.github/workflows/tag-release-from-merge.yml
+++ b/.github/workflows/tag-release-from-merge.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   tag-release:
+    if: github.repository == 'tiangong-lca/tiangong-cli'
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.TIANGONG_CLI_RELEASE_AUTOMATION_TOKEN }}

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -230,6 +230,26 @@ npm exec tiangong -- admin embedding-run --input ./jobs.json --dry-run
 
 这个命令当前只负责 deterministic direct-read，不负责任何远端写入、review、publish 或 workflow 编排。
 
+`tiangong process list` 现在是统一 CLI 持有的只读 process 列表命令，负责：
+
+- 从 `TIANGONG_LCA_API_BASE_URL` 推导 Supabase `/rest/v1/processes` 读取路径
+- 支持 `--id`、`--version`、`--user-id`、`--state-code` 过滤
+- 支持 `--limit` / `--offset`，以及 `--all --page-size <n>` 的显式分页收集
+- 对远端读取失败做有限重试
+- 输出稳定的结构化 JSON 报告，可直接作为 `tiangong review process --rows-file ...` 的输入
+
+这个命令当前只负责 deterministic direct-read list，不负责治理修复、反向引用追踪或远端写入。
+
+`tiangong process save-draft` 现在已经承担当前账号 draft process 的 state-aware 写入切片，负责：
+
+- 读取 process rows JSON/JSONL 或 publish request 中的 canonical process payload
+- 在本地先执行 `ProcessSchema` 校验，阻断 schema-invalid payload
+- 对精确版本做可见性预检，区分 current-user `state_code=0` draft 与其它可见行
+- 对 current-user draft 走 `cmd_dataset_save_draft`
+- 把 schema-invalid 或执行失败的行写入 `outputs/save-draft-rpc/failures.jsonl`
+
+这个命令当前只负责 current-user draft 的 save-draft/update 语义；它不会替代 public `state_code=100` 的版本修订 publish 路径。
+
 `tiangong process auto-build` 现在已经承担 `process_from_flow` 主链的第一个 CLI 切片，负责：
 
 - 读取单个 process-from-flow request

--- a/README.md
+++ b/README.md
@@ -170,10 +170,18 @@ Key `flow materialize-decisions` outputs:
 ## Other Common Commands
 
 ```bash
+tiangong process auto-build --input ./examples/process-auto-build.request.json --out-dir /abs/path/to/process-run --json
+tiangong process resume-build --run-dir /abs/path/to/process-run --json
+tiangong process publish-build --run-dir /abs/path/to/process-run --json
+tiangong process batch-build --input ./examples/process-batch-build.request.json --out-dir /abs/path/to/process-batch --json
+tiangong lifecyclemodel auto-build --input ./examples/lifecyclemodel-auto-build.request.json --out-dir /abs/path/to/lifecyclemodel-run --json
+tiangong lifecyclemodel validate-build --run-dir /abs/path/to/lifecyclemodel-run --json
+tiangong lifecyclemodel publish-build --run-dir /abs/path/to/lifecyclemodel-run --json
+tiangong lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir /abs/path/to/lifecyclemodel-recursive-run --json
 tiangong review process --rows-file ./process-list-report.json --out-dir ./review
-tiangong review process --run-root ./artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir ./review
-tiangong process save-draft --input ./patched-processes.jsonl --dry-run
-tiangong process save-draft --input ./patched-processes.jsonl --out-dir ./save-draft --commit
+tiangong review process --run-root /abs/path/to/process-run --run-id <run_id> --out-dir ./review
+tiangong process save-draft --input ./patched-processes.jsonl --out-dir /abs/path/to/process-save-draft --dry-run --json
+tiangong process save-draft --input ./patched-processes.jsonl --out-dir /abs/path/to/process-save-draft --commit --json
 tiangong publish run --input ./publish-request.json --dry-run
 tiangong doctor --json
 ```

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ Key `flow materialize-decisions` outputs:
 ```bash
 tiangong review process --rows-file ./process-list-report.json --out-dir ./review
 tiangong review process --run-root ./artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir ./review
+tiangong process save-draft --input ./patched-processes.jsonl --dry-run
+tiangong process save-draft --input ./patched-processes.jsonl --out-dir ./save-draft --commit
 tiangong publish run --input ./publish-request.json --dry-run
 tiangong doctor --json
 ```
@@ -179,6 +181,8 @@ tiangong doctor --json
 For `publish run`, relative `out_dir` values from either the request body or `--out-dir` are resolved against the request file directory, not the shell `cwd`. Use an absolute path when you want a fixed destination independent of the request file location.
 
 For `review process`, `--rows-file` accepts either raw process rows as JSON/JSONL or the full JSON report emitted by `tiangong process list --json`, as long as it contains a `rows` array.
+
+For `process save-draft`, canonical process payloads are validated locally with `ProcessSchema` before any `--commit` write. Schema-invalid rows remain in `outputs/save-draft-rpc/failures.jsonl` instead of being persisted.
 
 ## More Docs
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -302,19 +302,19 @@ Examples:
   tiangong search process --input ./request.json --dry-run
   tiangong process get --id <process-id>
   tiangong process list --state-code 100 --limit 20
-  tiangong process scope-statistics --out-dir ./process-scope --state-code 0 --state-code 100
-  tiangong process dedup-review --input ./duplicate-groups.json --out-dir ./process-dedup
-  tiangong process auto-build --input ./pff-request.json
-  tiangong process resume-build --run-id <id>
-  tiangong process publish-build --run-id <id>
-  tiangong process save-draft --input ./patched-processes.jsonl --dry-run
-  tiangong process batch-build --input ./batch-request.json
-  tiangong process refresh-references --out-dir ./process-refresh --dry-run
-  tiangong process verify-rows --rows-file ./process-list-report.json --out-dir ./process-verify
-  tiangong lifecyclemodel auto-build --input ./lifecyclemodel-auto-build.request.json
-  tiangong lifecyclemodel validate-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id>
-  tiangong lifecyclemodel publish-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id>
-  tiangong lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir ./artifacts/lifecyclemodel_recursive/run-001
+  tiangong process scope-statistics --out-dir /abs/path/to/process-scope --state-code 0 --state-code 100
+  tiangong process dedup-review --input ./duplicate-groups.json --out-dir /abs/path/to/process-dedup
+  tiangong process auto-build --input ./pff-request.json --out-dir /abs/path/to/process-run
+  tiangong process resume-build --run-dir /abs/path/to/process-run
+  tiangong process publish-build --run-dir /abs/path/to/process-run
+  tiangong process save-draft --input ./patched-processes.jsonl --out-dir /abs/path/to/process-save-draft --dry-run
+  tiangong process batch-build --input ./batch-request.json --out-dir /abs/path/to/process-batch
+  tiangong process refresh-references --out-dir /abs/path/to/process-refresh --dry-run
+  tiangong process verify-rows --rows-file ./process-list-report.json --out-dir /abs/path/to/process-verify
+  tiangong lifecyclemodel auto-build --input ./lifecyclemodel-auto-build.request.json --out-dir /abs/path/to/lifecyclemodel-run
+  tiangong lifecyclemodel validate-build --run-dir /abs/path/to/lifecyclemodel-run
+  tiangong lifecyclemodel publish-build --run-dir /abs/path/to/lifecyclemodel-run
+  tiangong lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir /abs/path/to/lifecyclemodel-recursive-run
   tiangong flow get --id <flow-id> --version <version>
   tiangong flow list --id <flow-id> --state-code 100 --limit 20
   tiangong flow fetch-rows --refs-file ./flow-refs.json --out-dir ./flow-fetch
@@ -329,9 +329,9 @@ Examples:
   tiangong flow regen-product --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-regeneration --apply
   tiangong flow validate-processes --original-processes-file ./before.jsonl --patched-processes-file ./after.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-validation
   tiangong review process --rows-file ./processes.jsonl --out-dir ./review
-  tiangong review process --run-root ./artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir ./review
+  tiangong review process --run-root /abs/path/to/process-run --run-id <run_id> --out-dir ./review
   tiangong review flow --rows-file ./flows.json --out-dir ./review
-  tiangong review lifecyclemodel --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id> --out-dir ./lifecyclemodel-review
+  tiangong review lifecyclemodel --run-dir /abs/path/to/lifecyclemodel-run --out-dir ./lifecyclemodel-review
   tiangong publish run --input ./publish-request.json --dry-run
   tiangong validation run --input-dir ./package --engine auto
   tiangong admin embedding-run --input ./jobs.json

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,6 +61,11 @@ import {
   type RunProcessScopeStatisticsOptions,
 } from './lib/process-scope-statistics.js';
 import {
+  runProcessRefreshReferences,
+  type ProcessRefreshReferencesReport,
+  type RunProcessRefreshReferencesOptions,
+} from './lib/process-refresh-references.js';
+import {
   runProcessDedupReview,
   type ProcessDedupReviewReport,
   type RunProcessDedupReviewOptions,
@@ -80,6 +85,11 @@ import {
   type ProcessSaveDraftReport,
   type RunProcessSaveDraftOptions,
 } from './lib/process-save-draft-run.js';
+import {
+  runProcessVerifyRows,
+  type ProcessVerifyRowsReport,
+  type RunProcessVerifyRowsOptions,
+} from './lib/process-verify-rows.js';
 import { runPublish, type PublishReport, type RunPublishOptions } from './lib/publish.js';
 import {
   runProcessReview,
@@ -187,6 +197,9 @@ export type CliDeps = {
   runProcessScopeStatisticsImpl?: (
     options: RunProcessScopeStatisticsOptions,
   ) => Promise<ProcessScopeStatisticsReport>;
+  runProcessRefreshReferencesImpl?: (
+    options: RunProcessRefreshReferencesOptions,
+  ) => Promise<ProcessRefreshReferencesReport>;
   runProcessDedupReviewImpl?: (
     options: RunProcessDedupReviewOptions,
   ) => Promise<ProcessDedupReviewReport>;
@@ -199,6 +212,9 @@ export type CliDeps = {
   runProcessSaveDraftImpl?: (
     options: RunProcessSaveDraftOptions,
   ) => Promise<ProcessSaveDraftReport>;
+  runProcessVerifyRowsImpl?: (
+    options: RunProcessVerifyRowsOptions,
+  ) => Promise<ProcessVerifyRowsReport>;
   runProcessReviewImpl?: (options: RunProcessReviewOptions) => Promise<ProcessReviewReport>;
   runFlowReviewImpl?: (options: RunFlowReviewOptions) => Promise<FlowReviewReport>;
   runLifecyclemodelReviewImpl?: (
@@ -266,7 +282,7 @@ Commands:
 Implemented Commands:
   doctor     show environment diagnostics
   search     flow | process | lifecyclemodel
-  process    get | list | scope-statistics | dedup-review | auto-build | resume-build | publish-build | save-draft | batch-build
+  process    get | list | scope-statistics | dedup-review | auto-build | resume-build | publish-build | save-draft | batch-build | refresh-references | verify-rows
   flow       get | list | fetch-rows | materialize-decisions | remediate | publish-version | publish-reviewed-data | build-alias-map | scan-process-flow-refs | plan-process-flow-repairs | apply-process-flow-repairs | regen-product | validate-processes
   lifecyclemodel auto-build | validate-build | publish-build | build-resulting-process | publish-resulting-process | orchestrate
   review     process | flow | lifecyclemodel
@@ -293,6 +309,8 @@ Examples:
   tiangong process publish-build --run-id <id>
   tiangong process save-draft --input ./patched-processes.jsonl --dry-run
   tiangong process batch-build --input ./batch-request.json
+  tiangong process refresh-references --out-dir ./process-refresh --dry-run
+  tiangong process verify-rows --rows-file ./process-list-report.json --out-dir ./process-verify
   tiangong lifecyclemodel auto-build --input ./lifecyclemodel-auto-build.request.json
   tiangong lifecyclemodel validate-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id>
   tiangong lifecyclemodel publish-build --run-dir ./artifacts/lifecyclemodel_auto_build/<run_id>
@@ -1172,6 +1190,58 @@ Outputs written under --out-dir:
 `.trim();
 }
 
+function renderProcessRefreshReferencesHelp(): string {
+  return `Usage:
+  tiangong process refresh-references --out-dir <dir> [options]
+
+Options:
+  --out-dir <dir>      Artifact root for manifest, progress, blockers, and reports
+  --apply              Commit state-aware draft writes after local validation passes
+  --dry-run            Refresh references locally only (default)
+  --reuse-manifest     Reuse inputs/processes.manifest.json instead of refetching the owner snapshot
+  --limit <n>          Process at most n manifest rows
+  --page-size <n>      Snapshot page size (default: 500)
+  --concurrency <n>    Parallel row workers (default: 1, max: 8)
+  --json               Print compact JSON
+  -h, --help
+
+Required env:
+  TIANGONG_LCA_API_BASE_URL
+  TIANGONG_LCA_API_KEY
+  TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY
+
+Guardrails:
+  - refresh only the current authenticated user's process snapshot
+  - skip rows with state_code >= 20 instead of forcing an unsupported write path
+  - block remote writes when ProcessSchema validation fails or references stay unresolved
+  - never requires raw SUPABASE_EMAIL / SUPABASE_PASSWORD in the skill layer
+
+Outputs written under --out-dir:
+  - inputs/processes.manifest.json
+  - outputs/progress.jsonl
+  - outputs/errors.jsonl
+  - outputs/validation-blockers.jsonl
+  - outputs/summary.json
+  - reports/process-refresh-references.md
+`.trim();
+}
+
+function renderProcessVerifyRowsHelp(): string {
+  return `Usage:
+  tiangong process verify-rows --rows-file <file> --out-dir <dir> [options]
+
+Options:
+  --rows-file <file>   Raw process rows JSON/JSONL file; full process list reports with rows[] are also accepted
+  --out-dir <dir>      Output directory for summary and verification JSONL artifacts
+  --json               Print compact JSON
+  -h, --help
+
+Outputs written under --out-dir:
+  - outputs/summary.json
+  - outputs/verification.jsonl
+`.trim();
+}
+
 function renderProcessBatchBuildHelp(): string {
   return `Usage:
   tiangong process batch-build --input <file> [options]
@@ -1198,6 +1268,8 @@ Implemented Subcommands:
   publish-build Prepare publish handoff artifacts from one existing process build run
   save-draft   Save canonical process datasets through the state-aware draft-maintenance path
   batch-build  Run multiple process auto-build requests through one batch-oriented CLI surface
+  refresh-references Refresh current-user process references to the latest reachable dataset versions
+  verify-rows  Re-validate fetched process rows and required naming fields locally
 
 Examples:
   tiangong process --help
@@ -1210,6 +1282,8 @@ Examples:
   tiangong process publish-build --run-id <id> --help
   tiangong process save-draft --input ./patched-processes.jsonl --help
   tiangong process batch-build --input ./batch-request.json --help
+  tiangong process refresh-references --out-dir ./process-refresh --help
+  tiangong process verify-rows --rows-file ./process-list-report.json --out-dir ./process-verify --help
 `.trim();
 }
 
@@ -3215,6 +3289,124 @@ function parseProcessSaveDraftFlags(args: string[]): {
   };
 }
 
+function parseProcessRefreshReferencesFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  outDir: string;
+  apply: boolean;
+  reuseManifest: boolean;
+  limit: number | null;
+  pageSize: number | null;
+  concurrency: number | null;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        'out-dir': { type: 'string' },
+        apply: { type: 'boolean' },
+        'dry-run': { type: 'boolean' },
+        'reuse-manifest': { type: 'boolean' },
+        limit: { type: 'string' },
+        'page-size': { type: 'string' },
+        concurrency: { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  if (values.apply && values['dry-run']) {
+    throw new CliError('Cannot pass both --apply and --dry-run.', {
+      code: 'PROCESS_REFRESH_MODE_CONFLICT',
+      exitCode: 2,
+    });
+  }
+
+  const parseOptionalPositiveIntegerFlag = (
+    value: unknown,
+    label: string,
+    code: string,
+  ): number | null => {
+    if (typeof value !== 'string') {
+      return null;
+    }
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      throw new CliError(`Expected ${label} to be a positive integer.`, {
+        code,
+        exitCode: 2,
+      });
+    }
+    return parsed;
+  };
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : '',
+    apply: Boolean(values.apply),
+    reuseManifest: Boolean(values['reuse-manifest']),
+    limit: parseOptionalPositiveIntegerFlag(
+      values.limit,
+      '--limit',
+      'INVALID_PROCESS_REFRESH_LIMIT',
+    ),
+    pageSize: parseOptionalPositiveIntegerFlag(
+      values['page-size'],
+      '--page-size',
+      'INVALID_PROCESS_REFRESH_PAGE_SIZE',
+    ),
+    concurrency: parseOptionalPositiveIntegerFlag(
+      values.concurrency,
+      '--concurrency',
+      'INVALID_PROCESS_REFRESH_CONCURRENCY',
+    ),
+  };
+}
+
+function parseProcessVerifyRowsFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  rowsFile: string;
+  outDir: string;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        'rows-file': { type: 'string' },
+        'out-dir': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    rowsFile: typeof values['rows-file'] === 'string' ? values['rows-file'] : '',
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : '',
+  };
+}
+
 function parseProcessBatchBuildFlags(args: string[]): {
   help: boolean;
   json: boolean;
@@ -3295,10 +3487,13 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
     const processBatchBuildImpl = deps.runProcessBatchBuildImpl ?? runProcessBatchBuild;
     const processScopeStatisticsImpl =
       deps.runProcessScopeStatisticsImpl ?? runProcessScopeStatistics;
+    const processRefreshReferencesImpl =
+      deps.runProcessRefreshReferencesImpl ?? runProcessRefreshReferences;
     const processDedupReviewImpl = deps.runProcessDedupReviewImpl ?? runProcessDedupReview;
     const processResumeBuildImpl = deps.runProcessResumeBuildImpl ?? runProcessResumeBuild;
     const processPublishBuildImpl = deps.runProcessPublishBuildImpl ?? runProcessPublishBuild;
     const processSaveDraftImpl = deps.runProcessSaveDraftImpl ?? runProcessSaveDraft;
+    const processVerifyRowsImpl = deps.runProcessVerifyRowsImpl ?? runProcessVerifyRows;
     const processReviewImpl = deps.runProcessReviewImpl ?? runProcessReview;
     const flowReviewImpl = deps.runFlowReviewImpl ?? runFlowReview;
     const lifecyclemodelReviewImpl = deps.runLifecyclemodelReviewImpl ?? runLifecyclemodelReview;
@@ -3728,6 +3923,56 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
 
       return {
         exitCode: report.status === 'completed_with_failures' ? 1 : 0,
+        stdout: stringifyJson(report, processFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'process' && subcommand === 'refresh-references') {
+      const processFlags = parseProcessRefreshReferencesFlags(commandArgs);
+      if (processFlags.help) {
+        return {
+          exitCode: 0,
+          stdout: `${renderProcessRefreshReferencesHelp()}\n`,
+          stderr: '',
+        };
+      }
+
+      const report = await processRefreshReferencesImpl({
+        outDir: processFlags.outDir,
+        apply: processFlags.apply,
+        reuseManifest: processFlags.reuseManifest,
+        limit: processFlags.limit,
+        pageSize: processFlags.pageSize,
+        concurrency: processFlags.concurrency,
+        env: deps.env,
+        fetchImpl: deps.fetchImpl,
+      });
+
+      return {
+        exitCode: report.status === 'completed_process_reference_refresh_with_errors' ? 1 : 0,
+        stdout: stringifyJson(report, processFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'process' && subcommand === 'verify-rows') {
+      const processFlags = parseProcessVerifyRowsFlags(commandArgs);
+      if (processFlags.help) {
+        return {
+          exitCode: 0,
+          stdout: `${renderProcessVerifyRowsHelp()}\n`,
+          stderr: '',
+        };
+      }
+
+      const report = await processVerifyRowsImpl({
+        rowsFile: processFlags.rowsFile,
+        outDir: processFlags.outDir,
+      });
+
+      return {
+        exitCode: report.invalid_count > 0 ? 1 : 0,
         stdout: stringifyJson(report, processFlags.json),
         stderr: '',
       };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1067,6 +1067,10 @@ Environment:
   TIANGONG_LCA_API_BASE_URL, TIANGONG_LCA_API_KEY, and TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY
   when --commit executes remote writes
 
+Local gate:
+  canonical process payloads are validated against ProcessSchema before any remote write;
+  schema-invalid rows stay in failures.jsonl instead of being committed
+
 Outputs written under --out-dir:
   - inputs/normalized-input.json
   - outputs/save-draft-rpc/selected-processes.jsonl

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,6 +56,16 @@ import {
   type RunProcessBatchBuildOptions,
 } from './lib/process-batch-build.js';
 import {
+  runProcessScopeStatistics,
+  type ProcessScopeStatisticsReport,
+  type RunProcessScopeStatisticsOptions,
+} from './lib/process-scope-statistics.js';
+import {
+  runProcessDedupReview,
+  type ProcessDedupReviewReport,
+  type RunProcessDedupReviewOptions,
+} from './lib/process-dedup-review.js';
+import {
   runProcessResumeBuild,
   type ProcessResumeBuildReport,
   type RunProcessResumeBuildOptions,
@@ -174,6 +184,12 @@ export type CliDeps = {
   runProcessBatchBuildImpl?: (
     options: RunProcessBatchBuildOptions,
   ) => Promise<ProcessBatchBuildReport>;
+  runProcessScopeStatisticsImpl?: (
+    options: RunProcessScopeStatisticsOptions,
+  ) => Promise<ProcessScopeStatisticsReport>;
+  runProcessDedupReviewImpl?: (
+    options: RunProcessDedupReviewOptions,
+  ) => Promise<ProcessDedupReviewReport>;
   runProcessResumeBuildImpl?: (
     options: RunProcessResumeBuildOptions,
   ) => Promise<ProcessResumeBuildReport>;
@@ -250,7 +266,7 @@ Commands:
 Implemented Commands:
   doctor     show environment diagnostics
   search     flow | process | lifecyclemodel
-  process    get | list | auto-build | resume-build | publish-build | save-draft | batch-build
+  process    get | list | scope-statistics | dedup-review | auto-build | resume-build | publish-build | save-draft | batch-build
   flow       get | list | fetch-rows | materialize-decisions | remediate | publish-version | publish-reviewed-data | build-alias-map | scan-process-flow-refs | plan-process-flow-repairs | apply-process-flow-repairs | regen-product | validate-processes
   lifecyclemodel auto-build | validate-build | publish-build | build-resulting-process | publish-resulting-process | orchestrate
   review     process | flow | lifecyclemodel
@@ -270,6 +286,8 @@ Examples:
   tiangong search process --input ./request.json --dry-run
   tiangong process get --id <process-id>
   tiangong process list --state-code 100 --limit 20
+  tiangong process scope-statistics --out-dir ./process-scope --state-code 0 --state-code 100
+  tiangong process dedup-review --input ./duplicate-groups.json --out-dir ./process-dedup
   tiangong process auto-build --input ./pff-request.json
   tiangong process resume-build --run-id <id>
   tiangong process publish-build --run-id <id>
@@ -1027,6 +1045,79 @@ Runtime note:
 `.trim();
 }
 
+function renderProcessScopeStatisticsHelp(): string {
+  return `Usage:
+  tiangong process scope-statistics --out-dir <dir> [options]
+
+Options:
+  --out-dir <dir>          Artifact root to write inputs/outputs/reports
+  --scope <name>           visible | current-user (default: visible)
+  --state-code <code>      Repeatable non-negative integer state code filter
+  --state-codes <csv>      Comma-separated alias for one or more state codes
+  --page-size <n>          Remote page size (default: 200)
+  --reuse-snapshot         Reuse inputs/processes.snapshot.rows.jsonl instead of refetching
+  --json                   Print compact JSON
+  -h, --help
+
+Outputs written under --out-dir:
+  - inputs/processes.snapshot.manifest.json
+  - inputs/processes.snapshot.rows.jsonl
+  - outputs/process-scope-summary.json
+  - outputs/domain-summary.json
+  - outputs/craft-summary.json
+  - outputs/product-summary.json
+  - outputs/type-of-dataset-summary.json
+  - reports/process-scope-statistics.md
+  - reports/process-scope-statistics.zh-CN.md
+`.trim();
+}
+
+function renderProcessDedupReviewHelp(): string {
+  return `Usage:
+  tiangong process dedup-review --input <file> --out-dir <dir> [options]
+
+Options:
+  --input <file>           Grouped duplicate-candidate JSON input
+  --out-dir <dir>          Artifact root to write inputs/outputs
+  --skip-remote            Skip optional TianGong remote enrichment and reference scans
+  --json                   Print compact JSON
+  -h, --help
+
+Input contract:
+  {
+    "source_label": "duplicate-processes-export",
+    "groups": [
+      {
+        "group_id": 1,
+        "processes": [
+          {
+            "process_id": "proc-1",
+            "version": "01.00.000",
+            "name_en": "Example",
+            "name_zh": "示例",
+            "sheet_exchange_rows": [
+              {
+                "flow_id": "flow-1",
+                "direction": "Input",
+                "mean_amount": "1",
+                "resulting_amount": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+
+Outputs written under --out-dir:
+  - inputs/dedup-input.manifest.json
+  - inputs/processes.remote-metadata.json (when remote enrichment succeeds)
+  - outputs/duplicate-groups.json
+  - outputs/delete-plan.json
+  - outputs/current-user-reference-scan.json (when reference scan succeeds)
+`.trim();
+}
+
 function renderProcessResumeBuildHelp(): string {
   return `Usage:
   tiangong process resume-build [--run-id <id>] [--run-dir <dir>] [options]
@@ -1100,6 +1191,8 @@ function renderProcessHelp(): string {
 Implemented Subcommands:
   get          Load one process dataset by identifier through direct Supabase access
   list         List visible process rows through direct Supabase access
+  scope-statistics Count repeatable coverage statistics from visible or owner-filtered process snapshots
+  dedup-review Review grouped duplicate process candidates and emit keep/delete evidence
   auto-build   Prepare a local process-from-flow run scaffold and artifact workspace
   resume-build Prepare a local resume handoff from one existing process build run
   publish-build Prepare publish handoff artifacts from one existing process build run
@@ -1110,6 +1203,8 @@ Examples:
   tiangong process --help
   tiangong process get --id <process-id>
   tiangong process list --state-code 100 --limit 20 --help
+  tiangong process scope-statistics --out-dir ./process-scope --state-code 0 --state-code 100 --help
+  tiangong process dedup-review --input ./duplicate-groups.json --out-dir ./process-dedup --help
   tiangong process auto-build --help
   tiangong process resume-build --run-id <id> --help
   tiangong process publish-build --run-id <id> --help
@@ -2882,6 +2977,131 @@ function parseProcessListFlags(args: string[]): {
   };
 }
 
+function parseProcessScopeStatisticsFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  outDir: string;
+  scope: 'visible' | 'current-user' | undefined;
+  stateCodes: number[];
+  pageSize: number | null;
+  reuseSnapshot: boolean;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        'out-dir': { type: 'string' },
+        scope: { type: 'string' },
+        'state-code': { type: 'string', multiple: true },
+        'state-codes': { type: 'string' },
+        'page-size': { type: 'string' },
+        'reuse-snapshot': { type: 'boolean' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  const parseStateCode = (value: string): number => {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isInteger(parsed) || parsed < 0) {
+      throw new CliError('Expected --state-code to be a non-negative integer.', {
+        code: 'INVALID_PROCESS_SCOPE_STATE_CODE',
+        exitCode: 2,
+      });
+    }
+    return parsed;
+  };
+
+  const stateCodes = [
+    ...(Array.isArray(values['state-code'])
+      ? values['state-code'].map((value) => parseStateCode(String(value)))
+      : []),
+    ...(typeof values['state-codes'] === 'string' ? values['state-codes'].split(',') : [])
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .map((value) => parseStateCode(value)),
+  ];
+
+  let pageSize: number | null = null;
+  if (typeof values['page-size'] === 'string') {
+    const parsed = Number.parseInt(values['page-size'], 10);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      throw new CliError('Expected --page-size to be a positive integer.', {
+        code: 'INVALID_PROCESS_SCOPE_PAGE_SIZE',
+        exitCode: 2,
+      });
+    }
+    pageSize = parsed;
+  }
+
+  let scope: 'visible' | 'current-user' | undefined;
+  if (typeof values.scope === 'string') {
+    if (values.scope !== 'visible' && values.scope !== 'current-user') {
+      throw new CliError("Expected --scope to be either 'visible' or 'current-user'.", {
+        code: 'INVALID_PROCESS_SCOPE_SCOPE',
+        exitCode: 2,
+      });
+    }
+    scope = values.scope;
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : '',
+    scope,
+    stateCodes,
+    pageSize,
+    reuseSnapshot: Boolean(values['reuse-snapshot']),
+  };
+}
+
+function parseProcessDedupReviewFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  inputPath: string;
+  outDir: string;
+  skipRemote: boolean;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        input: { type: 'string' },
+        'out-dir': { type: 'string' },
+        'skip-remote': { type: 'boolean' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    inputPath: typeof values.input === 'string' ? values.input : '',
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : '',
+    skipRemote: Boolean(values['skip-remote']),
+  };
+}
+
 function parseProcessResumeBuildFlags(args: string[]): {
   help: boolean;
   json: boolean;
@@ -3073,6 +3293,9 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
     const processListImpl = deps.runProcessListImpl ?? runProcessList;
     const processAutoBuildImpl = deps.runProcessAutoBuildImpl ?? runProcessAutoBuild;
     const processBatchBuildImpl = deps.runProcessBatchBuildImpl ?? runProcessBatchBuild;
+    const processScopeStatisticsImpl =
+      deps.runProcessScopeStatisticsImpl ?? runProcessScopeStatistics;
+    const processDedupReviewImpl = deps.runProcessDedupReviewImpl ?? runProcessDedupReview;
     const processResumeBuildImpl = deps.runProcessResumeBuildImpl ?? runProcessResumeBuild;
     const processPublishBuildImpl = deps.runProcessPublishBuildImpl ?? runProcessPublishBuild;
     const processSaveDraftImpl = deps.runProcessSaveDraftImpl ?? runProcessSaveDraft;
@@ -3356,6 +3579,58 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
         all: processFlags.all,
         pageSize: processFlags.pageSize,
         order: processFlags.order,
+        env: deps.env,
+        fetchImpl: deps.fetchImpl,
+      });
+
+      return {
+        exitCode: 0,
+        stdout: stringifyJson(report, processFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'process' && subcommand === 'scope-statistics') {
+      const processFlags = parseProcessScopeStatisticsFlags(commandArgs);
+      if (processFlags.help) {
+        return {
+          exitCode: 0,
+          stdout: `${renderProcessScopeStatisticsHelp()}\n`,
+          stderr: '',
+        };
+      }
+
+      const report = await processScopeStatisticsImpl({
+        outDir: processFlags.outDir,
+        scope: processFlags.scope,
+        stateCodes: processFlags.stateCodes,
+        pageSize: processFlags.pageSize,
+        reuseSnapshot: processFlags.reuseSnapshot,
+        env: deps.env,
+        fetchImpl: deps.fetchImpl,
+      });
+
+      return {
+        exitCode: 0,
+        stdout: stringifyJson(report, processFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'process' && subcommand === 'dedup-review') {
+      const processFlags = parseProcessDedupReviewFlags(commandArgs);
+      if (processFlags.help) {
+        return {
+          exitCode: 0,
+          stdout: `${renderProcessDedupReviewHelp()}\n`,
+          stderr: '',
+        };
+      }
+
+      const report = await processDedupReviewImpl({
+        inputPath: processFlags.inputPath,
+        outDir: processFlags.outDir,
+        skipRemote: processFlags.skipRemote,
         env: deps.env,
         fetchImpl: deps.fetchImpl,
       });

--- a/src/lib/process-dedup-review.ts
+++ b/src/lib/process-dedup-review.ts
@@ -1,0 +1,1238 @@
+import path from 'node:path';
+import { writeJsonArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+import type { FetchLike, ResponseLike } from './http.js';
+import { readJsonInput } from './io.js';
+import { deriveSupabaseProjectBaseUrl, requireSupabaseRestRuntime } from './supabase-client.js';
+import { resolveSupabaseUserSession } from './supabase-session.js';
+
+type JsonRecord = Record<string, unknown>;
+type ProcessGroupId = string | number;
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_RETRIES = 4;
+const DEFAULT_PAGE_SIZE = 100;
+
+type ExchangeSummaryRow = {
+  exchange_internal_id: string;
+  flow_id: string;
+  flow_version: string;
+  direction: string;
+  mean_amount: string;
+  resulting_amount: string;
+  flow_short_description_en: string;
+  flow_short_description_zh: string;
+};
+
+type DedupInputProcess = {
+  process_id: string;
+  version: string;
+  name_en: string;
+  name_zh: string;
+  exchange_count: number | null;
+  overview_fingerprint: string;
+  sheet_exchange_rows: ExchangeSummaryRow[];
+};
+
+type DedupInputGroup = {
+  group_id: ProcessGroupId;
+  processes: DedupInputProcess[];
+};
+
+type RemoteMetadataRecord = {
+  process_id: string;
+  version: string;
+  state_code: number | null;
+  created_at: string | null;
+  modified_at: string | null;
+  user_id: string | null;
+  team_id: string | null;
+  model_id: string | null;
+  remote_name_en: string;
+  remote_name_zh: string;
+  remote_exchanges: ExchangeSummaryRow[];
+};
+
+type ReferenceHitRecord = {
+  id: string;
+  version: string;
+  state_code: number | null;
+  model_id?: string | null;
+};
+
+type ReferenceHits = {
+  processes: Record<string, ReferenceHitRecord[]>;
+  lifecyclemodels: Record<string, ReferenceHitRecord[]>;
+};
+
+type RemoteStatus = {
+  enabled: boolean;
+  loaded: number;
+  error: string | null;
+  reference_scan:
+    | 'not_run'
+    | 'skipped_by_flag'
+    | 'skipped_missing_user_id'
+    | 'current_user_completed'
+    | 'failed';
+};
+
+type DedupAnalyzedProcess = DedupInputProcess &
+  Partial<RemoteMetadataRecord> & {
+    analysis_exchanges: ExchangeSummaryRow[];
+    normalized_exchange_signature: Array<[string, string, string, string]>;
+    name_score: number;
+    name_score_reasons: string[];
+  };
+
+export type ProcessDedupReviewGroup = {
+  group_id: ProcessGroupId;
+  group_pattern: string;
+  exact_duplicate: boolean;
+  processes: DedupAnalyzedProcess[];
+};
+
+type DeletePlanGroup = {
+  group_id: ProcessGroupId;
+  status: 'priority_delete_candidates';
+  confidence: 'high' | 'medium' | 'low';
+  current_user_reference_hits: {
+    keep_process_refs: number;
+    keep_lifecyclemodel_refs: number;
+    delete_refs: Record<
+      string,
+      {
+        process_refs: number;
+        lifecyclemodel_refs: number;
+      }
+    >;
+  };
+  keep: {
+    process_id: string;
+    name_en: string;
+    name_zh: string;
+    score: number;
+    reasons: string[];
+  };
+  delete: Array<{
+    process_id: string;
+    name_en: string;
+    name_zh: string;
+    score: number;
+    reasons: string[];
+  }>;
+  notes: string[];
+};
+
+type RemoteAuthContext = {
+  projectBaseUrl: string;
+  publishableKey: string;
+  accessToken: string;
+  userId: string | null;
+};
+
+export type RunProcessDedupReviewOptions = {
+  inputPath: string;
+  outDir: string;
+  skipRemote?: boolean;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: FetchLike;
+  timeoutMs?: number;
+  maxRetries?: number;
+  now?: Date;
+};
+
+export type ProcessDedupReviewReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: 'completed_process_dedup_review';
+  input_file: string;
+  out_dir: string;
+  source_label: string;
+  group_count: number;
+  exact_duplicate_group_count: number;
+  remote_status: RemoteStatus;
+  files: {
+    input_manifest: string;
+    remote_metadata: string | null;
+    duplicate_groups: string;
+    delete_plan: string;
+    current_user_reference_scan: string | null;
+  };
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function trimText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function nowIso(now: Date = new Date()): string {
+  return now.toISOString();
+}
+
+function requiredNonEmpty(value: string, label: string, code: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new CliError(`Missing required ${label}.`, {
+      code,
+      exitCode: 2,
+    });
+  }
+  return normalized;
+}
+
+function toPositiveInteger(value: number | undefined, label: string, code: string): number {
+  if (!Number.isInteger(value) || (value as number) <= 0) {
+    throw new CliError(`Expected ${label} to be a positive integer.`, {
+      code,
+      exitCode: 2,
+    });
+  }
+  return value as number;
+}
+
+function normalizeOptionalToken(value: unknown): string | null {
+  const normalized = trimText(value);
+  return normalized ? normalized : null;
+}
+
+function asArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (value === null || value === undefined || value === '') {
+    return [];
+  }
+  return [value];
+}
+
+function toGroupId(value: unknown, fallback: string): ProcessGroupId {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  const normalized = trimText(value);
+  if (!normalized) {
+    return fallback;
+  }
+  if (/^\d+$/u.test(normalized)) {
+    return Number.parseInt(normalized, 10);
+  }
+  return normalized;
+}
+
+function normalizeExchangeCount(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  const normalized = trimText(value);
+  if (!normalized) {
+    return null;
+  }
+  const parsed = Number.parseInt(normalized, 10);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+function normalizeAmount(value: unknown): string {
+  const normalized = trimText(value);
+  if (!normalized) {
+    return '';
+  }
+  if (/^[+-]?\d+(?:\.\d+)?$/u.test(normalized)) {
+    let result = normalized.replace(/^\+/u, '');
+    result = result.replace(/^(-?)0+(?=\d)/u, '$1');
+    if (result.includes('.')) {
+      result = result.replace(/0+$/u, '').replace(/\.$/u, '');
+    }
+    if (result === '' || result === '-' || result === '-0') {
+      return '0';
+    }
+    return result;
+  }
+  const parsed = Number(normalized);
+  if (Number.isFinite(parsed)) {
+    return parsed.toString();
+  }
+  return normalized;
+}
+
+function getLangList(value: unknown): JsonRecord[] {
+  if (value === null || value === undefined || value === '') {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is JsonRecord => isRecord(entry));
+  }
+  if (isRecord(value)) {
+    const langString = value['common:langString'];
+    if (Array.isArray(langString)) {
+      return langString.filter((entry): entry is JsonRecord => isRecord(entry));
+    }
+    if (isRecord(langString)) {
+      return [langString];
+    }
+    if (value['#text'] !== undefined || value['@xml:lang'] !== undefined) {
+      return [value];
+    }
+  }
+  if (typeof value === 'string') {
+    return [{ '@xml:lang': 'en', '#text': value }];
+  }
+  return [];
+}
+
+function getLangText(value: unknown, lang: string): string {
+  const entries = getLangList(value);
+  for (const entry of entries) {
+    if (
+      trimText(entry['@xml:lang']).toLowerCase() === lang.toLowerCase() &&
+      trimText(entry['#text'])
+    ) {
+      return trimText(entry['#text']);
+    }
+  }
+  for (const entry of entries) {
+    if (trimText(entry['#text'])) {
+      return trimText(entry['#text']);
+    }
+  }
+  return '';
+}
+
+function normalizeExchangeSummaryRow(value: unknown): ExchangeSummaryRow | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const flowRef = isRecord(value.referenceToFlowDataSet) ? value.referenceToFlowDataSet : {};
+  const flowShortDescription = value.flow_short_description ?? flowRef['common:shortDescription'];
+
+  const normalized: ExchangeSummaryRow = {
+    exchange_internal_id: trimText(value.exchange_internal_id ?? value['@dataSetInternalID']),
+    flow_id: trimText(value.flow_id ?? flowRef['@refObjectId']),
+    flow_version: trimText(value.flow_version ?? flowRef['@version']),
+    direction: trimText(value.direction ?? value.exchangeDirection),
+    mean_amount: trimText(value.mean_amount ?? value.meanAmount),
+    resulting_amount: trimText(value.resulting_amount ?? value.resultingAmount),
+    flow_short_description_en:
+      trimText(value.flow_short_description_en) || getLangText(flowShortDescription, 'en'),
+    flow_short_description_zh:
+      trimText(value.flow_short_description_zh) || getLangText(flowShortDescription, 'zh'),
+  };
+
+  if (
+    !normalized.exchange_internal_id &&
+    !normalized.flow_id &&
+    !normalized.direction &&
+    !normalized.mean_amount &&
+    !normalized.resulting_amount
+  ) {
+    return null;
+  }
+
+  return normalized;
+}
+
+function normalizeExchangeRows(value: unknown): ExchangeSummaryRow[] {
+  return asArray(value)
+    .map((entry) => normalizeExchangeSummaryRow(entry))
+    .filter((entry): entry is ExchangeSummaryRow => entry !== null);
+}
+
+function normalizeInputProcess(value: unknown): DedupInputProcess {
+  if (!isRecord(value)) {
+    throw new CliError('Each process dedup candidate must be a JSON object.', {
+      code: 'PROCESS_DEDUP_INPUT_INVALID_PROCESS',
+      exitCode: 2,
+    });
+  }
+
+  const processId = requiredNonEmpty(
+    trimText(value.process_id ?? value.id),
+    'process_id',
+    'PROCESS_DEDUP_PROCESS_ID_REQUIRED',
+  );
+
+  return {
+    process_id: processId,
+    version: trimText(value.version),
+    name_en: trimText(value.name_en ?? value.remote_name_en),
+    name_zh: trimText(value.name_zh ?? value.remote_name_zh),
+    exchange_count: normalizeExchangeCount(value.exchange_count),
+    overview_fingerprint: trimText(value.overview_fingerprint),
+    sheet_exchange_rows: normalizeExchangeRows(
+      value.sheet_exchange_rows ??
+        value.analysis_exchanges ??
+        value.remote_exchanges ??
+        value.exchanges,
+    ),
+  };
+}
+
+function normalizeInputGroup(
+  value: unknown,
+  fallbackGroupId: string,
+  index: number,
+): DedupInputGroup {
+  if (!isRecord(value)) {
+    throw new CliError('Each process dedup group must be a JSON object.', {
+      code: 'PROCESS_DEDUP_INPUT_INVALID_GROUP',
+      exitCode: 2,
+    });
+  }
+
+  const processes = asArray(value.processes).map((entry) => normalizeInputProcess(entry));
+  if (processes.length === 0) {
+    throw new CliError(`Process dedup group ${index + 1} is missing processes.`, {
+      code: 'PROCESS_DEDUP_GROUP_PROCESSES_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    group_id: toGroupId(value.group_id, fallbackGroupId),
+    processes,
+  };
+}
+
+function normalizeInputDocument(
+  value: unknown,
+  resolvedInputPath: string,
+): {
+  sourceLabel: string;
+  groups: DedupInputGroup[];
+} {
+  if (!isRecord(value)) {
+    throw new CliError('Process dedup review input must be a JSON object.', {
+      code: 'PROCESS_DEDUP_INPUT_INVALID',
+      exitCode: 2,
+    });
+  }
+
+  const sourceLabel =
+    trimText(value.source_label ?? value.source_workbook ?? value.source_file) ||
+    path.basename(resolvedInputPath);
+  const rawGroups = value.groups;
+  let groups: DedupInputGroup[] = [];
+
+  if (Array.isArray(rawGroups)) {
+    groups = rawGroups.map((entry, index) => normalizeInputGroup(entry, String(index + 1), index));
+  } else if (isRecord(rawGroups)) {
+    groups = Object.entries(rawGroups).map(([groupId, entry], index) =>
+      normalizeInputGroup(entry, groupId, index),
+    );
+  }
+
+  if (groups.length === 0) {
+    throw new CliError('Process dedup review input must contain at least one group.', {
+      code: 'PROCESS_DEDUP_GROUPS_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    sourceLabel,
+    groups,
+  };
+}
+
+async function parseJsonResponse(response: ResponseLike, label: string): Promise<unknown> {
+  const text = await response.text();
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!text.trim()) {
+    return null;
+  }
+  if (!contentType.includes('application/json')) {
+    return text;
+  }
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new CliError(`${label} returned invalid JSON.`, {
+      code: 'PROCESS_DEDUP_REMOTE_INVALID_JSON',
+      exitCode: 1,
+      details: String(error),
+    });
+  }
+}
+
+async function fetchJsonWithRetry(options: {
+  url: string;
+  init: RequestInit;
+  label: string;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+  maxRetries: number;
+}): Promise<{ status: number; headers: Headers; body: unknown }> {
+  let lastError: unknown = null;
+
+  for (let attempt = 1; attempt <= options.maxRetries; attempt += 1) {
+    try {
+      const response = await options.fetchImpl(options.url, {
+        ...options.init,
+        signal: AbortSignal.timeout(options.timeoutMs),
+      });
+      const body = await parseJsonResponse(response, options.label);
+      if (!response.ok) {
+        throw new CliError(`${options.label} failed with ${response.status}.`, {
+          code: 'PROCESS_DEDUP_REMOTE_REQUEST_FAILED',
+          exitCode: 1,
+          details: {
+            status: response.status,
+            body,
+            url: options.url,
+          },
+        });
+      }
+      return {
+        status: response.status,
+        headers: new Headers({
+          'content-range': response.headers.get('content-range') ?? '',
+          'content-type': response.headers.get('content-type') ?? '',
+        }),
+        body,
+      };
+    } catch (error) {
+      lastError = error;
+      if (attempt >= options.maxRetries) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, attempt * 1_500));
+    }
+  }
+
+  if (lastError instanceof CliError) {
+    throw lastError;
+  }
+
+  throw new CliError(`${options.label} failed after ${options.maxRetries} attempt(s).`, {
+    code: 'PROCESS_DEDUP_REMOTE_REQUEST_FAILED',
+    exitCode: 1,
+    details: String(lastError),
+  });
+}
+
+async function fetchCurrentUserId(options: {
+  projectBaseUrl: string;
+  publishableKey: string;
+  accessToken: string;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+  maxRetries: number;
+}): Promise<string | null> {
+  const response = await fetchJsonWithRetry({
+    url: `${options.projectBaseUrl}/auth/v1/user`,
+    init: {
+      method: 'GET',
+      headers: {
+        apikey: options.publishableKey,
+        Authorization: `Bearer ${options.accessToken}`,
+        Accept: 'application/json',
+      },
+    },
+    label: 'supabase current-user lookup',
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.timeoutMs,
+    maxRetries: options.maxRetries,
+  });
+
+  if (!isRecord(response.body)) {
+    return null;
+  }
+  return normalizeOptionalToken(response.body.id);
+}
+
+async function resolveRemoteAuthContext(options: {
+  env: NodeJS.ProcessEnv;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+  maxRetries: number;
+  now: Date;
+}): Promise<RemoteAuthContext> {
+  const runtime = requireSupabaseRestRuntime(options.env);
+  const session = await resolveSupabaseUserSession({
+    runtime,
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.timeoutMs,
+    now: options.now,
+  });
+  const projectBaseUrl = deriveSupabaseProjectBaseUrl(runtime.apiBaseUrl);
+
+  let userId: string | null;
+  try {
+    userId = await fetchCurrentUserId({
+      projectBaseUrl,
+      publishableKey: runtime.publishableKey,
+      accessToken: session.accessToken,
+      fetchImpl: options.fetchImpl,
+      timeoutMs: options.timeoutMs,
+      maxRetries: options.maxRetries,
+    });
+  } catch {
+    userId = null;
+  }
+
+  return {
+    projectBaseUrl,
+    publishableKey: runtime.publishableKey,
+    accessToken: session.accessToken,
+    userId,
+  };
+}
+
+function summarizeRemoteExchanges(processJson: unknown): ExchangeSummaryRow[] {
+  if (!isRecord(processJson)) {
+    return [];
+  }
+  const processDataSet = isRecord(processJson.processDataSet) ? processJson.processDataSet : {};
+  const exchanges = isRecord(processDataSet.exchanges) ? processDataSet.exchanges.exchange : [];
+  return normalizeExchangeRows(exchanges);
+}
+
+async function fetchRemoteMetadata(options: {
+  processIds: string[];
+  auth: RemoteAuthContext;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+  maxRetries: number;
+}): Promise<Record<string, RemoteMetadataRecord>> {
+  if (options.processIds.length === 0) {
+    return {};
+  }
+
+  const url = new URL(`${options.auth.projectBaseUrl}/rest/v1/processes`);
+  url.searchParams.set(
+    'select',
+    'id,version,state_code,created_at,modified_at,user_id,team_id,model_id,json',
+  );
+  url.searchParams.set('id', `in.(${options.processIds.join(',')})`);
+  url.searchParams.set('order', 'id.asc');
+
+  const response = await fetchJsonWithRetry({
+    url: url.toString(),
+    init: {
+      method: 'GET',
+      headers: {
+        apikey: options.auth.publishableKey,
+        Authorization: `Bearer ${options.auth.accessToken}`,
+        Accept: 'application/json',
+      },
+    },
+    label: 'process dedup remote metadata fetch',
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.timeoutMs,
+    maxRetries: options.maxRetries,
+  });
+
+  const rows = Array.isArray(response.body) ? response.body : [];
+  const byId: Record<string, RemoteMetadataRecord> = {};
+
+  for (const row of rows) {
+    if (!isRecord(row)) {
+      continue;
+    }
+    const processId = trimText(row.id);
+    if (!processId) {
+      continue;
+    }
+    const payload = row.json;
+    const processDataSet =
+      isRecord(payload) && isRecord(payload.processDataSet) ? payload.processDataSet : {};
+    const processInformation = isRecord(processDataSet.processInformation)
+      ? processDataSet.processInformation
+      : {};
+    const dataSetInformation = isRecord(processInformation.dataSetInformation)
+      ? processInformation.dataSetInformation
+      : {};
+    const name = isRecord(dataSetInformation.name) ? dataSetInformation.name : {};
+
+    byId[processId] = {
+      process_id: processId,
+      version: trimText(row.version),
+      state_code: typeof row.state_code === 'number' ? row.state_code : null,
+      created_at: normalizeOptionalToken(row.created_at),
+      modified_at: normalizeOptionalToken(row.modified_at),
+      user_id: normalizeOptionalToken(row.user_id),
+      team_id: normalizeOptionalToken(row.team_id),
+      model_id: normalizeOptionalToken(row.model_id),
+      remote_name_en: getLangText(name.baseName, 'en'),
+      remote_name_zh: getLangText(name.baseName, 'zh'),
+      remote_exchanges: summarizeRemoteExchanges(payload),
+    };
+  }
+
+  return byId;
+}
+
+async function fetchCurrentUserRows(options: {
+  auth: RemoteAuthContext;
+  tableName: 'processes' | 'lifecyclemodels';
+  userId: string;
+  select: string;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+  maxRetries: number;
+}): Promise<unknown[]> {
+  const rows: unknown[] = [];
+  let offset = 0;
+  let total: number | null = null;
+
+  while (total === null || offset < total) {
+    const url = new URL(`${options.auth.projectBaseUrl}/rest/v1/${options.tableName}`);
+    url.searchParams.set('select', options.select);
+    url.searchParams.set('user_id', `eq.${options.userId}`);
+    url.searchParams.set('order', 'id.asc');
+    url.searchParams.set('limit', String(DEFAULT_PAGE_SIZE));
+    url.searchParams.set('offset', String(offset));
+
+    const page = await fetchJsonWithRetry({
+      url: url.toString(),
+      init: {
+        method: 'GET',
+        headers: {
+          apikey: options.auth.publishableKey,
+          Authorization: `Bearer ${options.auth.accessToken}`,
+          Accept: 'application/json',
+          Prefer: total === null ? 'count=exact' : 'count=planned',
+        },
+      },
+      label: `${options.tableName} current-user reference scan`,
+      fetchImpl: options.fetchImpl,
+      timeoutMs: options.timeoutMs,
+      maxRetries: options.maxRetries,
+    });
+
+    const pageRows = Array.isArray(page.body) ? page.body : [];
+    rows.push(...pageRows);
+
+    if (total === null) {
+      const contentRange = page.headers.get('content-range') ?? '';
+      const match = contentRange.match(/\/(\d+)$/u);
+      total = match ? Number.parseInt(match[1] ?? '', 10) : rows.length;
+    }
+
+    if (pageRows.length === 0) {
+      break;
+    }
+    offset += DEFAULT_PAGE_SIZE;
+  }
+
+  return rows;
+}
+
+function collectReferenceHits(root: unknown, targetIds: Set<string>): string[] {
+  const hits: string[] = [];
+  const visited = new Set<object>();
+
+  const walk = (value: unknown): void => {
+    if (value === null || value === undefined) {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      if (visited.has(value)) {
+        return;
+      }
+      visited.add(value);
+      value.forEach((entry) => walk(entry));
+      return;
+    }
+
+    if (!isRecord(value)) {
+      return;
+    }
+
+    if (visited.has(value)) {
+      return;
+    }
+    visited.add(value);
+
+    const refObjectId = trimText(value['@refObjectId']);
+    if (refObjectId && targetIds.has(refObjectId)) {
+      hits.push(refObjectId);
+    }
+
+    Object.values(value).forEach((entry) => walk(entry));
+  };
+
+  walk(root);
+  return hits;
+}
+
+function buildEmptyReferenceHits(processIds: string[]): ReferenceHits {
+  return {
+    processes: Object.fromEntries(processIds.map((processId) => [processId, []])),
+    lifecyclemodels: Object.fromEntries(processIds.map((processId) => [processId, []])),
+  };
+}
+
+async function fetchCurrentUserReferenceHits(options: {
+  auth: RemoteAuthContext;
+  userId: string;
+  targetProcessIds: string[];
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+  maxRetries: number;
+}): Promise<ReferenceHits> {
+  const targetIds = new Set(options.targetProcessIds);
+  const results = buildEmptyReferenceHits(options.targetProcessIds);
+
+  const processRows = await fetchCurrentUserRows({
+    auth: options.auth,
+    tableName: 'processes',
+    userId: options.userId,
+    select: 'id,version,state_code,user_id,model_id,json',
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.timeoutMs,
+    maxRetries: options.maxRetries,
+  });
+
+  for (const row of processRows) {
+    if (!isRecord(row)) {
+      continue;
+    }
+    const rowId = trimText(row.id);
+    const hits = collectReferenceHits(row.json, targetIds);
+    for (const hit of hits) {
+      if (rowId === hit) {
+        continue;
+      }
+      results.processes[hit]?.push({
+        id: rowId,
+        version: trimText(row.version),
+        state_code: typeof row.state_code === 'number' ? row.state_code : null,
+        model_id: normalizeOptionalToken(row.model_id),
+      });
+    }
+  }
+
+  const lifecyclemodelRows = await fetchCurrentUserRows({
+    auth: options.auth,
+    tableName: 'lifecyclemodels',
+    userId: options.userId,
+    select: 'id,version,state_code,user_id,json',
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.timeoutMs,
+    maxRetries: options.maxRetries,
+  });
+
+  for (const row of lifecyclemodelRows) {
+    if (!isRecord(row)) {
+      continue;
+    }
+    const hits = collectReferenceHits(row.json, targetIds);
+    for (const hit of hits) {
+      results.lifecyclemodels[hit]?.push({
+        id: trimText(row.id),
+        version: trimText(row.version),
+        state_code: typeof row.state_code === 'number' ? row.state_code : null,
+      });
+    }
+  }
+
+  return results;
+}
+
+function normalizedSignature(
+  exchanges: ExchangeSummaryRow[],
+): Array<[string, string, string, string]> {
+  return [...exchanges]
+    .map(
+      (exchange) =>
+        [
+          trimText(exchange.flow_id),
+          trimText(exchange.direction),
+          normalizeAmount(exchange.mean_amount),
+          normalizeAmount(exchange.resulting_amount),
+        ] as [string, string, string, string],
+    )
+    .sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+}
+
+function normalizedSignatureKey(exchanges: ExchangeSummaryRow[]): string {
+  return JSON.stringify(normalizedSignature(exchanges));
+}
+
+function detectGroupPattern(processes: DedupAnalyzedProcess[]): string {
+  const sample = processes.find(
+    (process) => process.analysis_exchanges.length > 0,
+  )?.analysis_exchanges;
+  if (!sample || sample.length === 0) {
+    return 'unknown';
+  }
+
+  const inputExchanges = sample.filter(
+    (exchange) => trimText(exchange.direction).toLowerCase() === 'input',
+  );
+  const outputExchanges = sample.filter(
+    (exchange) => trimText(exchange.direction).toLowerCase() === 'output',
+  );
+  const inputFlowIds = new Set(
+    inputExchanges.map((exchange) => trimText(exchange.flow_id)).filter(Boolean),
+  );
+  const outputFlowIds = new Set(
+    outputExchanges.map((exchange) => trimText(exchange.flow_id)).filter(Boolean),
+  );
+
+  const hasTransportInput = inputExchanges.some((exchange) => {
+    const en = trimText(exchange.flow_short_description_en).toLowerCase();
+    const zh = trimText(exchange.flow_short_description_zh);
+    return en.includes('transport;') || zh.includes('运输;');
+  });
+
+  if (outputFlowIds.size > 0 && [...outputFlowIds].every((flowId) => inputFlowIds.has(flowId))) {
+    return hasTransportInput ? 'transport_pass_through' : 'same_flow_pass_through';
+  }
+  return 'other';
+}
+
+function scoreProcessName(
+  process: Pick<DedupAnalyzedProcess, 'name_en' | 'name_zh' | 'remote_name_en' | 'remote_name_zh'>,
+  groupPattern: string,
+): { score: number; reasons: string[] } {
+  const nameEn = trimText(process.remote_name_en ?? process.name_en);
+  const nameZh = trimText(process.remote_name_zh ?? process.name_zh);
+  const lowerEn = nameEn.toLowerCase();
+  const reasons: string[] = [];
+  let score = 0;
+
+  if (groupPattern === 'transport_pass_through') {
+    if (lowerEn.includes('transport') || nameZh.includes('运输')) {
+      score += 30;
+      reasons.push('name matches explicit transport-service input');
+    }
+    if (lowerEn.includes('logistics') || nameZh.includes('物流')) {
+      score -= 10;
+      reasons.push('name is broader than the observed transport-service input');
+    }
+  }
+
+  if (groupPattern === 'same_flow_pass_through') {
+    if (lowerEn.includes('processing') || nameZh.includes('加工')) {
+      score -= 20;
+      reasons.push('same-flow pass-through does not support a processing label');
+    }
+    if (lowerEn.includes('reception') || nameZh.includes('接收')) {
+      score += 20;
+      reasons.push('reception matches same-flow intake/output handling');
+    }
+  }
+
+  if (lowerEn.includes('collection') || nameZh.includes('收集')) {
+    score += 20;
+    reasons.push('collection is semantically consistent with a gather/sort process');
+  }
+  if (lowerEn.includes('wastepaper')) {
+    score -= 5;
+    reasons.push("compressed English form is less standardized than 'waste paper'");
+  }
+  if (lowerEn.includes('waste paper')) {
+    score += 3;
+    reasons.push('English wording is standardized');
+  }
+  if (nameEn.includes('/') || nameZh.includes('/')) {
+    score += 5;
+    reasons.push('name keeps the broader material scope explicit');
+  }
+
+  return { score, reasons };
+}
+
+function createdAtKey(process: Pick<DedupAnalyzedProcess, 'created_at'>): string {
+  return trimText(process.created_at) || '9999-12-31T23:59:59+00:00';
+}
+
+function compareGroupIds(left: ProcessGroupId, right: ProcessGroupId): number {
+  return String(left).localeCompare(String(right), 'en', { numeric: true });
+}
+
+function analyzeGroups(
+  groups: DedupInputGroup[],
+  remoteById: Record<string, RemoteMetadataRecord>,
+  referenceHits: ReferenceHits,
+): {
+  duplicateGroups: ProcessDedupReviewGroup[];
+  deletePlanGroups: DeletePlanGroup[];
+} {
+  const duplicateGroups: ProcessDedupReviewGroup[] = [];
+  const deletePlanGroups: DeletePlanGroup[] = [];
+
+  for (const group of [...groups].sort((left, right) =>
+    compareGroupIds(left.group_id, right.group_id),
+  )) {
+    const processes: DedupAnalyzedProcess[] = group.processes.map((process) => {
+      const remote = remoteById[process.process_id];
+      const analysisExchanges =
+        remote && remote.remote_exchanges.length > 0
+          ? remote.remote_exchanges
+          : process.sheet_exchange_rows;
+      const initialScore = scoreProcessName(
+        {
+          name_en: process.name_en,
+          name_zh: process.name_zh,
+          remote_name_en: remote?.remote_name_en,
+          remote_name_zh: remote?.remote_name_zh,
+        },
+        'unknown',
+      );
+
+      return {
+        ...process,
+        ...remote,
+        analysis_exchanges: analysisExchanges,
+        normalized_exchange_signature: normalizedSignature(analysisExchanges),
+        name_score: initialScore.score,
+        name_score_reasons: initialScore.reasons,
+      };
+    });
+
+    const exactDuplicate =
+      processes.length > 1 &&
+      new Set(processes.map((process) => normalizedSignatureKey(process.analysis_exchanges)))
+        .size === 1;
+    const groupPattern = detectGroupPattern(processes);
+
+    for (const process of processes) {
+      const rescored = scoreProcessName(process, groupPattern);
+      process.name_score = rescored.score;
+      process.name_score_reasons = rescored.reasons;
+    }
+
+    const sortedProcesses = [...processes].sort(
+      (left, right) =>
+        right.name_score - left.name_score ||
+        createdAtKey(left).localeCompare(createdAtKey(right)) ||
+        left.process_id.localeCompare(right.process_id),
+    );
+
+    duplicateGroups.push({
+      group_id: group.group_id,
+      group_pattern: groupPattern,
+      exact_duplicate: exactDuplicate,
+      processes,
+    });
+
+    if (!exactDuplicate) {
+      continue;
+    }
+
+    const keep = sortedProcesses[0] as DedupAnalyzedProcess;
+    const deleteCandidates = sortedProcesses.slice(1);
+    const scoreGap =
+      deleteCandidates.length > 0 ? keep.name_score - deleteCandidates[0].name_score : 0;
+    const confidence: 'high' | 'medium' | 'low' = scoreGap >= 15 ? 'high' : 'medium';
+
+    const keepProcessRefs = referenceHits.processes[keep.process_id] ?? [];
+    const keepLifecyclemodelRefs = referenceHits.lifecyclemodels[keep.process_id] ?? [];
+    const deleteRefs = Object.fromEntries(
+      deleteCandidates.map((candidate) => [
+        candidate.process_id,
+        {
+          process_refs: (referenceHits.processes[candidate.process_id] ?? []).length,
+          lifecyclemodel_refs: (referenceHits.lifecyclemodels[candidate.process_id] ?? []).length,
+        },
+      ]),
+    );
+
+    const notes = ['exact duplicate confirmed by normalized exchange signature'];
+    if (
+      Object.values(deleteRefs).every(
+        (entry) => entry.process_refs === 0 && entry.lifecyclemodel_refs === 0,
+      )
+    ) {
+      notes.push('current-user reference scan found no downstream hits for delete candidates');
+    } else {
+      notes.push(
+        'current-user reference scan found downstream hits; delete requires reference cleanup',
+      );
+    }
+    notes.push('global or shared-team reference verification is outside this command');
+
+    deletePlanGroups.push({
+      group_id: group.group_id,
+      status: 'priority_delete_candidates',
+      confidence,
+      current_user_reference_hits: {
+        keep_process_refs: keepProcessRefs.length,
+        keep_lifecyclemodel_refs: keepLifecyclemodelRefs.length,
+        delete_refs: deleteRefs,
+      },
+      keep: {
+        process_id: keep.process_id,
+        name_en: trimText(keep.remote_name_en ?? keep.name_en),
+        name_zh: trimText(keep.remote_name_zh ?? keep.name_zh),
+        score: keep.name_score,
+        reasons: keep.name_score_reasons,
+      },
+      delete: deleteCandidates.map((candidate) => ({
+        process_id: candidate.process_id,
+        name_en: trimText(candidate.remote_name_en ?? candidate.name_en),
+        name_zh: trimText(candidate.remote_name_zh ?? candidate.name_zh),
+        score: candidate.name_score,
+        reasons: candidate.name_score_reasons,
+      })),
+      notes,
+    });
+  }
+
+  return {
+    duplicateGroups,
+    deletePlanGroups,
+  };
+}
+
+export async function runProcessDedupReview(
+  options: RunProcessDedupReviewOptions,
+): Promise<ProcessDedupReviewReport> {
+  const inputPath = requiredNonEmpty(options.inputPath, '--input', 'PROCESS_DEDUP_INPUT_REQUIRED');
+  const outDir = requiredNonEmpty(options.outDir, '--out-dir', 'PROCESS_DEDUP_OUT_DIR_REQUIRED');
+  const resolvedInputPath = path.resolve(inputPath);
+  const resolvedOutDir = path.resolve(outDir);
+  const timeoutMs = toPositiveInteger(
+    options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    '--timeout-ms',
+    'PROCESS_DEDUP_TIMEOUT_INVALID',
+  );
+  const maxRetries = toPositiveInteger(
+    options.maxRetries ?? DEFAULT_MAX_RETRIES,
+    '--max-retries',
+    'PROCESS_DEDUP_MAX_RETRIES_INVALID',
+  );
+  const generatedAtUtc = nowIso(options.now);
+
+  const document = normalizeInputDocument(readJsonInput(resolvedInputPath), resolvedInputPath);
+  const processIds = [
+    ...new Set(
+      document.groups.flatMap((group) => group.processes.map((process) => process.process_id)),
+    ),
+  ];
+
+  const inputManifestPath = path.join(resolvedOutDir, 'inputs', 'dedup-input.manifest.json');
+  writeJsonArtifact(inputManifestPath, {
+    schema_version: 1,
+    generated_at_utc: generatedAtUtc,
+    input_file: resolvedInputPath,
+    source_label: document.sourceLabel,
+    group_count: document.groups.length,
+    process_count: processIds.length,
+  });
+
+  const remoteStatus: RemoteStatus = {
+    enabled: false,
+    loaded: 0,
+    error: null,
+    reference_scan: options.skipRemote ? 'skipped_by_flag' : 'not_run',
+  };
+
+  let remoteMetadataPath: string | null = null;
+  let referenceScanPath: string | null = null;
+  let remoteById: Record<string, RemoteMetadataRecord> = {};
+  let referenceHits = buildEmptyReferenceHits(processIds);
+
+  if (!options.skipRemote) {
+    try {
+      const env = options.env ?? process.env;
+      const fetchImpl = options.fetchImpl ?? (fetch as FetchLike);
+      const auth = await resolveRemoteAuthContext({
+        env,
+        fetchImpl,
+        timeoutMs,
+        maxRetries,
+        now: options.now ?? new Date(),
+      });
+
+      remoteById = await fetchRemoteMetadata({
+        processIds,
+        auth,
+        fetchImpl,
+        timeoutMs,
+        maxRetries,
+      });
+      remoteStatus.enabled = true;
+      remoteStatus.loaded = Object.keys(remoteById).length;
+      remoteMetadataPath = path.join(resolvedOutDir, 'inputs', 'processes.remote-metadata.json');
+      writeJsonArtifact(remoteMetadataPath, remoteById);
+
+      if (auth.userId) {
+        try {
+          referenceHits = await fetchCurrentUserReferenceHits({
+            auth,
+            userId: auth.userId,
+            targetProcessIds: processIds,
+            fetchImpl,
+            timeoutMs,
+            maxRetries,
+          });
+          referenceScanPath = path.join(
+            resolvedOutDir,
+            'outputs',
+            'current-user-reference-scan.json',
+          );
+          writeJsonArtifact(referenceScanPath, referenceHits);
+          remoteStatus.reference_scan = 'current_user_completed';
+        } catch (error) {
+          remoteStatus.reference_scan = 'failed';
+          remoteStatus.error = error instanceof Error ? error.message : String(error);
+        }
+      } else {
+        remoteStatus.reference_scan = 'skipped_missing_user_id';
+      }
+    } catch (error) {
+      remoteStatus.error = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  const analysis = analyzeGroups(document.groups, remoteById, referenceHits);
+  const duplicateGroupsPath = path.join(resolvedOutDir, 'outputs', 'duplicate-groups.json');
+  const deletePlanPath = path.join(resolvedOutDir, 'outputs', 'delete-plan.json');
+
+  writeJsonArtifact(duplicateGroupsPath, {
+    schema_version: 1,
+    generated_at_utc: generatedAtUtc,
+    input_file: resolvedInputPath,
+    source_label: document.sourceLabel,
+    remote_status: remoteStatus,
+    groups: analysis.duplicateGroups,
+  });
+  writeJsonArtifact(deletePlanPath, {
+    schema_version: 1,
+    generated_at_utc: generatedAtUtc,
+    input_file: resolvedInputPath,
+    source_label: document.sourceLabel,
+    remote_status: remoteStatus,
+    groups: analysis.deletePlanGroups,
+  });
+
+  return {
+    schema_version: 1,
+    generated_at_utc: generatedAtUtc,
+    status: 'completed_process_dedup_review',
+    input_file: resolvedInputPath,
+    out_dir: resolvedOutDir,
+    source_label: document.sourceLabel,
+    group_count: analysis.duplicateGroups.length,
+    exact_duplicate_group_count: analysis.duplicateGroups.filter((group) => group.exact_duplicate)
+      .length,
+    remote_status: remoteStatus,
+    files: {
+      input_manifest: inputManifestPath,
+      remote_metadata: remoteMetadataPath,
+      duplicate_groups: duplicateGroupsPath,
+      delete_plan: deletePlanPath,
+      current_user_reference_scan: referenceScanPath,
+    },
+  };
+}
+
+export const __testInternals = {
+  analyzeGroups,
+  collectReferenceHits,
+  detectGroupPattern,
+  normalizeAmount,
+  normalizeExchangeRows,
+  normalizeInputDocument,
+  normalizedSignature,
+  scoreProcessName,
+};

--- a/src/lib/process-dedup-review.ts
+++ b/src/lib/process-dedup-review.ts
@@ -169,6 +169,10 @@ function trimText(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 function nowIso(now: Date = new Date()): string {
   return now.toISOString();
 }
@@ -708,9 +712,9 @@ async function fetchCurrentUserRows(options: {
     rows.push(...pageRows);
 
     if (total === null) {
-      const contentRange = page.headers.get('content-range') ?? '';
-      const match = contentRange.match(/\/(\d+)$/u);
-      total = match ? Number.parseInt(match[1] ?? '', 10) : rows.length;
+      const contentRange = page.headers.get('content-range');
+      const match = contentRange ? contentRange.match(/\/(\d+)$/u) : null;
+      total = match ? Number.parseInt(match[1], 10) : rows.length;
     }
 
     if (pageRows.length === 0) {
@@ -1020,18 +1024,17 @@ function analyzeGroups(
 
     const keep = sortedProcesses[0] as DedupAnalyzedProcess;
     const deleteCandidates = sortedProcesses.slice(1);
-    const scoreGap =
-      deleteCandidates.length > 0 ? keep.name_score - deleteCandidates[0].name_score : 0;
+    const scoreGap = keep.name_score - deleteCandidates[0]!.name_score;
     const confidence: 'high' | 'medium' | 'low' = scoreGap >= 15 ? 'high' : 'medium';
 
-    const keepProcessRefs = referenceHits.processes[keep.process_id] ?? [];
-    const keepLifecyclemodelRefs = referenceHits.lifecyclemodels[keep.process_id] ?? [];
+    const keepProcessRefs = referenceHits.processes[keep.process_id]!;
+    const keepLifecyclemodelRefs = referenceHits.lifecyclemodels[keep.process_id]!;
     const deleteRefs = Object.fromEntries(
       deleteCandidates.map((candidate) => [
         candidate.process_id,
         {
-          process_refs: (referenceHits.processes[candidate.process_id] ?? []).length,
-          lifecyclemodel_refs: (referenceHits.lifecyclemodels[candidate.process_id] ?? []).length,
+          process_refs: referenceHits.processes[candidate.process_id]!.length,
+          lifecyclemodel_refs: referenceHits.lifecyclemodels[candidate.process_id]!.length,
         },
       ]),
     );
@@ -1174,13 +1177,13 @@ export async function runProcessDedupReview(
           remoteStatus.reference_scan = 'current_user_completed';
         } catch (error) {
           remoteStatus.reference_scan = 'failed';
-          remoteStatus.error = error instanceof Error ? error.message : String(error);
+          remoteStatus.error = errorMessage(error);
         }
       } else {
         remoteStatus.reference_scan = 'skipped_missing_user_id';
       }
     } catch (error) {
-      remoteStatus.error = error instanceof Error ? error.message : String(error);
+      remoteStatus.error = errorMessage(error);
     }
   }
 
@@ -1230,9 +1233,19 @@ export const __testInternals = {
   analyzeGroups,
   collectReferenceHits,
   detectGroupPattern,
+  errorMessage,
+  fetchCurrentUserId,
+  fetchCurrentUserReferenceHits,
+  fetchCurrentUserRows,
+  fetchJsonWithRetry,
+  fetchRemoteMetadata,
+  getLangList,
+  getLangText,
   normalizeAmount,
   normalizeExchangeRows,
   normalizeInputDocument,
   normalizedSignature,
+  parseJsonResponse,
+  resolveRemoteAuthContext,
   scoreProcessName,
 };

--- a/src/lib/process-payload-validation.ts
+++ b/src/lib/process-payload-validation.ts
@@ -1,0 +1,101 @@
+import * as tidasSdk from '@tiangong-lca/tidas-sdk';
+
+type JsonObject = Record<string, unknown>;
+
+type SafeParseIssue = {
+  code?: string;
+  message?: string;
+  path?: Array<string | number>;
+};
+
+type SafeParseResult =
+  | {
+      success: true;
+      data?: unknown;
+    }
+  | {
+      success: false;
+      error?: {
+        issues?: SafeParseIssue[];
+      };
+    };
+
+type SafeParseSchema = {
+  safeParse: (value: unknown) => SafeParseResult;
+};
+
+const PROCESS_SCHEMA_VALIDATOR = '@tiangong-lca/tidas-sdk/ProcessSchema';
+
+export type ProcessPayloadValidationIssue = {
+  path: string;
+  message: string;
+  code: string;
+};
+
+export type ProcessPayloadValidationResult =
+  | {
+      ok: true;
+      validator: string;
+      issue_count: 0;
+      issues: [];
+    }
+  | {
+      ok: false;
+      validator: string;
+      issue_count: number;
+      issues: ProcessPayloadValidationIssue[];
+    };
+
+function getProcessSchema(): SafeParseSchema {
+  const schema = (tidasSdk as { ProcessSchema?: SafeParseSchema }).ProcessSchema;
+  if (!schema?.safeParse) {
+    throw new Error(`${PROCESS_SCHEMA_VALIDATOR} is unavailable in the published CLI runtime.`);
+  }
+  return schema;
+}
+
+function normalizeIssuePath(pathParts: Array<string | number> | undefined): string {
+  if (!Array.isArray(pathParts) || pathParts.length === 0) {
+    return '<root>';
+  }
+  return pathParts.map((part) => String(part)).join('.');
+}
+
+export function summarizeProcessPayloadValidation(result: ProcessPayloadValidationResult): string {
+  if (result.ok) {
+    return 'local ProcessSchema validation passed';
+  }
+
+  const preview = result.issues
+    .slice(0, 3)
+    .map((issue) => `${issue.path}: ${issue.message}`)
+    .join('; ');
+  return `local ProcessSchema validation failed with ${result.issue_count} issue(s)${preview ? ` (${preview})` : ''}`;
+}
+
+export function validateProcessPayload(payload: JsonObject): ProcessPayloadValidationResult {
+  const schema = getProcessSchema();
+  const outcome = schema.safeParse(payload);
+
+  if (outcome.success) {
+    return {
+      ok: true,
+      validator: PROCESS_SCHEMA_VALIDATOR,
+      issue_count: 0,
+      issues: [],
+    };
+  }
+
+  const issues = (outcome.error?.issues ?? []).map((issue) => ({
+    path: normalizeIssuePath(issue.path),
+    message: issue.message ?? 'Validation failed',
+    code: issue.code ?? 'custom',
+  }));
+
+  return {
+    ok: false,
+    validator: PROCESS_SCHEMA_VALIDATOR,
+    issue_count: issues.length,
+    issues,
+  };
+}

--- a/src/lib/process-refresh-references.ts
+++ b/src/lib/process-refresh-references.ts
@@ -1,0 +1,1391 @@
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { writeJsonArtifact, writeJsonLinesArtifact, writeTextArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+import type { FetchLike, ResponseLike } from './http.js';
+import {
+  syncStateAwareProcessRecord,
+  type ProcessStateAwareWriteResult,
+  type SyncStateAwareProcessRecordOptions,
+} from './process-save-draft.js';
+import {
+  validateProcessPayload,
+  type ProcessPayloadValidationResult,
+} from './process-payload-validation.js';
+import { deriveSupabaseProjectBaseUrl, requireSupabaseRestRuntime } from './supabase-client.js';
+import { resolveSupabaseUserSession } from './supabase-session.js';
+import { redactEmail, requireUserApiKeyCredentials } from './user-api-key.js';
+
+type JsonObject = Record<string, unknown>;
+
+type ProcessManifestRow = {
+  id: string;
+  version: string;
+  modified_at: string | null;
+  state_code: number | null;
+  model_id: string | null;
+};
+
+type ProcessDetailRow = ProcessManifestRow & {
+  user_id: string | null;
+  json: JsonObject;
+};
+
+type LatestReferenceRow = {
+  id: string;
+  version: string;
+  json: JsonObject;
+  modified_at: string | null;
+  state_code: number | null;
+  user_id: string | null;
+  team_id: string | null;
+};
+
+type LatestReferenceCacheEntry = {
+  row: LatestReferenceRow | null;
+  count: number;
+  error?: string;
+};
+
+type ReferenceNode = JsonObject & {
+  '@refObjectId': string;
+  '@version': string;
+  '@type': string;
+};
+
+type CollectedReference = {
+  node: ReferenceNode;
+  path: string;
+};
+
+type TouchedReference = {
+  id: string;
+  type: string;
+  from_version: string;
+  to_version: string;
+  path: string;
+};
+
+type UnresolvedReference = {
+  id: string;
+  type: string;
+  version: string;
+  reason: string;
+};
+
+type UpdateSummary = {
+  version_updates: number;
+  description_updates: number;
+  touched_refs: TouchedReference[];
+  unresolved_refs: UnresolvedReference[];
+};
+
+type ProgressStatus = 'saved' | 'dry_run' | 'skipped' | 'validation_blocked' | 'error';
+
+type ProgressRecord = {
+  time: string;
+  key: string;
+  id?: string;
+  version?: string;
+  status: ProgressStatus;
+  note?: string;
+  ref_count?: number;
+  version_updates?: number;
+  description_updates?: number;
+  unresolved_count?: number;
+  changed_ref_count?: number;
+  schema_validator?: string;
+  schema_issue_count?: number;
+  schema_issues?: ProcessPayloadValidationResult['issues'];
+  touched_refs?: TouchedReference[];
+  unresolved_refs?: UnresolvedReference[];
+  write_path?: string;
+  write_operation?: string;
+  error?: string;
+};
+
+type RefreshManifest = {
+  schema_version: 1;
+  generated_at_utc: string;
+  user_id: string;
+  masked_user_email: string;
+  source: 'current_user_processes';
+  order: 'modified_at.desc,id.asc';
+  page_size: number;
+  count: number;
+  rows: ProcessManifestRow[];
+};
+
+export type ProcessRefreshReferencesReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: 'completed_process_reference_refresh' | 'completed_process_reference_refresh_with_errors';
+  out_dir: string;
+  mode: 'dry_run' | 'apply';
+  user_id: string;
+  masked_user_email: string;
+  counts: {
+    manifest: number;
+    selected: number;
+    already_completed: number;
+    pending: number;
+    saved: number;
+    dry_run: number;
+    skipped: number;
+    validation_blocked: number;
+    errors: number;
+  };
+  files: {
+    manifest: string;
+    progress_jsonl: string;
+    errors_jsonl: string;
+    validation_blockers_jsonl: string;
+    summary_json: string;
+    report_md: string;
+  };
+};
+
+export type RunProcessRefreshReferencesOptions = {
+  outDir: string;
+  apply?: boolean | null;
+  reuseManifest?: boolean | null;
+  limit?: number | null;
+  pageSize?: number | null;
+  concurrency?: number | null;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: FetchLike;
+  timeoutMs?: number;
+  maxRetries?: number;
+  now?: Date;
+  validateProcessPayloadImpl?: (payload: JsonObject) => ProcessPayloadValidationResult;
+  syncStateAwareProcessRecordImpl?: (
+    options: SyncStateAwareProcessRecordOptions,
+  ) => Promise<ProcessStateAwareWriteResult>;
+};
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_PAGE_SIZE = 500;
+const DEFAULT_CONCURRENCY = 1;
+const MAX_PAGE_SIZE = 1_000;
+const MAX_CONCURRENCY = 8;
+
+const TABLE_BY_TYPE = new Map<string, string>([
+  ['contact data set', 'contacts'],
+  ['source data set', 'sources'],
+  ['unit group data set', 'unitgroups'],
+  ['flow property data set', 'flowproperties'],
+  ['flow data set', 'flows'],
+  ['process data set', 'processes'],
+  ['lifeCycleModel data set', 'lifecyclemodels'],
+  ['LCIA method data set', 'lciamethods'],
+] as const);
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function trimText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function requiredNonEmpty(value: string, label: string, code: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new CliError(`Missing required ${label}.`, {
+      code,
+      exitCode: 2,
+    });
+  }
+  return normalized;
+}
+
+function toPositiveInteger(value: number, label: string, code: string, max?: number): number {
+  if (!Number.isInteger(value) || value <= 0 || (max !== undefined && value > max)) {
+    throw new CliError(
+      max === undefined
+        ? `Expected ${label} to be a positive integer.`
+        : `Expected ${label} to be a positive integer not greater than ${max}.`,
+      {
+        code,
+        exitCode: 2,
+      },
+    );
+  }
+  return value;
+}
+
+function toOptionalPositiveInteger(
+  value: number | null | undefined,
+  label: string,
+  code: string,
+): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return toPositiveInteger(value, label, code);
+}
+
+function nowIso(now: Date = new Date()): string {
+  return now.toISOString();
+}
+
+function recordKey(row: Pick<ProcessManifestRow, 'id' | 'version'>): string {
+  return `${row.id}:${row.version}`;
+}
+
+function parseContentRangeTotal(value: string | null): number | null {
+  if (!value) {
+    return null;
+  }
+  const match = value.match(/\/(\d+|\*)$/u);
+  if (!match || match[1] === '*') {
+    return null;
+  }
+  return Number.parseInt(match[1] ?? '', 10);
+}
+
+function normalizeVersion(version: string): string {
+  return version.trim();
+}
+
+function compareVersions(left: string, right: string): number {
+  const leftParts = normalizeVersion(left)
+    .split('.')
+    .map((part) => Number(part));
+  const rightParts = normalizeVersion(right)
+    .split('.')
+    .map((part) => Number(part));
+  const length = Math.max(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const leftValue = Number.isFinite(leftParts[index]) ? leftParts[index] : 0;
+    const rightValue = Number.isFinite(rightParts[index]) ? rightParts[index] : 0;
+    if (leftValue !== rightValue) {
+      return leftValue - rightValue;
+    }
+  }
+
+  return normalizeVersion(left).localeCompare(normalizeVersion(right));
+}
+
+function jsonToList(value: unknown): unknown[] {
+  if (value === null || value === undefined || value === '') {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+function getLangList(value: unknown): JsonObject[] {
+  if (value === null || value === undefined || value === '') {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is JsonObject => isRecord(entry));
+  }
+  if (isRecord(value)) {
+    const langString = value['common:langString'];
+    if (Array.isArray(langString)) {
+      return langString.filter((entry): entry is JsonObject => isRecord(entry));
+    }
+    if (isRecord(langString)) {
+      return [langString];
+    }
+    if (value['#text'] !== undefined || value['@xml:lang'] !== undefined) {
+      return [value];
+    }
+  }
+  if (typeof value === 'string') {
+    return [{ '@xml:lang': 'en', '#text': value }];
+  }
+  return [];
+}
+
+function getLangText(value: unknown, lang: string | null): string {
+  const entries = getLangList(value);
+  if (lang) {
+    for (const entry of entries) {
+      if (
+        trimText(entry['@xml:lang']).toLowerCase() === lang.toLowerCase() &&
+        trimText(entry['#text'])
+      ) {
+        return trimText(entry['#text']);
+      }
+    }
+  }
+  for (const entry of entries) {
+    if (trimText(entry['#text'])) {
+      return trimText(entry['#text']);
+    }
+  }
+  return '';
+}
+
+function genFlowName(name: JsonObject | null, lang: string): string {
+  if (!name) {
+    return '';
+  }
+  const parts = [
+    getLangText(name.baseName, lang),
+    getLangText(name.treatmentStandardsRoutes, lang),
+    getLangText(name.mixAndLocationTypes, lang),
+    getLangText(name.flowProperties, lang),
+  ].filter(Boolean);
+  return parts.join('; ');
+}
+
+function genFlowNameJson(name: JsonObject | null): JsonObject[] {
+  if (!name) {
+    return [];
+  }
+  const results: JsonObject[] = [];
+  for (const item of jsonToList(name.baseName)) {
+    const entry = isRecord(item) ? item : {};
+    const lang = trimText(entry['@xml:lang']);
+    const text = lang ? genFlowName(name, lang) : '';
+    if (lang && text) {
+      results.push({ '@xml:lang': lang, '#text': text });
+    }
+  }
+  return results;
+}
+
+function genProcessName(name: JsonObject | null, lang: string): string {
+  if (!name) {
+    return '';
+  }
+  const parts = [
+    getLangText(name.baseName, lang),
+    getLangText(name.treatmentStandardsRoutes, lang),
+    getLangText(name.mixAndLocationTypes, lang),
+    getLangText(name.functionalUnitFlowProperties, lang),
+  ].filter(Boolean);
+  return parts.join('; ');
+}
+
+function genProcessNameJson(name: JsonObject | null): JsonObject[] {
+  if (!name) {
+    return [];
+  }
+  const results: JsonObject[] = [];
+  for (const item of jsonToList(name.baseName)) {
+    const entry = isRecord(item) ? item : {};
+    const lang = trimText(entry['@xml:lang']);
+    const text = lang ? genProcessName(name, lang) : '';
+    if (lang && text) {
+      results.push({ '@xml:lang': lang, '#text': text });
+    }
+  }
+  return results;
+}
+
+function normalizeDatasetPayload(payload: unknown, label: string): JsonObject {
+  if (typeof payload === 'string') {
+    try {
+      const parsed = JSON.parse(payload) as unknown;
+      if (!isRecord(parsed)) {
+        throw new CliError(`Remote dataset payload was not a JSON object for ${label}.`, {
+          code: 'PROCESS_REFRESH_REMOTE_PAYLOAD_INVALID',
+          exitCode: 1,
+          details: parsed,
+        });
+      }
+      return parsed;
+    } catch (error) {
+      if (error instanceof CliError) {
+        throw error;
+      }
+      throw new CliError(`Remote dataset payload was not valid JSON for ${label}.`, {
+        code: 'PROCESS_REFRESH_REMOTE_PAYLOAD_INVALID_JSON',
+        exitCode: 1,
+        details: String(error),
+      });
+    }
+  }
+
+  if (!isRecord(payload)) {
+    throw new CliError(`Remote dataset payload was missing json for ${label}.`, {
+      code: 'PROCESS_REFRESH_REMOTE_PAYLOAD_MISSING',
+      exitCode: 1,
+      details: payload,
+    });
+  }
+
+  return payload;
+}
+
+function getShortDescription(payload: JsonObject, type: string): JsonObject[] {
+  if (type === 'flow data set') {
+    const flowDataSet = isRecord(payload.flowDataSet) ? payload.flowDataSet : {};
+    const info = isRecord(flowDataSet.flowInformation) ? flowDataSet.flowInformation : {};
+    const dataSetInformation = isRecord(info.dataSetInformation) ? info.dataSetInformation : {};
+    const name = isRecord(dataSetInformation.name) ? dataSetInformation.name : null;
+    return genFlowNameJson(name);
+  }
+
+  if (type === 'process data set') {
+    const processDataSet = isRecord(payload.processDataSet) ? payload.processDataSet : {};
+    const info = isRecord(processDataSet.processInformation)
+      ? processDataSet.processInformation
+      : {};
+    const dataSetInformation = isRecord(info.dataSetInformation) ? info.dataSetInformation : {};
+    const name = isRecord(dataSetInformation.name) ? dataSetInformation.name : null;
+    return genProcessNameJson(name);
+  }
+
+  if (type === 'contact data set') {
+    const contactDataSet = isRecord(payload.contactDataSet) ? payload.contactDataSet : {};
+    const info = isRecord(contactDataSet.contactInformation)
+      ? contactDataSet.contactInformation
+      : {};
+    const dataSetInformation = isRecord(info.dataSetInformation) ? info.dataSetInformation : {};
+    return getLangList(dataSetInformation['common:shortName']);
+  }
+
+  if (type === 'source data set') {
+    const sourceDataSet = isRecord(payload.sourceDataSet) ? payload.sourceDataSet : {};
+    const info = isRecord(sourceDataSet.sourceInformation) ? sourceDataSet.sourceInformation : {};
+    const dataSetInformation = isRecord(info.dataSetInformation) ? info.dataSetInformation : {};
+    return getLangList(dataSetInformation['common:shortName']);
+  }
+
+  if (type === 'flow property data set') {
+    const flowPropertyDataSet = isRecord(payload.flowPropertyDataSet)
+      ? payload.flowPropertyDataSet
+      : {};
+    const info = isRecord(flowPropertyDataSet.flowPropertyInformation)
+      ? flowPropertyDataSet.flowPropertyInformation
+      : {};
+    const dataSetInformation = isRecord(info.dataSetInformation) ? info.dataSetInformation : {};
+    return getLangList(dataSetInformation['common:shortName']);
+  }
+
+  if (type === 'unit group data set') {
+    const unitGroupDataSet = isRecord(payload.unitGroupDataSet) ? payload.unitGroupDataSet : {};
+    const info = isRecord(unitGroupDataSet.unitGroupInformation)
+      ? unitGroupDataSet.unitGroupInformation
+      : {};
+    const dataSetInformation = isRecord(info.dataSetInformation) ? info.dataSetInformation : {};
+    return getLangList(dataSetInformation['common:shortName']);
+  }
+
+  if (type === 'LCIA method data set') {
+    const lciaMethodDataSet = isRecord(payload.lciaMethodDataSet) ? payload.lciaMethodDataSet : {};
+    const info = isRecord(lciaMethodDataSet.LCIAMethodInformation)
+      ? lciaMethodDataSet.LCIAMethodInformation
+      : {};
+    const dataSetInformation = isRecord(info.dataSetInformation) ? info.dataSetInformation : {};
+    return getLangList(dataSetInformation['common:shortName']);
+  }
+
+  return [];
+}
+
+async function parseJsonResponse(response: ResponseLike, label: string): Promise<unknown> {
+  const text = await response.text();
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!text.trim()) {
+    return null;
+  }
+  if (!contentType.includes('application/json')) {
+    return text;
+  }
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new CliError(`${label} returned invalid JSON.`, {
+      code: 'PROCESS_REFRESH_REMOTE_INVALID_JSON',
+      exitCode: 1,
+      details: String(error),
+    });
+  }
+}
+
+async function fetchJsonWithRetry(options: {
+  url: string;
+  init: RequestInit;
+  label: string;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+  maxRetries: number;
+}): Promise<{ status: number; headers: Headers; body: unknown }> {
+  let lastError: unknown = null;
+
+  for (let attempt = 1; attempt <= options.maxRetries; attempt += 1) {
+    try {
+      const response = await options.fetchImpl(options.url, {
+        ...options.init,
+        signal: AbortSignal.timeout(options.timeoutMs),
+      });
+      const body = await parseJsonResponse(response, options.label);
+      if (!response.ok) {
+        throw new CliError(`${options.label} failed with ${response.status}.`, {
+          code: 'PROCESS_REFRESH_REMOTE_REQUEST_FAILED',
+          exitCode: 1,
+          details: {
+            status: response.status,
+            body,
+            url: options.url,
+          },
+        });
+      }
+      return {
+        status: response.status,
+        headers: new Headers({
+          'content-range': response.headers.get('content-range') ?? '',
+          'content-type': response.headers.get('content-type') ?? '',
+        }),
+        body,
+      };
+    } catch (error) {
+      lastError = error;
+      if (attempt >= options.maxRetries) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, attempt * 1_500));
+    }
+  }
+
+  if (lastError instanceof CliError) {
+    throw lastError;
+  }
+
+  throw new CliError(`${options.label} failed after ${options.maxRetries} attempt(s).`, {
+    code: 'PROCESS_REFRESH_REMOTE_REQUEST_FAILED',
+    exitCode: 1,
+    details: String(lastError),
+  });
+}
+
+async function resolveRemoteAuth(options: {
+  env: NodeJS.ProcessEnv;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+  now: Date;
+  maxRetries: number;
+}): Promise<{
+  projectBaseUrl: string;
+  publishableKey: string;
+  accessToken: string;
+  userId: string;
+  maskedUserEmail: string;
+}> {
+  const runtime = requireSupabaseRestRuntime(options.env);
+  const session = await resolveSupabaseUserSession({
+    runtime,
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.timeoutMs,
+    now: options.now,
+  });
+  const userResponse = await fetchJsonWithRetry({
+    url: `${deriveSupabaseProjectBaseUrl(runtime.apiBaseUrl)}/auth/v1/user`,
+    init: {
+      method: 'GET',
+      headers: {
+        apikey: runtime.publishableKey,
+        Authorization: `Bearer ${session.accessToken}`,
+        Accept: 'application/json',
+      },
+    },
+    label: 'supabase current-user lookup',
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.timeoutMs,
+    maxRetries: options.maxRetries,
+  });
+  const userId = isRecord(userResponse.body) ? trimText(userResponse.body.id) : '';
+  if (!userId) {
+    throw new CliError('Supabase current-user lookup succeeded without a user id.', {
+      code: 'PROCESS_REFRESH_CURRENT_USER_ID_MISSING',
+      exitCode: 1,
+    });
+  }
+
+  return {
+    projectBaseUrl: deriveSupabaseProjectBaseUrl(runtime.apiBaseUrl),
+    publishableKey: runtime.publishableKey,
+    accessToken: session.accessToken,
+    userId,
+    maskedUserEmail: redactEmail(requireUserApiKeyCredentials(runtime.userApiKey).email),
+  };
+}
+
+function normalizeManifestRow(value: unknown): ProcessManifestRow | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const id = trimText(value.id);
+  const version = trimText(value.version);
+  if (!id || !version) {
+    return null;
+  }
+  return {
+    id,
+    version,
+    modified_at: trimText(value.modified_at) || null,
+    state_code: typeof value.state_code === 'number' ? value.state_code : null,
+    model_id: trimText(value.model_id) || null,
+  };
+}
+
+function readManifest(filePath: string): RefreshManifest | null {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, 'utf8')) as unknown;
+    if (!isRecord(parsed) || !Array.isArray(parsed.rows)) {
+      throw new Error('manifest rows missing');
+    }
+    const rows = parsed.rows
+      .map((row) => normalizeManifestRow(row))
+      .filter((row): row is ProcessManifestRow => row !== null);
+    const userId = trimText(parsed.user_id);
+    const maskedUserEmail = trimText(parsed.masked_user_email);
+    if (!userId || !maskedUserEmail) {
+      throw new Error('manifest user metadata missing');
+    }
+    return {
+      schema_version: 1,
+      generated_at_utc: trimText(parsed.generated_at_utc) || nowIso(),
+      user_id: userId,
+      masked_user_email: maskedUserEmail,
+      source: 'current_user_processes',
+      order: 'modified_at.desc,id.asc',
+      page_size:
+        typeof parsed.page_size === 'number' && Number.isInteger(parsed.page_size)
+          ? parsed.page_size
+          : DEFAULT_PAGE_SIZE,
+      count:
+        typeof parsed.count === 'number' && Number.isInteger(parsed.count)
+          ? parsed.count
+          : rows.length,
+      rows,
+    };
+  } catch (error) {
+    throw new CliError(`Manifest file is not valid JSON: ${filePath}`, {
+      code: 'PROCESS_REFRESH_MANIFEST_INVALID',
+      exitCode: 2,
+      details: String(error),
+    });
+  }
+}
+
+async function snapshotProcesses(options: {
+  projectBaseUrl: string;
+  publishableKey: string;
+  accessToken: string;
+  userId: string;
+  pageSize: number;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+  maxRetries: number;
+}): Promise<ProcessManifestRow[]> {
+  const rows: ProcessManifestRow[] = [];
+  let total: number | null = null;
+
+  for (let offset = 0; total === null || offset < total; offset += options.pageSize) {
+    const url = new URL(`${options.projectBaseUrl}/rest/v1/processes`);
+    url.searchParams.set('select', 'id,version,modified_at,state_code,model_id');
+    url.searchParams.set('user_id', `eq.${options.userId}`);
+    url.searchParams.set('order', 'modified_at.desc,id.asc');
+    url.searchParams.set('limit', String(options.pageSize));
+    url.searchParams.set('offset', String(offset));
+
+    const page = await fetchJsonWithRetry({
+      url: url.toString(),
+      init: {
+        method: 'GET',
+        headers: {
+          apikey: options.publishableKey,
+          Authorization: `Bearer ${options.accessToken}`,
+          Accept: 'application/json',
+          Prefer: 'count=exact',
+        },
+      },
+      label: `process refresh snapshot page fetch (offset=${offset})`,
+      fetchImpl: options.fetchImpl,
+      timeoutMs: options.timeoutMs,
+      maxRetries: options.maxRetries,
+    });
+
+    const pageRows = Array.isArray(page.body) ? page.body : [];
+    const normalizedRows = pageRows
+      .map((row) => normalizeManifestRow(row))
+      .filter((row): row is ProcessManifestRow => row !== null);
+    rows.push(...normalizedRows);
+    total = parseContentRangeTotal(page.headers.get('content-range')) ?? rows.length;
+    if (normalizedRows.length === 0) {
+      break;
+    }
+  }
+
+  const deduped: ProcessManifestRow[] = [];
+  const seen = new Set<string>();
+  for (const row of rows) {
+    const key = recordKey(row);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(row);
+  }
+
+  return deduped;
+}
+
+function readCompleted(progressFile: string, applyMode: boolean): Set<string> {
+  const completed = new Set<string>();
+  if (!existsSync(progressFile)) {
+    return completed;
+  }
+  const doneStatuses = applyMode
+    ? new Set<ProgressStatus>(['saved', 'skipped', 'validation_blocked'])
+    : new Set<ProgressStatus>(['dry_run', 'skipped', 'validation_blocked']);
+  const lines = readFileSync(progressFile, 'utf8').split(/\r?\n/u).filter(Boolean);
+
+  for (const line of lines) {
+    try {
+      const record = JSON.parse(line) as unknown;
+      if (!isRecord(record)) {
+        continue;
+      }
+      const key = trimText(record.key);
+      const status = trimText(record.status) as ProgressStatus;
+      if (key && doneStatuses.has(status)) {
+        completed.add(key);
+      }
+    } catch {
+      // Ignore corrupt progress rows and continue resuming from the valid ones.
+    }
+  }
+
+  return completed;
+}
+
+async function fetchProcessDetail(options: {
+  projectBaseUrl: string;
+  publishableKey: string;
+  accessToken: string;
+  row: ProcessManifestRow;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+  maxRetries: number;
+}): Promise<ProcessDetailRow> {
+  const url = new URL(`${options.projectBaseUrl}/rest/v1/processes`);
+  url.searchParams.set('select', 'id,version,json,modified_at,state_code,model_id,user_id');
+  url.searchParams.set('id', `eq.${options.row.id}`);
+  url.searchParams.set('version', `eq.${options.row.version}`);
+  url.searchParams.set('limit', '1');
+
+  const response = await fetchJsonWithRetry({
+    url: url.toString(),
+    init: {
+      method: 'GET',
+      headers: {
+        apikey: options.publishableKey,
+        Authorization: `Bearer ${options.accessToken}`,
+        Accept: 'application/json',
+      },
+    },
+    label: `process refresh detail fetch (${recordKey(options.row)})`,
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.timeoutMs,
+    maxRetries: options.maxRetries,
+  });
+
+  const rows = Array.isArray(response.body) ? response.body : [];
+  const firstRow = rows[0];
+  if (!isRecord(firstRow)) {
+    throw new CliError(`Process not found for ${recordKey(options.row)}.`, {
+      code: 'PROCESS_REFRESH_DETAIL_NOT_FOUND',
+      exitCode: 1,
+    });
+  }
+
+  return {
+    id: trimText(firstRow.id) || options.row.id,
+    version: trimText(firstRow.version) || options.row.version,
+    modified_at: trimText(firstRow.modified_at) || null,
+    state_code: typeof firstRow.state_code === 'number' ? firstRow.state_code : null,
+    model_id: trimText(firstRow.model_id) || null,
+    user_id: trimText(firstRow.user_id) || null,
+    json: normalizeDatasetPayload(firstRow.json, recordKey(options.row)),
+  };
+}
+
+function collectRefs(root: JsonObject): CollectedReference[] {
+  const refs: CollectedReference[] = [];
+  const visited = new WeakSet<object>();
+
+  const walk = (current: unknown, pathParts: string[]) => {
+    if (!isRecord(current) && !Array.isArray(current)) {
+      return;
+    }
+    if (visited.has(current)) {
+      return;
+    }
+    visited.add(current);
+
+    if (
+      isRecord(current) &&
+      typeof current['@refObjectId'] === 'string' &&
+      typeof current['@version'] === 'string' &&
+      typeof current['@type'] === 'string' &&
+      TABLE_BY_TYPE.has(current['@type'])
+    ) {
+      refs.push({
+        node: current as ReferenceNode,
+        path: pathParts.join('.'),
+      });
+    }
+
+    if (Array.isArray(current)) {
+      current.forEach((item, index) => walk(item, [...pathParts, String(index)]));
+      return;
+    }
+
+    Object.entries(current).forEach(([key, value]) => walk(value, [...pathParts, key]));
+  };
+
+  walk(root, []);
+  return refs;
+}
+
+async function fetchLatestRefs(options: {
+  projectBaseUrl: string;
+  publishableKey: string;
+  accessToken: string;
+  refs: CollectedReference[];
+  cache: Map<string, LatestReferenceCacheEntry>;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+  maxRetries: number;
+}): Promise<void> {
+  const missingByTable = new Map<string, Set<string>>();
+
+  for (const ref of options.refs) {
+    const table = TABLE_BY_TYPE.get(ref.node['@type']);
+    const id = ref.node['@refObjectId'];
+    const cacheKey = table ? `${table}:${id}` : '';
+    if (!table || options.cache.has(cacheKey)) {
+      continue;
+    }
+    if (!missingByTable.has(table)) {
+      missingByTable.set(table, new Set<string>());
+    }
+    missingByTable.get(table)?.add(id);
+  }
+
+  for (const [table, idSet] of missingByTable.entries()) {
+    const ids = Array.from(idSet);
+    for (let offset = 0; offset < ids.length; offset += 50) {
+      const chunk = ids.slice(offset, offset + 50);
+      const url = new URL(`${options.projectBaseUrl}/rest/v1/${table}`);
+      url.searchParams.set('select', 'id,version,json,modified_at,state_code,user_id,team_id');
+      url.searchParams.set('id', `in.(${chunk.join(',')})`);
+      url.searchParams.set('order', 'version.desc');
+
+      try {
+        const response = await fetchJsonWithRetry({
+          url: url.toString(),
+          init: {
+            method: 'GET',
+            headers: {
+              apikey: options.publishableKey,
+              Authorization: `Bearer ${options.accessToken}`,
+              Accept: 'application/json',
+            },
+          },
+          label: `reference refresh ${table} lookup`,
+          fetchImpl: options.fetchImpl,
+          timeoutMs: options.timeoutMs,
+          maxRetries: options.maxRetries,
+        });
+
+        const rows = Array.isArray(response.body) ? response.body : [];
+        const byId = new Map<string, LatestReferenceRow[]>();
+        for (const rawRow of rows) {
+          if (!isRecord(rawRow)) {
+            continue;
+          }
+          const id = trimText(rawRow.id);
+          const version = trimText(rawRow.version);
+          if (!id || !version) {
+            continue;
+          }
+          const normalized: LatestReferenceRow = {
+            id,
+            version,
+            json: normalizeDatasetPayload(rawRow.json, `${table}:${id}@${version}`),
+            modified_at: trimText(rawRow.modified_at) || null,
+            state_code: typeof rawRow.state_code === 'number' ? rawRow.state_code : null,
+            user_id: trimText(rawRow.user_id) || null,
+            team_id: trimText(rawRow.team_id) || null,
+          };
+          const existing = byId.get(id) ?? [];
+          existing.push(normalized);
+          byId.set(id, existing);
+        }
+
+        for (const id of chunk) {
+          const versions = byId.get(id) ?? [];
+          versions.sort((left, right) => compareVersions(right.version, left.version));
+          options.cache.set(`${table}:${id}`, {
+            row: versions[0] ?? null,
+            count: versions.length,
+          });
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        for (const id of chunk) {
+          options.cache.set(`${table}:${id}`, {
+            row: null,
+            count: 0,
+            error: message,
+          });
+        }
+      }
+    }
+  }
+}
+
+function updateProcessJson(
+  payload: JsonObject,
+  refs: CollectedReference[],
+  cache: Map<string, LatestReferenceCacheEntry>,
+): UpdateSummary {
+  let versionUpdates = 0;
+  let descriptionUpdates = 0;
+  const touchedRefs: TouchedReference[] = [];
+  const unresolvedRefs: UnresolvedReference[] = [];
+
+  for (const ref of refs) {
+    const table = TABLE_BY_TYPE.get(ref.node['@type']);
+    const cacheKey = table ? `${table}:${ref.node['@refObjectId']}` : '';
+    const latest = cacheKey ? cache.get(cacheKey) : null;
+
+    if (!latest?.row) {
+      unresolvedRefs.push({
+        id: ref.node['@refObjectId'],
+        type: ref.node['@type'],
+        version: ref.node['@version'],
+        reason: latest?.error ?? 'no accessible version',
+      });
+      continue;
+    }
+
+    const currentVersion = ref.node['@version'];
+    const latestVersion = latest.row.version;
+    const description = getShortDescription(latest.row.json, ref.node['@type']);
+    const beforeDescription = JSON.stringify(ref.node['common:shortDescription'] ?? null);
+    const afterDescription = description.length ? JSON.stringify(description) : beforeDescription;
+
+    if (compareVersions(latestVersion, currentVersion) > 0) {
+      ref.node['@version'] = latestVersion;
+      versionUpdates += 1;
+    }
+
+    if (description.length && beforeDescription !== afterDescription) {
+      ref.node['common:shortDescription'] = description;
+      descriptionUpdates += 1;
+    }
+
+    if (ref.node['@version'] !== currentVersion || beforeDescription !== afterDescription) {
+      touchedRefs.push({
+        id: ref.node['@refObjectId'],
+        type: ref.node['@type'],
+        from_version: currentVersion,
+        to_version: ref.node['@version'],
+        path: ref.path,
+      });
+    }
+  }
+
+  void payload;
+  return {
+    version_updates: versionUpdates,
+    description_updates: descriptionUpdates,
+    touched_refs: touchedRefs,
+    unresolved_refs: unresolvedRefs,
+  };
+}
+
+function appendReportHeader(
+  reportFile: string,
+  context: {
+    mode: 'dry_run' | 'apply';
+    generatedAtUtc: string;
+    manifestCount: number;
+  },
+): void {
+  if (existsSync(reportFile)) {
+    return;
+  }
+  writeTextArtifact(
+    reportFile,
+    [
+      '# TianGong Process Reference Refresh',
+      '',
+      `- mode: ${context.mode}`,
+      `- generated_at_utc: ${context.generatedAtUtc}`,
+      `- manifest_count: ${context.manifestCount}`,
+      '',
+      '| time | status | key | version updates | description updates | refs | note |',
+      '| --- | --- | --- | ---: | ---: | ---: | --- |',
+      '',
+    ].join('\n'),
+  );
+}
+
+function appendReportRow(reportFile: string, record: ProgressRecord): void {
+  const note = trimText(record.note ?? record.error)
+    .replace(/\|/gu, '/')
+    .slice(0, 180);
+  appendFileSync(
+    reportFile,
+    `| ${record.time} | ${record.status} | ${record.key} | ${record.version_updates ?? 0} | ${record.description_updates ?? 0} | ${record.ref_count ?? 0} | ${note} |\n`,
+    'utf8',
+  );
+}
+
+async function processOne(options: {
+  row: ProcessManifestRow;
+  apply: boolean;
+  files: ProcessRefreshReferencesReport['files'];
+  auth: Awaited<ReturnType<typeof resolveRemoteAuth>>;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+  maxRetries: number;
+  env: NodeJS.ProcessEnv;
+  validateProcessPayloadImpl: (payload: JsonObject) => ProcessPayloadValidationResult;
+  syncStateAwareProcessRecordImpl: (
+    options: SyncStateAwareProcessRecordOptions,
+  ) => Promise<ProcessStateAwareWriteResult>;
+  refCache: Map<string, LatestReferenceCacheEntry>;
+}): Promise<ProgressRecord> {
+  const time = new Date().toISOString();
+  const key = recordKey(options.row);
+
+  try {
+    if (typeof options.row.state_code === 'number' && options.row.state_code >= 20) {
+      const record: ProgressRecord = {
+        time,
+        key,
+        status: 'skipped',
+        note: `state_code=${options.row.state_code}`,
+      };
+      writeJsonLinesArtifact(options.files.progress_jsonl, record, { append: true });
+      appendReportRow(options.files.report_md, record);
+      return record;
+    }
+
+    const detail = await fetchProcessDetail({
+      projectBaseUrl: options.auth.projectBaseUrl,
+      publishableKey: options.auth.publishableKey,
+      accessToken: options.auth.accessToken,
+      row: options.row,
+      fetchImpl: options.fetchImpl,
+      timeoutMs: options.timeoutMs,
+      maxRetries: options.maxRetries,
+    });
+    const payload = JSON.parse(JSON.stringify(detail.json)) as JsonObject;
+    const refs = collectRefs(payload);
+
+    await fetchLatestRefs({
+      projectBaseUrl: options.auth.projectBaseUrl,
+      publishableKey: options.auth.publishableKey,
+      accessToken: options.auth.accessToken,
+      refs,
+      cache: options.refCache,
+      fetchImpl: options.fetchImpl,
+      timeoutMs: options.timeoutMs,
+      maxRetries: options.maxRetries,
+    });
+
+    const update = updateProcessJson(payload, refs, options.refCache);
+    const validation = options.validateProcessPayloadImpl(payload);
+
+    if (!validation.ok || update.unresolved_refs.length > 0) {
+      const noteParts: string[] = [];
+      if (!validation.ok) {
+        noteParts.push(`schema_issue_count=${validation.issue_count}`);
+      }
+      if (update.unresolved_refs.length > 0) {
+        noteParts.push(`unresolved_refs=${update.unresolved_refs.length}`);
+      }
+
+      const record: ProgressRecord = {
+        time,
+        key,
+        id: options.row.id,
+        version: options.row.version,
+        status: 'validation_blocked',
+        ref_count: refs.length,
+        version_updates: update.version_updates,
+        description_updates: update.description_updates,
+        unresolved_count: update.unresolved_refs.length,
+        changed_ref_count: update.touched_refs.length,
+        schema_validator: validation.validator,
+        schema_issue_count: validation.issue_count,
+        schema_issues: validation.issues.slice(0, 20),
+        touched_refs: update.touched_refs.slice(0, 50),
+        unresolved_refs: update.unresolved_refs.slice(0, 50),
+        note: noteParts.join('; '),
+      };
+      writeJsonLinesArtifact(options.files.validation_blockers_jsonl, record, { append: true });
+      writeJsonLinesArtifact(options.files.progress_jsonl, record, { append: true });
+      appendReportRow(options.files.report_md, record);
+      return record;
+    }
+
+    let writeResult: ProcessStateAwareWriteResult | null = null;
+    if (options.apply) {
+      writeResult = await options.syncStateAwareProcessRecordImpl({
+        id: detail.id,
+        version: detail.version,
+        payload,
+        env: options.env,
+        fetchImpl: options.fetchImpl,
+        timeoutMs: options.timeoutMs,
+        audit: {
+          command: 'process_refresh_references',
+          source: 'tiangong process refresh-references',
+        },
+        modelId: detail.model_id,
+      });
+    }
+
+    const record: ProgressRecord = {
+      time,
+      key,
+      id: options.row.id,
+      version: options.row.version,
+      status: options.apply ? 'saved' : 'dry_run',
+      ref_count: refs.length,
+      version_updates: update.version_updates,
+      description_updates: update.description_updates,
+      unresolved_count: update.unresolved_refs.length,
+      changed_ref_count: update.touched_refs.length,
+      schema_validator: validation.validator,
+      schema_issue_count: validation.issue_count,
+      touched_refs: update.touched_refs.slice(0, 50),
+      unresolved_refs: update.unresolved_refs.slice(0, 50),
+      write_path:
+        writeResult && 'write_path' in writeResult ? (writeResult.write_path as string) : undefined,
+      write_operation: writeResult?.operation,
+    };
+    writeJsonLinesArtifact(options.files.progress_jsonl, record, { append: true });
+    appendReportRow(options.files.report_md, record);
+    return record;
+  } catch (error) {
+    const record: ProgressRecord = {
+      time,
+      key,
+      id: options.row.id,
+      version: options.row.version,
+      status: 'error',
+      error: error instanceof Error ? error.message : String(error),
+    };
+    writeJsonLinesArtifact(options.files.errors_jsonl, record, { append: true });
+    writeJsonLinesArtifact(options.files.progress_jsonl, record, { append: true });
+    appendReportRow(options.files.report_md, record);
+    return record;
+  }
+}
+
+async function workerPool<T, TResult>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<TResult>,
+): Promise<TResult[]> {
+  let cursor = 0;
+  const results: TResult[] = [];
+
+  async function runWorker() {
+    while (cursor < items.length) {
+      const currentIndex = cursor;
+      cursor += 1;
+      results[currentIndex] = await worker(items[currentIndex] as T, currentIndex);
+    }
+  }
+
+  await Promise.all(Array.from({ length: concurrency }, () => runWorker()));
+  return results;
+}
+
+export async function runProcessRefreshReferences(
+  options: RunProcessRefreshReferencesOptions,
+): Promise<ProcessRefreshReferencesReport> {
+  const outDir = path.resolve(
+    requiredNonEmpty(options.outDir, '--out-dir', 'PROCESS_REFRESH_OUT_DIR_REQUIRED'),
+  );
+  const apply = Boolean(options.apply);
+  const reuseManifest = Boolean(options.reuseManifest);
+  const limit = toOptionalPositiveInteger(
+    options.limit ?? null,
+    '--limit',
+    'PROCESS_REFRESH_LIMIT_INVALID',
+  );
+  const pageSize = toPositiveInteger(
+    options.pageSize ?? DEFAULT_PAGE_SIZE,
+    '--page-size',
+    'PROCESS_REFRESH_PAGE_SIZE_INVALID',
+    MAX_PAGE_SIZE,
+  );
+  const concurrency = toPositiveInteger(
+    options.concurrency ?? DEFAULT_CONCURRENCY,
+    '--concurrency',
+    'PROCESS_REFRESH_CONCURRENCY_INVALID',
+    MAX_CONCURRENCY,
+  );
+  const timeoutMs = toPositiveInteger(
+    options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    'timeout',
+    'PROCESS_REFRESH_TIMEOUT_INVALID',
+  );
+  const maxRetries = toPositiveInteger(
+    options.maxRetries ?? DEFAULT_MAX_RETRIES,
+    'retry count',
+    'PROCESS_REFRESH_MAX_RETRIES_INVALID',
+  );
+  const env = options.env ?? process.env;
+  const fetchImpl = options.fetchImpl ?? (fetch as FetchLike);
+  const generatedAtUtc = nowIso(options.now);
+  const validateProcessPayloadImpl = options.validateProcessPayloadImpl ?? validateProcessPayload;
+  const syncStateAwareProcessRecordImpl =
+    options.syncStateAwareProcessRecordImpl ?? syncStateAwareProcessRecord;
+
+  mkdirSync(outDir, { recursive: true });
+
+  const files: ProcessRefreshReferencesReport['files'] = {
+    manifest: path.join(outDir, 'inputs', 'processes.manifest.json'),
+    progress_jsonl: path.join(outDir, 'outputs', 'progress.jsonl'),
+    errors_jsonl: path.join(outDir, 'outputs', 'errors.jsonl'),
+    validation_blockers_jsonl: path.join(outDir, 'outputs', 'validation-blockers.jsonl'),
+    summary_json: path.join(outDir, 'outputs', 'summary.json'),
+    report_md: path.join(outDir, 'reports', 'process-refresh-references.md'),
+  };
+
+  const auth = await resolveRemoteAuth({
+    env,
+    fetchImpl,
+    timeoutMs,
+    now: options.now ?? new Date(),
+    maxRetries,
+  });
+
+  let manifest = readManifest(files.manifest);
+  if (!manifest || !reuseManifest) {
+    const rows = await snapshotProcesses({
+      projectBaseUrl: auth.projectBaseUrl,
+      publishableKey: auth.publishableKey,
+      accessToken: auth.accessToken,
+      userId: auth.userId,
+      pageSize,
+      fetchImpl,
+      timeoutMs,
+      maxRetries,
+    });
+    manifest = {
+      schema_version: 1,
+      generated_at_utc: generatedAtUtc,
+      user_id: auth.userId,
+      masked_user_email: auth.maskedUserEmail,
+      source: 'current_user_processes',
+      order: 'modified_at.desc,id.asc',
+      page_size: pageSize,
+      count: rows.length,
+      rows,
+    };
+    writeJsonArtifact(files.manifest, manifest);
+  }
+
+  appendReportHeader(files.report_md, {
+    mode: apply ? 'apply' : 'dry_run',
+    generatedAtUtc,
+    manifestCount: manifest.rows.length,
+  });
+
+  const completed = readCompleted(files.progress_jsonl, apply);
+  const selectedRows = manifest.rows.slice(0, limit ?? manifest.rows.length);
+  const pendingRows = selectedRows.filter((row) => !completed.has(recordKey(row)));
+  const refCache = new Map<string, LatestReferenceCacheEntry>();
+  const counts = {
+    manifest: manifest.rows.length,
+    selected: selectedRows.length,
+    already_completed: selectedRows.length - pendingRows.length,
+    pending: pendingRows.length,
+    saved: 0,
+    dry_run: 0,
+    skipped: 0,
+    validation_blocked: 0,
+    errors: 0,
+  };
+
+  const results = await workerPool(pendingRows, concurrency, (row) =>
+    processOne({
+      row,
+      apply,
+      files,
+      auth,
+      fetchImpl,
+      timeoutMs,
+      maxRetries,
+      env,
+      validateProcessPayloadImpl,
+      syncStateAwareProcessRecordImpl,
+      refCache,
+    }),
+  );
+
+  for (const record of results) {
+    if (record.status === 'saved') {
+      counts.saved += 1;
+    } else if (record.status === 'dry_run') {
+      counts.dry_run += 1;
+    } else if (record.status === 'skipped') {
+      counts.skipped += 1;
+    } else if (record.status === 'validation_blocked') {
+      counts.validation_blocked += 1;
+    } else if (record.status === 'error') {
+      counts.errors += 1;
+    }
+  }
+
+  const report: ProcessRefreshReferencesReport = {
+    schema_version: 1,
+    generated_at_utc: generatedAtUtc,
+    status:
+      counts.errors > 0
+        ? 'completed_process_reference_refresh_with_errors'
+        : 'completed_process_reference_refresh',
+    out_dir: outDir,
+    mode: apply ? 'apply' : 'dry_run',
+    user_id: manifest.user_id,
+    masked_user_email: manifest.masked_user_email,
+    counts,
+    files,
+  };
+
+  writeJsonArtifact(files.summary_json, report);
+  appendFileSync(
+    files.report_md,
+    `\n## Summary\n\n\`\`\`json\n${JSON.stringify(report, null, 2)}\n\`\`\`\n`,
+    'utf8',
+  );
+
+  return report;
+}
+
+export const __testInternals = {
+  collectRefs,
+  compareVersions,
+  getLangList,
+  getLangText,
+  getShortDescription,
+  normalizeDatasetPayload,
+  parseContentRangeTotal,
+  readCompleted,
+  recordKey,
+  updateProcessJson,
+};

--- a/src/lib/process-refresh-references.ts
+++ b/src/lib/process-refresh-references.ts
@@ -242,7 +242,7 @@ function parseContentRangeTotal(value: string | null): number | null {
   if (!match || match[1] === '*') {
     return null;
   }
-  return Number.parseInt(match[1] ?? '', 10);
+  return Number.parseInt(match[1]!, 10);
 }
 
 function normalizeVersion(version: string): string {
@@ -936,7 +936,7 @@ async function fetchLatestRefs(options: {
           });
         }
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = String(error);
         for (const id of chunk) {
           options.cache.set(`${table}:${id}`, {
             row: null,
@@ -1378,14 +1378,24 @@ export async function runProcessRefreshReferences(
 }
 
 export const __testInternals = {
+  appendReportHeader,
   collectRefs,
   compareVersions,
+  fetchLatestRefs,
+  fetchJsonWithRetry,
+  genFlowName,
+  genFlowNameJson,
+  genProcessName,
+  genProcessNameJson,
   getLangList,
   getLangText,
   getShortDescription,
   normalizeDatasetPayload,
+  normalizeManifestRow,
+  parseJsonResponse,
   parseContentRangeTotal,
   readCompleted,
+  readManifest,
   recordKey,
   updateProcessJson,
 };

--- a/src/lib/process-save-draft-run.ts
+++ b/src/lib/process-save-draft-run.ts
@@ -5,6 +5,11 @@ import { CliError } from './errors.js';
 import type { FetchLike } from './http.js';
 import { readJsonInput } from './io.js';
 import {
+  summarizeProcessPayloadValidation,
+  validateProcessPayload,
+  type ProcessPayloadValidationResult,
+} from './process-payload-validation.js';
+import {
   collectPublishInputs,
   normalizePublishRequest,
   type PublishCollectedDatasetEntry,
@@ -186,6 +191,7 @@ export type ProcessSaveDraftCandidate = {
   source: ProcessSaveDraftSource;
   bundle_path: string | null;
   payload: JsonObject;
+  validation?: ProcessPayloadValidationResult;
   error?: { message: string };
 };
 
@@ -195,6 +201,7 @@ export type ProcessSaveDraftProcessReport = {
   source: ProcessSaveDraftSource;
   bundle_path: string | null;
   status: 'prepared' | 'executed' | 'failed';
+  validation?: ProcessPayloadValidationResult;
   execution?: ProcessStateAwareWriteResult;
   error?: { message: string };
 };
@@ -232,6 +239,7 @@ export type RunProcessSaveDraftOptions = {
   fetchImpl?: FetchLike;
   timeoutMs?: number;
   now?: Date;
+  validateProcessPayloadImpl?: (payload: JsonObject) => ProcessPayloadValidationResult;
 };
 
 type PreparedProcessSaveDraftInput = {
@@ -244,15 +252,31 @@ function candidateFromPayload(
   payload: JsonObject,
   source: ProcessSaveDraftSource,
   bundlePath: string | null,
+  validateProcessPayloadImpl: (payload: JsonObject) => ProcessPayloadValidationResult,
 ): ProcessSaveDraftCandidate {
   try {
     const [id, version] = extractProcessIdentity(payload);
+    const validation = validateProcessPayloadImpl(payload);
+    if (!validation.ok) {
+      return {
+        id,
+        version,
+        source,
+        bundle_path: bundlePath,
+        payload,
+        validation,
+        error: {
+          message: summarizeProcessPayloadValidation(validation),
+        },
+      };
+    }
     return {
       id,
       version,
       source,
       bundle_path: bundlePath,
       payload,
+      validation,
     };
   } catch (error) {
     return {
@@ -276,15 +300,23 @@ function sourceFromPublishOrigin(origin: PublishCollectedOrigin): ProcessSaveDra
   return origin.source === 'bundle' ? 'bundle' : 'input';
 }
 
-function candidateFromPublishEntry(entry: PublishCollectedDatasetEntry): ProcessSaveDraftCandidate {
+function candidateFromPublishEntry(
+  entry: PublishCollectedDatasetEntry,
+  validateProcessPayloadImpl: (payload: JsonObject) => ProcessPayloadValidationResult,
+): ProcessSaveDraftCandidate {
   return candidateFromPayload(
     loadProcessPayloadFromDatasetEntry(entry.entry, entry.origin.base_dir),
     sourceFromPublishOrigin(entry.origin),
     entry.origin.bundle_path,
+    validateProcessPayloadImpl,
   );
 }
 
-function prepareRowsFileInput(inputPath: string, rawInput: unknown): PreparedProcessSaveDraftInput {
+function prepareRowsFileInput(
+  inputPath: string,
+  rawInput: unknown,
+  validateProcessPayloadImpl: (payload: JsonObject) => ProcessPayloadValidationResult,
+): PreparedProcessSaveDraftInput {
   const rows = Array.isArray(rawInput) ? rawInput : [rawInput];
   const normalizedRows = rows.map((row, index) => {
     if (!isRecord(row)) {
@@ -307,7 +339,7 @@ function prepareRowsFileInput(inputPath: string, rawInput: unknown): PreparedPro
       row_count: normalizedRows.length,
     },
     processes: normalizedRows.map((row) =>
-      candidateFromPayload(processPayloadFromRow(row), 'rows_file', null),
+      candidateFromPayload(processPayloadFromRow(row), 'rows_file', null, validateProcessPayloadImpl),
     ),
   };
 }
@@ -317,6 +349,7 @@ function preparePublishRequestInput(
   rawInput: unknown,
   commit: boolean,
   now: Date,
+  validateProcessPayloadImpl: (payload: JsonObject) => ProcessPayloadValidationResult,
 ): PreparedProcessSaveDraftInput {
   const normalized = normalizePublishRequest(rawInput, {
     requestPath: inputPath,
@@ -328,7 +361,9 @@ function preparePublishRequestInput(
   return {
     inputKind: 'publish_request',
     normalizedInput: normalized,
-    processes: collected.processes.map(candidateFromPublishEntry),
+    processes: collected.processes.map((entry) =>
+      candidateFromPublishEntry(entry, validateProcessPayloadImpl),
+    ),
   };
 }
 
@@ -337,10 +372,11 @@ function prepareProcessSaveDraftInput(
   rawInput: unknown,
   commit: boolean,
   now: Date,
+  validateProcessPayloadImpl: (payload: JsonObject) => ProcessPayloadValidationResult,
 ): PreparedProcessSaveDraftInput {
   return looksLikePublishRequest(rawInput)
-    ? preparePublishRequestInput(inputPath, rawInput, commit, now)
-    : prepareRowsFileInput(inputPath, rawInput);
+    ? preparePublishRequestInput(inputPath, rawInput, commit, now, validateProcessPayloadImpl)
+    : prepareRowsFileInput(inputPath, rawInput, validateProcessPayloadImpl);
 }
 
 function defaultOutDir(inputPath: string, commit: boolean, now: Date): string {
@@ -383,6 +419,7 @@ function compactCandidate(candidate: ProcessSaveDraftCandidate): JsonObject {
     source: candidate.source,
     bundle_path: candidate.bundle_path,
     payload: candidate.payload,
+    ...(candidate.validation ? { validation: candidate.validation } : {}),
     ...(candidate.error ? { error: candidate.error } : {}),
   };
 }
@@ -394,7 +431,14 @@ export async function runProcessSaveDraft(
   const inputPath = path.resolve(options.inputPath);
   const commit = options.commit === true;
   const rawInput = options.rawInput ?? readStructuredInput(inputPath);
-  const prepared = prepareProcessSaveDraftInput(inputPath, rawInput, commit, now);
+  const validateProcessPayloadImpl = options.validateProcessPayloadImpl ?? validateProcessPayload;
+  const prepared = prepareProcessSaveDraftInput(
+    inputPath,
+    rawInput,
+    commit,
+    now,
+    validateProcessPayloadImpl,
+  );
   const outDir = resolveOutDir(inputPath, options.outDir, commit, now);
   const files = buildFiles(outDir);
 
@@ -416,6 +460,7 @@ export async function runProcessSaveDraft(
       source: candidate.source,
       bundle_path: candidate.bundle_path,
       status: 'prepared',
+      ...(candidate.validation ? { validation: candidate.validation } : {}),
     };
 
     if (candidate.error) {

--- a/src/lib/process-save-draft-run.ts
+++ b/src/lib/process-save-draft-run.ts
@@ -339,7 +339,12 @@ function prepareRowsFileInput(
       row_count: normalizedRows.length,
     },
     processes: normalizedRows.map((row) =>
-      candidateFromPayload(processPayloadFromRow(row), 'rows_file', null, validateProcessPayloadImpl),
+      candidateFromPayload(
+        processPayloadFromRow(row),
+        'rows_file',
+        null,
+        validateProcessPayloadImpl,
+      ),
     ),
   };
 }

--- a/src/lib/process-scope-statistics.ts
+++ b/src/lib/process-scope-statistics.ts
@@ -1,0 +1,1216 @@
+import path from 'node:path';
+import {
+  readJsonArtifact,
+  readJsonLinesArtifact,
+  writeJsonArtifact,
+  writeJsonLinesArtifact,
+  writeTextArtifact,
+} from './artifacts.js';
+import { CliError } from './errors.js';
+import type { FetchLike, ResponseLike } from './http.js';
+import { deriveSupabaseProjectBaseUrl, requireSupabaseRestRuntime } from './supabase-client.js';
+import { resolveSupabaseUserSession } from './supabase-session.js';
+import { redactEmail, requireUserApiKeyCredentials } from './user-api-key.js';
+
+type JsonRecord = Record<string, unknown>;
+
+const DEFAULT_STATE_CODES = [0, 100] as const;
+const DEFAULT_PAGE_SIZE = 200;
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_RETRIES = 4;
+
+type ProcessScopeStatisticsScope = 'visible' | 'current-user';
+
+type SnapshotRow = {
+  id: string;
+  version: string;
+  state_code: number | null;
+  user_id: string | null;
+  modified_at: string | null;
+  model_id: string | null;
+  json: JsonRecord;
+};
+
+type ClassificationEntry = {
+  level: number;
+  text: string;
+};
+
+type StatisticsMetadata = {
+  userId: string | null;
+  maskedUserEmail: string | null;
+  totalRowsReportedByRemote: number | null;
+};
+
+type StatisticsOptions = {
+  scope: ProcessScopeStatisticsScope;
+  stateCodes: number[];
+};
+
+type CountRecord = {
+  count: number;
+  [key: string]: unknown;
+};
+
+export type RunProcessScopeStatisticsOptions = {
+  outDir: string;
+  scope?: ProcessScopeStatisticsScope;
+  stateCodes?: number[];
+  pageSize?: number | null;
+  reuseSnapshot?: boolean;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: FetchLike;
+  timeoutMs?: number;
+  maxRetries?: number;
+  now?: Date;
+};
+
+export type ProcessScopeStatisticsReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: 'completed_process_scope_statistics';
+  out_dir: string;
+  scope: ProcessScopeStatisticsScope;
+  state_codes: number[];
+  total_process_rows: number;
+  domain_count_primary: number;
+  domain_count_leaf: number;
+  craft_count: number;
+  unit_process_rows: number;
+  product_count: number;
+  files: {
+    snapshot_manifest: string;
+    snapshot_rows: string;
+    process_scope_summary: string;
+    domain_summary: string;
+    craft_summary: string;
+    product_summary: string;
+    type_of_dataset_summary: string;
+    report: string;
+    report_zh: string;
+  };
+};
+
+type ProcessScopeStatisticsSummary = {
+  schema_version: 1;
+  generated_at_utc: string;
+  scope: ProcessScopeStatisticsScope;
+  state_codes: number[];
+  user_id: string | null;
+  masked_user_email: string | null;
+  total_process_rows: number;
+  total_rows_reported_by_remote: number | null;
+  rows_by_state_code: Record<string, number>;
+  distinct_visible_owner_user_ids: number;
+  domain_count_primary: number;
+  domain_count_leaf: number;
+  craft_count: number;
+  unit_process_rows: number;
+  unit_process_share: number;
+  product_count: number;
+  products_with_flow_id: number;
+  products_without_flow_id: number;
+  rows_missing_classification: number;
+  rows_missing_craft: number;
+  rows_missing_product: number;
+  rows_missing_reference_exchange: number;
+  metric_definitions: Record<string, string>;
+};
+
+type ProcessScopeStatisticsArtifacts = {
+  summary: ProcessScopeStatisticsSummary;
+  domainPrimarySummary: Array<{
+    domain: string;
+    count: number;
+    sample_path?: string;
+  }>;
+  domainLeafSummary: Array<{
+    domain: string;
+    count: number;
+    sample_path?: string;
+  }>;
+  craftSummary: Array<{
+    craft_signature: string;
+    label: string;
+    count: number;
+    source_kind: string;
+  }>;
+  productSummary: Array<{
+    product_key: string;
+    label: string;
+    count: number;
+    stable_flow_id: string;
+    stable_flow_version: string;
+    source_kind: string;
+  }>;
+  typeOfDataSetSummary: Array<{
+    type_of_dataset: string;
+    count: number;
+  }>;
+  craftSourceSummary: Array<{
+    source_kind: string;
+    count: number;
+  }>;
+  productSourceSummary: Array<{
+    source_kind: string;
+    count: number;
+  }>;
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function trimText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeOptionalToken(value: unknown): string | null {
+  const trimmed = trimText(value);
+  return trimmed ? trimmed : null;
+}
+
+function nowIso(now: Date = new Date()): string {
+  return now.toISOString();
+}
+
+function toPositiveInteger(value: number | null | undefined, label: string, code: string): number {
+  if (!Number.isInteger(value) || (value as number) <= 0) {
+    throw new CliError(`Expected ${label} to be a positive integer.`, {
+      code,
+      exitCode: 2,
+    });
+  }
+  return value as number;
+}
+
+function normalizeStateCodes(value: readonly number[] | undefined): number[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    return [...DEFAULT_STATE_CODES];
+  }
+
+  const seen = new Set<number>();
+  const normalized: number[] = [];
+  for (const entry of value) {
+    if (!Number.isInteger(entry) || entry < 0) {
+      throw new CliError('Expected --state-codes to contain only non-negative integers.', {
+        code: 'PROCESS_SCOPE_STATE_CODES_INVALID',
+        exitCode: 2,
+      });
+    }
+    if (!seen.has(entry)) {
+      normalized.push(entry);
+      seen.add(entry);
+    }
+  }
+  if (normalized.length === 0) {
+    throw new CliError('--state-codes must contain at least one state code.', {
+      code: 'PROCESS_SCOPE_STATE_CODES_REQUIRED',
+      exitCode: 2,
+    });
+  }
+  return normalized;
+}
+
+function ensureScope(value: string | undefined): ProcessScopeStatisticsScope {
+  if (value === undefined || value === 'visible') {
+    return 'visible';
+  }
+  if (value === 'current-user') {
+    return 'current-user';
+  }
+  throw new CliError("Expected --scope to be either 'visible' or 'current-user'.", {
+    code: 'PROCESS_SCOPE_SCOPE_INVALID',
+    exitCode: 2,
+  });
+}
+
+async function parseJsonResponse(response: ResponseLike, label: string): Promise<unknown> {
+  const text = await response.text();
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!text.trim()) {
+    return null;
+  }
+  if (!contentType.includes('application/json')) {
+    return text;
+  }
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new CliError(`${label} returned invalid JSON.`, {
+      code: 'PROCESS_SCOPE_REMOTE_INVALID_JSON',
+      exitCode: 1,
+      details: String(error),
+    });
+  }
+}
+
+async function fetchJsonWithRetry(options: {
+  url: string;
+  init: RequestInit;
+  label: string;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+  maxRetries: number;
+}): Promise<{ status: number; headers: Headers; body: unknown }> {
+  let lastError: unknown = null;
+
+  for (let attempt = 1; attempt <= options.maxRetries; attempt += 1) {
+    try {
+      const response = await options.fetchImpl(options.url, {
+        ...options.init,
+        signal: AbortSignal.timeout(options.timeoutMs),
+      });
+      const body = await parseJsonResponse(response, options.label);
+      if (!response.ok) {
+        throw new CliError(`${options.label} failed with ${response.status}.`, {
+          code: 'PROCESS_SCOPE_REMOTE_REQUEST_FAILED',
+          exitCode: 1,
+          details: {
+            status: response.status,
+            body,
+            url: options.url,
+          },
+        });
+      }
+      return {
+        status: response.status,
+        headers: new Headers({
+          'content-range': response.headers.get('content-range') ?? '',
+          'content-type': response.headers.get('content-type') ?? '',
+        }),
+        body,
+      };
+    } catch (error) {
+      lastError = error;
+      if (attempt >= options.maxRetries) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, attempt * 1_500));
+    }
+  }
+
+  if (lastError instanceof CliError) {
+    throw lastError;
+  }
+
+  throw new CliError(`${options.label} failed after ${options.maxRetries} attempt(s).`, {
+    code: 'PROCESS_SCOPE_REMOTE_REQUEST_FAILED',
+    exitCode: 1,
+    details: String(lastError),
+  });
+}
+
+async function resolveCurrentUserId(options: {
+  env: NodeJS.ProcessEnv;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+  now: Date;
+  maxRetries: number;
+}): Promise<string> {
+  const runtime = requireSupabaseRestRuntime(options.env);
+  const session = await resolveSupabaseUserSession({
+    runtime,
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.timeoutMs,
+    now: options.now,
+  });
+  const body = await fetchJsonWithRetry({
+    url: `${deriveSupabaseProjectBaseUrl(runtime.apiBaseUrl)}/auth/v1/user`,
+    init: {
+      method: 'GET',
+      headers: {
+        apikey: runtime.publishableKey,
+        Authorization: `Bearer ${session.accessToken}`,
+        Accept: 'application/json',
+      },
+    },
+    label: 'supabase current-user lookup',
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.timeoutMs,
+    maxRetries: options.maxRetries,
+  });
+
+  const userId = isRecord(body.body) ? normalizeOptionalToken(body.body.id) : null;
+  if (!userId) {
+    throw new CliError('Supabase current-user lookup succeeded without a user id.', {
+      code: 'PROCESS_SCOPE_CURRENT_USER_ID_MISSING',
+      exitCode: 1,
+    });
+  }
+  return userId;
+}
+
+async function fetchProcessRows(options: {
+  env: NodeJS.ProcessEnv;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+  maxRetries: number;
+  scope: ProcessScopeStatisticsScope;
+  stateCodes: number[];
+  pageSize: number;
+  userId: string | null;
+}): Promise<{ rows: SnapshotRow[]; total: number | null }> {
+  const runtime = requireSupabaseRestRuntime(options.env);
+  const session = await resolveSupabaseUserSession({
+    runtime,
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.timeoutMs,
+  });
+  const projectBaseUrl = deriveSupabaseProjectBaseUrl(runtime.apiBaseUrl);
+  const rows: SnapshotRow[] = [];
+  let total = 0;
+
+  for (const stateCode of options.stateCodes) {
+    let stateTotal: number | null = null;
+    let cursorId = '';
+    let fetchedForState = 0;
+
+    while (true) {
+      const url = new URL(`${projectBaseUrl}/rest/v1/processes`);
+      url.searchParams.set('select', 'id,version,state_code,user_id,modified_at,model_id,json');
+      url.searchParams.set('state_code', `eq.${stateCode}`);
+      if (options.scope === 'current-user') {
+        url.searchParams.set('user_id', `eq.${options.userId ?? ''}`);
+      }
+      if (cursorId) {
+        url.searchParams.set('id', `gt.${cursorId}`);
+      }
+      url.searchParams.set('order', 'id.asc');
+      url.searchParams.set('limit', String(options.pageSize));
+
+      const page = await fetchJsonWithRetry({
+        url: url.toString(),
+        init: {
+          method: 'GET',
+          headers: {
+            apikey: runtime.publishableKey,
+            Authorization: `Bearer ${session.accessToken}`,
+            Accept: 'application/json',
+            ...(stateTotal === null ? { Prefer: 'count=exact' } : {}),
+          },
+        },
+        label: `process scope statistics page fetch (state_code=${stateCode})`,
+        fetchImpl: options.fetchImpl,
+        timeoutMs: options.timeoutMs,
+        maxRetries: options.maxRetries,
+      });
+
+      const pageRows = Array.isArray(page.body) ? page.body : [];
+      const normalizedRows = pageRows
+        .map((row) => normalizeSnapshotRow(row))
+        .filter((row): row is SnapshotRow => row !== null);
+      rows.push(...normalizedRows);
+      fetchedForState += normalizedRows.length;
+
+      if (stateTotal === null) {
+        const contentRange = page.headers.get('content-range') ?? '';
+        const match = contentRange.match(/\/(\d+)$/u);
+        stateTotal = match ? Number.parseInt(match[1] ?? '', 10) : null;
+        if (stateTotal !== null) {
+          total += stateTotal;
+        }
+      }
+
+      if (normalizedRows.length < options.pageSize) {
+        break;
+      }
+
+      cursorId = normalizedRows[normalizedRows.length - 1]?.id ?? '';
+      if (!cursorId) {
+        throw new CliError(
+          `Process scope statistics pagination could not continue after fetching ${fetchedForState} row(s) for state_code=${stateCode}.`,
+          {
+            code: 'PROCESS_SCOPE_CURSOR_ID_MISSING',
+            exitCode: 1,
+          },
+        );
+      }
+    }
+  }
+
+  return {
+    rows,
+    total: total || null,
+  };
+}
+
+function normalizeSnapshotRow(value: unknown): SnapshotRow | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const id = normalizeOptionalToken(value.id);
+  const version = normalizeOptionalToken(value.version);
+  const payload = normalizePayload(value.json);
+  if (!id || !version || !payload) {
+    return null;
+  }
+  return {
+    id,
+    version,
+    state_code: typeof value.state_code === 'number' ? value.state_code : null,
+    user_id: normalizeOptionalToken(value.user_id),
+    modified_at: normalizeOptionalToken(value.modified_at),
+    model_id: normalizeOptionalToken(value.model_id),
+    json: payload,
+  };
+}
+
+function normalizePayload(value: unknown): JsonRecord | null {
+  if (isRecord(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      const parsed = JSON.parse(value);
+      return isRecord(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function getLangList(value: unknown): JsonRecord[] {
+  if (value === null || value === undefined || value === '') {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value.filter((item): item is JsonRecord => isRecord(item));
+  }
+  if (isRecord(value)) {
+    const langString = value['common:langString'];
+    if (Array.isArray(langString)) {
+      return langString.filter((item): item is JsonRecord => isRecord(item));
+    }
+    if (isRecord(langString)) {
+      return [langString];
+    }
+    if (typeof value['#text'] === 'string' || typeof value['@xml:lang'] === 'string') {
+      return [value];
+    }
+  }
+  if (typeof value === 'string') {
+    return [{ '@xml:lang': 'en', '#text': value }];
+  }
+  return [];
+}
+
+function getLangText(value: unknown, lang: string | null): string {
+  const list = getLangList(value);
+  const exact =
+    lang === null
+      ? null
+      : list.find(
+          (item) =>
+            trimText(item['@xml:lang']).toLowerCase() === lang.toLowerCase() &&
+            trimText(item['#text']),
+        );
+  const fallback = list.find((item) => trimText(item['#text']));
+  return trimText((exact ?? fallback)?.['#text']);
+}
+
+function getAnyLangText(value: unknown): string {
+  return getLangText(value, null);
+}
+
+function asArray(value: unknown): unknown[] {
+  if (value === null || value === undefined || value === '') {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+function extractClassificationEntries(dataSetInformation: JsonRecord): ClassificationEntry[] {
+  const classes = asArray(
+    (dataSetInformation.classificationInformation as JsonRecord | undefined)?.[
+      'common:classification'
+    ] &&
+      (
+        (dataSetInformation.classificationInformation as JsonRecord)['common:classification'] as
+          | JsonRecord
+          | undefined
+      )?.['common:class'],
+  );
+
+  return classes
+    .map((entry) => {
+      if (!isRecord(entry)) {
+        return null;
+      }
+      const level = Number.parseInt(trimText(entry['@level']) || '0', 10);
+      const text = trimText(entry['#text']);
+      if (!text) {
+        return null;
+      }
+      return { level, text };
+    })
+    .filter((entry): entry is ClassificationEntry => entry !== null)
+    .sort((left, right) => left.level - right.level);
+}
+
+function normalizeSignature(text: string): string {
+  return trimText(text)
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[\u3000\u00a0]/gu, ' ')
+    .replace(/[，,;；:：()（）[\]{}<>|/\\]+/gu, ' ')
+    .replace(/\s+/gu, ' ')
+    .trim();
+}
+
+function firstClause(text: string): string {
+  const normalized = trimText(text);
+  if (!normalized) {
+    return '';
+  }
+  return normalized.split(/[.;；。]/u)[0]?.trim() ?? '';
+}
+
+function renderProcessName(name: JsonRecord): string {
+  const parts = [
+    getLangText(name.baseName, 'en') ||
+      getLangText(name.baseName, 'zh') ||
+      getAnyLangText(name.baseName),
+    getLangText(name.treatmentStandardsRoutes, 'en') ||
+      getLangText(name.treatmentStandardsRoutes, 'zh') ||
+      getAnyLangText(name.treatmentStandardsRoutes),
+    getLangText(name.mixAndLocationTypes, 'en') ||
+      getLangText(name.mixAndLocationTypes, 'zh') ||
+      getAnyLangText(name.mixAndLocationTypes),
+    getLangText(name.functionalUnitFlowProperties, 'en') ||
+      getLangText(name.functionalUnitFlowProperties, 'zh') ||
+      getAnyLangText(name.functionalUnitFlowProperties),
+  ].filter((part) => trimText(part));
+
+  return parts.join('; ');
+}
+
+function extractCraftCandidate(
+  dataSetInformation: JsonRecord,
+  technology: JsonRecord,
+): {
+  source_kind: string;
+  label: string;
+  signature: string;
+} {
+  const name = isRecord(dataSetInformation.name) ? dataSetInformation.name : {};
+  const candidates = [
+    {
+      source_kind: 'treatmentStandardsRoutes',
+      label:
+        getLangText(name.treatmentStandardsRoutes, 'en') ||
+        getLangText(name.treatmentStandardsRoutes, 'zh') ||
+        getAnyLangText(name.treatmentStandardsRoutes),
+    },
+    {
+      source_kind: 'technologyDescriptionAndIncludedProcesses',
+      label:
+        firstClause(getLangText(technology.technologyDescriptionAndIncludedProcesses, 'en')) ||
+        firstClause(getLangText(technology.technologyDescriptionAndIncludedProcesses, 'zh')) ||
+        firstClause(getAnyLangText(technology.technologyDescriptionAndIncludedProcesses)),
+    },
+    {
+      source_kind: 'baseName',
+      label:
+        getLangText(name.baseName, 'en') ||
+        getLangText(name.baseName, 'zh') ||
+        getAnyLangText(name.baseName),
+    },
+  ];
+
+  for (const candidate of candidates) {
+    if (trimText(candidate.label)) {
+      return {
+        ...candidate,
+        signature: normalizeSignature(candidate.label),
+      };
+    }
+  }
+
+  return {
+    source_kind: 'missing',
+    label: '',
+    signature: '',
+  };
+}
+
+function extractReferenceProduct(
+  processDataSet: JsonRecord,
+  dataSetInformation: JsonRecord,
+): {
+  key: string;
+  stable_flow_id: string;
+  stable_flow_version: string;
+  label: string;
+  source_kind: string;
+  missing_reference_exchange: boolean;
+} {
+  const processInformation = isRecord(processDataSet.processInformation)
+    ? processDataSet.processInformation
+    : {};
+  const quantRef = isRecord(processInformation.quantitativeReference)
+    ? processInformation.quantitativeReference
+    : {};
+  const refInternalId = trimText(quantRef.referenceToReferenceFlow);
+  const exchangesBlock = isRecord(processDataSet.exchanges) ? processDataSet.exchanges : {};
+  const exchanges = asArray(exchangesBlock.exchange);
+  const refExchange = exchanges.find(
+    (exchange) => isRecord(exchange) && trimText(exchange['@dataSetInternalID']) === refInternalId,
+  );
+  const exchange = isRecord(refExchange) ? refExchange : null;
+  const flowRef =
+    exchange && isRecord(exchange.referenceToFlowDataSet) ? exchange.referenceToFlowDataSet : {};
+
+  const flowRefId = trimText(flowRef['@refObjectId']);
+  const flowRefVersion = trimText(flowRef['@version']);
+  const shortDescription =
+    getLangText(flowRef['common:shortDescription'], 'en') ||
+    getLangText(flowRef['common:shortDescription'], 'zh') ||
+    getAnyLangText(flowRef['common:shortDescription']);
+  const name = isRecord(dataSetInformation.name) ? dataSetInformation.name : {};
+  const fallbackBaseName =
+    getLangText(name.baseName, 'en') ||
+    getLangText(name.baseName, 'zh') ||
+    getAnyLangText(name.baseName);
+  const fallbackProcessName = renderProcessName(name);
+
+  if (flowRefId) {
+    return {
+      key: `flow:${flowRefId}`,
+      stable_flow_id: flowRefId,
+      stable_flow_version: flowRefVersion,
+      label: shortDescription || fallbackProcessName || flowRefId,
+      source_kind: 'reference_flow_id',
+      missing_reference_exchange: exchange === null,
+    };
+  }
+
+  if (shortDescription) {
+    return {
+      key: `label:${normalizeSignature(shortDescription)}`,
+      stable_flow_id: '',
+      stable_flow_version: '',
+      label: shortDescription,
+      source_kind: 'reference_flow_short_description',
+      missing_reference_exchange: exchange === null,
+    };
+  }
+
+  if (fallbackBaseName) {
+    return {
+      key: `base:${normalizeSignature(fallbackBaseName)}`,
+      stable_flow_id: '',
+      stable_flow_version: '',
+      label: fallbackBaseName,
+      source_kind: 'process_base_name',
+      missing_reference_exchange: exchange === null,
+    };
+  }
+
+  return {
+    key: '',
+    stable_flow_id: '',
+    stable_flow_version: '',
+    label: '',
+    source_kind: 'missing',
+    missing_reference_exchange: exchange === null,
+  };
+}
+
+function incrementCount(
+  map: Map<string, CountRecord>,
+  key: string,
+  seed: Record<string, unknown> = {},
+): void {
+  const existing = map.get(key) ?? {
+    count: 0,
+    ...seed,
+  };
+  existing.count += 1;
+  map.set(key, existing);
+}
+
+function toSortedArray(map: Map<string, CountRecord>): Array<{ key: string } & CountRecord> {
+  return [...map.entries()]
+    .map(([key, value]) => ({
+      key,
+      ...value,
+    }))
+    .sort((left, right) => right.count - left.count || left.key.localeCompare(right.key));
+}
+
+function calculateStatistics(
+  rows: SnapshotRow[],
+  options: StatisticsOptions,
+  metadata: StatisticsMetadata,
+  generatedAtUtc: string,
+): ProcessScopeStatisticsArtifacts {
+  const stateCodeCounts = new Map<string, CountRecord>();
+  const typeOfDataSetCounts = new Map<string, CountRecord>();
+  const domainPrimaryCounts = new Map<string, CountRecord>();
+  const domainLeafCounts = new Map<string, CountRecord>();
+  const craftCounts = new Map<string, CountRecord>();
+  const craftSourceCounts = new Map<string, CountRecord>();
+  const productCounts = new Map<string, CountRecord>();
+  const productSourceCounts = new Map<string, CountRecord>();
+  const ownerCounts = new Map<string, CountRecord>();
+
+  let rowsMissingClassification = 0;
+  let rowsMissingCraft = 0;
+  let rowsMissingProduct = 0;
+  let rowsMissingReferenceExchange = 0;
+  let unitProcessRows = 0;
+
+  for (const row of rows) {
+    incrementCount(stateCodeCounts, String(row.state_code ?? 'null'));
+    incrementCount(ownerCounts, row.user_id ?? 'missing');
+
+    const processDataSet = isRecord(row.json.processDataSet) ? row.json.processDataSet : {};
+    const processInformation = isRecord(processDataSet.processInformation)
+      ? processDataSet.processInformation
+      : {};
+    const dataSetInformation = isRecord(processInformation.dataSetInformation)
+      ? processInformation.dataSetInformation
+      : {};
+    const technology = isRecord(processInformation.technology) ? processInformation.technology : {};
+    const modellingAndValidation = isRecord(processDataSet.modellingAndValidation)
+      ? processDataSet.modellingAndValidation
+      : {};
+    const lciMethod = isRecord(modellingAndValidation.LCIMethodAndAllocation)
+      ? modellingAndValidation.LCIMethodAndAllocation
+      : {};
+
+    const typeOfDataSet = trimText(lciMethod.typeOfDataSet) || 'missing';
+    incrementCount(typeOfDataSetCounts, typeOfDataSet);
+    if (typeOfDataSet.toLowerCase().includes('unit process')) {
+      unitProcessRows += 1;
+    }
+
+    const classificationEntries = extractClassificationEntries(dataSetInformation);
+    const primaryDomain =
+      classificationEntries.find((entry) => entry.level === 1)?.text ??
+      classificationEntries[classificationEntries.length - 1]?.text ??
+      '';
+    const leafDomain = classificationEntries[classificationEntries.length - 1]?.text ?? '';
+    if (primaryDomain) {
+      incrementCount(domainPrimaryCounts, primaryDomain, {
+        sample_path: classificationEntries.map((entry) => entry.text).join(' > '),
+      });
+    } else {
+      rowsMissingClassification += 1;
+    }
+    if (leafDomain) {
+      incrementCount(domainLeafCounts, leafDomain, {
+        sample_path: classificationEntries.map((entry) => entry.text).join(' > '),
+      });
+    }
+
+    const craft = extractCraftCandidate(dataSetInformation, technology);
+    if (craft.signature) {
+      incrementCount(craftCounts, craft.signature, {
+        label: craft.label,
+        source_kind: craft.source_kind,
+      });
+      incrementCount(craftSourceCounts, craft.source_kind);
+    } else {
+      rowsMissingCraft += 1;
+    }
+
+    const product = extractReferenceProduct(processDataSet, dataSetInformation);
+    if (product.key) {
+      incrementCount(productCounts, product.key, {
+        label: product.label,
+        stable_flow_id: product.stable_flow_id,
+        stable_flow_version: product.stable_flow_version,
+        source_kind: product.source_kind,
+      });
+      incrementCount(productSourceCounts, product.source_kind);
+    } else {
+      rowsMissingProduct += 1;
+    }
+    if (product.missing_reference_exchange) {
+      rowsMissingReferenceExchange += 1;
+    }
+  }
+
+  const domainPrimarySummary = toSortedArray(domainPrimaryCounts).map((item) => ({
+    domain: item.key,
+    count: item.count,
+    sample_path: typeof item.sample_path === 'string' ? item.sample_path : undefined,
+  }));
+  const domainLeafSummary = toSortedArray(domainLeafCounts).map((item) => ({
+    domain: item.key,
+    count: item.count,
+    sample_path: typeof item.sample_path === 'string' ? item.sample_path : undefined,
+  }));
+  const craftSummary = toSortedArray(craftCounts).map((item) => ({
+    craft_signature: item.key,
+    label: String(item.label ?? ''),
+    count: item.count,
+    source_kind: String(item.source_kind ?? ''),
+  }));
+  const productSummary = toSortedArray(productCounts).map((item) => ({
+    product_key: item.key,
+    label: String(item.label ?? ''),
+    count: item.count,
+    stable_flow_id: String(item.stable_flow_id ?? ''),
+    stable_flow_version: String(item.stable_flow_version ?? ''),
+    source_kind: String(item.source_kind ?? ''),
+  }));
+  const typeOfDataSetSummary = toSortedArray(typeOfDataSetCounts).map((item) => ({
+    type_of_dataset: item.key,
+    count: item.count,
+  }));
+
+  return {
+    summary: {
+      schema_version: 1,
+      generated_at_utc: generatedAtUtc,
+      scope: options.scope,
+      state_codes: options.stateCodes,
+      user_id: metadata.userId,
+      masked_user_email: metadata.maskedUserEmail,
+      total_process_rows: rows.length,
+      total_rows_reported_by_remote: metadata.totalRowsReportedByRemote,
+      rows_by_state_code: Object.fromEntries(
+        [...stateCodeCounts.entries()].map(([key, value]) => [key, value.count]),
+      ),
+      distinct_visible_owner_user_ids: ownerCounts.size,
+      domain_count_primary: domainPrimaryCounts.size,
+      domain_count_leaf: domainLeafCounts.size,
+      craft_count: craftCounts.size,
+      unit_process_rows: unitProcessRows,
+      unit_process_share: rows.length === 0 ? 0 : unitProcessRows / rows.length,
+      product_count: productCounts.size,
+      products_with_flow_id: productSummary.filter((item) => item.stable_flow_id).length,
+      products_without_flow_id: productSummary.filter((item) => !item.stable_flow_id).length,
+      rows_missing_classification: rowsMissingClassification,
+      rows_missing_craft: rowsMissingCraft,
+      rows_missing_product: rowsMissingProduct,
+      rows_missing_reference_exchange: rowsMissingReferenceExchange,
+      metric_definitions: {
+        domain_count_primary:
+          'Unique level-1 classification text; fallback to the deepest available classification when level 1 is missing.',
+        craft_count:
+          'Unique normalized craft or route signatures derived from treatmentStandardsRoutes, or fallback technology/base-name text.',
+        unit_process_rows: 'Rows whose typeOfDataSet contains the phrase "Unit process".',
+        product_count:
+          'Unique reference products, keyed by reference flow ID when present and by normalized label fallback otherwise.',
+      },
+    },
+    domainPrimarySummary,
+    domainLeafSummary,
+    craftSummary,
+    productSummary,
+    typeOfDataSetSummary,
+    craftSourceSummary: toSortedArray(craftSourceCounts).map((item) => ({
+      source_kind: item.key,
+      count: item.count,
+    })),
+    productSourceSummary: toSortedArray(productSourceCounts).map((item) => ({
+      source_kind: item.key,
+      count: item.count,
+    })),
+  };
+}
+
+function escapePipe(value: unknown): string {
+  return String(value ?? '').replace(/\|/gu, '\\|');
+}
+
+function renderMarkdownReport(
+  statistics: ProcessScopeStatisticsArtifacts,
+  reportLang: 'en' | 'zh',
+): string {
+  const isZh = reportLang === 'zh';
+  const summary = statistics.summary;
+  const lines: string[] = [];
+
+  lines.push(isZh ? '# Process 覆盖统计' : '# Process Scope Statistics');
+  lines.push('');
+  lines.push(
+    isZh ? `统计时间：${summary.generated_at_utc}` : `Generated at: ${summary.generated_at_utc}`,
+  );
+  lines.push(
+    isZh
+      ? `范围：\`scope=${summary.scope}\`, \`state_codes=${summary.state_codes.join(',')}\``
+      : `Scope: \`scope=${summary.scope}\`, \`state_codes=${summary.state_codes.join(',')}\``,
+  );
+  lines.push('');
+  lines.push(isZh ? '## 核心结果' : '## Headline Metrics');
+  lines.push('');
+  lines.push(
+    `- ${isZh ? '总 process 行数' : 'Total process rows'}: \`${summary.total_process_rows}\``,
+  );
+  lines.push(
+    `- ${isZh ? '可见 owner 数' : 'Distinct visible owners'}: \`${summary.distinct_visible_owner_user_ids}\``,
+  );
+  lines.push(
+    `- ${isZh ? '领域数量（一级分类口径）' : 'Domain count (primary definition)'}: \`${summary.domain_count_primary}\``,
+  );
+  lines.push(
+    `- ${isZh ? '领域数量（叶子分类口径）' : 'Domain count (leaf classification)'}: \`${summary.domain_count_leaf}\``,
+  );
+  lines.push(`- ${isZh ? '工艺/路线数量' : 'Craft / route count'}: \`${summary.craft_count}\``);
+  lines.push(`- ${isZh ? '单元过程行数' : 'Unit-process rows'}: \`${summary.unit_process_rows}\``);
+  lines.push(`- ${isZh ? '产品数量' : 'Product count'}: \`${summary.product_count}\``);
+  lines.push('');
+  lines.push(isZh ? '## 状态分布' : '## State-code Distribution');
+  lines.push('');
+  Object.entries(summary.rows_by_state_code).forEach(([stateCode, count]) => {
+    lines.push(`- \`state_code=${stateCode}\`: \`${count}\``);
+  });
+  lines.push('');
+  lines.push(isZh ? '## 统计口径' : '## Metric Definitions');
+  lines.push('');
+  lines.push(
+    `- ${isZh ? '领域' : 'Domain'}: ${
+      isZh
+        ? '优先使用 classification level=1；若缺失，则回退到最深层分类。'
+        : 'Prefer classification level 1; fall back to the deepest available classification when level 1 is missing.'
+    }`,
+  );
+  lines.push(
+    `- ${isZh ? '工艺' : 'Craft'}: ${
+      isZh
+        ? '优先使用 `treatmentStandardsRoutes`；为空时回退到技术说明首句，再回退到 `baseName`。'
+        : 'Prefer `treatmentStandardsRoutes`; fall back to the first clause of technology text, then to `baseName`.'
+    }`,
+  );
+  lines.push(
+    `- ${isZh ? '单元过程' : 'Unit process'}: ${
+      isZh
+        ? '以 `typeOfDataSet` 是否包含 `Unit process` 为准。'
+        : 'Rows are counted when `typeOfDataSet` contains `Unit process`.'
+    }`,
+  );
+  lines.push(
+    `- ${isZh ? '产品' : 'Product'}: ${
+      isZh
+        ? '优先按 reference flow UUID 聚合；缺失时回退到 reference flow 短描述，再回退到 process base name。'
+        : 'Prefer reference-flow UUIDs; fall back to reference-flow short descriptions, then to process base names.'
+    }`,
+  );
+  lines.push('');
+
+  lines.push(isZh ? '## Top 领域' : '## Top Domains');
+  lines.push('');
+  lines.push(`| ${isZh ? '领域' : 'Domain'} | ${isZh ? '数量' : 'Count'} |`);
+  lines.push('| --- | --- |');
+  statistics.domainPrimarySummary.slice(0, 15).forEach((item) => {
+    lines.push(`| ${escapePipe(item.domain)} | ${item.count} |`);
+  });
+  lines.push('');
+
+  lines.push(isZh ? '## Top 工艺/路线' : '## Top Crafts / Routes');
+  lines.push('');
+  lines.push(
+    `| ${isZh ? '工艺/路线' : 'Craft / Route'} | ${isZh ? '数量' : 'Count'} | ${isZh ? '来源' : 'Source'} |`,
+  );
+  lines.push('| --- | --- | --- |');
+  statistics.craftSummary.slice(0, 15).forEach((item) => {
+    lines.push(`| ${escapePipe(item.label)} | ${item.count} | ${item.source_kind} |`);
+  });
+  lines.push('');
+
+  lines.push(isZh ? '## Top 产品' : '## Top Products');
+  lines.push('');
+  lines.push(
+    `| ${isZh ? '产品' : 'Product'} | ${isZh ? '数量' : 'Count'} | ${isZh ? '标识来源' : 'Key source'} |`,
+  );
+  lines.push('| --- | --- | --- |');
+  statistics.productSummary.slice(0, 15).forEach((item) => {
+    lines.push(`| ${escapePipe(item.label)} | ${item.count} | ${item.source_kind} |`);
+  });
+  lines.push('');
+
+  return `${lines.join('\n')}\n`;
+}
+
+function readSnapshotRows(filePath: string): SnapshotRow[] {
+  return readJsonLinesArtifact(filePath)
+    .map((row) => normalizeSnapshotRow(row))
+    .filter((row): row is SnapshotRow => row !== null);
+}
+
+function readSnapshotManifest(filePath: string): JsonRecord | null {
+  const value = readJsonArtifact(filePath);
+  return isRecord(value) ? value : null;
+}
+
+export async function runProcessScopeStatistics(
+  options: RunProcessScopeStatisticsOptions,
+): Promise<ProcessScopeStatisticsReport> {
+  const outDir = trimText(options.outDir);
+  if (!outDir) {
+    throw new CliError('Missing required --out-dir value.', {
+      code: 'PROCESS_SCOPE_OUT_DIR_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  const scope = ensureScope(options.scope);
+  const stateCodes = normalizeStateCodes(options.stateCodes);
+  const pageSize = toPositiveInteger(
+    options.pageSize ?? DEFAULT_PAGE_SIZE,
+    '--page-size',
+    'PROCESS_SCOPE_PAGE_SIZE_INVALID',
+  );
+  const timeoutMs = toPositiveInteger(
+    options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    '--timeout-ms',
+    'PROCESS_SCOPE_TIMEOUT_INVALID',
+  );
+  const maxRetries = toPositiveInteger(
+    options.maxRetries ?? DEFAULT_MAX_RETRIES,
+    'process scope statistics retry count',
+    'PROCESS_SCOPE_MAX_RETRIES_INVALID',
+  );
+
+  const resolvedOutDir = path.resolve(outDir);
+  const snapshotRowsPath = path.join(resolvedOutDir, 'inputs', 'processes.snapshot.rows.jsonl');
+  const snapshotManifestPath = path.join(
+    resolvedOutDir,
+    'inputs',
+    'processes.snapshot.manifest.json',
+  );
+  const generatedAtUtc = nowIso(options.now);
+
+  let rows: SnapshotRow[];
+  let metadata: StatisticsMetadata;
+
+  if (options.reuseSnapshot) {
+    rows = readSnapshotRows(snapshotRowsPath);
+    const manifest = readSnapshotManifest(snapshotManifestPath);
+    metadata = {
+      userId: normalizeOptionalToken(manifest?.user_id),
+      maskedUserEmail: normalizeOptionalToken(manifest?.masked_user_email),
+      totalRowsReportedByRemote:
+        typeof manifest?.total_rows === 'number' ? manifest.total_rows : rows.length,
+    };
+  } else {
+    const env = options.env ?? process.env;
+    const fetchImpl = options.fetchImpl ?? (fetch as FetchLike);
+    const restRuntime = requireSupabaseRestRuntime(env);
+    const userApiKeyCredentials = requireUserApiKeyCredentials(restRuntime.userApiKey);
+    const userId =
+      scope === 'current-user'
+        ? await resolveCurrentUserId({
+            env,
+            fetchImpl,
+            timeoutMs,
+            now: options.now ?? new Date(),
+            maxRetries,
+          })
+        : null;
+    const snapshot = await fetchProcessRows({
+      env,
+      fetchImpl,
+      timeoutMs,
+      maxRetries,
+      scope,
+      stateCodes,
+      pageSize,
+      userId,
+    });
+    rows = snapshot.rows;
+    metadata = {
+      userId,
+      maskedUserEmail: redactEmail(userApiKeyCredentials.email),
+      totalRowsReportedByRemote: snapshot.total ?? rows.length,
+    };
+
+    writeJsonLinesArtifact(snapshotRowsPath, rows);
+    writeJsonArtifact(snapshotManifestPath, {
+      schema_version: 1,
+      generated_at_utc: generatedAtUtc,
+      masked_user_email: metadata.maskedUserEmail,
+      user_id: metadata.userId,
+      scope,
+      state_codes: stateCodes,
+      page_size: pageSize,
+      total_rows: metadata.totalRowsReportedByRemote,
+    });
+  }
+
+  const statistics = calculateStatistics(
+    rows,
+    {
+      scope,
+      stateCodes,
+    },
+    metadata,
+    generatedAtUtc,
+  );
+
+  const summaryPath = path.join(resolvedOutDir, 'outputs', 'process-scope-summary.json');
+  const domainPath = path.join(resolvedOutDir, 'outputs', 'domain-summary.json');
+  const craftPath = path.join(resolvedOutDir, 'outputs', 'craft-summary.json');
+  const productPath = path.join(resolvedOutDir, 'outputs', 'product-summary.json');
+  const datasetTypePath = path.join(resolvedOutDir, 'outputs', 'type-of-dataset-summary.json');
+  const reportPath = path.join(resolvedOutDir, 'reports', 'process-scope-statistics.md');
+  const reportZhPath = path.join(resolvedOutDir, 'reports', 'process-scope-statistics.zh-CN.md');
+
+  writeJsonArtifact(summaryPath, statistics.summary);
+  writeJsonArtifact(domainPath, {
+    primary: statistics.domainPrimarySummary,
+    leaf: statistics.domainLeafSummary,
+  });
+  writeJsonArtifact(craftPath, {
+    craft_summary: statistics.craftSummary,
+    source_summary: statistics.craftSourceSummary,
+  });
+  writeJsonArtifact(productPath, {
+    product_summary: statistics.productSummary,
+    source_summary: statistics.productSourceSummary,
+  });
+  writeJsonArtifact(datasetTypePath, statistics.typeOfDataSetSummary);
+  writeTextArtifact(reportPath, renderMarkdownReport(statistics, 'en'));
+  writeTextArtifact(reportZhPath, renderMarkdownReport(statistics, 'zh'));
+
+  return {
+    schema_version: 1,
+    generated_at_utc: generatedAtUtc,
+    status: 'completed_process_scope_statistics',
+    out_dir: resolvedOutDir,
+    scope,
+    state_codes: stateCodes,
+    total_process_rows: statistics.summary.total_process_rows,
+    domain_count_primary: statistics.summary.domain_count_primary,
+    domain_count_leaf: statistics.summary.domain_count_leaf,
+    craft_count: statistics.summary.craft_count,
+    unit_process_rows: statistics.summary.unit_process_rows,
+    product_count: statistics.summary.product_count,
+    files: {
+      snapshot_manifest: snapshotManifestPath,
+      snapshot_rows: snapshotRowsPath,
+      process_scope_summary: summaryPath,
+      domain_summary: domainPath,
+      craft_summary: craftPath,
+      product_summary: productPath,
+      type_of_dataset_summary: datasetTypePath,
+      report: reportPath,
+      report_zh: reportZhPath,
+    },
+  };
+}
+
+export const __testInternals = {
+  calculateStatistics,
+  ensureScope,
+  escapePipe,
+  extractClassificationEntries,
+  extractCraftCandidate,
+  extractReferenceProduct,
+  fetchJsonWithRetry,
+  getAnyLangText,
+  getLangList,
+  getLangText,
+  normalizePayload,
+  normalizeSignature,
+  normalizeSnapshotRow,
+  normalizeStateCodes,
+  readSnapshotManifest,
+  renderMarkdownReport,
+};

--- a/src/lib/process-scope-statistics.ts
+++ b/src/lib/process-scope-statistics.ts
@@ -364,7 +364,6 @@ async function fetchProcessRows(options: {
   for (const stateCode of options.stateCodes) {
     let stateTotal: number | null = null;
     let cursorId = '';
-    let fetchedForState = 0;
 
     while (true) {
       const url = new URL(`${projectBaseUrl}/rest/v1/processes`);
@@ -401,12 +400,10 @@ async function fetchProcessRows(options: {
         .map((row) => normalizeSnapshotRow(row))
         .filter((row): row is SnapshotRow => row !== null);
       rows.push(...normalizedRows);
-      fetchedForState += normalizedRows.length;
 
       if (stateTotal === null) {
-        const contentRange = page.headers.get('content-range') ?? '';
-        const match = contentRange.match(/\/(\d+)$/u);
-        stateTotal = match ? Number.parseInt(match[1] ?? '', 10) : null;
+        const match = page.headers.get('content-range')?.match(/\/(\d+)$/u) ?? null;
+        stateTotal = match ? Number.parseInt(match[1]!, 10) : null;
         if (stateTotal !== null) {
           total += stateTotal;
         }
@@ -416,16 +413,8 @@ async function fetchProcessRows(options: {
         break;
       }
 
-      cursorId = normalizedRows[normalizedRows.length - 1]?.id ?? '';
-      if (!cursorId) {
-        throw new CliError(
-          `Process scope statistics pagination could not continue after fetching ${fetchedForState} row(s) for state_code=${stateCode}.`,
-          {
-            code: 'PROCESS_SCOPE_CURSOR_ID_MISSING',
-            exitCode: 1,
-          },
-        );
-      }
+      const lastRow = normalizedRows[normalizedRows.length - 1]!;
+      cursorId = lastRow.id;
     }
   }
 
@@ -564,7 +553,8 @@ function firstClause(text: string): string {
   if (!normalized) {
     return '';
   }
-  return normalized.split(/[.;；。]/u)[0]?.trim() ?? '';
+  const [first] = normalized.split(/[.;；。]/u);
+  return first.trim();
 }
 
 function renderProcessName(name: JsonRecord): string {
@@ -837,26 +827,26 @@ function calculateStatistics(
   const domainPrimarySummary = toSortedArray(domainPrimaryCounts).map((item) => ({
     domain: item.key,
     count: item.count,
-    sample_path: typeof item.sample_path === 'string' ? item.sample_path : undefined,
+    sample_path: item.sample_path as string | undefined,
   }));
   const domainLeafSummary = toSortedArray(domainLeafCounts).map((item) => ({
     domain: item.key,
     count: item.count,
-    sample_path: typeof item.sample_path === 'string' ? item.sample_path : undefined,
+    sample_path: item.sample_path as string | undefined,
   }));
   const craftSummary = toSortedArray(craftCounts).map((item) => ({
     craft_signature: item.key,
-    label: String(item.label ?? ''),
+    label: item.label as string,
     count: item.count,
-    source_kind: String(item.source_kind ?? ''),
+    source_kind: item.source_kind as string,
   }));
   const productSummary = toSortedArray(productCounts).map((item) => ({
     product_key: item.key,
-    label: String(item.label ?? ''),
+    label: item.label as string,
     count: item.count,
-    stable_flow_id: String(item.stable_flow_id ?? ''),
-    stable_flow_version: String(item.stable_flow_version ?? ''),
-    source_kind: String(item.source_kind ?? ''),
+    stable_flow_id: item.stable_flow_id as string,
+    stable_flow_version: item.stable_flow_version as string,
+    source_kind: item.source_kind as string,
   }));
   const typeOfDataSetSummary = toSortedArray(typeOfDataSetCounts).map((item) => ({
     type_of_dataset: item.key,
@@ -1204,6 +1194,7 @@ export const __testInternals = {
   extractCraftCandidate,
   extractReferenceProduct,
   fetchJsonWithRetry,
+  fetchProcessRows,
   getAnyLangText,
   getLangList,
   getLangText,
@@ -1211,6 +1202,9 @@ export const __testInternals = {
   normalizeSignature,
   normalizeSnapshotRow,
   normalizeStateCodes,
+  parseJsonResponse,
   readSnapshotManifest,
+  resolveCurrentUserId,
   renderMarkdownReport,
+  toPositiveInteger,
 };

--- a/src/lib/process-verify-rows.ts
+++ b/src/lib/process-verify-rows.ts
@@ -1,0 +1,362 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { writeJsonArtifact, writeJsonLinesArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+import {
+  validateProcessPayload,
+  type ProcessPayloadValidationResult,
+} from './process-payload-validation.js';
+
+type JsonObject = Record<string, unknown>;
+
+type NameFieldKey =
+  | 'baseName'
+  | 'treatmentStandardsRoutes'
+  | 'mixAndLocationTypes'
+  | 'functionalUnitFlowProperties';
+
+export type ProcessVerifyNameFieldSummary = {
+  present: boolean;
+  en: string;
+  zh: string;
+  any: string;
+};
+
+export type ProcessVerifyRowRecord = {
+  row_index: number;
+  id: string | null;
+  version: string | null;
+  status: 'ok' | 'invalid';
+  validation: ProcessPayloadValidationResult;
+  name_summary: {
+    missing_required_fields: Array<'baseName' | 'treatmentStandardsRoutes' | 'mixAndLocationTypes'>;
+    fields: Record<NameFieldKey, ProcessVerifyNameFieldSummary>;
+  };
+};
+
+export type ProcessVerifyRowsReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: 'completed_process_row_verification' | 'completed_with_invalid_process_rows';
+  rows_file: string;
+  out_dir: string;
+  row_count: number;
+  invalid_count: number;
+  schema_invalid_count: number;
+  missing_required_name_field_count: number;
+  invalid_rows: Array<{
+    id: string | null;
+    version: string | null;
+    row_index: number;
+    missing_required_fields: Array<'baseName' | 'treatmentStandardsRoutes' | 'mixAndLocationTypes'>;
+    schema_issue_count: number;
+  }>;
+  files: {
+    summary_json: string;
+    verification_jsonl: string;
+  };
+};
+
+export type RunProcessVerifyRowsOptions = {
+  rowsFile: string;
+  outDir: string;
+  now?: Date;
+  validateProcessPayloadImpl?: (payload: JsonObject) => ProcessPayloadValidationResult;
+};
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function trimText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function requiredNonEmpty(value: string, label: string, code: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new CliError(`Missing required ${label}.`, {
+      code,
+      exitCode: 2,
+    });
+  }
+  return normalized;
+}
+
+function readRowsFile(filePath: string): unknown[] {
+  if (!existsSync(filePath)) {
+    throw new CliError(`Rows file not found: ${filePath}`, {
+      code: 'PROCESS_VERIFY_ROWS_FILE_NOT_FOUND',
+      exitCode: 2,
+    });
+  }
+
+  const text = readFileSync(filePath, 'utf8');
+  if (filePath.toLowerCase().endsWith('.jsonl')) {
+    return text
+      .split(/\r?\n/u)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line, index) => {
+        try {
+          return JSON.parse(line) as unknown;
+        } catch (error) {
+          throw new CliError(`Rows file contains invalid JSONL at line ${index + 1}: ${filePath}`, {
+            code: 'PROCESS_VERIFY_ROWS_FILE_INVALID_JSONL',
+            exitCode: 2,
+            details: String(error),
+          });
+        }
+      });
+  }
+
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (Array.isArray(parsed)) {
+      return parsed;
+    }
+    if (isRecord(parsed) && Array.isArray(parsed.rows)) {
+      return parsed.rows;
+    }
+    return [parsed];
+  } catch (error) {
+    throw new CliError(`Rows file is not valid JSON: ${filePath}`, {
+      code: 'PROCESS_VERIFY_ROWS_FILE_INVALID_JSON',
+      exitCode: 2,
+      details: String(error),
+    });
+  }
+}
+
+function getPayload(row: unknown): JsonObject {
+  if (isRecord(row) && isRecord(row.process)) {
+    return row.process;
+  }
+  if (isRecord(row) && isRecord(row.json_ordered)) {
+    return row.json_ordered;
+  }
+  if (isRecord(row) && isRecord(row.json)) {
+    return row.json;
+  }
+  if (isRecord(row)) {
+    return row;
+  }
+
+  return {};
+}
+
+function firstNonEmpty(...values: unknown[]): string | null {
+  for (const value of values) {
+    const normalized = trimText(value);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return null;
+}
+
+function getIdentity(row: unknown, payload: JsonObject, index: number) {
+  const root = isRecord(payload.processDataSet) ? payload.processDataSet : payload;
+  const processInformation = isRecord(root.processInformation) ? root.processInformation : {};
+  const dataSetInformation = isRecord(processInformation.dataSetInformation)
+    ? processInformation.dataSetInformation
+    : {};
+  const administrativeInformation = isRecord(root.administrativeInformation)
+    ? root.administrativeInformation
+    : {};
+  const publicationAndOwnership = isRecord(administrativeInformation.publicationAndOwnership)
+    ? administrativeInformation.publicationAndOwnership
+    : {};
+
+  return {
+    row_index: index,
+    id: firstNonEmpty(
+      isRecord(row) ? row.id : null,
+      isRecord(row) ? row.process_id : null,
+      dataSetInformation['common:UUID'],
+      payload.id,
+      payload['@id'],
+    ),
+    version: firstNonEmpty(
+      isRecord(row) ? row.version : null,
+      publicationAndOwnership['common:dataSetVersion'],
+      payload.version,
+      payload['@version'],
+    ),
+  };
+}
+
+function getLangList(value: unknown): JsonObject[] {
+  if (value === null || value === undefined || value === '') {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is JsonObject => isRecord(entry));
+  }
+  if (isRecord(value)) {
+    const langString = value['common:langString'];
+    if (Array.isArray(langString)) {
+      return langString.filter((entry): entry is JsonObject => isRecord(entry));
+    }
+    if (isRecord(langString)) {
+      return [langString];
+    }
+    if (value['#text'] !== undefined || value['@xml:lang'] !== undefined) {
+      return [value];
+    }
+  }
+  if (typeof value === 'string') {
+    return [{ '@xml:lang': 'en', '#text': value }];
+  }
+  return [];
+}
+
+function getLangText(value: unknown, lang: string | null): string {
+  const entries = getLangList(value);
+  if (lang) {
+    for (const entry of entries) {
+      if (
+        trimText(entry['@xml:lang']).toLowerCase() === lang.toLowerCase() &&
+        trimText(entry['#text'])
+      ) {
+        return trimText(entry['#text']);
+      }
+    }
+  }
+  for (const entry of entries) {
+    if (trimText(entry['#text'])) {
+      return trimText(entry['#text']);
+    }
+  }
+  return '';
+}
+
+function hasOwn(objectValue: JsonObject, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(objectValue, key);
+}
+
+function summarizeNameFields(payload: JsonObject): {
+  missing_required_fields: Array<'baseName' | 'treatmentStandardsRoutes' | 'mixAndLocationTypes'>;
+  fields: Record<NameFieldKey, ProcessVerifyNameFieldSummary>;
+} {
+  const root = isRecord(payload.processDataSet) ? payload.processDataSet : payload;
+  const processInformation = isRecord(root.processInformation) ? root.processInformation : {};
+  const dataSetInformation = isRecord(processInformation.dataSetInformation)
+    ? processInformation.dataSetInformation
+    : {};
+  const name = isRecord(dataSetInformation.name) ? dataSetInformation.name : {};
+
+  const fieldNames: NameFieldKey[] = [
+    'baseName',
+    'treatmentStandardsRoutes',
+    'mixAndLocationTypes',
+    'functionalUnitFlowProperties',
+  ];
+
+  const fields = {} as Record<NameFieldKey, ProcessVerifyNameFieldSummary>;
+  for (const fieldName of fieldNames) {
+    fields[fieldName] = {
+      present: hasOwn(name, fieldName),
+      en: getLangText(name[fieldName], 'en'),
+      zh: getLangText(name[fieldName], 'zh'),
+      any: getLangText(name[fieldName], null),
+    };
+  }
+
+  const missingRequired = ['baseName', 'treatmentStandardsRoutes', 'mixAndLocationTypes'].filter(
+    (fieldName) => !fields[fieldName as NameFieldKey].present,
+  ) as Array<'baseName' | 'treatmentStandardsRoutes' | 'mixAndLocationTypes'>;
+
+  return {
+    missing_required_fields: missingRequired,
+    fields,
+  };
+}
+
+function nowIso(now: Date = new Date()): string {
+  return now.toISOString();
+}
+
+export async function runProcessVerifyRows(
+  options: RunProcessVerifyRowsOptions,
+): Promise<ProcessVerifyRowsReport> {
+  const rowsFile = path.resolve(
+    requiredNonEmpty(options.rowsFile, '--rows-file', 'PROCESS_VERIFY_ROWS_FILE_REQUIRED'),
+  );
+  const outDir = path.resolve(
+    requiredNonEmpty(options.outDir, '--out-dir', 'PROCESS_VERIFY_OUT_DIR_REQUIRED'),
+  );
+  const validate = options.validateProcessPayloadImpl ?? validateProcessPayload;
+  const rows = readRowsFile(rowsFile);
+  const generatedAtUtc = nowIso(options.now);
+
+  const records: ProcessVerifyRowRecord[] = rows.map((row, index) => {
+    const payload = getPayload(row);
+    const identity = getIdentity(row, payload, index);
+    const validation = validate(payload);
+    const nameSummary = summarizeNameFields(payload);
+    return {
+      ...identity,
+      status: validation.ok && nameSummary.missing_required_fields.length === 0 ? 'ok' : 'invalid',
+      validation,
+      name_summary: nameSummary,
+    };
+  });
+
+  const invalidRows = records
+    .filter((record) => record.status === 'invalid')
+    .map((record) => ({
+      id: record.id,
+      version: record.version,
+      row_index: record.row_index,
+      missing_required_fields: record.name_summary.missing_required_fields,
+      schema_issue_count: record.validation.issue_count,
+    }));
+  const invalidCount = invalidRows.length;
+  const summaryPath = path.join(outDir, 'outputs', 'summary.json');
+  const verificationPath = path.join(outDir, 'outputs', 'verification.jsonl');
+
+  writeJsonArtifact(summaryPath, {
+    generated_at_utc: generatedAtUtc,
+    rows_file: rowsFile,
+    row_count: records.length,
+    invalid_count: invalidCount,
+    schema_invalid_count: records.filter((record) => !record.validation.ok).length,
+    missing_required_name_field_count: records.filter(
+      (record) => record.name_summary.missing_required_fields.length > 0,
+    ).length,
+    invalid_rows: invalidRows,
+  });
+  writeJsonLinesArtifact(verificationPath, records);
+
+  return {
+    schema_version: 1,
+    generated_at_utc: generatedAtUtc,
+    status:
+      invalidCount > 0
+        ? 'completed_with_invalid_process_rows'
+        : 'completed_process_row_verification',
+    rows_file: rowsFile,
+    out_dir: outDir,
+    row_count: records.length,
+    invalid_count: invalidCount,
+    schema_invalid_count: records.filter((record) => !record.validation.ok).length,
+    missing_required_name_field_count: records.filter(
+      (record) => record.name_summary.missing_required_fields.length > 0,
+    ).length,
+    invalid_rows: invalidRows,
+    files: {
+      summary_json: summaryPath,
+      verification_jsonl: verificationPath,
+    },
+  };
+}
+
+export const __testInternals = {
+  getIdentity,
+  getLangList,
+  getLangText,
+  getPayload,
+  readRowsFile,
+  summarizeNameFields,
+};

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -58,7 +58,10 @@ test('executeCli prints main help when no command is given', async () => {
   assert.match(result.stdout, /Unified TianGong command entrypoint/u);
   assert.match(result.stdout, /Implemented Commands:/u);
   assert.match(result.stdout, /Planned Surface \(not implemented yet\):/u);
-  assert.match(result.stdout, /process\s+get \| list \| auto-build/u);
+  assert.match(
+    result.stdout,
+    /process\s+get \| list \| scope-statistics \| dedup-review \| auto-build/u,
+  );
   assert.match(result.stdout, /process\s+auto-build/u);
   assert.match(result.stdout, /lifecyclemodel auto-build/u);
   assert.match(result.stdout, /lifecyclemodel auto-build \| validate-build \| publish-build/u);
@@ -981,6 +984,8 @@ test('executeCli returns help for the process namespace and implemented subcomma
   assert.match(processHelp.stdout, /tiangong process <subcommand>/u);
   assert.match(processHelp.stdout, /get/u);
   assert.match(processHelp.stdout, /list/u);
+  assert.match(processHelp.stdout, /scope-statistics/u);
+  assert.match(processHelp.stdout, /dedup-review/u);
   assert.match(processHelp.stdout, /auto-build/u);
   assert.match(processHelp.stdout, /resume-build/u);
   assert.match(processHelp.stdout, /publish-build/u);
@@ -1000,6 +1005,23 @@ test('executeCli returns help for the process namespace and implemented subcomma
   assert.match(listHelp.stdout, /--page-size/u);
   assert.match(listHelp.stdout, /TIANGONG_LCA_API_BASE_URL/u);
   assert.doesNotMatch(listHelp.stdout, /Planned command/u);
+
+  const scopeStatisticsHelp = await executeCli(
+    ['process', 'scope-statistics', '--help'],
+    makeDeps(),
+  );
+  assert.equal(scopeStatisticsHelp.exitCode, 0);
+  assert.match(scopeStatisticsHelp.stdout, /tiangong process scope-statistics --out-dir <dir>/u);
+  assert.match(scopeStatisticsHelp.stdout, /--state-code/u);
+  assert.match(scopeStatisticsHelp.stdout, /process-scope-statistics\.zh-CN\.md/u);
+  assert.doesNotMatch(scopeStatisticsHelp.stdout, /Planned command/u);
+
+  const dedupReviewHelp = await executeCli(['process', 'dedup-review', '--help'], makeDeps());
+  assert.equal(dedupReviewHelp.exitCode, 0);
+  assert.match(dedupReviewHelp.stdout, /tiangong process dedup-review --input <file>/u);
+  assert.match(dedupReviewHelp.stdout, /--skip-remote/u);
+  assert.match(dedupReviewHelp.stdout, /inputs\/dedup-input\.manifest\.json/u);
+  assert.doesNotMatch(dedupReviewHelp.stdout, /Planned command/u);
 
   const autoBuildHelp = await executeCli(['process', 'auto-build', '--help'], makeDeps());
   assert.equal(autoBuildHelp.exitCode, 0);
@@ -1037,6 +1059,116 @@ test('executeCli returns help for the process namespace and implemented subcomma
   assert.match(batchBuildHelp.stdout, /tiangong process batch-build --input <file>/u);
   assert.match(batchBuildHelp.stdout, /--out-dir/u);
   assert.doesNotMatch(batchBuildHelp.stdout, /Planned command/u);
+});
+
+test('executeCli executes process scope-statistics with injected implementation', async () => {
+  const result = await executeCli(
+    [
+      'process',
+      'scope-statistics',
+      '--json',
+      '--out-dir',
+      './out',
+      '--scope',
+      'current-user',
+      '--state-code',
+      '0',
+      '--state-codes',
+      '100,200',
+      '--page-size',
+      '50',
+      '--reuse-snapshot',
+    ],
+    {
+      ...makeDeps(),
+      runProcessScopeStatisticsImpl: async (options) => {
+        assert.equal(options.outDir, './out');
+        assert.equal(options.scope, 'current-user');
+        assert.deepEqual(options.stateCodes, [0, 100, 200]);
+        assert.equal(options.pageSize, 50);
+        assert.equal(options.reuseSnapshot, true);
+        return {
+          schema_version: 1,
+          generated_at_utc: '2026-04-18T00:00:00.000Z',
+          status: 'completed_process_scope_statistics',
+          out_dir: '/tmp/out',
+          scope: 'current-user',
+          state_codes: [0, 100, 200],
+          total_process_rows: 12,
+          domain_count_primary: 4,
+          domain_count_leaf: 6,
+          craft_count: 7,
+          unit_process_rows: 8,
+          product_count: 9,
+          files: {
+            snapshot_manifest: '/tmp/out/inputs/processes.snapshot.manifest.json',
+            snapshot_rows: '/tmp/out/inputs/processes.snapshot.rows.jsonl',
+            process_scope_summary: '/tmp/out/outputs/process-scope-summary.json',
+            domain_summary: '/tmp/out/outputs/domain-summary.json',
+            craft_summary: '/tmp/out/outputs/craft-summary.json',
+            product_summary: '/tmp/out/outputs/product-summary.json',
+            type_of_dataset_summary: '/tmp/out/outputs/type-of-dataset-summary.json',
+            report: '/tmp/out/reports/process-scope-statistics.md',
+            report_zh: '/tmp/out/reports/process-scope-statistics.zh-CN.md',
+          },
+        };
+      },
+    },
+  );
+
+  assert.equal(result.exitCode, 0);
+  assert.match(result.stdout, /"status":"completed_process_scope_statistics"/u);
+  assert.match(result.stdout, /"state_codes":\[0,100,200\]/u);
+});
+
+test('executeCli executes process dedup-review with injected implementation', async () => {
+  const result = await executeCli(
+    [
+      'process',
+      'dedup-review',
+      '--json',
+      '--input',
+      './dedup.json',
+      '--out-dir',
+      './artifacts',
+      '--skip-remote',
+    ],
+    {
+      ...makeDeps(),
+      runProcessDedupReviewImpl: async (options) => {
+        assert.equal(options.inputPath, './dedup.json');
+        assert.equal(options.outDir, './artifacts');
+        assert.equal(options.skipRemote, true);
+        return {
+          schema_version: 1,
+          generated_at_utc: '2026-04-18T00:00:00.000Z',
+          status: 'completed_process_dedup_review',
+          input_file: '/tmp/dedup.json',
+          out_dir: '/tmp/artifacts',
+          source_label: 'duplicate-export',
+          group_count: 3,
+          exact_duplicate_group_count: 2,
+          remote_status: {
+            enabled: false,
+            loaded: 0,
+            error: null,
+            reference_scan: 'skipped_by_flag',
+          },
+          files: {
+            input_manifest: '/tmp/artifacts/inputs/dedup-input.manifest.json',
+            remote_metadata: null,
+            duplicate_groups: '/tmp/artifacts/outputs/duplicate-groups.json',
+            delete_plan: '/tmp/artifacts/outputs/delete-plan.json',
+            current_user_reference_scan: null,
+          },
+        };
+      },
+    },
+  );
+
+  assert.equal(result.exitCode, 0);
+  assert.match(result.stdout, /"status":"completed_process_dedup_review"/u);
+  assert.match(result.stdout, /"reference_scan":"skipped_by_flag"/u);
 });
 
 test('executeCli executes lifecyclemodel build-resulting-process with injected implementation', async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -991,6 +991,8 @@ test('executeCli returns help for the process namespace and implemented subcomma
   assert.match(processHelp.stdout, /publish-build/u);
   assert.match(processHelp.stdout, /save-draft/u);
   assert.match(processHelp.stdout, /batch-build/u);
+  assert.match(processHelp.stdout, /refresh-references/u);
+  assert.match(processHelp.stdout, /verify-rows/u);
 
   const getHelp = await executeCli(['process', 'get', '--help'], makeDeps());
   assert.equal(getHelp.exitCode, 0);
@@ -1053,6 +1055,28 @@ test('executeCli returns help for the process namespace and implemented subcomma
   assert.match(saveDraftHelp.stdout, /--commit/u);
   assert.match(saveDraftHelp.stdout, /outputs\/save-draft-rpc\/summary\.json/u);
   assert.doesNotMatch(saveDraftHelp.stdout, /Planned command/u);
+
+  const refreshReferencesHelp = await executeCli(
+    ['process', 'refresh-references', '--help'],
+    makeDeps(),
+  );
+  assert.equal(refreshReferencesHelp.exitCode, 0);
+  assert.match(
+    refreshReferencesHelp.stdout,
+    /tiangong process refresh-references --out-dir <dir>/u,
+  );
+  assert.match(refreshReferencesHelp.stdout, /--reuse-manifest/u);
+  assert.match(refreshReferencesHelp.stdout, /never requires raw SUPABASE_EMAIL/u);
+  assert.doesNotMatch(refreshReferencesHelp.stdout, /Planned command/u);
+
+  const verifyRowsHelp = await executeCli(['process', 'verify-rows', '--help'], makeDeps());
+  assert.equal(verifyRowsHelp.exitCode, 0);
+  assert.match(
+    verifyRowsHelp.stdout,
+    /tiangong process verify-rows --rows-file <file> --out-dir <dir>/u,
+  );
+  assert.match(verifyRowsHelp.stdout, /outputs\/verification\.jsonl/u);
+  assert.doesNotMatch(verifyRowsHelp.stdout, /Planned command/u);
 
   const batchBuildHelp = await executeCli(['process', 'batch-build', '--help'], makeDeps());
   assert.equal(batchBuildHelp.exitCode, 0);
@@ -2142,6 +2166,118 @@ test('executeCli rejects conflicting process save-draft mode flags', async () =>
 
   assert.equal(result.exitCode, 2);
   assert.match(result.stderr, /INVALID_PROCESS_SAVE_DRAFT_MODE/u);
+});
+
+test('executeCli executes process refresh-references with injected implementation', async () => {
+  const result = await executeCli(
+    [
+      'process',
+      'refresh-references',
+      '--json',
+      '--out-dir',
+      './refresh-root',
+      '--apply',
+      '--reuse-manifest',
+      '--limit',
+      '5',
+      '--page-size',
+      '200',
+      '--concurrency',
+      '2',
+    ],
+    {
+      ...makeDeps(),
+      runProcessRefreshReferencesImpl: async (options) => {
+        assert.equal(options.outDir, './refresh-root');
+        assert.equal(options.apply, true);
+        assert.equal(options.reuseManifest, true);
+        assert.equal(options.limit, 5);
+        assert.equal(options.pageSize, 200);
+        assert.equal(options.concurrency, 2);
+        return {
+          schema_version: 1,
+          generated_at_utc: '2026-04-18T10:00:00.000Z',
+          status: 'completed_process_reference_refresh',
+          out_dir: '/tmp/refresh-root',
+          mode: 'apply',
+          user_id: 'user-1',
+          masked_user_email: 'us****@example.com',
+          counts: {
+            manifest: 8,
+            selected: 5,
+            already_completed: 1,
+            pending: 4,
+            saved: 3,
+            dry_run: 0,
+            skipped: 1,
+            validation_blocked: 0,
+            errors: 0,
+          },
+          files: {
+            manifest: '/tmp/refresh-root/inputs/processes.manifest.json',
+            progress_jsonl: '/tmp/refresh-root/outputs/progress.jsonl',
+            errors_jsonl: '/tmp/refresh-root/outputs/errors.jsonl',
+            validation_blockers_jsonl: '/tmp/refresh-root/outputs/validation-blockers.jsonl',
+            summary_json: '/tmp/refresh-root/outputs/summary.json',
+            report_md: '/tmp/refresh-root/reports/process-refresh-references.md',
+          },
+        };
+      },
+    },
+  );
+
+  assert.equal(result.exitCode, 0);
+  assert.match(result.stdout, /"status":"completed_process_reference_refresh"/u);
+  assert.match(result.stdout, /"saved":3/u);
+});
+
+test('executeCli executes process verify-rows with injected implementation', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-verify-rows-cli-'));
+  const rowsFile = path.join(dir, 'rows.json');
+  writeFileSync(rowsFile, '{}\n', 'utf8');
+
+  try {
+    const result = await executeCli(
+      ['process', 'verify-rows', '--json', '--rows-file', rowsFile, '--out-dir', './verify-root'],
+      {
+        ...makeDeps(),
+        runProcessVerifyRowsImpl: async (options) => {
+          assert.equal(options.rowsFile, rowsFile);
+          assert.equal(options.outDir, './verify-root');
+          return {
+            schema_version: 1,
+            generated_at_utc: '2026-04-18T10:05:00.000Z',
+            status: 'completed_with_invalid_process_rows',
+            rows_file: rowsFile,
+            out_dir: path.join(dir, 'verify-root'),
+            row_count: 2,
+            invalid_count: 1,
+            schema_invalid_count: 1,
+            missing_required_name_field_count: 1,
+            invalid_rows: [
+              {
+                id: 'proc-1',
+                version: '01.00.001',
+                row_index: 0,
+                missing_required_fields: ['mixAndLocationTypes'],
+                schema_issue_count: 2,
+              },
+            ],
+            files: {
+              summary_json: path.join(dir, 'verify-root', 'outputs', 'summary.json'),
+              verification_jsonl: path.join(dir, 'verify-root', 'outputs', 'verification.jsonl'),
+            },
+          };
+        },
+      },
+    );
+
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stdout, /"invalid_count":1/u);
+    assert.match(result.stdout, /"status":"completed_with_invalid_process_rows"/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test('executeCli executes process batch-build with injected implementation', async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2231,6 +2231,46 @@ test('executeCli executes process refresh-references with injected implementatio
   assert.match(result.stdout, /"saved":3/u);
 });
 
+test('executeCli returns exit code 1 when process refresh-references reports errors', async () => {
+  const result = await executeCli(
+    ['process', 'refresh-references', '--json', '--out-dir', './refresh-root'],
+    {
+      ...makeDeps(),
+      runProcessRefreshReferencesImpl: async () => ({
+        schema_version: 1,
+        generated_at_utc: '2026-04-18T10:02:00.000Z',
+        status: 'completed_process_reference_refresh_with_errors',
+        out_dir: '/tmp/refresh-root',
+        mode: 'dry_run',
+        user_id: 'user-1',
+        masked_user_email: 'us****@example.com',
+        counts: {
+          manifest: 1,
+          selected: 1,
+          already_completed: 0,
+          pending: 1,
+          saved: 0,
+          dry_run: 0,
+          skipped: 0,
+          validation_blocked: 0,
+          errors: 1,
+        },
+        files: {
+          manifest: '/tmp/refresh-root/inputs/processes.manifest.json',
+          progress_jsonl: '/tmp/refresh-root/outputs/progress.jsonl',
+          errors_jsonl: '/tmp/refresh-root/outputs/errors.jsonl',
+          validation_blockers_jsonl: '/tmp/refresh-root/outputs/validation-blockers.jsonl',
+          summary_json: '/tmp/refresh-root/outputs/summary.json',
+          report_md: '/tmp/refresh-root/reports/process-refresh-references.md',
+        },
+      }),
+    },
+  );
+
+  assert.equal(result.exitCode, 1);
+  assert.match(result.stdout, /"errors":1/u);
+});
+
 test('executeCli executes process verify-rows with injected implementation', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-verify-rows-cli-'));
   const rowsFile = path.join(dir, 'rows.json');
@@ -2275,6 +2315,42 @@ test('executeCli executes process verify-rows with injected implementation', asy
     assert.equal(result.exitCode, 1);
     assert.match(result.stdout, /"invalid_count":1/u);
     assert.match(result.stdout, /"status":"completed_with_invalid_process_rows"/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli returns exit code 0 when process verify-rows finds no invalid rows', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-verify-rows-cli-ok-'));
+  const rowsFile = path.join(dir, 'rows.json');
+  writeFileSync(rowsFile, '{}\n', 'utf8');
+
+  try {
+    const result = await executeCli(
+      ['process', 'verify-rows', '--json', '--rows-file', rowsFile, '--out-dir', './verify-root'],
+      {
+        ...makeDeps(),
+        runProcessVerifyRowsImpl: async () => ({
+          schema_version: 1,
+          generated_at_utc: '2026-04-18T10:06:00.000Z',
+          status: 'completed_process_row_verification',
+          rows_file: rowsFile,
+          out_dir: path.join(dir, 'verify-root'),
+          row_count: 1,
+          invalid_count: 0,
+          schema_invalid_count: 0,
+          missing_required_name_field_count: 0,
+          invalid_rows: [],
+          files: {
+            summary_json: path.join(dir, 'verify-root', 'outputs', 'summary.json'),
+            verification_jsonl: path.join(dir, 'verify-root', 'outputs', 'verification.jsonl'),
+          },
+        }),
+      },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /"status":"completed_process_row_verification"/u);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -2835,6 +2911,14 @@ test('executeCli returns parsing errors for invalid lifecyclemodel, process, and
   assert.equal(processResult.stdout, '');
   assert.match(processResult.stderr, /INVALID_ARGS/u);
 
+  const processDedupReviewResult = await executeCli(
+    ['process', 'dedup-review', '--bad-flag'],
+    makeDeps(),
+  );
+  assert.equal(processDedupReviewResult.exitCode, 2);
+  assert.equal(processDedupReviewResult.stdout, '');
+  assert.match(processDedupReviewResult.stderr, /INVALID_ARGS/u);
+
   const processResumeResult = await executeCli(
     ['process', 'resume-build', '--bad-flag'],
     makeDeps(),
@@ -2858,6 +2942,79 @@ test('executeCli returns parsing errors for invalid lifecyclemodel, process, and
   assert.equal(processSaveDraftResult.exitCode, 2);
   assert.equal(processSaveDraftResult.stdout, '');
   assert.match(processSaveDraftResult.stderr, /INVALID_ARGS/u);
+
+  const processRefreshArgsResult = await executeCli(
+    ['process', 'refresh-references', '--bad-flag'],
+    makeDeps(),
+  );
+  assert.equal(processRefreshArgsResult.exitCode, 2);
+  assert.equal(processRefreshArgsResult.stdout, '');
+  assert.match(processRefreshArgsResult.stderr, /INVALID_ARGS/u);
+
+  const processRefreshLimitResult = await executeCli(
+    ['process', 'refresh-references', '--out-dir', './refresh-root', '--limit', '0'],
+    makeDeps(),
+  );
+  assert.equal(processRefreshLimitResult.exitCode, 2);
+  assert.match(processRefreshLimitResult.stderr, /INVALID_PROCESS_REFRESH_LIMIT/u);
+
+  const processRefreshPageSizeResult = await executeCli(
+    ['process', 'refresh-references', '--out-dir', './refresh-root', '--page-size', '0'],
+    makeDeps(),
+  );
+  assert.equal(processRefreshPageSizeResult.exitCode, 2);
+  assert.match(processRefreshPageSizeResult.stderr, /INVALID_PROCESS_REFRESH_PAGE_SIZE/u);
+
+  const processRefreshConcurrencyResult = await executeCli(
+    ['process', 'refresh-references', '--out-dir', './refresh-root', '--concurrency', '0'],
+    makeDeps(),
+  );
+  assert.equal(processRefreshConcurrencyResult.exitCode, 2);
+  assert.match(processRefreshConcurrencyResult.stderr, /INVALID_PROCESS_REFRESH_CONCURRENCY/u);
+
+  const processRefreshModeConflictResult = await executeCli(
+    ['process', 'refresh-references', '--out-dir', './refresh-root', '--apply', '--dry-run'],
+    makeDeps(),
+  );
+  assert.equal(processRefreshModeConflictResult.exitCode, 2);
+  assert.match(processRefreshModeConflictResult.stderr, /PROCESS_REFRESH_MODE_CONFLICT/u);
+
+  const processScopeArgsResult = await executeCli(
+    ['process', 'scope-statistics', '--bad-flag'],
+    makeDeps(),
+  );
+  assert.equal(processScopeArgsResult.exitCode, 2);
+  assert.equal(processScopeArgsResult.stdout, '');
+  assert.match(processScopeArgsResult.stderr, /INVALID_ARGS/u);
+
+  const processScopeStateCodeResult = await executeCli(
+    ['process', 'scope-statistics', '--state-code=-1'],
+    makeDeps(),
+  );
+  assert.equal(processScopeStateCodeResult.exitCode, 2);
+  assert.match(processScopeStateCodeResult.stderr, /INVALID_PROCESS_SCOPE_STATE_CODE/u);
+
+  const processScopePageSizeResult = await executeCli(
+    ['process', 'scope-statistics', '--page-size', '0'],
+    makeDeps(),
+  );
+  assert.equal(processScopePageSizeResult.exitCode, 2);
+  assert.match(processScopePageSizeResult.stderr, /INVALID_PROCESS_SCOPE_PAGE_SIZE/u);
+
+  const processScopeInvalidScopeResult = await executeCli(
+    ['process', 'scope-statistics', '--scope', 'owner'],
+    makeDeps(),
+  );
+  assert.equal(processScopeInvalidScopeResult.exitCode, 2);
+  assert.match(processScopeInvalidScopeResult.stderr, /INVALID_PROCESS_SCOPE_SCOPE/u);
+
+  const processVerifyArgsResult = await executeCli(
+    ['process', 'verify-rows', '--bad-flag'],
+    makeDeps(),
+  );
+  assert.equal(processVerifyArgsResult.exitCode, 2);
+  assert.equal(processVerifyArgsResult.stdout, '');
+  assert.match(processVerifyArgsResult.stderr, /INVALID_ARGS/u);
 
   const processBatchResult = await executeCli(['process', 'batch-build', '--bad-flag'], makeDeps());
   assert.equal(processBatchResult.exitCode, 2);

--- a/test/process-dedup-review.test.ts
+++ b/test/process-dedup-review.test.ts
@@ -1,0 +1,385 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runProcessDedupReview } from '../src/lib/process-dedup-review.js';
+import type { FetchLike } from '../src/lib/http.js';
+import {
+  buildSupabaseTestEnv,
+  isSupabaseAuthTokenUrl,
+  makeSupabaseAuthResponse,
+} from './helpers/supabase-auth.js';
+
+type JsonRecord = Record<string, unknown>;
+
+function writeJson(filePath: string, value: unknown): void {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function jsonResponse(payload: unknown, headers: Record<string, string> = {}) {
+  return {
+    ok: true,
+    status: 200,
+    headers: {
+      get(name: string): string | null {
+        return (
+          headers[name.toLowerCase()] ??
+          (name.toLowerCase() === 'content-type' ? 'application/json' : null)
+        );
+      },
+    },
+    text: async () => JSON.stringify(payload),
+  };
+}
+
+function langEntries(en: string, zh: string): JsonRecord[] {
+  return [
+    { '@xml:lang': 'en', '#text': en },
+    { '@xml:lang': 'zh', '#text': zh },
+  ];
+}
+
+function flatExchange(options: {
+  flowId: string;
+  direction: 'Input' | 'Output';
+  meanAmount: string;
+  resultingAmount: string;
+  shortDescriptionEn?: string;
+  shortDescriptionZh?: string;
+  exchangeInternalId?: string;
+}): JsonRecord {
+  return {
+    exchange_internal_id: options.exchangeInternalId ?? `${options.flowId}-${options.direction}`,
+    flow_id: options.flowId,
+    direction: options.direction,
+    mean_amount: options.meanAmount,
+    resulting_amount: options.resultingAmount,
+    flow_short_description_en: options.shortDescriptionEn ?? '',
+    flow_short_description_zh: options.shortDescriptionZh ?? '',
+  };
+}
+
+function remoteExchange(options: {
+  flowId: string;
+  direction: 'Input' | 'Output';
+  meanAmount: string;
+  resultingAmount: string;
+  shortDescriptionEn?: string;
+  shortDescriptionZh?: string;
+  exchangeInternalId?: string;
+}): JsonRecord {
+  return {
+    '@dataSetInternalID': options.exchangeInternalId ?? `${options.flowId}-${options.direction}`,
+    exchangeDirection: options.direction,
+    meanAmount: options.meanAmount,
+    resultingAmount: options.resultingAmount,
+    referenceToFlowDataSet: {
+      '@refObjectId': options.flowId,
+      '@version': '01.00.000',
+      'common:shortDescription': langEntries(
+        options.shortDescriptionEn ?? '',
+        options.shortDescriptionZh ?? '',
+      ),
+    },
+  };
+}
+
+function createRemoteProcessJson(
+  nameEn: string,
+  nameZh: string,
+  exchanges: JsonRecord[],
+): JsonRecord {
+  return {
+    processDataSet: {
+      processInformation: {
+        dataSetInformation: {
+          name: {
+            baseName: langEntries(nameEn, nameZh),
+          },
+        },
+      },
+      exchanges: {
+        exchange: exchanges,
+      },
+    },
+  };
+}
+
+const DUPLICATE_EXCHANGES = [
+  flatExchange({
+    flowId: 'flow-waste-paper',
+    direction: 'Input',
+    meanAmount: '1.0',
+    resultingAmount: '1',
+    shortDescriptionEn: 'waste paper',
+    shortDescriptionZh: '废纸',
+  }),
+  flatExchange({
+    flowId: 'flow-product',
+    direction: 'Output',
+    meanAmount: '1',
+    resultingAmount: '1',
+    shortDescriptionEn: 'waste paper',
+    shortDescriptionZh: '废纸',
+  }),
+];
+
+test('runProcessDedupReview analyzes grouped duplicate candidates locally', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-dedup-local-'));
+  const inputPath = path.join(dir, 'dedup-input.json');
+  const outDir = path.join(dir, 'artifacts');
+
+  writeJson(inputPath, {
+    source_label: 'manual-dedup-export',
+    groups: [
+      {
+        group_id: 1,
+        processes: [
+          {
+            process_id: 'proc-keep',
+            version: '01.00.000',
+            name_en: 'Waste paper collection',
+            name_zh: '废纸收集',
+            sheet_exchange_rows: DUPLICATE_EXCHANGES,
+          },
+          {
+            process_id: 'proc-delete',
+            version: '01.00.000',
+            name_en: 'Wastepaper processing',
+            name_zh: '废纸加工',
+            sheet_exchange_rows: [...DUPLICATE_EXCHANGES].reverse(),
+          },
+        ],
+      },
+    ],
+  });
+
+  try {
+    const report = await runProcessDedupReview({
+      inputPath,
+      outDir,
+      skipRemote: true,
+      now: new Date('2026-04-18T00:00:00.000Z'),
+    });
+
+    assert.equal(report.status, 'completed_process_dedup_review');
+    assert.equal(report.group_count, 1);
+    assert.equal(report.exact_duplicate_group_count, 1);
+    assert.equal(report.remote_status.enabled, false);
+    assert.equal(report.remote_status.reference_scan, 'skipped_by_flag');
+
+    const duplicateGroups = JSON.parse(readFileSync(report.files.duplicate_groups, 'utf8')) as {
+      groups: Array<{
+        exact_duplicate: boolean;
+        processes: Array<{ process_id: string; analysis_exchanges: unknown[] }>;
+      }>;
+    };
+    const deletePlan = JSON.parse(readFileSync(report.files.delete_plan, 'utf8')) as {
+      groups: Array<{
+        keep: { process_id: string };
+        delete: Array<{ process_id: string }>;
+        confidence: string;
+        notes: string[];
+      }>;
+    };
+
+    assert.equal(duplicateGroups.groups[0]?.exact_duplicate, true);
+    assert.equal(duplicateGroups.groups[0]?.processes[0]?.analysis_exchanges.length, 2);
+    assert.equal(deletePlan.groups[0]?.keep.process_id, 'proc-keep');
+    assert.deepEqual(
+      deletePlan.groups[0]?.delete.map((entry) => entry.process_id),
+      ['proc-delete'],
+    );
+    assert.equal(deletePlan.groups[0]?.confidence, 'high');
+    assert.match(deletePlan.groups[0]?.notes.join('\n') ?? '', /normalized exchange signature/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessDedupReview enriches duplicate candidates with remote metadata and reference scans', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-dedup-remote-'));
+  const inputPath = path.join(dir, 'dedup-input.json');
+  const outDir = path.join(dir, 'artifacts');
+
+  writeJson(inputPath, {
+    source_label: 'remote-dedup-export',
+    groups: {
+      '1': {
+        processes: [
+          {
+            process_id: 'proc-keep',
+            version: '01.00.000',
+            sheet_exchange_rows: DUPLICATE_EXCHANGES,
+          },
+          {
+            process_id: 'proc-delete',
+            version: '01.00.000',
+            sheet_exchange_rows: [...DUPLICATE_EXCHANGES].reverse(),
+          },
+        ],
+      },
+    },
+  });
+
+  const remoteProcessRows = [
+    {
+      id: 'proc-delete',
+      version: '01.00.000',
+      state_code: 0,
+      created_at: '2026-04-10T00:00:00.000Z',
+      modified_at: '2026-04-16T00:00:00.000Z',
+      user_id: 'user-1',
+      team_id: 'team-1',
+      model_id: 'model-delete',
+      json: createRemoteProcessJson('Wastepaper processing', '废纸加工', [
+        remoteExchange({
+          flowId: 'flow-product',
+          direction: 'Output',
+          meanAmount: '1',
+          resultingAmount: '1',
+          shortDescriptionEn: 'waste paper',
+          shortDescriptionZh: '废纸',
+        }),
+        remoteExchange({
+          flowId: 'flow-waste-paper',
+          direction: 'Input',
+          meanAmount: '1.0',
+          resultingAmount: '1',
+          shortDescriptionEn: 'waste paper',
+          shortDescriptionZh: '废纸',
+        }),
+      ]),
+    },
+    {
+      id: 'proc-keep',
+      version: '01.00.000',
+      state_code: 0,
+      created_at: '2026-04-09T00:00:00.000Z',
+      modified_at: '2026-04-15T00:00:00.000Z',
+      user_id: 'user-1',
+      team_id: 'team-1',
+      model_id: 'model-keep',
+      json: createRemoteProcessJson('Waste paper collection', '废纸收集', [
+        remoteExchange({
+          flowId: 'flow-waste-paper',
+          direction: 'Input',
+          meanAmount: '1.0',
+          resultingAmount: '1',
+          shortDescriptionEn: 'waste paper',
+          shortDescriptionZh: '废纸',
+        }),
+        remoteExchange({
+          flowId: 'flow-product',
+          direction: 'Output',
+          meanAmount: '1',
+          resultingAmount: '1',
+          shortDescriptionEn: 'waste paper',
+          shortDescriptionZh: '废纸',
+        }),
+      ]),
+    },
+  ];
+
+  const fetchImpl = (async (input) => {
+    const url = String(input);
+    if (isSupabaseAuthTokenUrl(url)) {
+      return makeSupabaseAuthResponse({ userId: 'user-1' });
+    }
+    if (url.endsWith('/auth/v1/user')) {
+      return jsonResponse({ id: 'user-1' });
+    }
+    if (
+      url.includes('/rest/v1/processes?') &&
+      url.includes('id=in.') &&
+      !url.includes('user_id=eq.')
+    ) {
+      return jsonResponse(remoteProcessRows);
+    }
+    if (url.includes('/rest/v1/processes?') && url.includes('user_id=eq.user-1')) {
+      return jsonResponse(
+        [
+          {
+            id: 'proc-ref-1',
+            version: '01.00.000',
+            state_code: 0,
+            user_id: 'user-1',
+            model_id: 'ref-model',
+            json: {
+              downstream: {
+                '@refObjectId': 'proc-keep',
+              },
+            },
+          },
+        ],
+        {
+          'content-type': 'application/json',
+          'content-range': '0-0/1',
+        },
+      );
+    }
+    if (url.includes('/rest/v1/lifecyclemodels?') && url.includes('user_id=eq.user-1')) {
+      return jsonResponse(
+        [
+          {
+            id: 'lm-ref-1',
+            version: '01.00.000',
+            state_code: 0,
+            user_id: 'user-1',
+            json: {
+              processLink: {
+                '@refObjectId': 'proc-keep',
+              },
+            },
+          },
+        ],
+        {
+          'content-type': 'application/json',
+          'content-range': '0-0/1',
+        },
+      );
+    }
+
+    throw new Error(`Unexpected URL: ${url}`);
+  }) as FetchLike;
+
+  try {
+    const report = await runProcessDedupReview({
+      inputPath,
+      outDir,
+      env: buildSupabaseTestEnv(),
+      fetchImpl,
+      now: new Date('2026-04-18T01:00:00.000Z'),
+    });
+
+    assert.equal(report.remote_status.enabled, true);
+    assert.equal(report.remote_status.loaded, 2);
+    assert.equal(report.remote_status.reference_scan, 'current_user_completed');
+    assert.equal(report.files.remote_metadata !== null, true);
+    assert.equal(report.files.current_user_reference_scan !== null, true);
+
+    const deletePlan = JSON.parse(readFileSync(report.files.delete_plan, 'utf8')) as {
+      groups: Array<{
+        keep: { process_id: string };
+        current_user_reference_hits: {
+          keep_process_refs: number;
+          keep_lifecyclemodel_refs: number;
+          delete_refs: Record<string, { process_refs: number; lifecyclemodel_refs: number }>;
+        };
+      }>;
+    };
+
+    assert.equal(deletePlan.groups[0]?.keep.process_id, 'proc-keep');
+    assert.equal(deletePlan.groups[0]?.current_user_reference_hits.keep_process_refs, 1);
+    assert.equal(deletePlan.groups[0]?.current_user_reference_hits.keep_lifecyclemodel_refs, 1);
+    assert.deepEqual(deletePlan.groups[0]?.current_user_reference_hits.delete_refs, {
+      'proc-delete': {
+        process_refs: 0,
+        lifecyclemodel_refs: 0,
+      },
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/process-dedup-review.test.ts
+++ b/test/process-dedup-review.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { runProcessDedupReview } from '../src/lib/process-dedup-review.js';
+import { __testInternals, runProcessDedupReview } from '../src/lib/process-dedup-review.js';
 import type { FetchLike } from '../src/lib/http.js';
 import {
   buildSupabaseTestEnv,
@@ -30,6 +30,35 @@ function jsonResponse(payload: unknown, headers: Record<string, string> = {}) {
       },
     },
     text: async () => JSON.stringify(payload),
+  };
+}
+
+function responseLike(options: {
+  ok?: boolean;
+  status?: number;
+  body?: string;
+  headers?: Record<string, string>;
+}) {
+  return {
+    ok: options.ok ?? true,
+    status: options.status ?? 200,
+    headers: {
+      get(name: string): string | null {
+        return options.headers?.[name.toLowerCase()] ?? null;
+      },
+    },
+    text: async () => options.body ?? '',
+  };
+}
+
+function withSupabaseAuthBootstrap(fetchImpl: FetchLike): FetchLike {
+  return async (url, init) => {
+    if (isSupabaseAuthTokenUrl(String(url))) {
+      return makeSupabaseAuthResponse({
+        userId: 'user-1',
+      });
+    }
+    return fetchImpl(String(url), init);
   };
 }
 
@@ -193,6 +222,137 @@ test('runProcessDedupReview analyzes grouped duplicate candidates locally', asyn
     );
     assert.equal(deletePlan.groups[0]?.confidence, 'high');
     assert.match(deletePlan.groups[0]?.notes.join('\n') ?? '', /normalized exchange signature/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('process dedup helper scoring covers transport and same-flow pass-through naming branches', () => {
+  assert.deepEqual(
+    __testInternals.scoreProcessName(
+      {
+        name_en: 'Transport logistics collection',
+        name_zh: '运输物流收集',
+      },
+      'transport_pass_through',
+    ),
+    {
+      score: 40,
+      reasons: [
+        'name matches explicit transport-service input',
+        'name is broader than the observed transport-service input',
+        'collection is semantically consistent with a gather/sort process',
+      ],
+    },
+  );
+
+  assert.deepEqual(
+    __testInternals.scoreProcessName(
+      {
+        name_en: 'Waste reception processing',
+        name_zh: '废弃物接收加工',
+      },
+      'same_flow_pass_through',
+    ),
+    {
+      score: 0,
+      reasons: [
+        'same-flow pass-through does not support a processing label',
+        'reception matches same-flow intake/output handling',
+      ],
+    },
+  );
+});
+
+test('runProcessDedupReview sorts group ids, skips non-exact groups, and records slash-based naming reasons', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-dedup-sort-order-'));
+  const inputPath = path.join(dir, 'dedup-input.json');
+  const outDir = path.join(dir, 'artifacts');
+
+  writeJson(inputPath, {
+    source_label: 'manual-dedup-export',
+    groups: [
+      {
+        group_id: '10',
+        processes: [
+          {
+            process_id: 'proc-keep',
+            version: '01.00.000',
+            name_en: 'Waste paper/cardboard collection',
+            name_zh: '废纸/纸板收集',
+            sheet_exchange_rows: DUPLICATE_EXCHANGES,
+          },
+          {
+            process_id: 'proc-delete',
+            version: '01.00.000',
+            name_en: 'Waste paper/cardboard processing',
+            name_zh: '废纸/纸板处理',
+            sheet_exchange_rows: [...DUPLICATE_EXCHANGES].reverse(),
+          },
+        ],
+      },
+      {
+        group_id: '2',
+        processes: [
+          {
+            process_id: 'proc-non-exact-a',
+            version: '01.00.000',
+            name_en: 'Sorting A',
+            name_zh: '分选A',
+            sheet_exchange_rows: DUPLICATE_EXCHANGES,
+          },
+          {
+            process_id: 'proc-non-exact-b',
+            version: '01.00.000',
+            name_en: 'Sorting B',
+            name_zh: '分选B',
+            sheet_exchange_rows: [
+              ...DUPLICATE_EXCHANGES.slice(0, 1),
+              flatExchange({
+                flowId: 'flow-product',
+                direction: 'Output',
+                meanAmount: '2',
+                resultingAmount: '2',
+                shortDescriptionEn: 'waste paper',
+                shortDescriptionZh: '废纸',
+              }),
+            ],
+          },
+        ],
+      },
+    ],
+  });
+
+  try {
+    const report = await runProcessDedupReview({
+      inputPath,
+      outDir,
+      skipRemote: true,
+      now: new Date('2026-04-18T00:30:00.000Z'),
+    });
+
+    const duplicateGroups = JSON.parse(readFileSync(report.files.duplicate_groups, 'utf8')) as {
+      groups: Array<{
+        group_id: string;
+        exact_duplicate: boolean;
+        processes: Array<{ name_score_reasons: string[] }>;
+      }>;
+    };
+    const deletePlan = JSON.parse(readFileSync(report.files.delete_plan, 'utf8')) as {
+      groups: Array<{ group_id: string }>;
+    };
+
+    assert.deepEqual(
+      duplicateGroups.groups.map((group) => group.group_id),
+      [2, 10],
+    );
+    assert.equal(duplicateGroups.groups[0]?.exact_duplicate, false);
+    assert.equal(deletePlan.groups.length, 1);
+    assert.equal(deletePlan.groups[0]?.group_id, 10);
+    assert.match(
+      duplicateGroups.groups[1]?.processes[0]?.name_score_reasons.join('\n') ?? '',
+      /broader material scope explicit/u,
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -380,6 +540,1078 @@ test('runProcessDedupReview enriches duplicate candidates with remote metadata a
       },
     });
   } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessDedupReview skips the current-user reference scan when the user id is unavailable', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-dedup-no-user-id-'));
+  const inputPath = path.join(dir, 'dedup-input.json');
+  const outDir = path.join(dir, 'artifacts');
+
+  writeJson(inputPath, {
+    source_label: 'remote-dedup-export',
+    groups: [
+      {
+        group_id: 1,
+        processes: [
+          {
+            process_id: 'proc-keep',
+            version: '01.00.000',
+            sheet_exchange_rows: DUPLICATE_EXCHANGES,
+          },
+          {
+            process_id: 'proc-delete',
+            version: '01.00.000',
+            sheet_exchange_rows: [...DUPLICATE_EXCHANGES].reverse(),
+          },
+        ],
+      },
+    ],
+  });
+
+  const fetchImpl = (async (input) => {
+    const url = String(input);
+    if (isSupabaseAuthTokenUrl(url)) {
+      return makeSupabaseAuthResponse({ userId: 'session-user' });
+    }
+    if (url.endsWith('/auth/v1/user')) {
+      return jsonResponse({});
+    }
+    if (url.includes('/rest/v1/processes?') && url.includes('id=in.')) {
+      return jsonResponse([
+        {
+          id: 'proc-keep',
+          version: '01.00.000',
+          state_code: 0,
+          json: createRemoteProcessJson('Waste paper collection', '废纸收集', [
+            remoteExchange({
+              flowId: 'flow-waste-paper',
+              direction: 'Input',
+              meanAmount: '1',
+              resultingAmount: '1',
+            }),
+          ]),
+        },
+        {
+          id: 'proc-delete',
+          version: '01.00.000',
+          state_code: 0,
+          json: createRemoteProcessJson('Wastepaper processing', '废纸加工', [
+            remoteExchange({
+              flowId: 'flow-waste-paper',
+              direction: 'Input',
+              meanAmount: '1',
+              resultingAmount: '1',
+            }),
+          ]),
+        },
+      ]);
+    }
+
+    throw new Error(`Unexpected URL: ${url}`);
+  }) as FetchLike;
+
+  try {
+    const report = await runProcessDedupReview({
+      inputPath,
+      outDir,
+      env: buildSupabaseTestEnv(),
+      fetchImpl,
+      now: new Date('2026-04-18T02:00:00.000Z'),
+    });
+
+    assert.equal(report.remote_status.enabled, true);
+    assert.equal(report.remote_status.loaded, 2);
+    assert.equal(report.remote_status.reference_scan, 'skipped_missing_user_id');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessDedupReview records remote metadata load failures without aborting local analysis', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-dedup-remote-error-'));
+  const inputPath = path.join(dir, 'dedup-input.json');
+  const outDir = path.join(dir, 'artifacts');
+
+  writeJson(inputPath, {
+    source_label: 'remote-dedup-export',
+    groups: [
+      {
+        group_id: 1,
+        processes: [
+          {
+            process_id: 'proc-keep',
+            version: '01.00.000',
+            sheet_exchange_rows: DUPLICATE_EXCHANGES,
+          },
+          {
+            process_id: 'proc-delete',
+            version: '01.00.000',
+            sheet_exchange_rows: [...DUPLICATE_EXCHANGES].reverse(),
+          },
+        ],
+      },
+    ],
+  });
+
+  const fetchImpl = (async (input) => {
+    const url = String(input);
+    if (isSupabaseAuthTokenUrl(url)) {
+      return makeSupabaseAuthResponse({ userId: 'user-1' });
+    }
+    if (url.endsWith('/auth/v1/user')) {
+      return jsonResponse({ id: 'user-1' });
+    }
+    if (url.includes('/rest/v1/processes?') && url.includes('id=in.')) {
+      throw new Error('remote metadata fetch failed');
+    }
+
+    throw new Error(`Unexpected URL: ${url}`);
+  }) as FetchLike;
+
+  try {
+    const report = await runProcessDedupReview({
+      inputPath,
+      outDir,
+      env: buildSupabaseTestEnv(),
+      fetchImpl,
+      maxRetries: 1,
+      now: new Date('2026-04-18T03:00:00.000Z'),
+    });
+
+    assert.equal(report.status, 'completed_process_dedup_review');
+    assert.equal(report.remote_status.enabled, false);
+    assert.match(report.remote_status.error ?? '', /remote metadata fetch failed/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessDedupReview marks delete candidates that still have current-user downstream references', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-dedup-delete-refs-'));
+  const inputPath = path.join(dir, 'dedup-input.json');
+  const outDir = path.join(dir, 'artifacts');
+
+  writeJson(inputPath, {
+    source_label: 'remote-dedup-export',
+    groups: [
+      {
+        group_id: 1,
+        processes: [
+          {
+            process_id: 'proc-keep',
+            version: '01.00.000',
+            sheet_exchange_rows: DUPLICATE_EXCHANGES,
+          },
+          {
+            process_id: 'proc-delete',
+            version: '01.00.000',
+            sheet_exchange_rows: [...DUPLICATE_EXCHANGES].reverse(),
+          },
+        ],
+      },
+    ],
+  });
+
+  const fetchImpl = (async (input) => {
+    const url = String(input);
+    if (isSupabaseAuthTokenUrl(url)) {
+      return makeSupabaseAuthResponse({ userId: 'user-1' });
+    }
+    if (url.endsWith('/auth/v1/user')) {
+      return jsonResponse({ id: 'user-1' });
+    }
+    if (
+      url.includes('/rest/v1/processes?') &&
+      url.includes('id=in.') &&
+      !url.includes('user_id=eq.')
+    ) {
+      return jsonResponse([
+        {
+          id: 'proc-keep',
+          version: '01.00.000',
+          state_code: 0,
+          json: createRemoteProcessJson('Waste paper collection', '废纸收集', []),
+        },
+        {
+          id: 'proc-delete',
+          version: '01.00.000',
+          state_code: 0,
+          json: createRemoteProcessJson('Wastepaper processing', '废纸加工', []),
+        },
+      ]);
+    }
+    if (url.includes('/rest/v1/processes?') && url.includes('user_id=eq.user-1')) {
+      return jsonResponse(
+        [
+          {
+            id: 'proc-ref-delete',
+            version: '01.00.000',
+            state_code: 0,
+            user_id: 'user-1',
+            model_id: 'ref-model',
+            json: {
+              downstream: {
+                '@refObjectId': 'proc-delete',
+              },
+            },
+          },
+        ],
+        {
+          'content-type': 'application/json',
+          'content-range': '0-0/1',
+        },
+      );
+    }
+    if (url.includes('/rest/v1/lifecyclemodels?') && url.includes('user_id=eq.user-1')) {
+      return jsonResponse([], {
+        'content-type': 'application/json',
+        'content-range': '0-0/0',
+      });
+    }
+
+    throw new Error(`Unexpected URL: ${url}`);
+  }) as FetchLike;
+
+  try {
+    const report = await runProcessDedupReview({
+      inputPath,
+      outDir,
+      env: buildSupabaseTestEnv(),
+      fetchImpl,
+      now: new Date('2026-04-18T04:00:00.000Z'),
+    });
+
+    const deletePlan = JSON.parse(readFileSync(report.files.delete_plan, 'utf8')) as {
+      groups: Array<{ notes: string[] }>;
+    };
+    assert.match(
+      deletePlan.groups[0]?.notes.join('\n') ?? '',
+      /delete requires reference cleanup/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessDedupReview records current-user reference scan failures separately from metadata loading', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-dedup-scan-error-'));
+  const inputPath = path.join(dir, 'dedup-input.json');
+  const outDir = path.join(dir, 'artifacts');
+
+  writeJson(inputPath, {
+    source_label: 'remote-dedup-export',
+    groups: [
+      {
+        group_id: 1,
+        processes: [
+          {
+            process_id: 'proc-keep',
+            version: '01.00.000',
+            sheet_exchange_rows: DUPLICATE_EXCHANGES,
+          },
+          {
+            process_id: 'proc-delete',
+            version: '01.00.000',
+            sheet_exchange_rows: [...DUPLICATE_EXCHANGES].reverse(),
+          },
+        ],
+      },
+    ],
+  });
+
+  const fetchImpl = (async (input) => {
+    const url = String(input);
+    if (isSupabaseAuthTokenUrl(url)) {
+      return makeSupabaseAuthResponse({ userId: 'user-1' });
+    }
+    if (url.endsWith('/auth/v1/user')) {
+      return jsonResponse({ id: 'user-1' });
+    }
+    if (
+      url.includes('/rest/v1/processes?') &&
+      url.includes('id=in.') &&
+      !url.includes('user_id=eq.')
+    ) {
+      return jsonResponse([
+        {
+          id: 'proc-keep',
+          version: '01.00.000',
+          state_code: 0,
+          json: createRemoteProcessJson('Waste paper collection', '废纸收集', []),
+        },
+        {
+          id: 'proc-delete',
+          version: '01.00.000',
+          state_code: 0,
+          json: createRemoteProcessJson('Wastepaper processing', '废纸加工', []),
+        },
+      ]);
+    }
+    if (url.includes('/rest/v1/processes?') && url.includes('user_id=eq.user-1')) {
+      throw new Error('reference scan failed');
+    }
+
+    throw new Error(`Unexpected URL: ${url}`);
+  }) as FetchLike;
+
+  try {
+    const report = await runProcessDedupReview({
+      inputPath,
+      outDir,
+      env: buildSupabaseTestEnv(),
+      fetchImpl,
+      maxRetries: 1,
+      now: new Date('2026-04-18T05:00:00.000Z'),
+    });
+
+    assert.equal(report.remote_status.enabled, true);
+    assert.equal(report.remote_status.reference_scan, 'failed');
+    assert.match(report.remote_status.error ?? '', /reference scan failed/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('process dedup helper normalization and validation cover edge cases', async () => {
+  assert.deepEqual(__testInternals.normalizeExchangeRows(null), []);
+  assert.deepEqual(__testInternals.normalizeExchangeRows([null, {}]), []);
+  assert.equal(__testInternals.normalizeExchangeRows(DUPLICATE_EXCHANGES[0]).length, 1);
+
+  assert.equal(__testInternals.normalizeAmount(''), '');
+  assert.equal(__testInternals.normalizeAmount('001.2300'), '1.23');
+  assert.equal(__testInternals.normalizeAmount('-0'), '0');
+  assert.equal(__testInternals.normalizeAmount('1e3'), '1000');
+  assert.equal(__testInternals.normalizeAmount('not-a-number'), 'not-a-number');
+
+  assert.deepEqual(__testInternals.getLangList(null), []);
+  assert.deepEqual(
+    __testInternals.getLangList({
+      'common:langString': {
+        '@xml:lang': 'zh',
+        '#text': '中文名',
+      },
+    }),
+    [{ '@xml:lang': 'zh', '#text': '中文名' }],
+  );
+  assert.deepEqual(
+    __testInternals.getLangList({
+      'common:langString': [{ '@xml:lang': 'en', '#text': 'English name' }, null],
+    }),
+    [{ '@xml:lang': 'en', '#text': 'English name' }],
+  );
+  assert.deepEqual(__testInternals.getLangList({ '@xml:lang': 'en', '#text': 'Inline name' }), [
+    { '@xml:lang': 'en', '#text': 'Inline name' },
+  ]);
+  assert.deepEqual(__testInternals.getLangList({ '#text': 'Text only' }), [
+    { '#text': 'Text only' },
+  ]);
+  assert.deepEqual(__testInternals.getLangList({ '@xml:lang': 'en' }), [{ '@xml:lang': 'en' }]);
+  assert.deepEqual(__testInternals.getLangList('Plain name'), [
+    { '@xml:lang': 'en', '#text': 'Plain name' },
+  ]);
+  assert.deepEqual(__testInternals.getLangList(123), []);
+  assert.equal(
+    __testInternals.getLangText([{ '@xml:lang': 'en', '#text': 'Fallback name' }], 'zh'),
+    'Fallback name',
+  );
+
+  const namedGroup = __testInternals.normalizeInputDocument(
+    {
+      groups: [
+        {
+          group_id: 'named-group',
+          processes: [{ process_id: 'proc-named' }],
+        },
+      ],
+    },
+    '/tmp/named-group.json',
+  );
+  assert.equal(namedGroup.groups[0]?.group_id, 'named-group');
+
+  const normalized = __testInternals.normalizeInputDocument(
+    {
+      groups: {
+        alpha: {
+          processes: [
+            {
+              id: 'proc-analysis',
+              exchange_count: 2,
+              analysis_exchanges: [null, DUPLICATE_EXCHANGES[0]],
+            },
+            {
+              process_id: 'proc-remote',
+              exchange_count: 'nope',
+              remote_exchanges: [DUPLICATE_EXCHANGES[1]],
+            },
+            {
+              process_id: 'proc-direct',
+              exchange_count: '3',
+              exchanges: [DUPLICATE_EXCHANGES[0]],
+            },
+          ],
+        },
+      },
+    },
+    '/tmp/fallback-source.json',
+  );
+  assert.equal(normalized.sourceLabel, 'fallback-source.json');
+  assert.equal(normalized.groups[0]?.group_id, 'alpha');
+  assert.equal(normalized.groups[0]?.processes[0]?.exchange_count, 2);
+  assert.equal(normalized.groups[0]?.processes[1]?.exchange_count, null);
+  assert.equal(normalized.groups[0]?.processes[2]?.exchange_count, 3);
+  assert.equal(normalized.groups[0]?.processes[0]?.sheet_exchange_rows.length, 1);
+  assert.equal(normalized.groups[0]?.processes[1]?.sheet_exchange_rows[0]?.flow_id, 'flow-product');
+
+  assert.throws(
+    () => __testInternals.normalizeInputDocument(null, '/tmp/input.json'),
+    (error: unknown) => {
+      assert.equal((error as { code?: string }).code, 'PROCESS_DEDUP_INPUT_INVALID');
+      return true;
+    },
+  );
+  assert.throws(
+    () => __testInternals.normalizeInputDocument({ groups: [null] }, '/tmp/input.json'),
+    (error: unknown) => {
+      assert.equal((error as { code?: string }).code, 'PROCESS_DEDUP_INPUT_INVALID_GROUP');
+      return true;
+    },
+  );
+  assert.throws(
+    () =>
+      __testInternals.normalizeInputDocument(
+        { groups: [{ processes: [null] }] },
+        '/tmp/input.json',
+      ),
+    (error: unknown) => {
+      assert.equal((error as { code?: string }).code, 'PROCESS_DEDUP_INPUT_INVALID_PROCESS');
+      return true;
+    },
+  );
+  assert.throws(
+    () =>
+      __testInternals.normalizeInputDocument({ groups: [{ processes: [{}] }] }, '/tmp/input.json'),
+    (error: unknown) => {
+      assert.equal((error as { code?: string }).code, 'PROCESS_DEDUP_PROCESS_ID_REQUIRED');
+      return true;
+    },
+  );
+  assert.throws(
+    () =>
+      __testInternals.normalizeInputDocument({ groups: [{ processes: [] }] }, '/tmp/input.json'),
+    (error: unknown) => {
+      assert.equal((error as { code?: string }).code, 'PROCESS_DEDUP_GROUP_PROCESSES_REQUIRED');
+      return true;
+    },
+  );
+  assert.throws(
+    () => __testInternals.normalizeInputDocument({ groups: [] }, '/tmp/input.json'),
+    (error: unknown) => {
+      assert.equal((error as { code?: string }).code, 'PROCESS_DEDUP_GROUPS_REQUIRED');
+      return true;
+    },
+  );
+
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-dedup-validate-'));
+  const inputPath = path.join(dir, 'dedup-input.json');
+  writeJson(inputPath, {
+    groups: [
+      {
+        group_id: 1,
+        processes: [{ process_id: 'proc-1', sheet_exchange_rows: DUPLICATE_EXCHANGES }],
+      },
+    ],
+  });
+
+  try {
+    await assert.rejects(
+      () => runProcessDedupReview({ inputPath: '', outDir: dir }),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_DEDUP_INPUT_REQUIRED');
+        return true;
+      },
+    );
+    await assert.rejects(
+      () => runProcessDedupReview({ inputPath, outDir: '' }),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_DEDUP_OUT_DIR_REQUIRED');
+        return true;
+      },
+    );
+    await assert.rejects(
+      () => runProcessDedupReview({ inputPath, outDir: dir, timeoutMs: 0 }),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_DEDUP_TIMEOUT_INVALID');
+        return true;
+      },
+    );
+    await assert.rejects(
+      () => runProcessDedupReview({ inputPath, outDir: dir, maxRetries: 0 }),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_DEDUP_MAX_RETRIES_INVALID');
+        return true;
+      },
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('process dedup remote helper internals cover retries, metadata fallbacks, and cyclic reference scans', async () => {
+  assert.equal(
+    await __testInternals.parseJsonResponse(
+      responseLike({
+        headers: { 'content-type': 'application/json' },
+      }),
+      'dedup empty body',
+    ),
+    null,
+  );
+  assert.equal(
+    await __testInternals.parseJsonResponse(
+      responseLike({
+        body: '',
+      }),
+      'dedup missing content type',
+    ),
+    null,
+  );
+  assert.equal(
+    await __testInternals.parseJsonResponse(
+      responseLike({
+        body: 'plain-text',
+        headers: { 'content-type': 'text/plain' },
+      }),
+      'dedup text body',
+    ),
+    'plain-text',
+  );
+  await assert.rejects(
+    () =>
+      __testInternals.parseJsonResponse(
+        responseLike({
+          body: '{',
+          headers: { 'content-type': 'application/json' },
+        }),
+        'dedup invalid json',
+      ),
+    (error: unknown) => {
+      assert.equal((error as { code?: string }).code, 'PROCESS_DEDUP_REMOTE_INVALID_JSON');
+      return true;
+    },
+  );
+
+  await assert.rejects(
+    () =>
+      __testInternals.fetchJsonWithRetry({
+        url: 'https://example.test/dedup-error',
+        init: { method: 'GET' },
+        label: 'dedup http error',
+        fetchImpl: async () =>
+          responseLike({
+            ok: false,
+            status: 503,
+            body: JSON.stringify({ error: 'unavailable' }),
+            headers: { 'content-type': 'application/json' },
+          }),
+        timeoutMs: 10,
+        maxRetries: 1,
+      }),
+    (error: unknown) => {
+      assert.equal((error as { code?: string }).code, 'PROCESS_DEDUP_REMOTE_REQUEST_FAILED');
+      return true;
+    },
+  );
+
+  const originalSetTimeout = globalThis.setTimeout;
+  const retryDelays: number[] = [];
+  globalThis.setTimeout = ((
+    callback: (...args: unknown[]) => void,
+    ms?: number,
+    ...args: unknown[]
+  ) => {
+    retryDelays.push(Number(ms ?? 0));
+    callback(...args);
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+
+  try {
+    let attempts = 0;
+    const retried = await __testInternals.fetchJsonWithRetry({
+      url: 'https://example.test/dedup-retry',
+      init: { method: 'GET' },
+      label: 'dedup retry',
+      fetchImpl: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new Error('temporary network issue');
+        }
+        return responseLike({
+          body: JSON.stringify({ ok: true }),
+          headers: { 'content-type': 'application/json' },
+        });
+      },
+      timeoutMs: 10,
+      maxRetries: 2,
+    });
+    assert.equal(attempts, 2);
+    assert.deepEqual(retryDelays, [1500]);
+    assert.deepEqual(retried.body, { ok: true });
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+  }
+
+  const currentUserId = await __testInternals.fetchCurrentUserId({
+    projectBaseUrl: 'https://example.supabase.co',
+    publishableKey: 'pk',
+    accessToken: 'token',
+    fetchImpl: async () =>
+      responseLike({
+        body: JSON.stringify('not-an-object'),
+        headers: { 'content-type': 'application/json' },
+      }),
+    timeoutMs: 10,
+    maxRetries: 1,
+  });
+  assert.equal(currentUserId, null);
+
+  const successWithoutHeader = await __testInternals.fetchJsonWithRetry({
+    url: 'https://example.test/dedup-no-header',
+    init: { method: 'GET' },
+    label: 'dedup missing content header',
+    fetchImpl: async () =>
+      responseLike({
+        body: JSON.stringify({ ok: true }),
+        headers: {
+          'content-range': '0-0/1',
+        },
+      }),
+    timeoutMs: 10,
+    maxRetries: 1,
+  });
+  assert.equal(successWithoutHeader.headers.get('content-type'), '');
+
+  const resolvedAuth = await __testInternals.resolveRemoteAuthContext({
+    env: buildSupabaseTestEnv(),
+    fetchImpl: withSupabaseAuthBootstrap(async (url) => {
+      if (String(url).endsWith('/auth/v1/user')) {
+        return responseLike({
+          body: '{',
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      throw new Error(`Unexpected URL: ${String(url)}`);
+    }),
+    timeoutMs: 10,
+    maxRetries: 1,
+    now: new Date('2026-04-18T06:00:00.000Z'),
+  });
+  assert.equal(resolvedAuth.userId, null);
+
+  assert.deepEqual(
+    await __testInternals.fetchRemoteMetadata({
+      processIds: [],
+      auth: resolvedAuth,
+      fetchImpl: async () => {
+        throw new Error('fetchRemoteMetadata should not fetch with empty ids');
+      },
+      timeoutMs: 10,
+      maxRetries: 1,
+    }),
+    {},
+  );
+
+  const remoteMetadata = await __testInternals.fetchRemoteMetadata({
+    processIds: ['proc-1'],
+    auth: {
+      ...resolvedAuth,
+      userId: 'user-1',
+    },
+    fetchImpl: async () =>
+      jsonResponse([
+        null,
+        {
+          id: '',
+          version: '01.00.000',
+          json: createRemoteProcessJson('skip', '跳过', []),
+        },
+        {
+          id: 'proc-1',
+          version: '01.00.000',
+          state_code: 'draft',
+          json: null,
+        },
+      ]),
+    timeoutMs: 10,
+    maxRetries: 1,
+  });
+  assert.deepEqual(Object.keys(remoteMetadata), ['proc-1']);
+  assert.equal(remoteMetadata['proc-1']?.remote_name_en, '');
+  assert.deepEqual(remoteMetadata['proc-1']?.remote_exchanges, []);
+  assert.equal(remoteMetadata['proc-1']?.state_code, null);
+
+  const remoteMetadataFromObjectBody = await __testInternals.fetchRemoteMetadata({
+    processIds: ['proc-2'],
+    auth: {
+      ...resolvedAuth,
+      userId: 'user-1',
+    },
+    fetchImpl: async () => jsonResponse({ rows: [] }),
+    timeoutMs: 10,
+    maxRetries: 1,
+  });
+  assert.deepEqual(remoteMetadataFromObjectBody, {});
+
+  const remoteMetadataWithoutProcessDataSet = await __testInternals.fetchRemoteMetadata({
+    processIds: ['proc-3'],
+    auth: {
+      ...resolvedAuth,
+      userId: 'user-1',
+    },
+    fetchImpl: async () =>
+      jsonResponse([
+        {
+          id: 'proc-3',
+          version: '01.00.000',
+          json: {
+            processDataSet: {},
+          },
+        },
+      ]),
+    timeoutMs: 10,
+    maxRetries: 1,
+  });
+  assert.deepEqual(remoteMetadataWithoutProcessDataSet['proc-3']?.remote_exchanges, []);
+
+  const remoteMetadataWithNonRecordProcessDataSet = await __testInternals.fetchRemoteMetadata({
+    processIds: ['proc-4'],
+    auth: {
+      ...resolvedAuth,
+      userId: 'user-1',
+    },
+    fetchImpl: async () =>
+      jsonResponse([
+        {
+          id: 'proc-4',
+          version: '01.00.000',
+          json: {
+            processDataSet: [],
+          },
+        },
+      ]),
+    timeoutMs: 10,
+    maxRetries: 1,
+  });
+  assert.deepEqual(remoteMetadataWithNonRecordProcessDataSet['proc-4']?.remote_exchanges, []);
+
+  const preferHeaders: string[] = [];
+  const currentUserRows = await __testInternals.fetchCurrentUserRows({
+    auth: {
+      ...resolvedAuth,
+      userId: 'user-1',
+    },
+    tableName: 'processes',
+    userId: 'user-1',
+    select: 'id',
+    fetchImpl: async (input, init) => {
+      const headers = init?.headers as Record<string, string> | undefined;
+      preferHeaders.push(headers?.Prefer ?? headers?.prefer ?? '');
+      const offset = new URL(String(input)).searchParams.get('offset');
+      if (offset === '0') {
+        return jsonResponse([{ id: 'row-1' }], {
+          'content-type': 'application/json',
+          'content-range': '0-0/501',
+        });
+      }
+      return jsonResponse([], {
+        'content-type': 'application/json',
+      });
+    },
+    timeoutMs: 10,
+    maxRetries: 1,
+  });
+  assert.equal(currentUserRows.length, 1);
+  assert.deepEqual(preferHeaders, ['count=exact', 'count=planned']);
+
+  const nonArrayCurrentUserRows = await __testInternals.fetchCurrentUserRows({
+    auth: {
+      ...resolvedAuth,
+      userId: 'user-1',
+    },
+    tableName: 'processes',
+    userId: 'user-1',
+    select: 'id',
+    fetchImpl: async () => jsonResponse({ ok: true }),
+    timeoutMs: 10,
+    maxRetries: 1,
+  });
+  assert.deepEqual(nonArrayCurrentUserRows, []);
+
+  const cyclicArray: unknown[] = [];
+  const cyclicObject: Record<string, unknown> = { self: null };
+  cyclicArray.push(cyclicArray, { '@refObjectId': 'proc-keep' }, null);
+  cyclicObject.self = cyclicObject;
+  assert.deepEqual(
+    __testInternals.collectReferenceHits(
+      {
+        array: cyclicArray,
+        object: cyclicObject,
+        nested: { '@refObjectId': 'proc-keep' },
+      },
+      new Set(['proc-keep']),
+    ),
+    ['proc-keep', 'proc-keep'],
+  );
+
+  const referenceHits = await __testInternals.fetchCurrentUserReferenceHits({
+    auth: {
+      ...resolvedAuth,
+      userId: 'user-1',
+    },
+    userId: 'user-1',
+    targetProcessIds: ['proc-keep'],
+    fetchImpl: async (input) => {
+      const url = String(input);
+      if (url.includes('/rest/v1/processes?')) {
+        return jsonResponse(
+          [
+            null,
+            {
+              id: 'proc-keep',
+              version: '01.00.000',
+              state_code: 'draft',
+              model_id: 'self-model',
+              json: { nested: { '@refObjectId': 'proc-keep' } },
+            },
+            {
+              id: 'proc-ref-1',
+              version: '01.00.000',
+              state_code: 'draft',
+              model_id: 'ref-model',
+              json: { nested: [{ '@refObjectId': 'proc-keep' }] },
+            },
+          ],
+          {
+            'content-type': 'application/json',
+            'content-range': '0-2/3',
+          },
+        );
+      }
+      if (url.includes('/rest/v1/lifecyclemodels?')) {
+        return jsonResponse(
+          [
+            null,
+            {
+              id: 'lm-ref-1',
+              version: '01.00.000',
+              state_code: 'draft',
+              json: { processLink: { '@refObjectId': 'proc-keep' } },
+            },
+          ],
+          {
+            'content-type': 'application/json',
+            'content-range': '0-1/2',
+          },
+        );
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    },
+    timeoutMs: 10,
+    maxRetries: 1,
+  });
+  assert.deepEqual(referenceHits.processes['proc-keep'], [
+    {
+      id: 'proc-ref-1',
+      version: '01.00.000',
+      state_code: null,
+      model_id: 'ref-model',
+    },
+  ]);
+  assert.deepEqual(referenceHits.lifecyclemodels['proc-keep'], [
+    {
+      id: 'lm-ref-1',
+      version: '01.00.000',
+      state_code: null,
+    },
+  ]);
+
+  assert.equal(
+    __testInternals.detectGroupPattern([{ analysis_exchanges: [] }] as never),
+    'unknown',
+  );
+  assert.equal(
+    __testInternals.detectGroupPattern([
+      {
+        analysis_exchanges: [
+          {
+            flow_id: 'flow-transport',
+            direction: 'Input',
+            mean_amount: '1',
+            resulting_amount: '1',
+            flow_short_description_en: 'transport; service',
+            flow_short_description_zh: '运输;服务',
+          },
+          {
+            flow_id: 'flow-transport',
+            direction: 'Output',
+            mean_amount: '1',
+            resulting_amount: '1',
+            flow_short_description_en: 'transport; service',
+            flow_short_description_zh: '运输;服务',
+          },
+        ],
+      },
+    ] as never),
+    'transport_pass_through',
+  );
+  assert.equal(
+    __testInternals.detectGroupPattern([
+      {
+        analysis_exchanges: [
+          {
+            flow_id: 'flow-same',
+            direction: 'Input',
+            mean_amount: '1',
+            resulting_amount: '1',
+            flow_short_description_en: 'waste paper',
+            flow_short_description_zh: '废纸',
+          },
+          {
+            flow_id: 'flow-same',
+            direction: 'Output',
+            mean_amount: '1',
+            resulting_amount: '1',
+            flow_short_description_en: 'waste paper',
+            flow_short_description_zh: '废纸',
+          },
+        ],
+      },
+    ] as never),
+    'same_flow_pass_through',
+  );
+  assert.deepEqual(
+    __testInternals.scoreProcessName(
+      {
+        name_en: 'Service route',
+        name_zh: '运输物流服务',
+      },
+      'transport_pass_through',
+    ),
+    {
+      score: 20,
+      reasons: [
+        'name matches explicit transport-service input',
+        'name is broader than the observed transport-service input',
+      ],
+    },
+  );
+  assert.deepEqual(
+    __testInternals.scoreProcessName(
+      {
+        name_en: 'Handling service',
+        name_zh: '接收加工',
+      },
+      'same_flow_pass_through',
+    ),
+    {
+      score: 0,
+      reasons: [
+        'same-flow pass-through does not support a processing label',
+        'reception matches same-flow intake/output handling',
+      ],
+    },
+  );
+});
+
+test('process dedup runtime fallbacks and non-Error failures are covered', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-dedup-runtime-'));
+  const inputPath = path.join(dir, 'dedup-input.json');
+  writeJson(inputPath, {
+    groups: [
+      {
+        group_id: 1,
+        processes: [
+          { process_id: 'proc-keep', sheet_exchange_rows: DUPLICATE_EXCHANGES },
+          { process_id: 'proc-delete', sheet_exchange_rows: [...DUPLICATE_EXCHANGES].reverse() },
+        ],
+      },
+    ],
+  });
+
+  const originalFetch = globalThis.fetch;
+  const originalSetTimeout = globalThis.setTimeout;
+  const envKeys = Object.keys(buildSupabaseTestEnv());
+  const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+
+  try {
+    Object.assign(process.env, buildSupabaseTestEnv());
+    globalThis.setTimeout = ((
+      callback: (...args: unknown[]) => void,
+      _ms?: number,
+      ...args: unknown[]
+    ) => {
+      callback(...args);
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
+    globalThis.fetch = withSupabaseAuthBootstrap(async (url) => {
+      const rawUrl = String(url);
+      if (rawUrl.endsWith('/auth/v1/user')) {
+        return jsonResponse({ id: 'user-1' });
+      }
+      if (rawUrl.includes('/rest/v1/processes?') && rawUrl.includes('id=in.')) {
+        return jsonResponse([]);
+      }
+      if (rawUrl.includes('/rest/v1/processes?') && rawUrl.includes('user_id=eq.user-1')) {
+        throw 'scan failed as string';
+      }
+      if (rawUrl.includes('/rest/v1/lifecyclemodels?')) {
+        return jsonResponse([], {
+          'content-type': 'application/json',
+          'content-range': '0-0/0',
+        });
+      }
+      throw new Error(`Unexpected URL: ${rawUrl}`);
+    }) as typeof fetch;
+
+    const fallbackReport = await runProcessDedupReview({
+      inputPath,
+      outDir: path.join(dir, 'global-fetch'),
+    });
+    assert.equal(fallbackReport.remote_status.enabled, true);
+    assert.equal(fallbackReport.remote_status.reference_scan, 'failed');
+    assert.match(fallbackReport.remote_status.error ?? '', /failed after 4 attempt\(s\)/u);
+
+    const stringErrorReport = await runProcessDedupReview({
+      inputPath,
+      outDir: path.join(dir, 'outer-string-error'),
+      env: buildSupabaseTestEnv(),
+      fetchImpl: withSupabaseAuthBootstrap(async (url) => {
+        const rawUrl = String(url);
+        if (rawUrl.endsWith('/auth/v1/user')) {
+          return jsonResponse({ id: 'user-1' });
+        }
+        if (rawUrl.includes('/rest/v1/processes?') && rawUrl.includes('id=in.')) {
+          throw 'metadata failed as string';
+        }
+        throw new Error(`Unexpected URL: ${rawUrl}`);
+      }),
+      now: new Date('2026-04-18T07:00:00.000Z'),
+      maxRetries: 1,
+    });
+    assert.match(stringErrorReport.remote_status.error ?? '', /failed after 1 attempt\(s\)/u);
+    assert.equal(__testInternals.errorMessage(new Error('boom')), 'boom');
+    assert.equal(__testInternals.errorMessage('plain-text-error'), 'plain-text-error');
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.setTimeout = originalSetTimeout;
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
     rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/test/process-payload-validation.test.ts
+++ b/test/process-payload-validation.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import * as tidasSdk from '@tiangong-lca/tidas-sdk';
+import {
+  summarizeProcessPayloadValidation,
+  validateProcessPayload,
+} from '../src/lib/process-payload-validation.js';
+
+test('process payload validation summarizes ok and failure results with normalized issue paths', () => {
+  const originalSafeParse = tidasSdk.ProcessSchema.safeParse;
+
+  try {
+    tidasSdk.ProcessSchema.safeParse = (() =>
+      ({
+        success: true,
+        data: {},
+      }) as unknown as ReturnType<typeof originalSafeParse>) as typeof originalSafeParse;
+
+    const okResult = validateProcessPayload({});
+    assert.deepEqual(okResult, {
+      ok: true,
+      validator: '@tiangong-lca/tidas-sdk/ProcessSchema',
+      issue_count: 0,
+      issues: [],
+    });
+    assert.equal(
+      summarizeProcessPayloadValidation(okResult),
+      'local ProcessSchema validation passed',
+    );
+
+    tidasSdk.ProcessSchema.safeParse = (() =>
+      ({
+        success: false,
+        error: {
+          issues: [
+            {
+              path: [],
+              message: 'Top-level failure',
+              code: 'custom',
+            },
+            {
+              path: ['processDataSet', 'exchanges', 0],
+            },
+          ],
+        },
+      }) as unknown as ReturnType<typeof originalSafeParse>) as typeof originalSafeParse;
+
+    const invalidResult = validateProcessPayload({});
+    assert.equal(invalidResult.ok, false);
+    assert.equal(invalidResult.issue_count, 2);
+    assert.deepEqual(invalidResult.issues, [
+      {
+        path: '<root>',
+        message: 'Top-level failure',
+        code: 'custom',
+      },
+      {
+        path: 'processDataSet.exchanges.0',
+        message: 'Validation failed',
+        code: 'custom',
+      },
+    ]);
+    assert.match(
+      summarizeProcessPayloadValidation(invalidResult),
+      /local ProcessSchema validation failed with 2 issue\(s\) \(<root>: Top-level failure; processDataSet\.exchanges\.0: Validation failed\)/u,
+    );
+
+    tidasSdk.ProcessSchema.safeParse = (() =>
+      ({
+        success: false,
+        error: undefined,
+      }) as unknown as ReturnType<typeof originalSafeParse>) as typeof originalSafeParse;
+    const emptyIssueResult = validateProcessPayload({});
+    assert.equal(emptyIssueResult.ok, false);
+    assert.equal(emptyIssueResult.issue_count, 0);
+    assert.equal(
+      summarizeProcessPayloadValidation(emptyIssueResult),
+      'local ProcessSchema validation failed with 0 issue(s)',
+    );
+
+    tidasSdk.ProcessSchema.safeParse = undefined as unknown as typeof originalSafeParse;
+    assert.throws(
+      () => validateProcessPayload({}),
+      /@tiangong-lca\/tidas-sdk\/ProcessSchema is unavailable/u,
+    );
+  } finally {
+    tidasSdk.ProcessSchema.safeParse = originalSafeParse;
+  }
+});

--- a/test/process-refresh-references.test.ts
+++ b/test/process-refresh-references.test.ts
@@ -1,9 +1,12 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import { runProcessRefreshReferences } from '../src/lib/process-refresh-references.js';
+import {
+  __testInternals,
+  runProcessRefreshReferences,
+} from '../src/lib/process-refresh-references.js';
 import type { FetchLike } from '../src/lib/http.js';
 import {
   buildSupabaseTestEnv,
@@ -341,5 +344,1722 @@ test('runProcessRefreshReferences blocks unresolved refs before invoking writes'
     assert.equal(blockers[0]?.unresolved_count, 1);
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessRefreshReferences apply saves refreshed rows and counts saved results', async () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-refresh-apply-'));
+  let savedPayload: Record<string, unknown> | null = null;
+
+  try {
+    const fetchImpl = withSupabaseAuthBootstrap(async (url) => {
+      const parsed = new URL(String(url));
+
+      if (parsed.pathname === '/auth/v1/user') {
+        return makeJsonResponse({
+          body: { id: 'user-1' },
+        });
+      }
+
+      if (parsed.pathname === '/rest/v1/processes') {
+        const select = parsed.searchParams.get('select');
+        if (select === 'id,version,modified_at,state_code,model_id') {
+          return makeJsonResponse({
+            body: [
+              {
+                id: 'proc-draft',
+                version: '01.00.001',
+                modified_at: '2026-04-18T00:00:00.000Z',
+                state_code: 0,
+                model_id: 'model-1',
+              },
+            ],
+            headers: {
+              'content-type': 'application/json',
+              'content-range': '0-0/1',
+            },
+          });
+        }
+
+        if (
+          select === 'id,version,json,modified_at,state_code,model_id,user_id' &&
+          parsed.searchParams.get('id') === 'eq.proc-draft'
+        ) {
+          return makeJsonResponse({
+            body: [
+              {
+                id: 'proc-draft',
+                version: '01.00.001',
+                modified_at: '2026-04-18T00:00:00.000Z',
+                state_code: 0,
+                model_id: 'model-1',
+                user_id: 'user-1',
+                json: buildProcessPayload('flow-1', '01.00.000', 'Old flow short'),
+              },
+            ],
+          });
+        }
+      }
+
+      if (parsed.pathname === '/rest/v1/flows') {
+        return makeJsonResponse({
+          body: [
+            {
+              id: 'flow-1',
+              version: '',
+              json: buildFlowPayload('Ignored invalid row'),
+            },
+            {
+              id: 'flow-1',
+              version: '01.00.002',
+              json: buildFlowPayload('Updated flow'),
+            },
+          ],
+        });
+      }
+
+      throw new Error(`Unexpected URL: ${String(url)}`);
+    });
+
+    const report = await runProcessRefreshReferences({
+      outDir: tempDir,
+      apply: true,
+      env: buildSupabaseTestEnv({
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
+      }),
+      fetchImpl,
+      validateProcessPayloadImpl: () => ({
+        ok: true,
+        validator: 'test-validator',
+        issue_count: 0,
+        issues: [],
+      }),
+      syncStateAwareProcessRecordImpl: async (options) => {
+        savedPayload = options.payload as Record<string, unknown>;
+        return {
+          status: 'success',
+          operation: 'save_draft',
+          write_path: 'cmd_dataset_save_draft',
+          rpc_result: { ok: true },
+          visible_row: {
+            id: 'proc-draft',
+            version: '01.00.001',
+            user_id: 'user-1',
+            state_code: 0,
+          },
+        };
+      },
+    });
+
+    assert.equal(report.status, 'completed_process_reference_refresh');
+    assert.equal(report.mode, 'apply');
+    assert.equal(report.counts.saved, 1);
+    assert.ok(savedPayload);
+    assert.match(JSON.stringify(savedPayload), /01\.00\.002/u);
+
+    const progressRows = readFileSync(report.files.progress_jsonl, 'utf8')
+      .trim()
+      .split('\n')
+      .map(
+        (line) =>
+          JSON.parse(line) as { status: string; write_path?: string; write_operation?: string },
+      );
+    assert.equal(progressRows[0]?.status, 'saved');
+    assert.equal(progressRows[0]?.write_path, 'cmd_dataset_save_draft');
+    assert.equal(progressRows[0]?.write_operation, 'save_draft');
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessRefreshReferences records schema-validation blockers and reference lookup failures', async () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-refresh-blocker-notes-'));
+
+  try {
+    const schemaBlockedFetch = withSupabaseAuthBootstrap(async (url) => {
+      const parsed = new URL(String(url));
+
+      if (parsed.pathname === '/auth/v1/user') {
+        return makeJsonResponse({
+          body: { id: 'user-1' },
+        });
+      }
+
+      if (parsed.pathname === '/rest/v1/processes') {
+        const select = parsed.searchParams.get('select');
+        if (select === 'id,version,modified_at,state_code,model_id') {
+          return makeJsonResponse({
+            body: [
+              {
+                id: 'proc-draft',
+                version: '01.00.001',
+                modified_at: '2026-04-18T00:00:00.000Z',
+                state_code: 0,
+                model_id: 'model-1',
+              },
+            ],
+            headers: {
+              'content-type': 'application/json',
+              'content-range': '0-0/1',
+            },
+          });
+        }
+
+        if (
+          select === 'id,version,json,modified_at,state_code,model_id,user_id' &&
+          parsed.searchParams.get('id') === 'eq.proc-draft'
+        ) {
+          return makeJsonResponse({
+            body: [
+              {
+                id: 'proc-draft',
+                version: '01.00.001',
+                modified_at: '2026-04-18T00:00:00.000Z',
+                state_code: 0,
+                model_id: 'model-1',
+                user_id: 'user-1',
+                json: buildProcessPayload('flow-1', '01.00.000', 'Old flow short'),
+              },
+            ],
+          });
+        }
+      }
+
+      if (parsed.pathname === '/rest/v1/flows') {
+        return makeJsonResponse({
+          body: [
+            {
+              id: 'flow-1',
+              version: '01.00.002',
+              json: buildFlowPayload('Updated flow'),
+            },
+          ],
+        });
+      }
+
+      throw new Error(`Unexpected URL: ${String(url)}`);
+    });
+
+    const schemaBlockedReport = await runProcessRefreshReferences({
+      outDir: tempDir,
+      env: buildSupabaseTestEnv({
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
+      }),
+      fetchImpl: schemaBlockedFetch,
+      validateProcessPayloadImpl: () => ({
+        ok: false,
+        validator: 'test-validator',
+        issue_count: 2,
+        issues: [
+          {
+            path: 'processDataSet',
+            message: 'Broken payload',
+            code: 'custom',
+          },
+        ],
+      }),
+    });
+
+    const schemaBlockedRows = readFileSync(
+      schemaBlockedReport.files.validation_blockers_jsonl,
+      'utf8',
+    )
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as { note: string });
+    assert.match(schemaBlockedRows[0]?.note ?? '', /schema_issue_count=2/u);
+
+    const lookupFailureFetch = withSupabaseAuthBootstrap(async (url) => {
+      const parsed = new URL(String(url));
+
+      if (parsed.pathname === '/auth/v1/user') {
+        return makeJsonResponse({
+          body: { id: 'user-1' },
+        });
+      }
+
+      if (parsed.pathname === '/rest/v1/processes') {
+        const select = parsed.searchParams.get('select');
+        if (select === 'id,version,modified_at,state_code,model_id') {
+          return makeJsonResponse({
+            body: [
+              {
+                id: 'proc-draft',
+                version: '01.00.001',
+                modified_at: '2026-04-18T00:00:00.000Z',
+                state_code: 0,
+                model_id: 'model-1',
+              },
+            ],
+            headers: {
+              'content-type': 'application/json',
+              'content-range': '0-0/1',
+            },
+          });
+        }
+
+        if (
+          select === 'id,version,json,modified_at,state_code,model_id,user_id' &&
+          parsed.searchParams.get('id') === 'eq.proc-draft'
+        ) {
+          return makeJsonResponse({
+            body: [
+              {
+                id: 'proc-draft',
+                version: '01.00.001',
+                modified_at: '2026-04-18T00:00:00.000Z',
+                state_code: 0,
+                model_id: 'model-1',
+                user_id: 'user-1',
+                json: buildProcessPayload('flow-1', '01.00.000', 'Old flow short'),
+              },
+            ],
+          });
+        }
+      }
+
+      if (parsed.pathname === '/rest/v1/flows') {
+        throw new Error('flow lookup failed');
+      }
+
+      throw new Error(`Unexpected URL: ${String(url)}`);
+    });
+
+    const lookupFailureReport = await runProcessRefreshReferences({
+      outDir: path.join(tempDir, 'lookup-failure'),
+      env: buildSupabaseTestEnv({
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
+      }),
+      fetchImpl: lookupFailureFetch,
+      maxRetries: 1,
+      validateProcessPayloadImpl: () => ({
+        ok: true,
+        validator: 'test-validator',
+        issue_count: 0,
+        issues: [],
+      }),
+    });
+
+    const lookupFailureRows = readFileSync(
+      lookupFailureReport.files.validation_blockers_jsonl,
+      'utf8',
+    )
+      .trim()
+      .split('\n')
+      .map(
+        (line) => JSON.parse(line) as { note: string; unresolved_refs: Array<{ reason: string }> },
+      );
+    assert.match(lookupFailureRows[0]?.note ?? '', /unresolved_refs=1/u);
+    assert.match(
+      lookupFailureRows[0]?.unresolved_refs?.[0]?.reason ?? '',
+      /reference refresh flows lookup failed after 1 attempt\(s\)\./u,
+    );
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('process refresh helper internals cover dataset parsing, manifests, report headers, and retries', async () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-refresh-helpers-'));
+
+  try {
+    assert.equal(__testInternals.parseContentRangeTotal(null), null);
+    assert.equal(__testInternals.parseContentRangeTotal('items 0-0/*'), null);
+    assert.equal(__testInternals.parseContentRangeTotal('items 0-4/5'), 5);
+
+    assert.equal(__testInternals.compareVersions('01.00.010', '01.00.002') > 0, true);
+    assert.equal(__testInternals.compareVersions('01.0', '01.00.000') < 0, true);
+
+    assert.deepEqual(__testInternals.getLangList('Flow name'), [
+      { '@xml:lang': 'en', '#text': 'Flow name' },
+    ]);
+    assert.deepEqual(
+      __testInternals.getLangList({
+        'common:langString': {
+          '@xml:lang': 'zh',
+          '#text': '流程名称',
+        },
+      }),
+      [{ '@xml:lang': 'zh', '#text': '流程名称' }],
+    );
+    assert.deepEqual(__testInternals.getLangList([{ '@xml:lang': 'en', '#text': 'ok' }, 'skip']), [
+      { '@xml:lang': 'en', '#text': 'ok' },
+    ]);
+    assert.equal(
+      __testInternals.getLangText(
+        [
+          { '@xml:lang': 'en', '#text': 'English' },
+          { '@xml:lang': 'zh', '#text': '中文' },
+        ],
+        'zh',
+      ),
+      '中文',
+    );
+    assert.equal(__testInternals.getLangText([{ '#text': 'Fallback' }], 'zh'), 'Fallback');
+
+    assert.deepEqual(
+      __testInternals.normalizeDatasetPayload('{"flowDataSet":{"ok":true}}', 'flow-1'),
+      { flowDataSet: { ok: true } },
+    );
+    assert.throws(
+      () => __testInternals.normalizeDatasetPayload('[1,2,3]', 'flow-2'),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_REFRESH_REMOTE_PAYLOAD_INVALID');
+        return true;
+      },
+    );
+    assert.throws(
+      () => __testInternals.normalizeDatasetPayload('{', 'flow-3'),
+      (error: unknown) => {
+        assert.equal(
+          (error as { code?: string }).code,
+          'PROCESS_REFRESH_REMOTE_PAYLOAD_INVALID_JSON',
+        );
+        return true;
+      },
+    );
+    assert.throws(
+      () => __testInternals.normalizeDatasetPayload(null, 'flow-4'),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_REFRESH_REMOTE_PAYLOAD_MISSING');
+        return true;
+      },
+    );
+
+    assert.deepEqual(
+      __testInternals.getShortDescription(buildFlowPayload('Flow name'), 'flow data set')[0],
+      {
+        '@xml:lang': 'en',
+        '#text': 'Flow name; hydration; at plant; kg',
+      },
+    );
+    assert.deepEqual(
+      __testInternals.getShortDescription(
+        buildProcessPayload('flow-1', '01.00.000', 'Short description'),
+        'process data set',
+      )[0],
+      {
+        '@xml:lang': 'en',
+        '#text': 'Draft process; draft route; draft mix; draft fu',
+      },
+    );
+    assert.deepEqual(
+      __testInternals.getShortDescription(
+        {
+          contactDataSet: {
+            contactInformation: {
+              dataSetInformation: {
+                'common:shortName': [lang('Contact short'), lang('联系人简称', 'zh')],
+              },
+            },
+          },
+        },
+        'contact data set',
+      )[0],
+      lang('Contact short'),
+    );
+    assert.deepEqual(
+      __testInternals.getShortDescription(
+        {
+          sourceDataSet: {
+            sourceInformation: {
+              dataSetInformation: {
+                'common:shortName': [lang('Source short')],
+              },
+            },
+          },
+        },
+        'source data set',
+      )[0],
+      lang('Source short'),
+    );
+    assert.deepEqual(
+      __testInternals.getShortDescription(
+        {
+          flowPropertyDataSet: {
+            flowPropertyInformation: {
+              dataSetInformation: {
+                'common:shortName': [lang('Mass')],
+              },
+            },
+          },
+        },
+        'flow property data set',
+      )[0],
+      lang('Mass'),
+    );
+    assert.deepEqual(
+      __testInternals.getShortDescription(
+        {
+          unitGroupDataSet: {
+            unitGroupInformation: {
+              dataSetInformation: {
+                'common:shortName': [lang('kilogram')],
+              },
+            },
+          },
+        },
+        'unit group data set',
+      )[0],
+      lang('kilogram'),
+    );
+    assert.deepEqual(
+      __testInternals.getShortDescription(
+        {
+          lciaMethodDataSet: {
+            LCIAMethodInformation: {
+              dataSetInformation: {
+                'common:shortName': [lang('LCIA short')],
+              },
+            },
+          },
+        },
+        'LCIA method data set',
+      )[0],
+      lang('LCIA short'),
+    );
+    assert.deepEqual(__testInternals.getShortDescription({}, 'unknown type'), []);
+
+    assert.equal(
+      await __testInternals.parseJsonResponse(
+        makeJsonResponse({
+          body: 'plain response',
+          headers: { 'content-type': 'text/plain' },
+        }),
+        'plain-response',
+      ),
+      'plain response',
+    );
+    assert.equal(
+      await __testInternals.parseJsonResponse(
+        makeJsonResponse({
+          body: '   ',
+          headers: { 'content-type': 'application/json' },
+        }),
+        'blank-response',
+      ),
+      null,
+    );
+    await assert.rejects(
+      () =>
+        __testInternals.parseJsonResponse(
+          makeJsonResponse({
+            body: '{',
+            headers: { 'content-type': 'application/json' },
+          }),
+          'invalid-json-response',
+        ),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_REFRESH_REMOTE_INVALID_JSON');
+        return true;
+      },
+    );
+
+    const originalSetTimeout = globalThis.setTimeout;
+    globalThis.setTimeout = ((callback: (...args: unknown[]) => void) => {
+      callback();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
+
+    try {
+      let retryAttempts = 0;
+      const retryResult = await __testInternals.fetchJsonWithRetry({
+        url: 'https://example.test/retry',
+        init: { method: 'GET' },
+        label: 'retry lookup',
+        fetchImpl: async () => {
+          retryAttempts += 1;
+          if (retryAttempts === 1) {
+            throw new Error('transient network error');
+          }
+          return makeJsonResponse({
+            body: { ok: true },
+            headers: {
+              'content-type': 'application/json',
+              'content-range': '0-0/1',
+            },
+          });
+        },
+        timeoutMs: 10,
+        maxRetries: 2,
+      });
+      assert.equal(retryAttempts, 2);
+      assert.equal(retryResult.status, 200);
+      assert.deepEqual(retryResult.body, { ok: true });
+      assert.equal(retryResult.headers.get('content-range'), '0-0/1');
+
+      await assert.rejects(
+        () =>
+          __testInternals.fetchJsonWithRetry({
+            url: 'https://example.test/http-error',
+            init: { method: 'GET' },
+            label: 'http-error lookup',
+            fetchImpl: async () =>
+              makeJsonResponse({
+                ok: false,
+                status: 500,
+                body: { error: 'failed' },
+              }),
+            timeoutMs: 10,
+            maxRetries: 1,
+          }),
+        (error: unknown) => {
+          assert.equal((error as { code?: string }).code, 'PROCESS_REFRESH_REMOTE_REQUEST_FAILED');
+          return true;
+        },
+      );
+
+      await assert.rejects(
+        () =>
+          __testInternals.fetchJsonWithRetry({
+            url: 'https://example.test/network-error',
+            init: { method: 'GET' },
+            label: 'network-error lookup',
+            fetchImpl: async () => {
+              throw new Error('network down');
+            },
+            timeoutMs: 10,
+            maxRetries: 1,
+          }),
+        (error: unknown) => {
+          const cliError = error as { code?: string; details?: unknown };
+          assert.equal(cliError.code, 'PROCESS_REFRESH_REMOTE_REQUEST_FAILED');
+          assert.match(String(cliError.details), /network down/u);
+          return true;
+        },
+      );
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+
+    const refCache = new Map([
+      [
+        'flows:cached-flow',
+        {
+          row: null,
+          count: 0,
+        },
+      ],
+    ]);
+    await __testInternals.fetchLatestRefs({
+      projectBaseUrl: 'https://example.test',
+      publishableKey: 'publishable',
+      accessToken: 'token',
+      refs: [
+        {
+          node: {
+            '@type': 'flow data set',
+            '@refObjectId': 'cached-flow',
+            '@version': '01.00.000',
+          },
+          path: 'cached',
+        },
+        {
+          node: {
+            '@type': 'flow data set',
+            '@refObjectId': 'flow-1',
+            '@version': '01.00.000',
+          },
+          path: 'fresh',
+        },
+        {
+          node: {
+            '@type': 'unsupported data set',
+            '@refObjectId': 'skip-me',
+            '@version': '01.00.000',
+          },
+          path: 'unsupported',
+        },
+      ],
+      cache: refCache,
+      fetchImpl: async () =>
+        makeJsonResponse({
+          body: [
+            null,
+            {
+              id: 'flow-1',
+              version: '',
+              json: buildFlowPayload('Ignored invalid row'),
+            },
+            {
+              id: 'flow-1',
+              version: '01.00.002',
+              json: buildFlowPayload('Latest flow'),
+              modified_at: '2026-04-18T00:00:00.000Z',
+              state_code: 0,
+              user_id: 'user-1',
+              team_id: 'team-1',
+            },
+          ],
+        }),
+      timeoutMs: 10,
+      maxRetries: 1,
+    });
+    assert.equal(refCache.has('flows:cached-flow'), true);
+    const fetchedFlow = refCache.get('flows:flow-1') as
+      | { row: { version: string } | null }
+      | undefined;
+    assert.equal(fetchedFlow?.row?.version, '01.00.002');
+
+    const missingManifestPath = path.join(tempDir, 'missing.manifest.json');
+    assert.equal(__testInternals.readManifest(missingManifestPath), null);
+
+    const invalidManifestPath = path.join(tempDir, 'invalid.manifest.json');
+    writeFileSync(invalidManifestPath, '{"rows":[]}', 'utf8');
+    assert.throws(
+      () => __testInternals.readManifest(invalidManifestPath),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_REFRESH_MANIFEST_INVALID');
+        return true;
+      },
+    );
+
+    const manifestPath = path.join(tempDir, 'manifest.json');
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify(
+        {
+          rows: [
+            {
+              id: 'proc-1',
+              version: '01.00.001',
+              modified_at: '2026-04-18T00:00:00.000Z',
+              state_code: 0,
+              model_id: 'model-1',
+            },
+            {
+              id: '',
+              version: '01.00.001',
+            },
+          ],
+          user_id: 'user-1',
+          masked_user_email: 'us****@example.com',
+        },
+        null,
+        2,
+      )}\n`,
+      'utf8',
+    );
+    const manifest = __testInternals.readManifest(manifestPath);
+    assert.ok(manifest);
+    assert.equal(manifest?.rows.length, 1);
+    assert.equal(manifest?.count, 1);
+    assert.equal(manifest?.page_size, 500);
+
+    const progressPath = path.join(tempDir, 'progress.jsonl');
+    writeFileSync(
+      progressPath,
+      [
+        JSON.stringify({ key: 'proc-1:01.00.001', status: 'dry_run' }),
+        '{"broken":',
+        JSON.stringify({ key: 'proc-2:01.00.001', status: 'validation_blocked' }),
+        JSON.stringify({ key: 'proc-3:01.00.001', status: 'saved' }),
+      ].join('\n'),
+      'utf8',
+    );
+    assert.deepEqual(Array.from(__testInternals.readCompleted(progressPath, false)).sort(), [
+      'proc-1:01.00.001',
+      'proc-2:01.00.001',
+    ]);
+    assert.deepEqual(Array.from(__testInternals.readCompleted(progressPath, true)), [
+      'proc-2:01.00.001',
+      'proc-3:01.00.001',
+    ]);
+
+    const cyclicPayload = {
+      nested: [
+        {
+          referenceToFlowDataSet: {
+            '@type': 'flow data set',
+            '@refObjectId': 'flow-1',
+            '@version': '01.00.000',
+            'common:shortDescription': [lang('Old flow short')],
+          },
+        },
+        {
+          referenceToSourceDataSet: {
+            '@type': 'source data set',
+            '@refObjectId': 'source-1',
+            '@version': '01.00.000',
+          },
+        },
+      ],
+    } as {
+      nested: Array<Record<string, unknown>>;
+      self?: unknown;
+    };
+    cyclicPayload.self = cyclicPayload;
+
+    const refs = __testInternals.collectRefs(cyclicPayload);
+    assert.equal(refs.length, 2);
+    assert.equal(refs[0]?.path.includes('referenceToFlowDataSet'), true);
+
+    const update = __testInternals.updateProcessJson(
+      cyclicPayload,
+      refs,
+      new Map([
+        [
+          'flows:flow-1',
+          {
+            row: {
+              id: 'flow-1',
+              version: '01.00.002',
+              json: buildFlowPayload('Updated flow'),
+              modified_at: null,
+              state_code: 0,
+              user_id: null,
+              team_id: null,
+            },
+            count: 2,
+          },
+        ],
+        [
+          'sources:source-1',
+          {
+            row: null,
+            count: 0,
+            error: 'not accessible',
+          },
+        ],
+      ]),
+    );
+    assert.equal(update.version_updates, 1);
+    assert.equal(update.description_updates, 1);
+    assert.equal(update.touched_refs.length, 1);
+    assert.equal(update.unresolved_refs[0]?.reason, 'not accessible');
+
+    const reportPath = path.join(tempDir, 'report.md');
+    __testInternals.appendReportHeader(reportPath, {
+      mode: 'dry_run',
+      generatedAtUtc: '2026-04-18T00:00:00.000Z',
+      manifestCount: 2,
+    });
+    const initialReport = readFileSync(reportPath, 'utf8');
+    __testInternals.appendReportHeader(reportPath, {
+      mode: 'apply',
+      generatedAtUtc: '2026-04-18T01:00:00.000Z',
+      manifestCount: 3,
+    });
+    assert.equal(readFileSync(reportPath, 'utf8'), initialReport);
+    assert.match(initialReport, /TianGong Process Reference Refresh/u);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessRefreshReferences validates direct options and reports completed_with_errors', async () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-refresh-errors-'));
+
+  try {
+    await assert.rejects(
+      () => runProcessRefreshReferences({ outDir: '' }),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_REFRESH_OUT_DIR_REQUIRED');
+        return true;
+      },
+    );
+    await assert.rejects(
+      () => runProcessRefreshReferences({ outDir: tempDir, limit: 0 }),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_REFRESH_LIMIT_INVALID');
+        return true;
+      },
+    );
+    await assert.rejects(
+      () => runProcessRefreshReferences({ outDir: tempDir, pageSize: 0 }),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_REFRESH_PAGE_SIZE_INVALID');
+        return true;
+      },
+    );
+    await assert.rejects(
+      () => runProcessRefreshReferences({ outDir: tempDir, concurrency: 0 }),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_REFRESH_CONCURRENCY_INVALID');
+        return true;
+      },
+    );
+    await assert.rejects(
+      () => runProcessRefreshReferences({ outDir: tempDir, timeoutMs: 0 }),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_REFRESH_TIMEOUT_INVALID');
+        return true;
+      },
+    );
+    await assert.rejects(
+      () => runProcessRefreshReferences({ outDir: tempDir, maxRetries: 0 }),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_REFRESH_MAX_RETRIES_INVALID');
+        return true;
+      },
+    );
+
+    const fetchImpl = withSupabaseAuthBootstrap(async (url) => {
+      const parsed = new URL(String(url));
+
+      if (parsed.pathname === '/auth/v1/user') {
+        return makeJsonResponse({
+          body: { id: 'user-1' },
+        });
+      }
+
+      if (parsed.pathname === '/rest/v1/processes') {
+        const select = parsed.searchParams.get('select');
+        if (select === 'id,version,modified_at,state_code,model_id') {
+          return makeJsonResponse({
+            body: [
+              {
+                id: 'proc-error',
+                version: '01.00.001',
+                modified_at: '2026-04-18T00:00:00.000Z',
+                state_code: 0,
+                model_id: 'model-1',
+              },
+            ],
+            headers: {
+              'content-type': 'application/json',
+              'content-range': '0-0/1',
+            },
+          });
+        }
+
+        if (
+          select === 'id,version,json,modified_at,state_code,model_id,user_id' &&
+          parsed.searchParams.get('id') === 'eq.proc-error'
+        ) {
+          return makeJsonResponse({
+            body: [],
+          });
+        }
+      }
+
+      throw new Error(`Unexpected URL: ${String(url)}`);
+    });
+
+    const report = await runProcessRefreshReferences({
+      outDir: tempDir,
+      env: buildSupabaseTestEnv({
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
+      }),
+      fetchImpl,
+      validateProcessPayloadImpl: () => ({
+        ok: true,
+        validator: 'test-validator',
+        issue_count: 0,
+        issues: [],
+      }),
+    });
+
+    assert.equal(report.status, 'completed_process_reference_refresh_with_errors');
+    assert.equal(report.counts.errors, 1);
+    const errorRows = readFileSync(report.files.errors_jsonl, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as { status: string; error: string });
+    assert.equal(errorRows[0]?.status, 'error');
+    assert.match(errorRows[0]?.error ?? '', /Process not found/u);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('process refresh helper internals cover null name generators, manifest validation, and progress row filtering', () => {
+  assert.equal(__testInternals.genFlowName(null, 'en'), '');
+  assert.deepEqual(__testInternals.genFlowNameJson(null), []);
+  assert.deepEqual(__testInternals.genFlowNameJson({}), []);
+  assert.equal(__testInternals.genProcessName(null, 'en'), '');
+  assert.deepEqual(__testInternals.genProcessNameJson(null), []);
+  assert.deepEqual(__testInternals.genProcessNameJson({}), []);
+
+  assert.deepEqual(__testInternals.getLangList(null), []);
+  assert.deepEqual(
+    __testInternals.getLangList({
+      'common:langString': [{ '@xml:lang': 'en', '#text': 'Flow name' }, null],
+    }),
+    [{ '@xml:lang': 'en', '#text': 'Flow name' }],
+  );
+  assert.deepEqual(
+    __testInternals.getLangList({
+      'common:langString': {
+        '@xml:lang': 'zh',
+        '#text': '流程名',
+      },
+    }),
+    [{ '@xml:lang': 'zh', '#text': '流程名' }],
+  );
+  assert.deepEqual(__testInternals.getLangList({ '#text': 'Fallback short name' }), [
+    { '#text': 'Fallback short name' },
+  ]);
+
+  assert.equal(__testInternals.normalizeManifestRow(null), null);
+  assert.deepEqual(__testInternals.getShortDescription({ flowDataSet: {} }, 'flow data set'), []);
+  assert.deepEqual(
+    __testInternals.getShortDescription({ processDataSet: {} }, 'process data set'),
+    [],
+  );
+  assert.deepEqual(
+    __testInternals.getShortDescription({ contactDataSet: {} }, 'contact data set'),
+    [],
+  );
+  assert.deepEqual(
+    __testInternals.getShortDescription({ sourceDataSet: {} }, 'source data set'),
+    [],
+  );
+  assert.deepEqual(
+    __testInternals.getShortDescription({ flowPropertyDataSet: {} }, 'flow property data set'),
+    [],
+  );
+  assert.deepEqual(__testInternals.getShortDescription({}, 'flow property data set'), []);
+  assert.deepEqual(
+    __testInternals.getShortDescription({ unitGroupDataSet: {} }, 'unit group data set'),
+    [],
+  );
+  assert.deepEqual(
+    __testInternals.getShortDescription({ lciaMethodDataSet: {} }, 'LCIA method data set'),
+    [],
+  );
+
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-refresh-helper-'));
+  try {
+    const missingRowsPath = path.join(tempDir, 'missing-rows.manifest.json');
+    writeFileSync(missingRowsPath, '{}\n', 'utf8');
+    assert.throws(
+      () => __testInternals.readManifest(missingRowsPath),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_REFRESH_MANIFEST_INVALID');
+        return true;
+      },
+    );
+
+    const explicitManifestPath = path.join(tempDir, 'explicit.manifest.json');
+    writeFileSync(
+      explicitManifestPath,
+      `${JSON.stringify(
+        {
+          rows: [
+            null,
+            {
+              id: 'proc-1',
+              version: '01.00.001',
+              modified_at: '2026-04-18T00:00:00.000Z',
+              state_code: 0,
+              model_id: 'model-1',
+            },
+          ],
+          user_id: 'user-1',
+          masked_user_email: 'us****@example.com',
+          page_size: 12,
+          count: 34,
+        },
+        null,
+        2,
+      )}\n`,
+      'utf8',
+    );
+    const explicitManifest = __testInternals.readManifest(explicitManifestPath);
+    assert.ok(explicitManifest);
+    assert.equal(explicitManifest?.rows.length, 1);
+    assert.equal(explicitManifest?.page_size, 12);
+    assert.equal(explicitManifest?.count, 34);
+
+    const progressPath = path.join(tempDir, 'helper-progress.jsonl');
+    writeFileSync(
+      progressPath,
+      [
+        JSON.stringify('skip-me'),
+        JSON.stringify({ key: 'proc-1:01.00.001', status: 'dry_run' }),
+        JSON.stringify({ key: 'proc-2:01.00.001', status: 'saved' }),
+      ].join('\n'),
+      'utf8',
+    );
+    assert.deepEqual(Array.from(__testInternals.readCompleted(progressPath, false)), [
+      'proc-1:01.00.001',
+    ]);
+    assert.deepEqual(Array.from(__testInternals.readCompleted(progressPath, true)), [
+      'proc-2:01.00.001',
+    ]);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('process refresh helper internals cover fallback branches and no-header responses', async () => {
+  assert.equal(__testInternals.compareVersions('01.00.001', '01') > 0, true);
+  assert.deepEqual(__testInternals.getLangList({ unexpected: true }), []);
+  assert.equal(__testInternals.getLangText([{ '@xml:lang': 'zh', '#text': '' }], 'en'), '');
+  assert.deepEqual(
+    __testInternals.genFlowNameJson({
+      baseName: ['raw'],
+    }),
+    [],
+  );
+  assert.deepEqual(
+    __testInternals.genFlowNameJson({
+      baseName: {
+        '@xml:lang': 'en',
+        '#text': 'Flow name',
+      },
+      treatmentStandardsRoutes: {
+        '@xml:lang': 'en',
+        '#text': 'hydration',
+      },
+      mixAndLocationTypes: {
+        '@xml:lang': 'en',
+        '#text': 'at plant',
+      },
+      flowProperties: {
+        '@xml:lang': 'en',
+        '#text': 'kg',
+      },
+    }),
+    [
+      {
+        '@xml:lang': 'en',
+        '#text': 'Flow name; hydration; at plant; kg',
+      },
+    ],
+  );
+  assert.deepEqual(
+    __testInternals.genProcessNameJson({
+      baseName: ['raw'],
+    }),
+    [],
+  );
+  assert.deepEqual(__testInternals.getShortDescription({ flowDataSet: '' }, 'flow data set'), []);
+  assert.deepEqual(
+    __testInternals.getShortDescription({ processDataSet: '' }, 'process data set'),
+    [],
+  );
+  assert.deepEqual(
+    __testInternals.getShortDescription({ contactDataSet: '' }, 'contact data set'),
+    [],
+  );
+  assert.deepEqual(
+    __testInternals.getShortDescription({ sourceDataSet: '' }, 'source data set'),
+    [],
+  );
+  assert.deepEqual(
+    __testInternals.getShortDescription({ flowPropertyDataSet: '' }, 'flow property data set'),
+    [],
+  );
+  assert.deepEqual(
+    __testInternals.getShortDescription({ unitGroupDataSet: '' }, 'unit group data set'),
+    [],
+  );
+  assert.deepEqual(
+    __testInternals.getShortDescription({ lciaMethodDataSet: '' }, 'LCIA method data set'),
+    [],
+  );
+
+  const noHeaderResult = await __testInternals.fetchJsonWithRetry({
+    url: 'https://example.test/refresh-no-header',
+    init: { method: 'GET' },
+    label: 'refresh no header',
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      headers: {
+        get(): string | null {
+          return null;
+        },
+      },
+      async text(): Promise<string> {
+        return 'plain-text';
+      },
+    }),
+    timeoutMs: 10,
+    maxRetries: 1,
+  });
+  assert.equal(noHeaderResult.headers.get('content-type'), '');
+  assert.equal(noHeaderResult.headers.get('content-range'), '');
+  assert.equal(noHeaderResult.body, 'plain-text');
+
+  assert.deepEqual(
+    __testInternals.normalizeManifestRow({
+      id: 'proc-1',
+      version: '01.00.001',
+      modified_at: '',
+      state_code: 'draft',
+      model_id: '',
+    }),
+    {
+      id: 'proc-1',
+      version: '01.00.001',
+      modified_at: null,
+      state_code: null,
+      model_id: null,
+    },
+  );
+
+  const latestCache = new Map([
+    [
+      'flows:flow-1',
+      {
+        row: {
+          id: 'flow-1',
+          version: '01.00.002',
+          json: {},
+          modified_at: null,
+          state_code: null,
+          user_id: null,
+          team_id: null,
+        },
+        count: 1,
+      },
+    ],
+  ]);
+  const update = __testInternals.updateProcessJson(
+    {},
+    [
+      {
+        node: {
+          '@type': 'unsupported data set',
+          '@refObjectId': 'skip-me',
+          '@version': '01.00.000',
+        },
+        path: 'unsupported',
+      },
+      {
+        node: {
+          '@type': 'flow data set',
+          '@refObjectId': 'flow-1',
+          '@version': '01.00.002',
+        },
+        path: 'unchanged',
+      },
+    ],
+    latestCache,
+  );
+  assert.equal(update.version_updates, 0);
+  assert.equal(update.description_updates, 0);
+  assert.equal(update.touched_refs.length, 0);
+  assert.equal(update.unresolved_refs[0]?.reason, 'no accessible version');
+
+  const refCache = new Map();
+  await __testInternals.fetchLatestRefs({
+    projectBaseUrl: 'https://example.test',
+    publishableKey: 'publishable',
+    accessToken: 'token',
+    refs: [
+      {
+        node: {
+          '@type': 'flow data set',
+          '@refObjectId': 'flow-2',
+          '@version': '01.00.000',
+        },
+        path: 'flow',
+      },
+    ],
+    cache: refCache,
+    fetchImpl: async () =>
+      makeJsonResponse({
+        body: {
+          unexpected: true,
+        },
+      }),
+    timeoutMs: 10,
+    maxRetries: 1,
+  });
+  assert.deepEqual(refCache.get('flows:flow-2'), {
+    row: null,
+    count: 0,
+  });
+});
+
+test('runProcessRefreshReferences covers missing current user ids, duplicate manifests, and empty snapshot pages', async () => {
+  const missingUserDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-refresh-no-user-'));
+  try {
+    await assert.rejects(
+      () =>
+        runProcessRefreshReferences({
+          outDir: missingUserDir,
+          env: buildSupabaseTestEnv({
+            TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
+          }),
+          fetchImpl: withSupabaseAuthBootstrap(async (url) => {
+            const parsed = new URL(String(url));
+            if (parsed.pathname === '/auth/v1/user') {
+              return makeJsonResponse({
+                body: {},
+              });
+            }
+            throw new Error(`Unexpected URL: ${String(url)}`);
+          }),
+          maxRetries: 1,
+        }),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_REFRESH_CURRENT_USER_ID_MISSING');
+        return true;
+      },
+    );
+  } finally {
+    rmSync(missingUserDir, { recursive: true, force: true });
+  }
+
+  const dedupeDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-refresh-dedupe-'));
+  try {
+    const dedupeFetch = withSupabaseAuthBootstrap(async (url) => {
+      const parsed = new URL(String(url));
+      if (parsed.pathname === '/auth/v1/user') {
+        return makeJsonResponse({
+          body: { id: 'user-1' },
+        });
+      }
+      if (parsed.pathname === '/rest/v1/processes') {
+        const select = parsed.searchParams.get('select');
+        if (select === 'id,version,modified_at,state_code,model_id') {
+          return makeJsonResponse({
+            body: [
+              {
+                id: 'proc-draft',
+                version: '01.00.001',
+                modified_at: '2026-04-18T00:00:00.000Z',
+                state_code: 0,
+                model_id: 'model-1',
+              },
+              {
+                id: 'proc-draft',
+                version: '01.00.001',
+                modified_at: '2026-04-18T00:00:00.000Z',
+                state_code: 0,
+                model_id: 'model-1',
+              },
+            ],
+            headers: {
+              'content-type': 'application/json',
+              'content-range': '0-1/2',
+            },
+          });
+        }
+        if (
+          select === 'id,version,json,modified_at,state_code,model_id,user_id' &&
+          parsed.searchParams.get('id') === 'eq.proc-draft'
+        ) {
+          return makeJsonResponse({
+            body: [
+              {
+                id: 'proc-draft',
+                version: '01.00.001',
+                modified_at: '2026-04-18T00:00:00.000Z',
+                state_code: 0,
+                model_id: 'model-1',
+                user_id: 'user-1',
+                json: buildProcessPayload('flow-1', '01.00.000', 'Old flow short'),
+              },
+            ],
+          });
+        }
+      }
+      if (parsed.pathname === '/rest/v1/flows') {
+        return makeJsonResponse({
+          body: [
+            {
+              id: 'flow-1',
+              version: '01.00.002',
+              json: buildFlowPayload('Updated flow'),
+            },
+          ],
+        });
+      }
+      throw new Error(`Unexpected URL: ${String(url)}`);
+    });
+
+    const dedupeReport = await runProcessRefreshReferences({
+      outDir: dedupeDir,
+      env: buildSupabaseTestEnv({
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
+      }),
+      fetchImpl: dedupeFetch,
+      validateProcessPayloadImpl: () => ({
+        ok: true,
+        validator: 'test-validator',
+        issue_count: 0,
+        issues: [],
+      }),
+    });
+
+    assert.equal(dedupeReport.counts.manifest, 1);
+    assert.equal(dedupeReport.counts.selected, 1);
+    assert.equal(dedupeReport.counts.pending, 1);
+  } finally {
+    rmSync(dedupeDir, { recursive: true, force: true });
+  }
+
+  const emptySnapshotDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-refresh-empty-'));
+  try {
+    const emptySnapshotReport = await runProcessRefreshReferences({
+      outDir: emptySnapshotDir,
+      env: buildSupabaseTestEnv({
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
+      }),
+      fetchImpl: withSupabaseAuthBootstrap(async (url) => {
+        const parsed = new URL(String(url));
+        if (parsed.pathname === '/auth/v1/user') {
+          return makeJsonResponse({
+            body: { id: 'user-1' },
+          });
+        }
+        if (parsed.pathname === '/rest/v1/processes') {
+          return makeJsonResponse({
+            body: [{ id: '', version: '01.00.001' }],
+            headers: {
+              'content-type': 'application/json',
+              'content-range': '0-0/1',
+            },
+          });
+        }
+        throw new Error(`Unexpected URL: ${String(url)}`);
+      }),
+      validateProcessPayloadImpl: () => ({
+        ok: true,
+        validator: 'test-validator',
+        issue_count: 0,
+        issues: [],
+      }),
+    });
+
+    assert.equal(emptySnapshotReport.status, 'completed_process_reference_refresh');
+    assert.deepEqual(emptySnapshotReport.counts, {
+      manifest: 0,
+      selected: 0,
+      already_completed: 0,
+      pending: 0,
+      saved: 0,
+      dry_run: 0,
+      skipped: 0,
+      validation_blocked: 0,
+      errors: 0,
+    });
+  } finally {
+    rmSync(emptySnapshotDir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessRefreshReferences covers runtime defaults, reused manifests, and fallback detail fields', async () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-refresh-runtime-defaults-'));
+  const manifestPath = path.join(tempDir, 'inputs', 'processes.manifest.json');
+  const envPatch = buildSupabaseTestEnv({
+    TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
+  });
+  const envBackup = new Map(Object.keys(envPatch).map((key) => [key, process.env[key]]));
+  const originalFetch = globalThis.fetch;
+
+  try {
+    mkdirSync(path.join(tempDir, 'inputs'), { recursive: true });
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify(
+        {
+          rows: [
+            {
+              id: 'proc-default',
+              version: '01.00.001',
+              modified_at: '2026-04-18T00:00:00.000Z',
+              state_code: 0,
+              model_id: null,
+            },
+          ],
+          user_id: 'user-1',
+          masked_user_email: 'us****@example.com',
+        },
+        null,
+        2,
+      )}\n`,
+      'utf8',
+    );
+
+    Object.assign(process.env, envPatch);
+    globalThis.fetch = (async (input) => {
+      const url = String(input);
+      const parsed = new URL(url);
+
+      if (isSupabaseAuthTokenUrl(url)) {
+        return makeSupabaseAuthResponse({
+          userId: 'user-1',
+        });
+      }
+
+      if (parsed.pathname === '/auth/v1/user') {
+        return makeJsonResponse({
+          body: { id: 'user-1' },
+        });
+      }
+
+      if (
+        parsed.pathname === '/rest/v1/processes' &&
+        parsed.searchParams.get('select') ===
+          'id,version,json,modified_at,state_code,model_id,user_id' &&
+        parsed.searchParams.get('id') === 'eq.proc-default'
+      ) {
+        return makeJsonResponse({
+          body: [
+            {
+              json: buildProcessPayload('flow-1', '01.00.002', 'Old flow short'),
+            },
+          ],
+        });
+      }
+
+      if (parsed.pathname === '/rest/v1/flows') {
+        return makeJsonResponse({
+          body: [
+            {
+              id: 'flow-1',
+              version: '01.00.002',
+              json: buildFlowPayload('Updated flow'),
+            },
+          ],
+        });
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
+    }) as typeof fetch;
+
+    const report = await runProcessRefreshReferences({
+      outDir: tempDir,
+      reuseManifest: true,
+      timeoutMs: 10,
+      maxRetries: 1,
+      validateProcessPayloadImpl: () => ({
+        ok: true,
+        validator: 'test-validator',
+        issue_count: 0,
+        issues: [],
+      }),
+    });
+
+    assert.equal(report.status, 'completed_process_reference_refresh');
+    assert.equal(report.counts.manifest, 1);
+    assert.equal(report.counts.pending, 1);
+    assert.equal(report.counts.dry_run, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    for (const [key, value] of envBackup) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessRefreshReferences covers non-array auth, snapshot, and detail responses plus string failures', async () => {
+  const missingUserDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-refresh-no-user-array-'),
+  );
+  try {
+    await assert.rejects(
+      () =>
+        runProcessRefreshReferences({
+          outDir: missingUserDir,
+          env: buildSupabaseTestEnv({
+            TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
+          }),
+          fetchImpl: withSupabaseAuthBootstrap(async (url) => {
+            const parsed = new URL(String(url));
+            if (parsed.pathname === '/auth/v1/user') {
+              return makeJsonResponse({
+                body: [],
+              });
+            }
+            throw new Error(`Unexpected URL: ${String(url)}`);
+          }),
+          maxRetries: 1,
+        }),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_REFRESH_CURRENT_USER_ID_MISSING');
+        return true;
+      },
+    );
+  } finally {
+    rmSync(missingUserDir, { recursive: true, force: true });
+  }
+
+  const emptySnapshotDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-refresh-empty-object-snapshot-'),
+  );
+  try {
+    const report = await runProcessRefreshReferences({
+      outDir: emptySnapshotDir,
+      env: buildSupabaseTestEnv({
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
+      }),
+      fetchImpl: withSupabaseAuthBootstrap(async (url) => {
+        const parsed = new URL(String(url));
+        if (parsed.pathname === '/auth/v1/user') {
+          return makeJsonResponse({
+            body: { id: 'user-1' },
+          });
+        }
+        if (parsed.pathname === '/rest/v1/processes') {
+          return makeJsonResponse({
+            body: {
+              unexpected: true,
+            },
+            headers: {
+              'content-type': 'application/json',
+            },
+          });
+        }
+        throw new Error(`Unexpected URL: ${String(url)}`);
+      }),
+      validateProcessPayloadImpl: () => ({
+        ok: true,
+        validator: 'test-validator',
+        issue_count: 0,
+        issues: [],
+      }),
+    });
+
+    assert.equal(report.counts.manifest, 0);
+    assert.equal(report.counts.pending, 0);
+  } finally {
+    rmSync(emptySnapshotDir, { recursive: true, force: true });
+  }
+
+  const detailObjectDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-refresh-detail-object-'),
+  );
+  try {
+    const report = await runProcessRefreshReferences({
+      outDir: detailObjectDir,
+      env: buildSupabaseTestEnv({
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
+      }),
+      fetchImpl: withSupabaseAuthBootstrap(async (url) => {
+        const parsed = new URL(String(url));
+        if (parsed.pathname === '/auth/v1/user') {
+          return makeJsonResponse({
+            body: { id: 'user-1' },
+          });
+        }
+        if (parsed.pathname === '/rest/v1/processes') {
+          const select = parsed.searchParams.get('select');
+          if (select === 'id,version,modified_at,state_code,model_id') {
+            return makeJsonResponse({
+              body: [
+                {
+                  id: 'proc-error',
+                  version: '01.00.001',
+                  modified_at: '2026-04-18T00:00:00.000Z',
+                  state_code: 0,
+                  model_id: 'model-1',
+                },
+              ],
+              headers: {
+                'content-type': 'application/json',
+                'content-range': '0-0/1',
+              },
+            });
+          }
+          if (
+            select === 'id,version,json,modified_at,state_code,model_id,user_id' &&
+            parsed.searchParams.get('id') === 'eq.proc-error'
+          ) {
+            return makeJsonResponse({
+              body: {
+                unexpected: true,
+              },
+            });
+          }
+        }
+        throw new Error(`Unexpected URL: ${String(url)}`);
+      }),
+      validateProcessPayloadImpl: () => ({
+        ok: true,
+        validator: 'test-validator',
+        issue_count: 0,
+        issues: [],
+      }),
+    });
+
+    assert.equal(report.status, 'completed_process_reference_refresh_with_errors');
+    assert.equal(report.counts.errors, 1);
+  } finally {
+    rmSync(detailObjectDir, { recursive: true, force: true });
+  }
+
+  const stringFailureDir = mkdtempSync(
+    path.join(os.tmpdir(), 'tg-cli-process-refresh-string-failure-'),
+  );
+  try {
+    const report = await runProcessRefreshReferences({
+      outDir: stringFailureDir,
+      env: buildSupabaseTestEnv({
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
+      }),
+      fetchImpl: withSupabaseAuthBootstrap(async (url) => {
+        const parsed = new URL(String(url));
+        if (parsed.pathname === '/auth/v1/user') {
+          return makeJsonResponse({
+            body: { id: 'user-1' },
+          });
+        }
+        if (parsed.pathname === '/rest/v1/processes') {
+          const select = parsed.searchParams.get('select');
+          if (select === 'id,version,modified_at,state_code,model_id') {
+            return makeJsonResponse({
+              body: [
+                {
+                  id: 'proc-string',
+                  version: '01.00.001',
+                  modified_at: '2026-04-18T00:00:00.000Z',
+                  state_code: 0,
+                  model_id: 'model-1',
+                },
+              ],
+              headers: {
+                'content-type': 'application/json',
+                'content-range': '0-0/1',
+              },
+            });
+          }
+          if (
+            select === 'id,version,json,modified_at,state_code,model_id,user_id' &&
+            parsed.searchParams.get('id') === 'eq.proc-string'
+          ) {
+            return makeJsonResponse({
+              body: [
+                {
+                  id: 'proc-string',
+                  version: '01.00.001',
+                  modified_at: '2026-04-18T00:00:00.000Z',
+                  state_code: 0,
+                  model_id: 'model-1',
+                  user_id: 'user-1',
+                  json: buildProcessPayload('flow-1', '01.00.000', 'Old flow short'),
+                },
+              ],
+            });
+          }
+        }
+        if (parsed.pathname === '/rest/v1/flows') {
+          return makeJsonResponse({
+            body: [
+              {
+                id: 'flow-1',
+                version: '01.00.002',
+                json: buildFlowPayload('Updated flow'),
+              },
+            ],
+          });
+        }
+        throw new Error(`Unexpected URL: ${String(url)}`);
+      }),
+      validateProcessPayloadImpl: () => {
+        throw 'string failure';
+      },
+    });
+
+    assert.equal(report.counts.errors, 1);
+    const errorRows = readFileSync(report.files.errors_jsonl, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as { error: string });
+    assert.equal(errorRows[0]?.error, 'string failure');
+  } finally {
+    rmSync(stringFailureDir, { recursive: true, force: true });
   }
 });

--- a/test/process-refresh-references.test.ts
+++ b/test/process-refresh-references.test.ts
@@ -1,0 +1,345 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { runProcessRefreshReferences } from '../src/lib/process-refresh-references.js';
+import type { FetchLike } from '../src/lib/http.js';
+import {
+  buildSupabaseTestEnv,
+  isSupabaseAuthTokenUrl,
+  makeSupabaseAuthResponse,
+} from './helpers/supabase-auth.js';
+
+function lang(text: string, langCode = 'en') {
+  return { '@xml:lang': langCode, '#text': text };
+}
+
+function makeJsonResponse(options: {
+  ok?: boolean;
+  status?: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+}) {
+  return {
+    ok: options.ok ?? true,
+    status: options.status ?? 200,
+    headers: {
+      get(name: string): string | null {
+        const key = name.toLowerCase();
+        if (options.headers && key in options.headers) {
+          return options.headers[key] ?? null;
+        }
+        return key === 'content-type' ? 'application/json' : null;
+      },
+    },
+    async text(): Promise<string> {
+      if (typeof options.body === 'string') {
+        return options.body;
+      }
+      return JSON.stringify(options.body ?? null);
+    },
+  };
+}
+
+function withSupabaseAuthBootstrap(fetchImpl: FetchLike): FetchLike {
+  return async (url, init) => {
+    if (isSupabaseAuthTokenUrl(String(url))) {
+      return makeSupabaseAuthResponse({
+        userId: 'user-1',
+      });
+    }
+
+    return fetchImpl(String(url), init);
+  };
+}
+
+function buildProcessPayload(flowId: string, flowVersion: string, shortDescription: string) {
+  return {
+    processDataSet: {
+      processInformation: {
+        dataSetInformation: {
+          'common:UUID': 'proc-draft',
+          name: {
+            baseName: [lang('Draft process')],
+            treatmentStandardsRoutes: [lang('draft route')],
+            mixAndLocationTypes: [lang('draft mix')],
+            functionalUnitFlowProperties: [lang('draft fu')],
+          },
+        },
+      },
+      exchanges: {
+        exchange: [
+          {
+            referenceToFlowDataSet: {
+              '@type': 'flow data set',
+              '@refObjectId': flowId,
+              '@version': flowVersion,
+              'common:shortDescription': [lang(shortDescription)],
+            },
+          },
+        ],
+      },
+      administrativeInformation: {
+        publicationAndOwnership: {
+          'common:dataSetVersion': '01.00.001',
+        },
+      },
+    },
+  };
+}
+
+function buildFlowPayload(baseName: string) {
+  return {
+    flowDataSet: {
+      flowInformation: {
+        dataSetInformation: {
+          name: {
+            baseName: [lang(baseName)],
+            treatmentStandardsRoutes: [lang('hydration')],
+            mixAndLocationTypes: [lang('at plant')],
+            flowProperties: [lang('kg')],
+          },
+        },
+      },
+    },
+  };
+}
+
+test('runProcessRefreshReferences dry-run refreshes reachable refs and skips public rows', async () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-refresh-'));
+  try {
+    const fetchImpl = withSupabaseAuthBootstrap(async (url) => {
+      const parsed = new URL(String(url));
+
+      if (parsed.pathname === '/auth/v1/user') {
+        return makeJsonResponse({
+          body: { id: 'user-1' },
+        });
+      }
+
+      if (parsed.pathname === '/rest/v1/processes') {
+        const select = parsed.searchParams.get('select');
+        if (select === 'id,version,modified_at,state_code,model_id') {
+          return makeJsonResponse({
+            body: [
+              {
+                id: 'proc-draft',
+                version: '01.00.001',
+                modified_at: '2026-04-18T00:00:00.000Z',
+                state_code: 0,
+                model_id: 'model-1',
+              },
+              {
+                id: 'proc-public',
+                version: '01.00.001',
+                modified_at: '2026-04-17T00:00:00.000Z',
+                state_code: 100,
+                model_id: null,
+              },
+            ],
+            headers: {
+              'content-type': 'application/json',
+              'content-range': '0-1/2',
+            },
+          });
+        }
+
+        if (
+          select === 'id,version,json,modified_at,state_code,model_id,user_id' &&
+          parsed.searchParams.get('id') === 'eq.proc-draft'
+        ) {
+          return makeJsonResponse({
+            body: [
+              {
+                id: 'proc-draft',
+                version: '01.00.001',
+                modified_at: '2026-04-18T00:00:00.000Z',
+                state_code: 0,
+                model_id: 'model-1',
+                user_id: 'user-1',
+                json: buildProcessPayload('flow-1', '01.00.000', 'Old flow short'),
+              },
+            ],
+          });
+        }
+      }
+
+      if (parsed.pathname === '/rest/v1/flows') {
+        return makeJsonResponse({
+          body: [
+            {
+              id: 'flow-1',
+              version: '01.00.000',
+              json: buildFlowPayload('Old flow'),
+            },
+            {
+              id: 'flow-1',
+              version: '01.00.002',
+              json: buildFlowPayload('Updated flow'),
+            },
+          ],
+        });
+      }
+
+      throw new Error(`Unexpected URL: ${String(url)}`);
+    });
+
+    const report = await runProcessRefreshReferences({
+      outDir: tempDir,
+      env: buildSupabaseTestEnv({
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
+      }),
+      fetchImpl,
+      validateProcessPayloadImpl: () => ({
+        ok: true,
+        validator: 'test-validator',
+        issue_count: 0,
+        issues: [],
+      }),
+    });
+
+    assert.equal(report.status, 'completed_process_reference_refresh');
+    assert.equal(report.mode, 'dry_run');
+    assert.equal(report.masked_user_email, 'us****@example.com');
+    assert.deepEqual(report.counts, {
+      manifest: 2,
+      selected: 2,
+      already_completed: 0,
+      pending: 2,
+      saved: 0,
+      dry_run: 1,
+      skipped: 1,
+      validation_blocked: 0,
+      errors: 0,
+    });
+
+    const progressRows = readFileSync(report.files.progress_jsonl, 'utf8')
+      .trim()
+      .split('\n')
+      .map(
+        (line) =>
+          JSON.parse(line) as { status: string; touched_refs?: Array<{ to_version: string }> },
+      );
+    assert.equal(progressRows.length, 2);
+    const dryRunRow = progressRows.find((row) => row.status === 'dry_run');
+    assert.ok(dryRunRow);
+    assert.equal(dryRunRow?.touched_refs?.[0]?.to_version, '01.00.002');
+    const skippedRow = progressRows.find((row) => row.status === 'skipped');
+    assert.ok(skippedRow);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessRefreshReferences blocks unresolved refs before invoking writes', async () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-refresh-blocked-'));
+  let writes = 0;
+
+  try {
+    const fetchImpl = withSupabaseAuthBootstrap(async (url) => {
+      const parsed = new URL(String(url));
+
+      if (parsed.pathname === '/auth/v1/user') {
+        return makeJsonResponse({
+          body: { id: 'user-1' },
+        });
+      }
+
+      if (parsed.pathname === '/rest/v1/processes') {
+        const select = parsed.searchParams.get('select');
+        if (select === 'id,version,modified_at,state_code,model_id') {
+          return makeJsonResponse({
+            body: [
+              {
+                id: 'proc-draft',
+                version: '01.00.001',
+                modified_at: '2026-04-18T00:00:00.000Z',
+                state_code: 0,
+                model_id: 'model-1',
+              },
+            ],
+            headers: {
+              'content-type': 'application/json',
+              'content-range': '0-0/1',
+            },
+          });
+        }
+
+        if (
+          select === 'id,version,json,modified_at,state_code,model_id,user_id' &&
+          parsed.searchParams.get('id') === 'eq.proc-draft'
+        ) {
+          return makeJsonResponse({
+            body: [
+              {
+                id: 'proc-draft',
+                version: '01.00.001',
+                modified_at: '2026-04-18T00:00:00.000Z',
+                state_code: 0,
+                model_id: 'model-1',
+                user_id: 'user-1',
+                json: buildProcessPayload('flow-missing', '01.00.000', 'Missing flow'),
+              },
+            ],
+          });
+        }
+      }
+
+      if (parsed.pathname === '/rest/v1/flows') {
+        return makeJsonResponse({
+          body: [],
+        });
+      }
+
+      throw new Error(`Unexpected URL: ${String(url)}`);
+    });
+
+    const report = await runProcessRefreshReferences({
+      outDir: tempDir,
+      apply: true,
+      env: buildSupabaseTestEnv({
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
+      }),
+      fetchImpl,
+      validateProcessPayloadImpl: () => ({
+        ok: true,
+        validator: 'test-validator',
+        issue_count: 0,
+        issues: [],
+      }),
+      syncStateAwareProcessRecordImpl: async () => {
+        writes += 1;
+        return {
+          status: 'success',
+          operation: 'save_draft',
+          write_path: 'cmd_dataset_save_draft',
+          rpc_result: { ok: true },
+          visible_row: {
+            id: 'proc-draft',
+            version: '01.00.001',
+            user_id: 'user-1',
+            state_code: 0,
+          },
+        };
+      },
+    });
+
+    assert.equal(report.status, 'completed_process_reference_refresh');
+    assert.equal(report.mode, 'apply');
+    assert.equal(report.counts.saved, 0);
+    assert.equal(report.counts.validation_blocked, 1);
+    assert.equal(report.counts.errors, 0);
+    assert.equal(writes, 0);
+
+    const blockers = readFileSync(report.files.validation_blockers_jsonl, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as { status: string; unresolved_count: number });
+    assert.equal(blockers.length, 1);
+    assert.equal(blockers[0]?.status, 'validation_blocked');
+    assert.equal(blockers[0]?.unresolved_count, 1);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/process-save-draft-run.test.ts
+++ b/test/process-save-draft-run.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { CliError } from '../src/lib/errors.js';
+import type { ProcessPayloadValidationResult } from '../src/lib/process-payload-validation.js';
 import { runProcessSaveDraft } from '../src/lib/process-save-draft-run.js';
 import type { FetchLike } from '../src/lib/http.js';
 import {
@@ -12,13 +13,12 @@ import {
   makeSupabaseAuthResponse,
 } from './helpers/supabase-auth.js';
 
-const VALIDATION_OK = () =>
-  ({
-    ok: true,
-    validator: 'test-validator',
-    issue_count: 0,
-    issues: [],
-  }) as const;
+const VALIDATION_OK = (): ProcessPayloadValidationResult => ({
+  ok: true,
+  validator: 'test-validator',
+  issue_count: 0,
+  issues: [],
+});
 
 function writeJson(filePath: string, value: unknown): void {
   writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');

--- a/test/process-save-draft-run.test.ts
+++ b/test/process-save-draft-run.test.ts
@@ -12,6 +12,14 @@ import {
   makeSupabaseAuthResponse,
 } from './helpers/supabase-auth.js';
 
+const VALIDATION_OK = () =>
+  ({
+    ok: true,
+    validator: 'test-validator',
+    issue_count: 0,
+    issues: [],
+  }) as const;
+
 function writeJson(filePath: string, value: unknown): void {
   writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
 }
@@ -103,6 +111,7 @@ test('runProcessSaveDraft produces dry-run artifacts from a rows file', async ()
     const report = await runProcessSaveDraft({
       inputPath,
       now: new Date('2026-04-14T00:00:00.000Z'),
+      validateProcessPayloadImpl: VALIDATION_OK,
     });
 
     assert.equal(report.commit, false);
@@ -161,6 +170,7 @@ test('runProcessSaveDraft extracts processes from publish-request inputs', async
     const report = await runProcessSaveDraft({
       inputPath: requestPath,
       now: new Date('2026-04-14T00:10:00.000Z'),
+      validateProcessPayloadImpl: VALIDATION_OK,
     });
     const normalizedInput = readJson(report.files.normalized_input) as {
       inputs: {
@@ -231,6 +241,7 @@ test('runProcessSaveDraft executes state-aware save-draft writes on commit', asy
         });
       }),
       now: new Date('2026-04-14T00:20:00.000Z'),
+      validateProcessPayloadImpl: VALIDATION_OK,
     });
 
     assert.deepEqual(
@@ -295,6 +306,34 @@ test('runProcessSaveDraft records non-canonical payloads as failed entries', asy
   }
 });
 
+test('runProcessSaveDraft blocks schema-invalid canonical payloads before write planning', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-save-draft-schema-invalid-'));
+  const inputPath = path.join(dir, 'patched-processes.jsonl');
+
+  writeJsonl(inputPath, [makeCanonicalProcess('proc-schema-invalid')]);
+
+  try {
+    const report = await runProcessSaveDraft({
+      inputPath,
+      now: new Date('2026-04-14T00:35:00.000Z'),
+    });
+
+    assert.equal(report.status, 'completed_with_failures');
+    assert.deepEqual(report.counts, {
+      selected: 1,
+      prepared: 0,
+      executed: 0,
+      failed: 1,
+    });
+    assert.equal(report.processes[0]?.status, 'failed');
+    assert.match(report.processes[0]?.error?.message ?? '', /ProcessSchema validation failed/u);
+    assert.equal(report.processes[0]?.validation?.ok, false);
+    assert.equal(readJsonl(report.files.failures_jsonl).length, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('runProcessSaveDraft validates JSONL inputs before processing', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-save-draft-jsonl-errors-'));
   const missingPath = path.join(dir, 'missing.jsonl');
@@ -347,6 +386,7 @@ test('runProcessSaveDraft supports publish-request entry variants and validates 
         },
       },
       now: new Date('2026-04-14T00:40:00.000Z'),
+      validateProcessPayloadImpl: VALIDATION_OK,
     });
 
     assert.equal(report.input_kind, 'publish_request');
@@ -418,6 +458,7 @@ test('runProcessSaveDraft accepts single-row raw input and explicit output overr
       inputPath,
       rawInput: makeCanonicalProcess('proc-single-row'),
       now: new Date('2026-04-14T00:45:00.000Z'),
+      validateProcessPayloadImpl: VALIDATION_OK,
     });
 
     assert.equal(singleRowReport.input_kind, 'rows_file');
@@ -435,6 +476,7 @@ test('runProcessSaveDraft accepts single-row raw input and explicit output overr
       },
       outDir: explicitOutDir,
       now: new Date('2026-04-14T00:46:00.000Z'),
+      validateProcessPayloadImpl: VALIDATION_OK,
     });
 
     assert.equal(publishHintReport.input_kind, 'publish_request');
@@ -462,6 +504,7 @@ test('runProcessSaveDraft rejects invalid prepared rows and missing commit runti
         runProcessSaveDraft({
           inputPath,
           rawInput: [1],
+          validateProcessPayloadImpl: VALIDATION_OK,
         }),
       (error) => error instanceof CliError && error.code === 'PROCESS_SAVE_DRAFT_INVALID_ROW',
     );
@@ -472,6 +515,7 @@ test('runProcessSaveDraft rejects invalid prepared rows and missing commit runti
           inputPath,
           commit: true,
           rawInput: [makeCanonicalProcess('proc-runtime-check')],
+          validateProcessPayloadImpl: VALIDATION_OK,
         }),
       (error) => error instanceof CliError && error.code === 'PROCESS_SAVE_DRAFT_RUNTIME_REQUIRED',
     );
@@ -513,6 +557,7 @@ test('runProcessSaveDraft records execution failures and non-canonical extractio
         throw 'rpc exploded';
       }),
       now: new Date('2026-04-14T00:50:00.000Z'),
+      validateProcessPayloadImpl: VALIDATION_OK,
     });
 
     assert.equal(failureReport.status, 'completed_with_failures');
@@ -523,6 +568,7 @@ test('runProcessSaveDraft records execution failures and non-canonical extractio
       inputPath: path.join(dir, 'getter.json'),
       rawInput: [getterExplodes],
       now: new Date('2026-04-14T01:00:00.000Z'),
+      validateProcessPayloadImpl: VALIDATION_OK,
     });
 
     assert.equal(getterReport.status, 'completed_with_failures');

--- a/test/process-scope-statistics.test.ts
+++ b/test/process-scope-statistics.test.ts
@@ -1,0 +1,294 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runProcessScopeStatistics } from '../src/lib/process-scope-statistics.js';
+import type { FetchLike } from '../src/lib/http.js';
+import {
+  buildSupabaseTestEnv,
+  isSupabaseAuthTokenUrl,
+  makeSupabaseAuthResponse,
+} from './helpers/supabase-auth.js';
+
+type JsonRecord = Record<string, unknown>;
+
+function jsonResponse(payload: unknown, headers: Record<string, string> = {}) {
+  return {
+    ok: true,
+    status: 200,
+    headers: {
+      get(name: string): string | null {
+        return (
+          headers[name.toLowerCase()] ??
+          (name.toLowerCase() === 'content-type' ? 'application/json' : null)
+        );
+      },
+    },
+    text: async () => JSON.stringify(payload),
+  };
+}
+
+function langEntries(en: string, zh: string): JsonRecord[] {
+  return [
+    { '@xml:lang': 'en', '#text': en },
+    { '@xml:lang': 'zh', '#text': zh },
+  ];
+}
+
+function createProcessPayload(options: {
+  primaryDomain: string;
+  leafDomain: string;
+  route?: string;
+  routeZh?: string;
+  technology: string;
+  technologyZh: string;
+  typeOfDataSet: string;
+  referenceFlowId: string;
+  referenceFlowVersion?: string;
+  referenceFlowLabelEn: string;
+  referenceFlowLabelZh: string;
+  baseNameEn: string;
+  baseNameZh: string;
+}): JsonRecord {
+  return {
+    processDataSet: {
+      processInformation: {
+        dataSetInformation: {
+          name: {
+            baseName: langEntries(options.baseNameEn, options.baseNameZh),
+            treatmentStandardsRoutes: options.route
+              ? langEntries(options.route, options.routeZh ?? options.route)
+              : '',
+          },
+          classificationInformation: {
+            'common:classification': {
+              'common:class': [
+                {
+                  '@level': '1',
+                  '#text': options.primaryDomain,
+                },
+                {
+                  '@level': '2',
+                  '#text': options.leafDomain,
+                },
+              ],
+            },
+          },
+        },
+        technology: {
+          technologyDescriptionAndIncludedProcesses: langEntries(
+            options.technology,
+            options.technologyZh,
+          ),
+        },
+        quantitativeReference: {
+          referenceToReferenceFlow: '1',
+        },
+      },
+      modellingAndValidation: {
+        LCIMethodAndAllocation: {
+          typeOfDataSet: options.typeOfDataSet,
+        },
+      },
+      exchanges: {
+        exchange: [
+          {
+            '@dataSetInternalID': '1',
+            exchangeDirection: 'Output',
+            meanAmount: '1',
+            resultingAmount: '1',
+            referenceToFlowDataSet: {
+              '@refObjectId': options.referenceFlowId,
+              '@version': options.referenceFlowVersion ?? '01.00.000',
+              'common:shortDescription': langEntries(
+                options.referenceFlowLabelEn,
+                options.referenceFlowLabelZh,
+              ),
+            },
+          },
+        ],
+      },
+    },
+  };
+}
+
+test('runProcessScopeStatistics fetches visible process rows and writes summary artifacts', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-scope-'));
+
+  const fetchImpl = (async (input) => {
+    const url = String(input);
+    if (isSupabaseAuthTokenUrl(url)) {
+      return makeSupabaseAuthResponse();
+    }
+    if (url.includes('/rest/v1/processes?')) {
+      return jsonResponse(
+        [
+          {
+            id: 'proc-1',
+            version: '01.00.000',
+            state_code: 100,
+            user_id: 'user-1',
+            modified_at: '2026-04-17T00:00:00.000Z',
+            model_id: 'model-1',
+            json: createProcessPayload({
+              primaryDomain: 'Waste management',
+              leafDomain: 'Paper sorting',
+              route: 'Sorting',
+              routeZh: '分选',
+              technology: 'Sorting line. downstream note',
+              technologyZh: '分选线。附加说明',
+              typeOfDataSet: 'Unit process, single operation',
+              referenceFlowId: 'flow-product-1',
+              referenceFlowLabelEn: 'sorted waste paper',
+              referenceFlowLabelZh: '分选废纸',
+              baseNameEn: 'Waste paper sorting',
+              baseNameZh: '废纸分选',
+            }),
+          },
+          {
+            id: 'proc-2',
+            version: '01.00.000',
+            state_code: 100,
+            user_id: 'user-2',
+            modified_at: '2026-04-17T01:00:00.000Z',
+            model_id: 'model-2',
+            json: createProcessPayload({
+              primaryDomain: 'Waste management',
+              leafDomain: 'Transport',
+              technology: 'Transport service. additional note',
+              technologyZh: '运输服务。附加说明',
+              typeOfDataSet: 'Aggregated process',
+              referenceFlowId: '',
+              referenceFlowLabelEn: 'transport service',
+              referenceFlowLabelZh: '运输服务',
+              baseNameEn: 'Waste transfer',
+              baseNameZh: '废弃物转运',
+            }),
+          },
+        ],
+        {
+          'content-type': 'application/json',
+          'content-range': '0-1/2',
+        },
+      );
+    }
+
+    throw new Error(`Unexpected URL: ${url}`);
+  }) as FetchLike;
+
+  try {
+    const report = await runProcessScopeStatistics({
+      outDir: dir,
+      scope: 'visible',
+      stateCodes: [100],
+      env: buildSupabaseTestEnv(),
+      fetchImpl,
+      now: new Date('2026-04-18T00:00:00.000Z'),
+    });
+
+    assert.equal(report.status, 'completed_process_scope_statistics');
+    assert.equal(report.total_process_rows, 2);
+    assert.equal(report.domain_count_primary, 1);
+    assert.equal(report.domain_count_leaf, 2);
+    assert.equal(report.craft_count, 2);
+    assert.equal(report.unit_process_rows, 1);
+    assert.equal(report.product_count, 2);
+    assert.equal(existsSync(report.files.process_scope_summary), true);
+    assert.equal(existsSync(report.files.report), true);
+    assert.equal(existsSync(report.files.report_zh), true);
+
+    const summary = JSON.parse(readFileSync(report.files.process_scope_summary, 'utf8')) as {
+      total_process_rows: number;
+      rows_by_state_code: Record<string, number>;
+      distinct_visible_owner_user_ids: number;
+      products_with_flow_id: number;
+      products_without_flow_id: number;
+      rows_missing_reference_exchange: number;
+    };
+
+    assert.equal(summary.total_process_rows, 2);
+    assert.deepEqual(summary.rows_by_state_code, { '100': 2 });
+    assert.equal(summary.distinct_visible_owner_user_ids, 2);
+    assert.equal(summary.products_with_flow_id, 1);
+    assert.equal(summary.products_without_flow_id, 1);
+    assert.equal(summary.rows_missing_reference_exchange, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessScopeStatistics can reuse a prior snapshot without remote fetches', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-scope-reuse-'));
+
+  const fetchImpl = (async (input) => {
+    const url = String(input);
+    if (isSupabaseAuthTokenUrl(url)) {
+      return makeSupabaseAuthResponse();
+    }
+    if (url.includes('/rest/v1/processes?')) {
+      return jsonResponse(
+        [
+          {
+            id: 'proc-1',
+            version: '01.00.000',
+            state_code: 100,
+            user_id: 'user-1',
+            modified_at: '2026-04-17T00:00:00.000Z',
+            model_id: 'model-1',
+            json: createProcessPayload({
+              primaryDomain: 'Waste management',
+              leafDomain: 'Paper sorting',
+              route: 'Sorting',
+              routeZh: '分选',
+              technology: 'Sorting line. downstream note',
+              technologyZh: '分选线。附加说明',
+              typeOfDataSet: 'Unit process, single operation',
+              referenceFlowId: 'flow-product-1',
+              referenceFlowLabelEn: 'sorted waste paper',
+              referenceFlowLabelZh: '分选废纸',
+              baseNameEn: 'Waste paper sorting',
+              baseNameZh: '废纸分选',
+            }),
+          },
+        ],
+        {
+          'content-type': 'application/json',
+          'content-range': '0-0/1',
+        },
+      );
+    }
+    throw new Error(`Unexpected URL: ${url}`);
+  }) as FetchLike;
+
+  try {
+    const first = await runProcessScopeStatistics({
+      outDir: dir,
+      stateCodes: [100],
+      env: buildSupabaseTestEnv(),
+      fetchImpl,
+      now: new Date('2026-04-18T01:00:00.000Z'),
+    });
+    assert.equal(first.total_process_rows, 1);
+
+    const reused = await runProcessScopeStatistics({
+      outDir: dir,
+      stateCodes: [100],
+      reuseSnapshot: true,
+      fetchImpl: (async () => {
+        throw new Error('reuseSnapshot should not fetch');
+      }) as FetchLike,
+      now: new Date('2026-04-18T02:00:00.000Z'),
+    });
+
+    assert.equal(reused.total_process_rows, 1);
+    const summary = JSON.parse(readFileSync(reused.files.process_scope_summary, 'utf8')) as {
+      total_process_rows: number;
+      total_rows_reported_by_remote: number | null;
+    };
+    assert.equal(summary.total_process_rows, 1);
+    assert.equal(summary.total_rows_reported_by_remote, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/process-scope-statistics.test.ts
+++ b/test/process-scope-statistics.test.ts
@@ -1,9 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { runProcessScopeStatistics } from '../src/lib/process-scope-statistics.js';
+import { __testInternals, runProcessScopeStatistics } from '../src/lib/process-scope-statistics.js';
 import type { FetchLike } from '../src/lib/http.js';
 import {
   buildSupabaseTestEnv,
@@ -26,6 +26,24 @@ function jsonResponse(payload: unknown, headers: Record<string, string> = {}) {
       },
     },
     text: async () => JSON.stringify(payload),
+  };
+}
+
+function responseLike(options: {
+  ok?: boolean;
+  status?: number;
+  body?: string;
+  headers?: Record<string, string>;
+}) {
+  return {
+    ok: options.ok ?? true,
+    status: options.status ?? 200,
+    headers: {
+      get(name: string): string | null {
+        return options.headers?.[name.toLowerCase()] ?? null;
+      },
+    },
+    text: async () => options.body ?? '',
   };
 }
 
@@ -112,6 +130,34 @@ function createProcessPayload(options: {
     },
   };
 }
+
+test('process scope helper internals cover sparse classification entries', () => {
+  assert.deepEqual(
+    __testInternals.extractClassificationEntries({
+      classificationInformation: {
+        'common:classification': {
+          'common:class': [
+            null,
+            {
+              '@level': '1',
+              '#text': '',
+            },
+            {
+              '@level': '2',
+              '#text': 'Paper sorting',
+            },
+          ],
+        },
+      },
+    }),
+    [
+      {
+        level: 2,
+        text: 'Paper sorting',
+      },
+    ],
+  );
+});
 
 test('runProcessScopeStatistics fetches visible process rows and writes summary artifacts', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-scope-'));
@@ -291,4 +337,940 @@ test('runProcessScopeStatistics can reuse a prior snapshot without remote fetche
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test('runProcessScopeStatistics validates outDir and supports current-user scope resolution', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-scope-current-user-'));
+
+  try {
+    await assert.rejects(
+      () => runProcessScopeStatistics({ outDir: '' }),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_SCOPE_OUT_DIR_REQUIRED');
+        return true;
+      },
+    );
+
+    const fetchImpl = (async (input) => {
+      const url = String(input);
+      if (isSupabaseAuthTokenUrl(url)) {
+        return makeSupabaseAuthResponse({ userId: 'user-1' });
+      }
+      if (url.endsWith('/auth/v1/user')) {
+        return jsonResponse({ id: 'user-1' });
+      }
+      if (url.includes('/rest/v1/processes?') && url.includes('user_id=eq.user-1')) {
+        return jsonResponse(
+          [
+            {
+              id: 'proc-1',
+              version: '01.00.000',
+              state_code: 0,
+              user_id: 'user-1',
+              modified_at: '2026-04-17T00:00:00.000Z',
+              model_id: 'model-1',
+              json: createProcessPayload({
+                primaryDomain: 'Waste management',
+                leafDomain: 'Paper sorting',
+                route: 'Sorting',
+                routeZh: '分选',
+                technology: 'Sorting line. downstream note',
+                technologyZh: '分选线。附加说明',
+                typeOfDataSet: 'Unit process, single operation',
+                referenceFlowId: 'flow-product-1',
+                referenceFlowLabelEn: 'sorted waste paper',
+                referenceFlowLabelZh: '分选废纸',
+                baseNameEn: 'Waste paper sorting',
+                baseNameZh: '废纸分选',
+              }),
+            },
+          ],
+          {
+            'content-type': 'application/json',
+            'content-range': '0-0/1',
+          },
+        );
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
+    }) as FetchLike;
+
+    const report = await runProcessScopeStatistics({
+      outDir: dir,
+      scope: 'current-user',
+      stateCodes: [0],
+      env: buildSupabaseTestEnv(),
+      fetchImpl,
+      now: new Date('2026-04-18T03:00:00.000Z'),
+    });
+
+    assert.equal(report.status, 'completed_process_scope_statistics');
+    assert.equal(report.total_process_rows, 1);
+    assert.equal(report.files.snapshot_manifest.endsWith('processes.snapshot.manifest.json'), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessScopeStatistics counts rows that are missing products and reference exchanges', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-scope-missing-product-'));
+
+  const fetchImpl = (async (input) => {
+    const url = String(input);
+    if (isSupabaseAuthTokenUrl(url)) {
+      return makeSupabaseAuthResponse();
+    }
+    if (url.includes('/rest/v1/processes?')) {
+      return jsonResponse(
+        [
+          {
+            id: 'proc-missing',
+            version: '01.00.000',
+            state_code: 100,
+            user_id: 'user-1',
+            modified_at: '2026-04-17T00:00:00.000Z',
+            model_id: 'model-1',
+            json: {
+              processDataSet: {
+                processInformation: 'bad-data',
+                modellingAndValidation: 'bad-data',
+                exchanges: {
+                  exchange: [],
+                },
+              },
+            },
+          },
+        ],
+        {
+          'content-type': 'application/json',
+          'content-range': '0-0/1',
+        },
+      );
+    }
+
+    throw new Error(`Unexpected URL: ${url}`);
+  }) as FetchLike;
+
+  try {
+    const report = await runProcessScopeStatistics({
+      outDir: dir,
+      scope: 'visible',
+      stateCodes: [100],
+      env: buildSupabaseTestEnv(),
+      fetchImpl,
+      now: new Date('2026-04-18T04:00:00.000Z'),
+    });
+
+    const summary = JSON.parse(readFileSync(report.files.process_scope_summary, 'utf8')) as {
+      products_without_flow_id: number;
+      rows_missing_product: number;
+      rows_missing_reference_exchange: number;
+      product_count: number;
+    };
+    assert.equal(summary.product_count, 0);
+    assert.equal(summary.products_without_flow_id, 0);
+    assert.equal(summary.rows_missing_product, 1);
+    assert.equal(summary.rows_missing_reference_exchange, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessScopeStatistics falls back to process base names when reference-flow labels are missing', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-scope-base-name-product-'));
+
+  const fetchImpl = (async (input) => {
+    const url = String(input);
+    if (isSupabaseAuthTokenUrl(url)) {
+      return makeSupabaseAuthResponse();
+    }
+    if (url.includes('/rest/v1/processes?')) {
+      return jsonResponse(
+        [
+          {
+            id: 'proc-base-name',
+            version: '01.00.000',
+            state_code: 100,
+            user_id: 'user-1',
+            modified_at: '2026-04-17T00:00:00.000Z',
+            model_id: 'model-1',
+            json: {
+              processDataSet: {
+                processInformation: {
+                  dataSetInformation: {
+                    name: {
+                      baseName: langEntries('Fallback product', '回退产品'),
+                    },
+                  },
+                  quantitativeReference: {
+                    referenceToReferenceFlow: '1',
+                  },
+                },
+                modellingAndValidation: {
+                  LCIMethodAndAllocation: {
+                    typeOfDataSet: 'Aggregated process',
+                  },
+                },
+                exchanges: {
+                  exchange: [],
+                },
+              },
+            },
+          },
+        ],
+        {
+          'content-type': 'application/json',
+          'content-range': '0-0/1',
+        },
+      );
+    }
+
+    throw new Error(`Unexpected URL: ${url}`);
+  }) as FetchLike;
+
+  try {
+    const report = await runProcessScopeStatistics({
+      outDir: dir,
+      scope: 'visible',
+      stateCodes: [100],
+      env: buildSupabaseTestEnv(),
+      fetchImpl,
+      now: new Date('2026-04-18T05:00:00.000Z'),
+    });
+
+    const summary = JSON.parse(readFileSync(report.files.process_scope_summary, 'utf8')) as {
+      product_count: number;
+      products_without_flow_id: number;
+      rows_missing_reference_exchange: number;
+    };
+    assert.equal(summary.product_count, 1);
+    assert.equal(summary.products_without_flow_id, 1);
+    assert.equal(summary.rows_missing_reference_exchange, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('process scope helper internals cover option parsing, response parsing, and payload normalization', async () => {
+  assert.equal(
+    __testInternals.toPositiveInteger(5, '--page-size', 'PROCESS_SCOPE_TEST_INVALID'),
+    5,
+  );
+  assert.throws(
+    () => __testInternals.toPositiveInteger(0, '--page-size', 'PROCESS_SCOPE_TEST_INVALID'),
+    (error: unknown) => {
+      assert.equal((error as { code?: string }).code, 'PROCESS_SCOPE_TEST_INVALID');
+      return true;
+    },
+  );
+
+  assert.deepEqual(__testInternals.normalizeStateCodes(undefined), [0, 100]);
+  assert.throws(
+    () => __testInternals.normalizeStateCodes([-1]),
+    (error: unknown) => {
+      assert.equal((error as { code?: string }).code, 'PROCESS_SCOPE_STATE_CODES_INVALID');
+      return true;
+    },
+  );
+  const noIteration = [100] as number[];
+  noIteration[Symbol.iterator] = () => [][Symbol.iterator]();
+  assert.throws(
+    () => __testInternals.normalizeStateCodes(noIteration),
+    (error: unknown) => {
+      assert.equal((error as { code?: string }).code, 'PROCESS_SCOPE_STATE_CODES_REQUIRED');
+      return true;
+    },
+  );
+
+  assert.equal(__testInternals.ensureScope(undefined), 'visible');
+  assert.equal(__testInternals.ensureScope('current-user'), 'current-user');
+  assert.throws(
+    () => __testInternals.ensureScope('drafts'),
+    (error: unknown) => {
+      assert.equal((error as { code?: string }).code, 'PROCESS_SCOPE_SCOPE_INVALID');
+      return true;
+    },
+  );
+
+  assert.equal(
+    await __testInternals.parseJsonResponse(
+      responseLike({
+        headers: { 'content-type': 'application/json' },
+      }),
+      'scope empty body',
+    ),
+    null,
+  );
+  assert.equal(
+    await __testInternals.parseJsonResponse(
+      responseLike({
+        body: 'plain-text',
+        headers: { 'content-type': 'text/plain' },
+      }),
+      'scope text body',
+    ),
+    'plain-text',
+  );
+  await assert.rejects(
+    () =>
+      __testInternals.parseJsonResponse(
+        responseLike({
+          body: '{',
+          headers: { 'content-type': 'application/json' },
+        }),
+        'scope invalid json',
+      ),
+    (error: unknown) => {
+      assert.equal((error as { code?: string }).code, 'PROCESS_SCOPE_REMOTE_INVALID_JSON');
+      return true;
+    },
+  );
+
+  await assert.rejects(
+    () =>
+      __testInternals.fetchJsonWithRetry({
+        url: 'https://example.test/scope-http-error',
+        init: { method: 'GET' },
+        label: 'scope http error',
+        fetchImpl: async () =>
+          responseLike({
+            ok: false,
+            status: 500,
+            body: JSON.stringify({ error: 'failed' }),
+            headers: { 'content-type': 'application/json' },
+          }),
+        timeoutMs: 10,
+        maxRetries: 1,
+      }),
+    (error: unknown) => {
+      assert.equal((error as { code?: string }).code, 'PROCESS_SCOPE_REMOTE_REQUEST_FAILED');
+      return true;
+    },
+  );
+
+  const originalSetTimeout = globalThis.setTimeout;
+  const retryDelays: number[] = [];
+  globalThis.setTimeout = ((
+    callback: (...args: unknown[]) => void,
+    ms?: number,
+    ...args: unknown[]
+  ) => {
+    retryDelays.push(Number(ms ?? 0));
+    callback(...args);
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+
+  try {
+    let attempts = 0;
+    const retryResult = await __testInternals.fetchJsonWithRetry({
+      url: 'https://example.test/scope-retry',
+      init: { method: 'GET' },
+      label: 'scope retry',
+      fetchImpl: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new Error('temporary failure');
+        }
+        return responseLike({
+          body: JSON.stringify({ ok: true }),
+          headers: { 'content-type': 'application/json' },
+        });
+      },
+      timeoutMs: 10,
+      maxRetries: 2,
+    });
+    assert.equal(attempts, 2);
+    assert.deepEqual(retryDelays, [1500]);
+    assert.deepEqual(retryResult.body, { ok: true });
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+  }
+
+  await assert.rejects(
+    () =>
+      __testInternals.fetchJsonWithRetry({
+        url: 'https://example.test/scope-transport-failure',
+        init: { method: 'GET' },
+        label: 'scope transport failure',
+        fetchImpl: async () => {
+          throw new Error('network unavailable');
+        },
+        timeoutMs: 10,
+        maxRetries: 1,
+      }),
+    (error: unknown) => {
+      assert.equal((error as { code?: string }).code, 'PROCESS_SCOPE_REMOTE_REQUEST_FAILED');
+      return true;
+    },
+  );
+
+  await assert.rejects(
+    () =>
+      __testInternals.resolveCurrentUserId({
+        env: buildSupabaseTestEnv(),
+        fetchImpl: async (input) => {
+          const url = String(input);
+          if (isSupabaseAuthTokenUrl(url)) {
+            return makeSupabaseAuthResponse({ userId: 'user-1' });
+          }
+          if (url.endsWith('/auth/v1/user')) {
+            return jsonResponse({});
+          }
+          throw new Error(`Unexpected URL: ${url}`);
+        },
+        timeoutMs: 10,
+        maxRetries: 1,
+        now: new Date('2026-04-18T06:00:00.000Z'),
+      }),
+    (error: unknown) => {
+      assert.equal((error as { code?: string }).code, 'PROCESS_SCOPE_CURRENT_USER_ID_MISSING');
+      return true;
+    },
+  );
+
+  assert.equal(__testInternals.normalizeSnapshotRow(null), null);
+  assert.equal(
+    __testInternals.normalizeSnapshotRow({
+      id: 'proc-1',
+      version: '01.00.000',
+      json: null,
+    }),
+    null,
+  );
+  assert.deepEqual(__testInternals.normalizePayload({ ok: true }), { ok: true });
+  assert.deepEqual(__testInternals.normalizePayload('{"ok":true}'), { ok: true });
+  assert.equal(__testInternals.normalizePayload('['), null);
+  assert.equal(__testInternals.normalizePayload(''), null);
+
+  assert.deepEqual(
+    __testInternals.getLangList({
+      'common:langString': {
+        '@xml:lang': 'zh',
+        '#text': '中文',
+      },
+    }),
+    [{ '@xml:lang': 'zh', '#text': '中文' }],
+  );
+  assert.deepEqual(
+    __testInternals.getLangList({
+      'common:langString': [{ '@xml:lang': 'en', '#text': 'English' }, null],
+    }),
+    [{ '@xml:lang': 'en', '#text': 'English' }],
+  );
+  assert.deepEqual(__testInternals.getLangList({ '@xml:lang': 'en', '#text': 'English' }), [
+    { '@xml:lang': 'en', '#text': 'English' },
+  ]);
+  assert.deepEqual(__testInternals.getLangList('Fallback'), [
+    { '@xml:lang': 'en', '#text': 'Fallback' },
+  ]);
+  assert.deepEqual(__testInternals.getLangList(123), []);
+});
+
+test('process scope helper internals cover sparse fallbacks and zero-row statistics', async () => {
+  assert.equal(
+    await __testInternals.parseJsonResponse(
+      responseLike({
+        body: 'plain-text',
+      }),
+      'scope text without header',
+    ),
+    'plain-text',
+  );
+
+  const noHeaderResult = await __testInternals.fetchJsonWithRetry({
+    url: 'https://example.test/scope-no-header',
+    init: { method: 'GET' },
+    label: 'scope no header',
+    fetchImpl: async () =>
+      responseLike({
+        body: '{"ok":true}',
+      }),
+    timeoutMs: 10,
+    maxRetries: 1,
+  });
+  assert.equal(noHeaderResult.headers.get('content-type'), '');
+  assert.equal(noHeaderResult.headers.get('content-range'), '');
+  assert.equal(noHeaderResult.body, '{"ok":true}');
+
+  await assert.rejects(
+    () =>
+      __testInternals.resolveCurrentUserId({
+        env: buildSupabaseTestEnv(),
+        fetchImpl: async (input) => {
+          const url = String(input);
+          if (isSupabaseAuthTokenUrl(url)) {
+            return makeSupabaseAuthResponse({ userId: 'user-1' });
+          }
+          if (url.endsWith('/auth/v1/user')) {
+            return jsonResponse([]);
+          }
+          throw new Error(`Unexpected URL: ${url}`);
+        },
+        timeoutMs: 10,
+        maxRetries: 1,
+        now: new Date('2026-04-18T06:30:00.000Z'),
+      }),
+    (error: unknown) => {
+      assert.equal((error as { code?: string }).code, 'PROCESS_SCOPE_CURRENT_USER_ID_MISSING');
+      return true;
+    },
+  );
+
+  assert.deepEqual(
+    __testInternals.normalizeSnapshotRow({
+      id: 'proc-1',
+      version: '01.00.000',
+      state_code: 'draft',
+      user_id: '',
+      modified_at: '',
+      model_id: '',
+      json: {},
+    }),
+    {
+      id: 'proc-1',
+      version: '01.00.000',
+      state_code: null,
+      user_id: null,
+      modified_at: null,
+      model_id: null,
+      json: {},
+    },
+  );
+  assert.equal(__testInternals.normalizePayload('[1]'), null);
+  assert.deepEqual(__testInternals.getLangList({ '@xml:lang': 'en' }), [{ '@xml:lang': 'en' }]);
+  assert.equal(__testInternals.getLangText([{ '@xml:lang': 'zh', '#text': '' }], 'en'), '');
+  assert.deepEqual(
+    __testInternals.extractClassificationEntries({
+      classificationInformation: {
+        'common:classification': {
+          'common:class': {
+            '#text': 'Fallback domain',
+          },
+        },
+      },
+    }),
+    [
+      {
+        level: 0,
+        text: 'Fallback domain',
+      },
+    ],
+  );
+  assert.deepEqual(
+    __testInternals.extractCraftCandidate(
+      {
+        name: {
+          baseName: langEntries('Base fallback', '基础回退'),
+        },
+      },
+      {},
+    ),
+    {
+      source_kind: 'baseName',
+      label: 'Base fallback',
+      signature: 'base fallback',
+    },
+  );
+  assert.deepEqual(
+    __testInternals.extractReferenceProduct(
+      {
+        processInformation: {
+          quantitativeReference: {
+            referenceToReferenceFlow: '9',
+          },
+        },
+        exchanges: {
+          exchange: [
+            {
+              '@dataSetInternalID': '9',
+              referenceToFlowDataSet: {
+                '@refObjectId': 'flow-9',
+              },
+            },
+          ],
+        },
+      },
+      {
+        name: {},
+      },
+    ),
+    {
+      key: 'flow:flow-9',
+      stable_flow_id: 'flow-9',
+      stable_flow_version: '',
+      label: 'flow-9',
+      source_kind: 'reference_flow_id',
+      missing_reference_exchange: false,
+    },
+  );
+  assert.deepEqual(
+    __testInternals.extractReferenceProduct(
+      {
+        processInformation: {},
+        exchanges: {},
+      },
+      {
+        name: {},
+      },
+    ),
+    {
+      key: '',
+      stable_flow_id: '',
+      stable_flow_version: '',
+      label: '',
+      source_kind: 'missing',
+      missing_reference_exchange: true,
+    },
+  );
+
+  const sparseStatistics = __testInternals.calculateStatistics(
+    [
+      {
+        id: 'proc-null',
+        version: '01.00.000',
+        state_code: null,
+        user_id: null,
+        modified_at: null,
+        model_id: null,
+        json: {},
+      },
+      {
+        id: 'proc-fallback',
+        version: '01.00.001',
+        state_code: 0,
+        user_id: null,
+        modified_at: null,
+        model_id: null,
+        json: {
+          processDataSet: {
+            processInformation: {
+              dataSetInformation: {
+                name: {
+                  baseName: langEntries('Fallback base', '基础回退'),
+                },
+                classificationInformation: {
+                  'common:classification': {
+                    'common:class': {
+                      '@level': '2',
+                      '#text': 'Fallback leaf',
+                    },
+                  },
+                },
+              },
+              technology: {},
+            },
+            modellingAndValidation: {
+              LCIMethodAndAllocation: {
+                typeOfDataSet: 'Aggregated process',
+              },
+            },
+            exchanges: {},
+          },
+        },
+      },
+    ],
+    {
+      scope: 'visible',
+      stateCodes: [0],
+    },
+    {
+      userId: null,
+      maskedUserEmail: null,
+      totalRowsReportedByRemote: null,
+    },
+    '2026-04-18T06:45:00.000Z',
+  );
+  assert.deepEqual(sparseStatistics.summary.rows_by_state_code, {
+    '0': 1,
+    null: 1,
+  });
+  assert.equal(sparseStatistics.summary.distinct_visible_owner_user_ids, 1);
+  assert.equal(sparseStatistics.summary.domain_count_primary, 1);
+  assert.equal(sparseStatistics.domainPrimarySummary[0]?.domain, 'Fallback leaf');
+  assert.equal(sparseStatistics.summary.rows_missing_classification, 1);
+  assert.equal(sparseStatistics.summary.rows_missing_craft, 1);
+  assert.equal(sparseStatistics.summary.rows_missing_product, 1);
+  assert.equal(sparseStatistics.summary.rows_missing_reference_exchange, 2);
+
+  const emptyStatistics = __testInternals.calculateStatistics(
+    [],
+    {
+      scope: 'visible',
+      stateCodes: [0],
+    },
+    {
+      userId: null,
+      maskedUserEmail: null,
+      totalRowsReportedByRemote: 0,
+    },
+    '2026-04-18T06:50:00.000Z',
+  );
+  assert.equal(emptyStatistics.summary.unit_process_share, 0);
+  assert.equal(__testInternals.escapePipe(undefined), '');
+});
+
+test('process scope fetch internals cover null current-user ids and non-array pages', async () => {
+  const urls: string[] = [];
+  const result = await __testInternals.fetchProcessRows({
+    env: buildSupabaseTestEnv(),
+    fetchImpl: (async (input) => {
+      const url = String(input);
+      urls.push(url);
+      if (isSupabaseAuthTokenUrl(url)) {
+        return makeSupabaseAuthResponse({ userId: 'user-1' });
+      }
+      if (url.includes('/rest/v1/processes?') && url.includes('user_id=eq.')) {
+        return jsonResponse(
+          {
+            unexpected: true,
+          },
+          {
+            'content-type': 'application/json',
+          },
+        );
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    }) as FetchLike,
+    timeoutMs: 10,
+    maxRetries: 1,
+    scope: 'current-user',
+    stateCodes: [0],
+    pageSize: 10,
+    userId: null,
+  });
+
+  assert.equal(result.rows.length, 0);
+  assert.equal(result.total, null);
+  assert.equal(
+    urls.some((url) => url.includes('user_id=eq.')),
+    true,
+  );
+});
+
+test('runProcessScopeStatistics covers snapshot-manifest and runtime defaults', async () => {
+  const reuseDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-scope-reuse-fallback-'));
+  try {
+    const snapshotRowsPath = path.join(reuseDir, 'inputs', 'processes.snapshot.rows.jsonl');
+    const snapshotManifestPath = path.join(reuseDir, 'inputs', 'processes.snapshot.manifest.json');
+    mkdirSync(path.join(reuseDir, 'inputs'), { recursive: true });
+    writeFileSync(
+      snapshotRowsPath,
+      `${JSON.stringify({
+        id: 'proc-reused',
+        version: '01.00.000',
+        state_code: 100,
+        user_id: 'user-1',
+        modified_at: '2026-04-18T07:00:00.000Z',
+        model_id: 'model-1',
+        json: createProcessPayload({
+          primaryDomain: 'Waste management',
+          leafDomain: 'Paper sorting',
+          route: 'Sorting',
+          routeZh: '分选',
+          technology: 'Sorting line',
+          technologyZh: '分选线',
+          typeOfDataSet: 'Unit process, single operation',
+          referenceFlowId: 'flow-1',
+          referenceFlowLabelEn: 'sorted paper',
+          referenceFlowLabelZh: '分选纸张',
+          baseNameEn: 'Waste paper sorting',
+          baseNameZh: '废纸分选',
+        }),
+      })}\n`,
+      'utf8',
+    );
+    writeFileSync(snapshotManifestPath, '[]\n', 'utf8');
+
+    assert.equal(__testInternals.readSnapshotManifest(snapshotManifestPath), null);
+
+    const reused = await runProcessScopeStatistics({
+      outDir: reuseDir,
+      reuseSnapshot: true,
+      now: new Date('2026-04-18T07:05:00.000Z'),
+    });
+
+    const reusedSummary = JSON.parse(readFileSync(reused.files.process_scope_summary, 'utf8')) as {
+      total_rows_reported_by_remote: number | null;
+      user_id: string | null;
+      masked_user_email: string | null;
+    };
+    assert.equal(reusedSummary.total_rows_reported_by_remote, 1);
+    assert.equal(reusedSummary.user_id, null);
+    assert.equal(reusedSummary.masked_user_email, null);
+  } finally {
+    rmSync(reuseDir, { recursive: true, force: true });
+  }
+
+  const runtimeDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-scope-runtime-defaults-'));
+  const envPatch = buildSupabaseTestEnv();
+  const envBackup = new Map(Object.keys(envPatch).map((key) => [key, process.env[key]]));
+  const originalFetch = globalThis.fetch;
+
+  try {
+    Object.assign(process.env, envPatch);
+    globalThis.fetch = (async (input) => {
+      const url = String(input);
+      if (isSupabaseAuthTokenUrl(url)) {
+        return makeSupabaseAuthResponse({ userId: 'user-1' });
+      }
+      if (url.endsWith('/auth/v1/user')) {
+        return jsonResponse({ id: 'user-1' });
+      }
+      if (url.includes('/rest/v1/processes?') && url.includes('user_id=eq.user-1')) {
+        return jsonResponse([
+          {
+            id: 'proc-defaults',
+            version: '01.00.000',
+            state_code: 0,
+            user_id: 'user-1',
+            modified_at: '2026-04-18T08:00:00.000Z',
+            model_id: 'model-1',
+            json: createProcessPayload({
+              primaryDomain: 'Waste management',
+              leafDomain: 'Sorting',
+              route: 'Sorting',
+              routeZh: '分选',
+              technology: 'Sorting line',
+              technologyZh: '分选线',
+              typeOfDataSet: 'Unit process, single operation',
+              referenceFlowId: 'flow-1',
+              referenceFlowLabelEn: 'sorted paper',
+              referenceFlowLabelZh: '分选纸张',
+              baseNameEn: 'Waste paper sorting',
+              baseNameZh: '废纸分选',
+            }),
+          },
+        ]);
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    }) as typeof fetch;
+
+    const report = await runProcessScopeStatistics({
+      outDir: runtimeDir,
+      scope: 'current-user',
+      stateCodes: [0],
+      pageSize: 10,
+      timeoutMs: 10,
+      maxRetries: 1,
+    });
+
+    const summary = JSON.parse(readFileSync(report.files.process_scope_summary, 'utf8')) as {
+      total_rows_reported_by_remote: number | null;
+      user_id: string | null;
+      masked_user_email: string | null;
+    };
+    assert.equal(summary.total_rows_reported_by_remote, 1);
+    assert.equal(summary.user_id, 'user-1');
+    assert.equal(summary.masked_user_email, 'us****@example.com');
+  } finally {
+    globalThis.fetch = originalFetch;
+    for (const [key, value] of envBackup) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    rmSync(runtimeDir, { recursive: true, force: true });
+  }
+});
+
+test('process scope fetch internals cover current-user pagination and cursor failures', async () => {
+  const urls: string[] = [];
+  const multiPageFetch = (async (input) => {
+    const url = String(input);
+    urls.push(url);
+    if (isSupabaseAuthTokenUrl(url)) {
+      return makeSupabaseAuthResponse({ userId: 'user-1' });
+    }
+    if (url.includes('/rest/v1/processes?') && url.includes('state_code=eq.0')) {
+      const parsed = new URL(url);
+      if (parsed.searchParams.get('id') === 'gt.proc-2') {
+        return jsonResponse([], {
+          'content-type': 'application/json',
+        });
+      }
+      if (parsed.searchParams.get('id') === 'gt.proc-1') {
+        return jsonResponse(
+          [
+            {
+              id: 'proc-2',
+              version: '01.00.000',
+              state_code: 0,
+              user_id: 'user-1',
+              modified_at: '2026-04-18T01:00:00.000Z',
+              model_id: 'model-2',
+              json: createProcessPayload({
+                primaryDomain: 'Waste management',
+                leafDomain: 'Transport',
+                technology: 'Transport service',
+                technologyZh: '运输服务',
+                typeOfDataSet: 'Aggregated process',
+                referenceFlowId: 'flow-2',
+                referenceFlowLabelEn: 'transport service',
+                referenceFlowLabelZh: '运输服务',
+                baseNameEn: 'Waste transfer',
+                baseNameZh: '废弃物转运',
+              }),
+            },
+          ],
+          {
+            'content-type': 'application/json',
+          },
+        );
+      }
+      return jsonResponse(
+        [
+          {
+            id: 'proc-1',
+            version: '01.00.000',
+            state_code: 0,
+            user_id: 'user-1',
+            modified_at: '2026-04-18T00:00:00.000Z',
+            model_id: 'model-1',
+            json: createProcessPayload({
+              primaryDomain: 'Waste management',
+              leafDomain: 'Paper sorting',
+              route: 'Sorting',
+              routeZh: '分选',
+              technology: 'Sorting line',
+              technologyZh: '分选线',
+              typeOfDataSet: 'Unit process, single operation',
+              referenceFlowId: 'flow-1',
+              referenceFlowLabelEn: 'sorted paper',
+              referenceFlowLabelZh: '分选纸张',
+              baseNameEn: 'Waste paper sorting',
+              baseNameZh: '废纸分选',
+            }),
+          },
+        ],
+        {
+          'content-type': 'application/json',
+          'content-range': '0-0/2',
+        },
+      );
+    }
+    throw new Error(`Unexpected URL: ${url}`);
+  }) as FetchLike;
+
+  const paged = await __testInternals.fetchProcessRows({
+    env: buildSupabaseTestEnv(),
+    fetchImpl: multiPageFetch,
+    timeoutMs: 10,
+    maxRetries: 1,
+    scope: 'current-user',
+    stateCodes: [0],
+    pageSize: 1,
+    userId: 'user-1',
+  });
+  assert.equal(paged.rows.length, 2);
+  assert.equal(paged.total, 2);
+  assert.equal(
+    urls.some((url) => url.includes('user_id=eq.user-1')),
+    true,
+  );
+  assert.equal(
+    urls.some((url) => url.includes('id=gt.proc-1')),
+    true,
+  );
 });

--- a/test/process-verify-rows.test.ts
+++ b/test/process-verify-rows.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  runProcessVerifyRows,
+  type ProcessVerifyRowRecord,
+} from '../src/lib/process-verify-rows.js';
+
+function lang(text: string, langCode = 'en') {
+  return { '@xml:lang': langCode, '#text': text };
+}
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+test('runProcessVerifyRows accepts process list reports and writes invalid-row artifacts', async () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-verify-rows-'));
+  try {
+    const rowsFile = path.join(tempDir, 'rows.json');
+    writeFileSync(
+      rowsFile,
+      `${JSON.stringify(
+        {
+          rows: [
+            {
+              id: 'proc-valid',
+              version: '01.00.001',
+              process: {
+                processDataSet: {
+                  processInformation: {
+                    dataSetInformation: {
+                      'common:UUID': 'proc-valid',
+                      name: {
+                        baseName: [lang('Valid process')],
+                        treatmentStandardsRoutes: [lang('route')],
+                        mixAndLocationTypes: [lang('mix')],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            {
+              id: 'proc-invalid',
+              version: '01.00.002',
+              process: {
+                test_invalid: true,
+                processDataSet: {
+                  processInformation: {
+                    dataSetInformation: {
+                      'common:UUID': 'proc-invalid',
+                      name: {
+                        baseName: [lang('Invalid process')],
+                        treatmentStandardsRoutes: [lang('route')],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+      'utf8',
+    );
+
+    const report = await runProcessVerifyRows({
+      rowsFile,
+      outDir: tempDir,
+      validateProcessPayloadImpl: (payload) =>
+        payload.test_invalid === true
+          ? {
+              ok: false,
+              validator: 'test-validator',
+              issue_count: 2,
+              issues: [
+                {
+                  path: 'processDataSet.processInformation',
+                  message: 'Broken payload',
+                  code: 'custom',
+                },
+                {
+                  path: 'processDataSet.exchanges',
+                  message: 'Missing exchanges',
+                  code: 'custom',
+                },
+              ],
+            }
+          : {
+              ok: true,
+              validator: 'test-validator',
+              issue_count: 0,
+              issues: [],
+            },
+    });
+
+    assert.equal(report.status, 'completed_with_invalid_process_rows');
+    assert.equal(report.row_count, 2);
+    assert.equal(report.invalid_count, 1);
+    assert.equal(report.schema_invalid_count, 1);
+    assert.equal(report.missing_required_name_field_count, 1);
+    assert.deepEqual(report.invalid_rows, [
+      {
+        id: 'proc-invalid',
+        version: '01.00.002',
+        row_index: 1,
+        missing_required_fields: ['mixAndLocationTypes'],
+        schema_issue_count: 2,
+      },
+    ]);
+
+    const summary = readJson(report.files.summary_json) as {
+      invalid_count: number;
+      invalid_rows: unknown[];
+    };
+    assert.equal(summary.invalid_count, 1);
+    assert.equal(summary.invalid_rows.length, 1);
+
+    const verificationRows = readFileSync(report.files.verification_jsonl, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as ProcessVerifyRowRecord);
+    assert.equal(verificationRows.length, 2);
+    assert.equal(verificationRows[0]?.status, 'ok');
+    assert.equal(verificationRows[1]?.status, 'invalid');
+    assert.deepEqual(verificationRows[1]?.name_summary.missing_required_fields, [
+      'mixAndLocationTypes',
+    ]);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/process-verify-rows.test.ts
+++ b/test/process-verify-rows.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import {
+  __testInternals,
   runProcessVerifyRows,
   type ProcessVerifyRowRecord,
 } from '../src/lib/process-verify-rows.js';
@@ -131,6 +132,272 @@ test('runProcessVerifyRows accepts process list reports and writes invalid-row a
     assert.deepEqual(verificationRows[1]?.name_summary.missing_required_fields, [
       'mixAndLocationTypes',
     ]);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('process verify helper internals cover row loading, payload selection, identities, and name summaries', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-verify-helper-'));
+
+  try {
+    const missingFile = path.join(tempDir, 'missing.jsonl');
+    assert.throws(
+      () => __testInternals.readRowsFile(missingFile),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_VERIFY_ROWS_FILE_NOT_FOUND');
+        return true;
+      },
+    );
+
+    const invalidJsonl = path.join(tempDir, 'invalid.jsonl');
+    writeFileSync(invalidJsonl, '{"ok":true}\n{broken\n', 'utf8');
+    assert.throws(
+      () => __testInternals.readRowsFile(invalidJsonl),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_VERIFY_ROWS_FILE_INVALID_JSONL');
+        return true;
+      },
+    );
+
+    const invalidJson = path.join(tempDir, 'invalid.json');
+    writeFileSync(invalidJson, '{', 'utf8');
+    assert.throws(
+      () => __testInternals.readRowsFile(invalidJson),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_VERIFY_ROWS_FILE_INVALID_JSON');
+        return true;
+      },
+    );
+
+    const arrayFile = path.join(tempDir, 'rows.json');
+    writeFileSync(arrayFile, `${JSON.stringify([{ id: 'proc-array' }])}\n`, 'utf8');
+    assert.deepEqual(__testInternals.readRowsFile(arrayFile), [{ id: 'proc-array' }]);
+
+    const wrappedRowsFile = path.join(tempDir, 'wrapped.json');
+    writeFileSync(wrappedRowsFile, `${JSON.stringify({ rows: [{ id: 'proc-rows' }] })}\n`, 'utf8');
+    assert.deepEqual(__testInternals.readRowsFile(wrappedRowsFile), [{ id: 'proc-rows' }]);
+
+    const singleObjectFile = path.join(tempDir, 'single.json');
+    writeFileSync(singleObjectFile, `${JSON.stringify({ id: 'proc-single' })}\n`, 'utf8');
+    assert.deepEqual(__testInternals.readRowsFile(singleObjectFile), [{ id: 'proc-single' }]);
+
+    assert.deepEqual(__testInternals.getPayload({ process: { id: 'proc-process' } }), {
+      id: 'proc-process',
+    });
+    assert.deepEqual(__testInternals.getPayload({ json_ordered: { id: 'proc-json-ordered' } }), {
+      id: 'proc-json-ordered',
+    });
+    assert.deepEqual(__testInternals.getPayload({ json: { id: 'proc-json' } }), {
+      id: 'proc-json',
+    });
+    assert.deepEqual(__testInternals.getPayload({ id: 'proc-root' }), { id: 'proc-root' });
+    assert.deepEqual(__testInternals.getPayload('not-an-object'), {});
+
+    assert.deepEqual(
+      __testInternals.getIdentity({ process_id: 'proc-row', version: '01.00.001' }, {}, 2),
+      {
+        row_index: 2,
+        id: 'proc-row',
+        version: '01.00.001',
+      },
+    );
+    assert.deepEqual(
+      __testInternals.getIdentity(
+        {},
+        {
+          processDataSet: {
+            processInformation: {
+              dataSetInformation: {
+                'common:UUID': 'proc-payload',
+              },
+            },
+            administrativeInformation: {
+              publicationAndOwnership: {
+                'common:dataSetVersion': '01.00.002',
+              },
+            },
+          },
+        },
+        0,
+      ),
+      {
+        row_index: 0,
+        id: 'proc-payload',
+        version: '01.00.002',
+      },
+    );
+    assert.deepEqual(
+      __testInternals.getIdentity(
+        {},
+        {
+          id: 'proc-root',
+          '@version': '01.00.003',
+        },
+        1,
+      ),
+      {
+        row_index: 1,
+        id: 'proc-root',
+        version: '01.00.003',
+      },
+    );
+    assert.deepEqual(__testInternals.getIdentity('not-an-object', {}, 3), {
+      row_index: 3,
+      id: null,
+      version: null,
+    });
+
+    assert.deepEqual(__testInternals.getLangList('Plain English'), [
+      { '@xml:lang': 'en', '#text': 'Plain English' },
+    ]);
+    assert.deepEqual(
+      __testInternals.getLangList({
+        'common:langString': {
+          '@xml:lang': 'zh',
+          '#text': '中文',
+        },
+      }),
+      [{ '@xml:lang': 'zh', '#text': '中文' }],
+    );
+    assert.deepEqual(
+      __testInternals.getLangList({
+        'common:langString': [
+          { '@xml:lang': 'en', '#text': 'English' },
+          { '@xml:lang': 'zh', '#text': '中文' },
+        ],
+      }),
+      [
+        { '@xml:lang': 'en', '#text': 'English' },
+        { '@xml:lang': 'zh', '#text': '中文' },
+      ],
+    );
+    assert.deepEqual(__testInternals.getLangList({ '@xml:lang': 'en', '#text': 'Direct text' }), [
+      { '@xml:lang': 'en', '#text': 'Direct text' },
+    ]);
+    assert.equal(
+      __testInternals.getLangText(
+        [
+          { '@xml:lang': 'en', '#text': 'English' },
+          { '@xml:lang': 'zh', '#text': '中文' },
+        ],
+        'zh',
+      ),
+      '中文',
+    );
+    assert.equal(
+      __testInternals.getLangText([{ '#text': 'Fallback text' }], 'zh'),
+      'Fallback text',
+    );
+    assert.deepEqual(__testInternals.getLangList({ other: true }), []);
+
+    const summary = __testInternals.summarizeNameFields({
+      processDataSet: {
+        processInformation: {
+          dataSetInformation: {
+            name: {
+              baseName: [lang('Valid process')],
+              functionalUnitFlowProperties: [lang('1 kg output')],
+            },
+          },
+        },
+      },
+    });
+    assert.deepEqual(summary.missing_required_fields, [
+      'treatmentStandardsRoutes',
+      'mixAndLocationTypes',
+    ]);
+    assert.equal(summary.fields.baseName.present, true);
+    assert.equal(summary.fields.baseName.en, 'Valid process');
+    assert.equal(summary.fields.functionalUnitFlowProperties.any, '1 kg output');
+    assert.deepEqual(__testInternals.summarizeNameFields({}).missing_required_fields, [
+      'baseName',
+      'treatmentStandardsRoutes',
+      'mixAndLocationTypes',
+    ]);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('runProcessVerifyRows returns a completed status for fully valid rows and validates required args', async () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-verify-valid-'));
+
+  try {
+    const rowsFile = path.join(tempDir, 'rows.json');
+    writeFileSync(
+      rowsFile,
+      `${JSON.stringify({
+        id: 'proc-valid',
+        version: '01.00.001',
+        process: {
+          processDataSet: {
+            processInformation: {
+              dataSetInformation: {
+                'common:UUID': 'proc-valid',
+                name: {
+                  baseName: [lang('Valid process')],
+                  treatmentStandardsRoutes: [lang('route')],
+                  mixAndLocationTypes: [lang('mix')],
+                  functionalUnitFlowProperties: [lang('1 kg output')],
+                },
+              },
+            },
+          },
+        },
+      })}\n`,
+      'utf8',
+    );
+
+    await assert.rejects(
+      () => runProcessVerifyRows({ rowsFile: '', outDir: tempDir }),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_VERIFY_ROWS_FILE_REQUIRED');
+        return true;
+      },
+    );
+    await assert.rejects(
+      () => runProcessVerifyRows({ rowsFile, outDir: '' }),
+      (error: unknown) => {
+        assert.equal((error as { code?: string }).code, 'PROCESS_VERIFY_OUT_DIR_REQUIRED');
+        return true;
+      },
+    );
+
+    const report = await runProcessVerifyRows({
+      rowsFile,
+      outDir: tempDir,
+      validateProcessPayloadImpl: () => ({
+        ok: true,
+        validator: 'test-validator',
+        issue_count: 0,
+        issues: [],
+      }),
+    });
+
+    assert.equal(report.status, 'completed_process_row_verification');
+    assert.equal(report.invalid_count, 0);
+    assert.equal(report.schema_invalid_count, 0);
+    assert.equal(report.missing_required_name_field_count, 0);
+    assert.deepEqual(report.invalid_rows, []);
+
+    const tidasSdk = await import('@tiangong-lca/tidas-sdk');
+    const originalSafeParse = tidasSdk.ProcessSchema.safeParse;
+    tidasSdk.ProcessSchema.safeParse = (() =>
+      ({
+        success: true,
+        data: {},
+      }) as unknown as ReturnType<typeof originalSafeParse>) as typeof originalSafeParse;
+
+    try {
+      const defaultValidationReport = await runProcessVerifyRows({
+        rowsFile,
+        outDir: tempDir,
+      });
+      assert.equal(defaultValidationReport.status, 'completed_process_row_verification');
+    } finally {
+      tidasSdk.ProcessSchema.safeParse = originalSafeParse;
+    }
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- limit the merge-tag release workflow to the upstream repository so fork `main` does not require release secrets
- harden process-command quality-gate coverage for `dedup-review`, `refresh-references`, `scope-statistics`, `verify-rows`, and payload validation
- add CLI argument and exit-code assertions for the affected process commands and cover runtime fallback branches required by the strict coverage gate

## Testing
- npm run lint
- npm run test:coverage
- npm run test:coverage:assert-full

@chukeaa 