### PR TITLE
Upgrade docpact CI pin to 0.1.4

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: a9a2a0507ea237b9e64b86ea2f79613c9be57ae5
+lastReviewedAt: "2026-04-24"
+lastReviewedCommit: "365e939315ea8f02136816f575e1f6e89b003627"
 
 catalog:
   repos:

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -20,7 +20,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
-        run: cargo install docpact --version 0.1.2 --force
+        run: cargo install docpact --version 0.1.4 --force
 
       - name: Validate docpact config
         run: docpact validate-config --root . --strict

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ checkPaths:
   - test/**
   - scripts/**
   - .github/workflows/**
-lastReviewedAt: 2026-04-19
-lastReviewedCommit: 6bf15e712cc54c5f06b8c333afc57b91896e3a1f
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: 365e939315ea8f02136816f575e1f6e89b003627
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,8 +22,8 @@ checkPaths:
   - src/**
   - test/**
   - scripts/**
-lastReviewedAt: 2026-04-19
-lastReviewedCommit: 6bf15e712cc54c5f06b8c333afc57b91896e3a1f
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: 365e939315ea8f02136816f575e1f6e89b003627
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -23,8 +23,8 @@ checkPaths:
   - test/**
   - scripts/**
   - .github/workflows/**
-lastReviewedAt: 2026-04-19
-lastReviewedCommit: 6bf15e712cc54c5f06b8c333afc57b91896e3a1f
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: 365e939315ea8f02136816f575e1f6e89b003627
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
Closes #90

## Summary
- Upgrade .github/workflows/ai-doc-lint.yml from docpact 0.1.2 to 0.1.4.
- Preserve the existing ai-doc-lint workflow/check name and command shape.
- Refresh governed doc review metadata required by the repo-local docpact rules for workflow changes.

## Key Decisions
- Do not change runtime code, package versions, release automation, or root workspace submodule pointers.

## Validation
- docpact validate-config --root . --strict with docpact 0.1.4.
- docpact lint --root . --worktree --mode enforce with docpact 0.1.4.
- docpact lint --root . --base origin/main --head HEAD --mode enforce with docpact 0.1.4.

## Risks / Rollback
- Root workspace integration remains pending until this child PR merges and the submodule pointer is deliberately bumped.

## Workspace Integration
- Part of tiangong-lca/workspace#77; child issue keeps Workspace Integration Pending.