### PR TITLE
[codex] Expand CLI platform matrix

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-08"
-lastReviewedCommit: "06dbec3287513cf94c5d64c73bd467ed5347f40a"
+lastReviewedAt: "2026-05-10"
+lastReviewedCommit: "ea4e5b546ffdd4d5b57d266a58a3d3d5d83c8e5b"
 
 catalog:
   repos:

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -20,6 +20,8 @@ jobs:
             arch: x64
           - os: macos-latest
             arch: arm64
+          - os: ubuntu-24.04-arm
+            arch: arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,8 @@ checkPaths:
   - .githooks/**
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 4f364eb9e47017e3e54850108c65b53e3c860dbc
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: ea4e5b546ffdd4d5b57d266a58a3d3d5d83c8e5b
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 4f364eb9e47017e3e54850108c65b53e3c860dbc
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: e362b575b7baa15bbb9d4e0f697e46570ac8365d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -26,8 +26,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 4f364eb9e47017e3e54850108c65b53e3c860dbc
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: ea4e5b546ffdd4d5b57d266a58a3d3d5d83c8e5b
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -20,8 +20,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 06dbec3287513cf94c5d64c73bd467ed5347f40a
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: ea4e5b546ffdd4d5b57d266a58a3d3d5d83c8e5b
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -17,8 +17,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 06dbec3287513cf94c5d64c73bd467ed5347f40a
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: ea4e5b546ffdd4d5b57d266a58a3d3d5d83c8e5b
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml


### PR DESCRIPTION
## Summary
- Add ubuntu-24.04-arm / arm64 to the CLI quality-gate matrix.
- Record docpact review evidence for the validation and release governance docs touched by this workflow change.

## Validation
- scripts/docpact-gate.sh
- YAML syntax parsed locally before push
- GitHub Actions checks pending on this PR