### PR TITLE
docs: hide README metadata from public landing page

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -271,11 +271,9 @@ rules:
         kind: repo-landing
     requiredDocs:
       - path: AGENTS.md
-        mode: review_or_update
-      - path: README.md
-        mode: review_or_update
+        mode: must_exist
       - path: .docpact/config.yaml
-        mode: review_or_update
+        mode: must_exist
     reason: User-facing CLI invocation docs should stay aligned with the current public command and package surface.
   - id: cli-maintainer-docs-contract
     scope: repo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ checkPaths:
   - test/**
   - scripts/**
   - .github/workflows/**
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: 365e939315ea8f02136816f575e1f6e89b003627
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 5cabf59d9c845ded012d660a247bc62834667dbb
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -1,31 +1,3 @@
----
-title: TianGong LCA CLI README
-docType: guide
-scope: repo
-status: active
-authoritative: false
-owner: cli
-language: en
-whenToUse:
-  - when you need user-facing package installation, CLI invocation, env, or command examples
-whenToUpdate:
-  - when public CLI commands, required env, package installation, or user-facing examples change
-checkPaths:
-  - README.md
-  - package.json
-  - bin/**
-  - src/cli.ts
-  - src/main.ts
-  - src/lib/**
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: a9a2a0507ea237b9e64b86ea2f79613c9be57ae5
-related:
-  - AGENTS.md
-  - .docpact/config.yaml
-  - DEV_CN.md
-  - docs/IMPLEMENTATION_GUIDE_CN.md
----
-
 # TianGong LCA CLI
 
 Package: `@tiangong-lca/cli` Executable: `tiangong` Node: `24.x`

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,8 +22,8 @@ checkPaths:
   - src/**
   - test/**
   - scripts/**
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: 365e939315ea8f02136816f575e1f6e89b003627
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 5cabf59d9c845ded012d660a247bc62834667dbb
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -23,8 +23,8 @@ checkPaths:
   - test/**
   - scripts/**
   - .github/workflows/**
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: 365e939315ea8f02136816f575e1f6e89b003627
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 5cabf59d9c845ded012d660a247bc62834667dbb
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
Closes #92

## Summary
- Remove visible YAML front matter from the root README so GitHub renders the public landing page from the heading.
- Adjust the README landing docpact rule to keep README changes covered without requiring README.md to carry governance metadata.
- Refresh review metadata on the repo entry/governance docs required by the docpact rule change.

## Key Decisions
- README landing rules now use must_exist checks for AGENTS.md and .docpact/config.yaml instead of review_or_update on README.md.

## Validation
- docpact validate-config --strict
- docpact lint --merge-base <target-base> --mode enforce

## Risks / Rollback
- Low-risk docs/governance change; rollback is restoring the prior README front matter and rule modes.

## Workspace Integration
- After merge, lca-workspace should bump the submodule pointer for this repo.