### PR TITLE
feat: add dataset governance CLI primitives

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -48,6 +48,7 @@ ownership:
         include:
           - src/lib/artifacts.ts
           - src/lib/dataset-command.ts
+          - src/lib/dataset-*.ts
           - src/lib/errors.ts
           - src/lib/flow-*.ts
           - src/lib/io.ts
@@ -177,6 +178,7 @@ routing:
       paths:
         - src/lib/artifacts.ts
         - src/lib/dataset-command.ts
+        - src/lib/dataset-*.ts
         - src/lib/errors.ts
         - src/lib/flow-*.ts
         - src/lib/io.ts
@@ -350,6 +352,8 @@ rules:
       - path: src/lib/artifacts.ts
         kind: artifact-runtime
       - path: src/lib/dataset-command.ts
+        kind: command-logic
+      - path: src/lib/dataset-*.ts
         kind: command-logic
       - path: src/lib/errors.ts
         kind: shared-runtime

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,8 @@ Route those tasks to:
 - Runtime style: TypeScript source, Node-native CLI, direct REST and Edge Function access only
 - Newly added process-maintenance commands such as `process scope-statistics`, `process dedup-review`, `process refresh-references`, and `process verify-rows` still belong to the native CLI command surface in `src/cli.ts` and `src/lib/process-*.ts`.
 - `process save-draft` now has a local `ProcessSchema` validation gate before any commit path writes remote state.
+- Dataset-level local governance commands such as `dataset validate` and `dataset references rewrite` belong to the same native CLI command surface in `src/cli.ts` and `src/lib/dataset-*.ts`.
+- `lifecyclemodel save-draft` validates canonical lifecyclemodel payloads with `LifeCycleModelSchema` before any commit path writes remote state; `lifecyclemodel graph` remains a local artifact command.
 - The canonical minimum validation command is `npm run lint`
 - The authoritative full gate is `npm run prepush:gate`
 - Release tagging is guarded in `.github/workflows/tag-release-from-merge.yml` so only the upstream repository can execute the merge-tag flow.

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -61,9 +61,13 @@ related:
 - `tiangong-lca process resume-build`
 - `tiangong-lca process publish-build`
 - `tiangong-lca process batch-build`
+- `tiangong-lca dataset validate`
+- `tiangong-lca dataset references rewrite`
 - `tiangong-lca lifecyclemodel auto-build`
 - `tiangong-lca lifecyclemodel validate-build`
 - `tiangong-lca lifecyclemodel publish-build`
+- `tiangong-lca lifecyclemodel save-draft`
+- `tiangong-lca lifecyclemodel graph`
 - `tiangong-lca lifecyclemodel build-resulting-process`
 - `tiangong-lca lifecyclemodel publish-resulting-process`
 - `tiangong-lca lifecyclemodel orchestrate`
@@ -177,13 +181,16 @@ TIANGONG_LCA_UNSTRUCTURED_RETURN_TXT=true
 命令级 env 现实如下：
 
 | 命令组 | 必需 env |
-| --- | --- | --- | --- | --- |
+| --- | --- |
 | `doctor` | 无 |
-| `search flow | process | lifecyclemodel` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY`（`TIANGONG_LCA_REGION` 可选） |
+| `search flow \| process \| lifecyclemodel` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY`（`TIANGONG_LCA_REGION` 可选） |
 | `admin embedding-run` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY`（`TIANGONG_LCA_REGION` 可选） |
-| `process get | list` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` |
-| `process auto-build | resume-build | publish-build | batch-build` | 无 |
-| `lifecyclemodel auto-build | validate-build | publish-build | orchestrate` | 无 |
+| `process get \| list` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` |
+| `process auto-build \| resume-build \| publish-build \| batch-build` | 无 |
+| `dataset validate` | 无 |
+| `dataset references rewrite` | 本地 rewrite 默认无；若 `--commit` 写入 patched rows，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` |
+| `lifecyclemodel auto-build \| validate-build \| publish-build \| graph \| orchestrate` | 无 |
+| `lifecyclemodel save-draft` | 本地 dry-run 默认无；若 `--commit` 写入 lifecyclemodel draft，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` |
 | `lifecyclemodel build-resulting-process` | 本地运行默认无；若 request 打开 `process_sources.allow_remote_lookup=true`，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` |
 | `lifecyclemodel publish-resulting-process` | 无 |
 | `review process` | 纯规则 review 默认无；若显式启用 `--enable-llm`，则需要 `TIANGONG_LCA_REVIEW_LLM_BASE_URL`、`TIANGONG_LCA_REVIEW_LLM_API_KEY`、`TIANGONG_LCA_REVIEW_LLM_MODEL` |
@@ -224,9 +231,13 @@ npm exec tiangong-lca -- process auto-build --input ./examples/process-auto-buil
 npm exec tiangong-lca -- process resume-build --run-dir /abs/path/to/process-run --json
 npm exec tiangong-lca -- process publish-build --run-dir /abs/path/to/process-run --json
 npm exec tiangong-lca -- process batch-build --input ./examples/process-batch-build.request.json --out-dir /abs/path/to/process-batch --json
+npm exec tiangong-lca -- dataset validate --input ./rows.jsonl --type auto --out-dir ./dataset-validate --json
+npm exec tiangong-lca -- dataset references rewrite --input ./rows.jsonl --from flow:<old-id>@<old-version> --to flow:<new-id>@<new-version> --out-dir ./dataset-rewrite --json
 npm exec tiangong-lca -- lifecyclemodel auto-build --input ./examples/lifecyclemodel-auto-build.request.json --out-dir /abs/path/to/lifecyclemodel-run --json
 npm exec tiangong-lca -- lifecyclemodel validate-build --run-dir /abs/path/to/lifecyclemodel-run --json
 npm exec tiangong-lca -- lifecyclemodel publish-build --run-dir /abs/path/to/lifecyclemodel-run --json
+npm exec tiangong-lca -- lifecyclemodel save-draft --input ./lifecyclemodels.jsonl --out-dir ./lifecyclemodel-save-draft --dry-run --json
+npm exec tiangong-lca -- lifecyclemodel graph --input ./lifecyclemodels.jsonl --out-dir ./lifecyclemodel-graph --format all --json
 npm exec tiangong-lca -- lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir /abs/path/to/lifecyclemodel-recursive-run --json
 npm exec tiangong-lca -- lifecyclemodel build-resulting-process --input ./request.json --json
 npm exec tiangong-lca -- lifecyclemodel publish-resulting-process --run-dir ./runs/example --publish-processes --publish-relations --json

--- a/README.md
+++ b/README.md
@@ -197,9 +197,13 @@ tiangong-lca process auto-build --input ./examples/process-auto-build.request.js
 tiangong-lca process resume-build --run-dir /abs/path/to/process-run --json
 tiangong-lca process publish-build --run-dir /abs/path/to/process-run --json
 tiangong-lca process batch-build --input ./examples/process-batch-build.request.json --out-dir /abs/path/to/process-batch --json
+tiangong-lca dataset validate --input ./rows.jsonl --type auto --out-dir /abs/path/to/dataset-validate --json
+tiangong-lca dataset references rewrite --input ./rows.jsonl --from flow:<old-id>@<old-version> --to flow:<new-id>@<new-version> --out-dir /abs/path/to/dataset-rewrite --json
 tiangong-lca lifecyclemodel auto-build --input ./examples/lifecyclemodel-auto-build.request.json --out-dir /abs/path/to/lifecyclemodel-run --json
 tiangong-lca lifecyclemodel validate-build --run-dir /abs/path/to/lifecyclemodel-run --json
 tiangong-lca lifecyclemodel publish-build --run-dir /abs/path/to/lifecyclemodel-run --json
+tiangong-lca lifecyclemodel save-draft --input ./lifecyclemodels.jsonl --out-dir /abs/path/to/lifecyclemodel-save-draft --dry-run --json
+tiangong-lca lifecyclemodel graph --input ./lifecyclemodels.jsonl --out-dir /abs/path/to/lifecyclemodel-graph --format all --json
 tiangong-lca lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir /abs/path/to/lifecyclemodel-recursive-run --json
 tiangong-lca review process --rows-file ./process-list-report.json --out-dir ./review
 tiangong-lca review process --run-root /abs/path/to/process-run --run-id <run_id> --out-dir ./review
@@ -214,6 +218,10 @@ For `publish run`, relative `out_dir` values from either the request body or `--
 For `review process`, `--rows-file` accepts either raw process rows as JSON/JSONL or the full JSON report emitted by `tiangong-lca process list --json`, as long as it contains a `rows` array.
 
 For `process save-draft`, canonical process payloads are validated locally with `ProcessSchema` before any `--commit` write. Schema-invalid rows remain in `outputs/save-draft-rpc/failures.jsonl` instead of being persisted.
+
+For `lifecyclemodel save-draft`, canonical lifecyclemodel payloads are validated locally with `LifeCycleModelSchema` before any `--commit` write. Schema-invalid rows remain in `outputs/save-draft-bundle/failures.jsonl` instead of being persisted.
+
+For `dataset references rewrite`, `--commit` executes the state-aware save-draft path for patched process and lifecyclemodel rows; without `--commit`, the command only writes local rewrite artifacts.
 
 ## More Docs
 

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -83,10 +83,15 @@ tiangong-lca
     resume-build
     publish-build
     batch-build
+  dataset
+    validate
+    references rewrite
   lifecyclemodel
     auto-build
     validate-build
     publish-build
+    save-draft
+    graph
     build-resulting-process
     publish-resulting-process
     orchestrate
@@ -125,9 +130,13 @@ tiangong-lca
 | `tiangong-lca process resume-build` | 本地 `process_from_flow` resume handoff、state-lock/manifest 收口、resume 元数据与报告输出 |
 | `tiangong-lca process publish-build` | 本地 `process_from_flow` publish handoff、publish bundle/request/intent 产出、state/invocation/handoff 更新 |
 | `tiangong-lca process batch-build` | 本地 `process_from_flow` batch manifest 编排、批量调用 auto-build、batch report 输出 |
+| `tiangong-lca dataset validate` | 本地 flow / process / lifecyclemodel rows 的统一 TIDAS SDK validation 与稳定报告输出 |
+| `tiangong-lca dataset references rewrite` | 本地 process / lifecyclemodel rows 的 flow reference rewrite、patch evidence 输出，并可选走 state-aware save-draft commit |
 | `tiangong-lca lifecyclemodel auto-build` | 本地 lifecyclemodel local-run intake、graph 推断、reference process 选择、`json_ordered` artifact 输出 |
 | `tiangong-lca lifecyclemodel validate-build` | 本地 lifecyclemodel build run 校验重跑、per-model 校验报告与 aggregate report 输出 |
 | `tiangong-lca lifecyclemodel publish-build` | 本地 lifecyclemodel publish handoff、publish bundle/request/intent 产出、validation 摘要复用 |
+| `tiangong-lca lifecyclemodel save-draft` | 本地 lifecyclemodel rows 的 schema validation、dry-run bundle 输出与可选远端 save-draft 写入 |
+| `tiangong-lca lifecyclemodel graph` | 本地 lifecyclemodel graph / DOT / SVG artifact 输出与连接检查报告 |
 | `tiangong-lca lifecyclemodel build-resulting-process` | 本地 lifecycle model resulting process 聚合、内部 flow 抵消、artifact 输出 |
 | `tiangong-lca lifecyclemodel publish-resulting-process` | 读取 resulting-process run，生成 `publish-bundle.json` / `publish-intent.json` 本地交付物 |
 | `tiangong-lca lifecyclemodel orchestrate` | 递归装配的 plan / execute / publish-handoff 命令；写出 graph/lineage/publish bundle 工件，并只调用原生 CLI builder slices |
@@ -142,6 +151,8 @@ tiangong-lca
 - `tiangong-lca lifecyclemodel auto-build` 已可执行
 - `tiangong-lca lifecyclemodel validate-build` 已可执行
 - `tiangong-lca lifecyclemodel publish-build` 已可执行
+- `tiangong-lca lifecyclemodel save-draft` 已可执行
+- `tiangong-lca lifecyclemodel graph` 已可执行
 - `tiangong-lca lifecyclemodel build-resulting-process` 已可执行
 - `tiangong-lca lifecyclemodel publish-resulting-process` 已可执行
 - `tiangong-lca lifecyclemodel orchestrate` 已可执行
@@ -174,6 +185,11 @@ tiangong-lca
 - `tiangong-lca process publish-build` 已可执行
 - `tiangong-lca process batch-build` 已可执行
 
+`tiangong-lca dataset ...` 现在已经开始承接跨 dataset 的本地治理切片，其中：
+
+- `tiangong-lca dataset validate` 已可执行
+- `tiangong-lca dataset references rewrite` 已可执行
+
 注意：
 
 - `process get` 当前固定为 CLI 内部共享的 deterministic direct-read 面，内部执行已收口到原生 `@supabase/supabase-js`，供 lifecyclemodel resulting-process 和后续 review/governance 迁移复用
@@ -185,6 +201,8 @@ tiangong-lca
 - `process publish-build` 当前只负责本地 publish handoff，不直接执行远端 publish commit 或数据库写入
 - 已实现的 `process batch-build` 继续走本地优先、artifact-first 路径，并把批量 item 编排、聚合 report、显式 batch root 下的 item run_dir 分配统一收口到 CLI
 - `process batch-build` 当前只负责本地 batch orchestration，不直接串接 resume / publish 或远端执行器
+- 已实现的 `dataset validate` 把 flow / process / lifecyclemodel 本地 rows 的 TIDAS SDK 校验收口到一个 dataset 级入口，并输出 type summary、validation report 与 failures jsonl
+- 已实现的 `dataset references rewrite` 把 process / lifecyclemodel rows 中的 flow reference rewrite 收口到一个 deterministic 本地入口，默认只写 patch artifacts，只有显式 `--commit` 时才调用 state-aware save-draft 写入路径
 - 已实现的 `lifecyclemodel auto-build` 走本地只读、artifact-first 路径，输入固定为 local run manifest，不依赖 Python、MCP、KB、LLM 或远端 CRUD
 - `lifecyclemodel auto-build` 当前负责 graph 推断、reference process 选择、`@multiplicationFactor` 计算与 `json_ordered` lifecyclemodel 产物输出，并保留 `run-plan.json`、`resolved-manifest.json`、`selection/selection-brief.md`、`discovery/reference-model-summary.json`、`connections.json`、`process-catalog.json` 等 CLI 契约
 - `lifecyclemodel auto-build` 当前明确不负责 reference-model discovery、任何远端 lifecyclemodel 写入，也不会自动串接 validate-build / publish-build
@@ -192,6 +210,8 @@ tiangong-lca
 - `lifecyclemodel validate-build` 当前只负责本地 validation handoff，不直接触发 publish，也不做任何远端写入
 - 已实现的 `lifecyclemodel publish-build` 继续保留同一套 run 布局，并把本地 publish-bundle/request/intent、validation 摘要复用、invocation index 更新统一收口到 CLI
 - `lifecyclemodel publish-build` 当前只负责本地 publish handoff，不直接执行远端 publish commit 或数据库写入；真正的 dry-run / commit 边界仍由 `tiangong-lca publish run` 负责
+- 已实现的 `lifecyclemodel save-draft` 读取 lifecyclemodel rows JSON/JSONL，先用 `LifeCycleModelSchema` 做本地校验，再按 dry-run / commit 边界输出 selected、progress、failures 与 summary artifacts
+- 已实现的 `lifecyclemodel graph` 从本地 lifecyclemodel rows 生成 graph report、JSON graph、DOT 与 SVG artifacts，并可检查连接问题
 - 已实现的 `build-resulting-process` 和 `publish-resulting-process` 都走本地优先、artifact-first 路径，不依赖 Python 或 MCP
 - `build-resulting-process` 现在还支持一个显式的 deterministic direct-read 补全路径：当 request 打开 `process_sources.allow_remote_lookup=true` 时，CLI 会从 `TIANGONG_LCA_API_BASE_URL` 推导 Supabase 目标，并通过原生 `@supabase/supabase-js` 按 `process_id/version` 直接补齐缺失的 process dataset
 - `publish-resulting-process` 当前负责生成本地 publish handoff 产物，还没有把提交语义直接并入 `publish run`

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -42,6 +42,7 @@ related:
 - 自 2026-04-01 起，这份文档主要作为“Python / POSIX runtime 脱离”审计记录保留
 - 关于 `@supabase/supabase-js`、`@tiangong-lca/tidas-sdk` 直接依赖收口的当前执行状态，以 `docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md` 为准
 - 如果两份文档冲突，以后者代表当前待办和当前结论
+- 2026-05-13 复核：新增 `dataset validate`、`dataset references rewrite`、`lifecyclemodel save-draft` 和 `lifecyclemodel graph` 仍属于既有 CLI-native 迁移方向，不重新引入 Python、POSIX shell 或 MCP runtime 前提
 
 这份文档记录的是：
 

--- a/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
+++ b/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
@@ -33,6 +33,7 @@ related:
 - 这是一份临时 RFC。
 - 在 `tiangong-lca-cli` 正式实现新的认证链之前，这份文件作为后续实现、测试和文档同步的工作底稿。
 - 在方案正式落地前，不把这里的内容视为对外稳定 contract。
+- 2026-05-13 复核：`dataset references rewrite --commit` 与 `lifecyclemodel save-draft --commit` 继续复用现有用户 session 链，不新增认证 env 或 alternate bearer 模式。
 
 ## 1. 已确认事实
 

--- a/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
+++ b/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
@@ -66,6 +66,7 @@ related:
 
 最近更新：
 
+- 2026-05-13：已复核 dataset / lifecyclemodel governance 命令扩展；新增本地 validation、reference rewrite、save-draft 和 graph 路径继续使用当前 `@supabase/supabase-js` 与 `@tiangong-lca/tidas-sdk` 直接依赖模型，不重开 Issue #55 的直接依赖 TODO。
 - 2026-04-01：已提交 `7bd8a93`，推送分支 `codex/chore-issue-55-direct-deps` 到 fork，并创建 PR `tiangong-lca/tiangong-cli#56`；child issue `#55` 的执行 TODO 已同步为完成态，parent / child issue 都已补充结构化进展评论。
 - 2026-04-01：`npm run prepush:gate` 已通过，包含 `lint`、`test:coverage`、`test:coverage:assert-full` 全绿；repo-local 质量门已全部满足。
 - 2026-04-01：已用 Prettier 修复 `test/tidas-sdk-package-validator.test.ts` 的格式问题，当前准备重跑 `npm run prepush:gate`。

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -83,6 +83,7 @@ This is where the CLI-owned remote access contract lives.
 The widest feature families currently live in:
 
 - `src/lib/flow-*.ts`
+- `src/lib/dataset-*.ts`
 - `src/lib/review-*.ts`
 - `src/lib/process-*.ts`
 - `src/lib/lifecyclemodel-*.ts`
@@ -108,6 +109,18 @@ These modules share one contract:
 - `src/cli.ts` owns subcommand registration, help, and exit semantics
 - `process save-draft` validates canonical payloads with `ProcessSchema` before remote writes
 - maintenance and review commands still emit artifact-first local outputs and remain covered by the strict `src/**/*.ts` coverage gate
+
+### Dataset and lifecyclemodel governance commands
+
+Dataset-local governance now uses the same CLI-native command layer:
+
+- `src/lib/dataset-validate.ts`
+- `src/lib/dataset-references-rewrite.ts`
+- `src/lib/dataset-local.ts`
+- `src/lib/lifecyclemodel-save-draft-run.ts`
+- `src/lib/lifecyclemodel-graph.ts`
+
+These modules keep validation, reference rewrites, save-draft preparation, graph extraction, and local artifact reports inside the CLI instead of routing through skills or MCP transports.
 
 ### Artifact and filesystem behavior
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -67,7 +67,7 @@ docpact lint --root . --base <base> --head <head> --mode enforce
 | --- | --- | --- | --- |
 | `bin/**`, `src/main.ts`, or `src/cli.ts` | `npm run lint`; `npm test`; `npm run build` | run the relevant `tiangong-lca --help` or subcommand help path after build | Launcher and dispatch changes affect the public command surface directly. |
 | session, auth, env, or remote adapter helpers under `src/lib/{dotenv,env,user-api-key,supabase-*,remote,http}*` | `npm run lint`; `npm test`; `npm run build` | run focused tests for the touched helper plus one command that exercises the changed path | Record any required live env assumptions in the PR note. |
-| flow, process, lifecyclemodel, review, publish, or run command families | `npm run lint`; `npm test`; `npm run build` | run focused tests for the touched command family; run `npm run test:coverage:assert-full` if the change touched uncovered branches; prefer `npm run prepush:gate` when the change adds new command paths | Preserve the low-entropy command contract and structured artifact outputs. |
+| flow, process, dataset, lifecyclemodel, review, publish, or run command families | `npm run lint`; `npm test`; `npm run build` | run focused tests for the touched command family; run `npm run test:coverage:assert-full` if the change touched uncovered branches; prefer `npm run prepush:gate` when the change adds new command paths | Preserve the low-entropy command contract and structured artifact outputs. |
 | artifact, IO, or state-lock behavior | `npm run lint`; `npm test`; `npm run build` | run one representative command path that writes the changed artifact layout, if safe | Path and file layout regressions matter for downstream automation. |
 | `test/**` or coverage gate scripts | `npm run lint`; `npm test`; `npm run test:coverage`; `npm run test:coverage:assert-full` | run `npm run prepush:gate` when the change affects the protected-branch gate directly | Coverage for `src/**/*.ts` is expected to remain at `100%`. |
 | `package.json`, `.nvmrc`, `scripts/ci/**`, or `.github/workflows/**` | `npm run lint`; `npm test`; `npm run build` | run `npm run prepush:gate`; run `docpact lint` when the change affects release or documentation gates | Release-tag checks, workflow guards, and dependency baselines change the repo contract. |
@@ -80,7 +80,7 @@ Facts that matter:
 - `npm run test:coverage` is the full coverage proof
 - `npm run test:coverage:assert-full` verifies the latest coverage artifact without rerunning coverage
 - `npm run prepush:gate` is the exact protected-branch gate
-- `process save-draft` and the newer process maintenance commands are expected to preserve `100%` coverage even when they add schema-validation or fallback branches
+- `process save-draft`, `lifecyclemodel save-draft`, dataset governance commands, and the newer process maintenance commands are expected to preserve `100%` coverage even when they add schema-validation, rewrite, or fallback branches
 - release-tag and docpact lint workflow changes should be described in the PR note when they alter the local or protected-branch proof
 
 If the task changes control flow, add or update tests instead of using coverage-ignore pragmas.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -49,6 +49,7 @@ Before starting a release:
 - work from the latest `main`
 - keep the release-prep change scoped to CLI package version metadata
 - confirm npm has not already published the target version
+- confirm any command-surface feature PRs that will be included in the release have passed `npm run prepush:gate` and the docpact CI gate before preparing the version bump
 
 Useful commands:
 

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -93,6 +93,7 @@ Leave the environment name unset unless the workflow is explicitly updated to us
 - `publish.yml` validates that the Git tag matches the package version before upload.
 - `tag-release-from-merge.yml` only creates a tag when `package.json` version changes on `main`.
 - The release-prep PR should update only the intended versioned release metadata for the CLI package.
+- Adding CLI command families such as dataset or lifecyclemodel maintenance commands does not require release setup changes by itself; those feature PRs are covered by the normal quality and docpact gates before a later version bump.
 
 ## Local Docpact Push Gate
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,16 @@ import {
   type RunLifecyclemodelPublishBuildOptions,
 } from './lib/lifecyclemodel-publish-build.js';
 import {
+  runLifecyclemodelSaveDraft,
+  type LifecyclemodelSaveDraftReport,
+  type RunLifecyclemodelSaveDraftOptions,
+} from './lib/lifecyclemodel-save-draft-run.js';
+import {
+  runLifecyclemodelGraph,
+  type LifecyclemodelGraphReport,
+  type RunLifecyclemodelGraphOptions,
+} from './lib/lifecyclemodel-graph.js';
+import {
   runLifecyclemodelOrchestrate,
   type LifecyclemodelOrchestrateReport,
   type RunLifecyclemodelOrchestrateOptions,
@@ -161,6 +171,16 @@ import {
   type RunValidationOptions,
   type ValidationRunReport,
 } from './lib/validation.js';
+import {
+  runDatasetValidate,
+  type DatasetValidateReport,
+  type RunDatasetValidateOptions,
+} from './lib/dataset-validate.js';
+import {
+  runDatasetReferencesRewrite,
+  type DatasetReferencesRewriteReport,
+  type RunDatasetReferencesRewriteOptions,
+} from './lib/dataset-references-rewrite.js';
 
 export type CliDeps = {
   env: NodeJS.ProcessEnv;
@@ -183,6 +203,12 @@ export type CliDeps = {
   runLifecyclemodelPublishBuildImpl?: (
     options: RunLifecyclemodelPublishBuildOptions,
   ) => Promise<LifecyclemodelPublishBuildReport>;
+  runLifecyclemodelSaveDraftImpl?: (
+    options: RunLifecyclemodelSaveDraftOptions,
+  ) => Promise<LifecyclemodelSaveDraftReport>;
+  runLifecyclemodelGraphImpl?: (
+    options: RunLifecyclemodelGraphOptions,
+  ) => Promise<LifecyclemodelGraphReport>;
   runLifecyclemodelOrchestrateImpl?: (
     options: RunLifecyclemodelOrchestrateOptions,
   ) => Promise<LifecyclemodelOrchestrateReport>;
@@ -251,6 +277,10 @@ export type CliDeps = {
   runFlowValidateProcessesImpl?: (
     options: RunFlowValidateProcessesOptions,
   ) => Promise<FlowValidateProcessesReport>;
+  runDatasetValidateImpl?: (options: RunDatasetValidateOptions) => Promise<DatasetValidateReport>;
+  runDatasetReferencesRewriteImpl?: (
+    options: RunDatasetReferencesRewriteOptions,
+  ) => Promise<DatasetReferencesRewriteReport>;
 };
 
 export type CliResult = {
@@ -283,8 +313,9 @@ Implemented Commands:
   doctor     show environment diagnostics
   search     flow | process | lifecyclemodel
   process    get | list | scope-statistics | dedup-review | auto-build | resume-build | publish-build | save-draft | batch-build | refresh-references | verify-rows
+  dataset    validate | references rewrite
   flow       get | list | fetch-rows | materialize-decisions | remediate | publish-version | publish-reviewed-data | build-alias-map | scan-process-flow-refs | plan-process-flow-repairs | apply-process-flow-repairs | regen-product | validate-processes
-  lifecyclemodel auto-build | validate-build | publish-build | build-resulting-process | publish-resulting-process | orchestrate
+  lifecyclemodel auto-build | validate-build | publish-build | save-draft | graph | build-resulting-process | publish-resulting-process | orchestrate
   review     process | flow | lifecyclemodel
   publish    run
   validation run
@@ -311,9 +342,13 @@ Examples:
   tiangong-lca process batch-build --input ./batch-request.json --out-dir /abs/path/to/process-batch
   tiangong-lca process refresh-references --out-dir /abs/path/to/process-refresh --dry-run
   tiangong-lca process verify-rows --rows-file ./process-list-report.json --out-dir /abs/path/to/process-verify
+  tiangong-lca dataset validate --input ./rows.jsonl --type auto --out-dir /abs/path/to/dataset-validate
+  tiangong-lca dataset references rewrite --input ./rows.jsonl --from flow:<old-id>@<old-version> --to flow:<new-id>@<new-version> --out-dir /abs/path/to/dataset-rewrite
   tiangong-lca lifecyclemodel auto-build --input ./lifecyclemodel-auto-build.request.json --out-dir /abs/path/to/lifecyclemodel-run
   tiangong-lca lifecyclemodel validate-build --run-dir /abs/path/to/lifecyclemodel-run
   tiangong-lca lifecyclemodel publish-build --run-dir /abs/path/to/lifecyclemodel-run
+  tiangong-lca lifecyclemodel save-draft --input ./lifecyclemodels.jsonl --out-dir /abs/path/to/lifecyclemodel-save-draft --dry-run
+  tiangong-lca lifecyclemodel graph --input ./lifecyclemodels.jsonl --out-dir /abs/path/to/lifecyclemodel-graph --format all
   tiangong-lca lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir /abs/path/to/lifecyclemodel-recursive-run
   tiangong-lca flow get --id <flow-id> --version <version>
   tiangong-lca flow list --id <flow-id> --state-code 100 --limit 20
@@ -428,6 +463,67 @@ Options:
   --report-file <file> Write the structured validation report to a file
   --json               Print compact JSON
   -h, --help
+`.trim();
+}
+
+function renderDatasetHelp(): string {
+  return `Usage:
+  tiangong-lca dataset <subcommand> [options]
+
+Implemented Subcommands:
+  validate             Validate local flow / process / lifecyclemodel rows with the TIDAS SDK
+  references rewrite   Rewrite flow references in local process and lifecyclemodel rows
+
+Examples:
+  tiangong-lca dataset validate --input ./rows.jsonl --type auto --out-dir ./dataset-validate --help
+  tiangong-lca dataset references rewrite --input ./rows.jsonl --from flow:<old-id>@<old-version> --to flow:<new-id>@<new-version> --out-dir ./dataset-rewrite --help
+`.trim();
+}
+
+function renderDatasetValidateHelp(): string {
+  return `Usage:
+  tiangong-lca dataset validate --input <file> [options]
+
+Options:
+  --input <file>   Local rows as JSON or JSONL; objects with rows[] are also accepted
+  --type <type>    auto | flow | process | lifecyclemodel (default: auto)
+  --out-dir <dir>  Optional artifact directory for validation report and row splits
+  --json           Print compact JSON
+  -h, --help
+
+Outputs written under --out-dir:
+  - outputs/validation-report.json
+  - outputs/valid-rows.jsonl
+  - outputs/invalid-rows.jsonl
+`.trim();
+}
+
+function renderDatasetReferencesHelp(): string {
+  return `Usage:
+  tiangong-lca dataset references rewrite --input <file> --from flow:<id>[@<version>] --to flow:<id>[@<version>] [options]
+
+Options:
+  --input <file>   Local rows as JSON or JSONL; process and lifecyclemodel rows are supported
+  --from <ref>     Source flow reference, for example flow:<old-id>@01.00.000
+  --to <ref>       Target flow reference, for example flow:<new-id>@01.01.000
+  --type <type>    Repeatable row type filter: process | lifecyclemodel (default: both)
+  --types <csv>    Comma-separated alias for one or more row types
+  --scope <label>  Optional artifact label for the already-frozen input scope
+  --out-dir <dir>  Artifact directory for rewrite plan and patched rows
+  --commit         Execute state-aware save-draft writes for patched rows
+  --dry-run        Keep the command local-only (default)
+  --json           Print compact JSON
+  -h, --help
+
+Environment:
+  none for local dry-run
+  TIANGONG_LCA_API_BASE_URL, TIANGONG_LCA_API_KEY, and TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY
+  when --commit executes remote writes
+
+Outputs written under --out-dir:
+  - outputs/patched-rows.jsonl
+  - outputs/rewrite-plan.json
+  - outputs/summary.json
 `.trim();
 }
 
@@ -896,6 +992,57 @@ Options:
 `.trim();
 }
 
+function renderLifecyclemodelSaveDraftHelp(): string {
+  return `Usage:
+  tiangong-lca lifecyclemodel save-draft --input <file> [options]
+
+Options:
+  --input <file>     Lifecyclemodel rows JSON/JSONL file or publish-request.json
+  --out-dir <dir>    Run root written relative to cwd when a relative path is passed
+  --commit           Execute remote save-draft writes
+  --dry-run          Keep the command local-only (default)
+  --json             Print compact JSON
+  -h, --help
+
+Environment:
+  none for local dry-run
+  TIANGONG_LCA_API_BASE_URL, TIANGONG_LCA_API_KEY, and TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY
+  when --commit executes remote writes
+
+Local gate:
+  canonical lifecyclemodel payloads are validated against LifeCycleModelSchema before any remote write;
+  schema-invalid rows stay in failures.jsonl instead of being committed
+
+Outputs written under --out-dir:
+  - inputs/normalized-input.json
+  - outputs/save-draft-bundle/selected-lifecyclemodels.jsonl
+  - outputs/save-draft-bundle/progress.jsonl
+  - outputs/save-draft-bundle/failures.jsonl
+  - outputs/save-draft-bundle/summary.json
+`.trim();
+}
+
+function renderLifecyclemodelGraphHelp(): string {
+  return `Usage:
+  tiangong-lca lifecyclemodel graph --input <file> [options]
+
+Options:
+  --input <file>          Lifecyclemodel rows JSON/JSONL file
+  --out-dir <dir>         Artifact directory for graph files and findings
+  --format <format>       json | dot | svg | all (default: all)
+  --check-connections     Fail when process-instance links are missing or unresolved
+  --json                  Print compact JSON
+  -h, --help
+
+Outputs written under --out-dir:
+  - outputs/graph-report.json
+  - outputs/findings.jsonl
+  - graphs/*.json
+  - graphs/*.dot
+  - graphs/*.svg
+`.trim();
+}
+
 function renderLifecyclemodelHelp(): string {
   return `Usage:
   tiangong-lca lifecyclemodel <subcommand> [options]
@@ -904,6 +1051,8 @@ Implemented Subcommands:
   auto-build                Build native lifecyclemodel json_ordered artifacts from local process run exports
   validate-build            Re-run local validation on one lifecyclemodel build run
   publish-build             Prepare lifecyclemodel publish handoff artifacts from one local build run
+  save-draft                Save canonical lifecyclemodel datasets through the bundle save path
+  graph                     Derive lifecyclemodel graph artifacts and connection findings
   build-resulting-process   Deterministically aggregate a lifecycle model into a resulting process bundle
   publish-resulting-process Prepare publish-bundle.json and publish-intent.json from a prior resulting-process run
   orchestrate               Plan, execute, or publish a recursive lifecyclemodel assembly run
@@ -913,6 +1062,8 @@ Examples:
   tiangong-lca lifecyclemodel auto-build --help
   tiangong-lca lifecyclemodel validate-build --help
   tiangong-lca lifecyclemodel publish-build --help
+  tiangong-lca lifecyclemodel save-draft --help
+  tiangong-lca lifecyclemodel graph --help
   tiangong-lca lifecyclemodel build-resulting-process --help
   tiangong-lca lifecyclemodel orchestrate --help
 `.trim();
@@ -1539,6 +1690,108 @@ function parseValidationFlags(args: string[]): {
     inputDir: typeof values['input-dir'] === 'string' ? values['input-dir'] : '',
     engine: typeof values.engine === 'string' ? values.engine : undefined,
     reportFile: typeof values['report-file'] === 'string' ? values['report-file'] : null,
+  };
+}
+
+function parseDatasetValidateFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  inputPath: string;
+  type: string | undefined;
+  outDir: string | null;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        input: { type: 'string' },
+        type: { type: 'string' },
+        'out-dir': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    inputPath: typeof values.input === 'string' ? values.input : '',
+    type: typeof values.type === 'string' ? values.type : undefined,
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : null,
+  };
+}
+
+function parseDatasetReferencesRewriteFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  inputPath: string;
+  from: string;
+  to: string;
+  types: string[];
+  scope: string | null;
+  outDir: string;
+  commit: boolean;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        input: { type: 'string' },
+        from: { type: 'string' },
+        to: { type: 'string' },
+        type: { type: 'string', multiple: true },
+        types: { type: 'string', multiple: true },
+        scope: { type: 'string' },
+        'out-dir': { type: 'string' },
+        commit: { type: 'boolean' },
+        'dry-run': { type: 'boolean' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  if (values.commit && values['dry-run']) {
+    throw new CliError('Cannot pass both --commit and --dry-run.', {
+      code: 'DATASET_REFERENCES_REWRITE_MODE_CONFLICT',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    inputPath: typeof values.input === 'string' ? values.input : '',
+    from: typeof values.from === 'string' ? values.from : '',
+    to: typeof values.to === 'string' ? values.to : '',
+    types: [
+      ...(Array.isArray(values.type)
+        ? values.type.filter((value): value is string => typeof value === 'string')
+        : []),
+      ...(Array.isArray(values.types)
+        ? values.types.filter((value): value is string => typeof value === 'string')
+        : []),
+    ],
+    scope: typeof values.scope === 'string' ? values.scope : null,
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : '',
+    commit: Boolean(values.commit),
   };
 }
 
@@ -2776,6 +3029,91 @@ function parseLifecyclemodelPublishBuildFlags(args: string[]): {
   };
 }
 
+function parseLifecyclemodelSaveDraftFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  inputPath: string;
+  outDir: string | null;
+  commit: boolean;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        input: { type: 'string' },
+        'out-dir': { type: 'string' },
+        commit: { type: 'boolean' },
+        'dry-run': { type: 'boolean' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  if (values.commit && values['dry-run']) {
+    throw new CliError('Cannot pass both --commit and --dry-run.', {
+      code: 'INVALID_LIFECYCLEMODEL_SAVE_DRAFT_MODE',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    inputPath: typeof values.input === 'string' ? values.input : '',
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : null,
+    commit: Boolean(values.commit),
+  };
+}
+
+function parseLifecyclemodelGraphFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  inputPath: string;
+  outDir: string;
+  format: string | undefined;
+  checkConnections: boolean;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        input: { type: 'string' },
+        'out-dir': { type: 'string' },
+        format: { type: 'string' },
+        'check-connections': { type: 'boolean' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    inputPath: typeof values.input === 'string' ? values.input : '',
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : '',
+    format: typeof values.format === 'string' ? values.format : undefined,
+    checkConnections: Boolean(values['check-connections']),
+  };
+}
+
 function parseLifecyclemodelBuildFlags(args: string[]): {
   help: boolean;
   json: boolean;
@@ -3484,6 +3822,9 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
       deps.runLifecyclemodelValidateBuildImpl ?? runLifecyclemodelValidateBuild;
     const lifecyclemodelPublishBuildImpl =
       deps.runLifecyclemodelPublishBuildImpl ?? runLifecyclemodelPublishBuild;
+    const lifecyclemodelSaveDraftImpl =
+      deps.runLifecyclemodelSaveDraftImpl ?? runLifecyclemodelSaveDraft;
+    const lifecyclemodelGraphImpl = deps.runLifecyclemodelGraphImpl ?? runLifecyclemodelGraph;
     const lifecyclemodelOrchestrateImpl =
       deps.runLifecyclemodelOrchestrateImpl ?? runLifecyclemodelOrchestrate;
     const processGetImpl = deps.runProcessGetImpl ?? runProcessGet;
@@ -3520,6 +3861,9 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
       deps.runFlowApplyProcessFlowRepairsImpl ?? runFlowApplyProcessFlowRepairs;
     const flowRegenProductImpl = deps.runFlowRegenProductImpl ?? runFlowRegenProduct;
     const flowValidateProcessesImpl = deps.runFlowValidateProcessesImpl ?? runFlowValidateProcesses;
+    const datasetValidateImpl = deps.runDatasetValidateImpl ?? runDatasetValidate;
+    const datasetReferencesRewriteImpl =
+      deps.runDatasetReferencesRewriteImpl ?? runDatasetReferencesRewrite;
 
     if (flags.version) {
       return { exitCode: 0, stdout: `${loadCliPackageVersion(import.meta.url)}\n`, stderr: '' };
@@ -3565,6 +3909,65 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
           compactJson: remoteFlags.json,
           fetchImpl: deps.fetchImpl,
         }),
+        stderr: '',
+      };
+    }
+
+    if (command === 'dataset' && !subcommand) {
+      return { exitCode: 0, stdout: `${renderDatasetHelp()}\n`, stderr: '' };
+    }
+
+    if (command === 'dataset' && subcommand === 'validate') {
+      const datasetFlags = parseDatasetValidateFlags(commandArgs);
+      if (datasetFlags.help) {
+        return { exitCode: 0, stdout: `${renderDatasetValidateHelp()}\n`, stderr: '' };
+      }
+
+      const report = await datasetValidateImpl({
+        inputPath: datasetFlags.inputPath,
+        type: datasetFlags.type,
+        outDir: datasetFlags.outDir,
+      });
+
+      return {
+        exitCode: report.counts.invalid > 0 ? 1 : 0,
+        stdout: stringifyJson(report, datasetFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'dataset' && subcommand === 'references') {
+      const action = commandArgs[0] ?? '';
+      if (!action || action === '--help' || action === '-h') {
+        return { exitCode: 0, stdout: `${renderDatasetReferencesHelp()}\n`, stderr: '' };
+      }
+      if (action !== 'rewrite') {
+        throw new CliError("dataset references action must be 'rewrite'.", {
+          code: 'INVALID_ARGS',
+          exitCode: 2,
+        });
+      }
+
+      const datasetFlags = parseDatasetReferencesRewriteFlags(commandArgs.slice(1));
+      if (datasetFlags.help) {
+        return { exitCode: 0, stdout: `${renderDatasetReferencesHelp()}\n`, stderr: '' };
+      }
+
+      const report = await datasetReferencesRewriteImpl({
+        inputPath: datasetFlags.inputPath,
+        from: datasetFlags.from,
+        to: datasetFlags.to,
+        types: datasetFlags.types,
+        scope: datasetFlags.scope,
+        outDir: datasetFlags.outDir,
+        commit: datasetFlags.commit,
+        env: deps.env,
+        fetchImpl: deps.fetchImpl,
+      });
+
+      return {
+        exitCode: report.status === 'completed_with_failures' ? 1 : 0,
+        stdout: stringifyJson(report, datasetFlags.json),
         stderr: '',
       };
     }
@@ -3683,6 +4086,55 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
 
       return {
         exitCode: 0,
+        stdout: stringifyJson(report, lifecyclemodelFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'lifecyclemodel' && subcommand === 'save-draft') {
+      const lifecyclemodelFlags = parseLifecyclemodelSaveDraftFlags(commandArgs);
+      if (lifecyclemodelFlags.help) {
+        return {
+          exitCode: 0,
+          stdout: `${renderLifecyclemodelSaveDraftHelp()}\n`,
+          stderr: '',
+        };
+      }
+
+      const report = await lifecyclemodelSaveDraftImpl({
+        inputPath: lifecyclemodelFlags.inputPath,
+        outDir: lifecyclemodelFlags.outDir,
+        commit: lifecyclemodelFlags.commit,
+        env: deps.env,
+        fetchImpl: deps.fetchImpl,
+      });
+
+      return {
+        exitCode: report.status === 'completed_with_failures' ? 1 : 0,
+        stdout: stringifyJson(report, lifecyclemodelFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'lifecyclemodel' && subcommand === 'graph') {
+      const lifecyclemodelFlags = parseLifecyclemodelGraphFlags(commandArgs);
+      if (lifecyclemodelFlags.help) {
+        return {
+          exitCode: 0,
+          stdout: `${renderLifecyclemodelGraphHelp()}\n`,
+          stderr: '',
+        };
+      }
+
+      const report = await lifecyclemodelGraphImpl({
+        inputPath: lifecyclemodelFlags.inputPath,
+        outDir: lifecyclemodelFlags.outDir,
+        format: lifecyclemodelFlags.format,
+        checkConnections: lifecyclemodelFlags.checkConnections,
+      });
+
+      return {
+        exitCode: report.status === 'completed_with_findings' ? 1 : 0,
         stdout: stringifyJson(report, lifecyclemodelFlags.json),
         stderr: '',
       };

--- a/src/lib/dataset-local.ts
+++ b/src/lib/dataset-local.ts
@@ -1,0 +1,273 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { CliError } from './errors.js';
+import { readJsonInput } from './io.js';
+
+export type JsonObject = Record<string, unknown>;
+
+export type DatasetKind = 'flow' | 'process' | 'lifecyclemodel';
+
+export type DatasetRowInput = {
+  index: number;
+  row: JsonObject;
+  payload: JsonObject;
+  kind: DatasetKind | null;
+  id: string | null;
+  version: string | null;
+};
+
+export function isRecord(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export function trimToken(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+export function firstNonEmpty(...values: unknown[]): string | null {
+  for (const value of values) {
+    const token = trimToken(value);
+    if (token) {
+      return token;
+    }
+  }
+  return null;
+}
+
+function readJsonLinesInput(inputPath: string): JsonObject[] {
+  const resolved = path.resolve(inputPath);
+  if (!existsSync(resolved)) {
+    throw new CliError(`Input file not found: ${resolved}`, {
+      code: 'INPUT_NOT_FOUND',
+      exitCode: 2,
+    });
+  }
+
+  return readFileSync(resolved, 'utf8')
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line, index) => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch (error) {
+        throw new CliError(`Input file contains invalid JSONL at line ${index + 1}: ${resolved}`, {
+          code: 'INPUT_INVALID_JSONL',
+          exitCode: 2,
+          details: String(error),
+        });
+      }
+      if (!isRecord(parsed)) {
+        throw new CliError(
+          `Expected JSON object rows in JSONL input: ${resolved} (line ${index + 1})`,
+          {
+            code: 'INPUT_INVALID_JSONL_ROW',
+            exitCode: 2,
+          },
+        );
+      }
+      return parsed;
+    });
+}
+
+function normalizeStructuredRows(value: unknown, inputPath: string): JsonObject[] {
+  const rows = isRecord(value) && Array.isArray(value.rows) ? value.rows : value;
+  const normalizedRows = Array.isArray(rows) ? rows : [rows];
+  return normalizedRows.map((row, index) => {
+    if (!isRecord(row)) {
+      throw new CliError(
+        `Expected JSON object rows in dataset input: ${inputPath} (index ${index})`,
+        {
+          code: 'DATASET_INPUT_INVALID_ROW',
+          exitCode: 2,
+        },
+      );
+    }
+    return row;
+  });
+}
+
+export function readDatasetRowsInput(inputPath: string, rawInput?: unknown): JsonObject[] {
+  if (!inputPath) {
+    throw new CliError('Missing required --input value.', {
+      code: 'DATASET_INPUT_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  if (rawInput !== undefined) {
+    return normalizeStructuredRows(rawInput, inputPath);
+  }
+
+  const resolved = path.resolve(inputPath);
+  return resolved.toLowerCase().endsWith('.jsonl')
+    ? readJsonLinesInput(resolved)
+    : normalizeStructuredRows(readJsonInput(resolved), resolved);
+}
+
+export function datasetRoot(payload: JsonObject, kind: DatasetKind): JsonObject {
+  if (kind === 'flow') {
+    return isRecord(payload.flowDataSet) ? payload.flowDataSet : payload;
+  }
+  if (kind === 'process') {
+    return isRecord(payload.processDataSet) ? payload.processDataSet : payload;
+  }
+  return isRecord(payload.lifeCycleModelDataSet) ? payload.lifeCycleModelDataSet : payload;
+}
+
+export function detectDatasetKind(value: JsonObject): DatasetKind | null {
+  const payload = unwrapDatasetPayload(value);
+  if (isRecord(payload.flowDataSet)) {
+    return 'flow';
+  }
+  if (isRecord(payload.processDataSet)) {
+    return 'process';
+  }
+  if (isRecord(payload.lifeCycleModelDataSet)) {
+    return 'lifecyclemodel';
+  }
+  if (isRecord(value.flow)) {
+    return 'flow';
+  }
+  if (isRecord(value.process)) {
+    return 'process';
+  }
+  if (isRecord(value.lifecyclemodel)) {
+    return 'lifecyclemodel';
+  }
+  return null;
+}
+
+export function unwrapDatasetPayload(row: JsonObject): JsonObject {
+  for (const key of ['json_ordered', 'jsonOrdered', 'json', 'payload'] as const) {
+    if (isRecord(row[key])) {
+      return row[key];
+    }
+  }
+  if (isRecord(row.flow)) {
+    return row.flow;
+  }
+  if (isRecord(row.process)) {
+    return row.process;
+  }
+  if (isRecord(row.lifecyclemodel)) {
+    return row.lifecyclemodel;
+  }
+  return row;
+}
+
+function flowIdentity(payload: JsonObject): { id: string | null; version: string | null } {
+  const root = datasetRoot(payload, 'flow');
+  const information = isRecord(root.flowInformation) ? root.flowInformation : {};
+  const dataSetInformation = isRecord(information.dataSetInformation)
+    ? information.dataSetInformation
+    : {};
+  const administrativeInformation = isRecord(root.administrativeInformation)
+    ? root.administrativeInformation
+    : {};
+  const publicationAndOwnership = isRecord(administrativeInformation.publicationAndOwnership)
+    ? administrativeInformation.publicationAndOwnership
+    : {};
+  return {
+    id: firstNonEmpty(dataSetInformation['common:UUID']),
+    version: firstNonEmpty(publicationAndOwnership['common:dataSetVersion']),
+  };
+}
+
+function processIdentity(payload: JsonObject): { id: string | null; version: string | null } {
+  const root = datasetRoot(payload, 'process');
+  const information = isRecord(root.processInformation) ? root.processInformation : {};
+  const dataSetInformation = isRecord(information.dataSetInformation)
+    ? information.dataSetInformation
+    : {};
+  const administrativeInformation = isRecord(root.administrativeInformation)
+    ? root.administrativeInformation
+    : {};
+  const publicationAndOwnership = isRecord(administrativeInformation.publicationAndOwnership)
+    ? administrativeInformation.publicationAndOwnership
+    : {};
+  return {
+    id: firstNonEmpty(dataSetInformation['common:UUID']),
+    version: firstNonEmpty(publicationAndOwnership['common:dataSetVersion']),
+  };
+}
+
+function lifecyclemodelIdentity(payload: JsonObject): {
+  id: string | null;
+  version: string | null;
+} {
+  const root = datasetRoot(payload, 'lifecyclemodel');
+  const information = isRecord(root.lifeCycleModelInformation)
+    ? root.lifeCycleModelInformation
+    : {};
+  const dataSetInformation = isRecord(information.dataSetInformation)
+    ? information.dataSetInformation
+    : {};
+  const administrativeInformation = isRecord(root.administrativeInformation)
+    ? root.administrativeInformation
+    : {};
+  const publicationAndOwnership = isRecord(administrativeInformation.publicationAndOwnership)
+    ? administrativeInformation.publicationAndOwnership
+    : {};
+  return {
+    id: firstNonEmpty(dataSetInformation['common:UUID']),
+    version: firstNonEmpty(publicationAndOwnership['common:dataSetVersion']),
+  };
+}
+
+export function datasetIdentity(
+  row: JsonObject,
+  payload: JsonObject,
+  kind: DatasetKind | null,
+): { id: string | null; version: string | null } {
+  if (kind === 'flow') {
+    const identity = flowIdentity(payload);
+    return {
+      id: firstNonEmpty(row.id, identity.id),
+      version: firstNonEmpty(row.version, identity.version),
+    };
+  }
+  if (kind === 'process') {
+    const identity = processIdentity(payload);
+    return {
+      id: firstNonEmpty(row.id, identity.id),
+      version: firstNonEmpty(row.version, identity.version),
+    };
+  }
+  if (kind === 'lifecyclemodel') {
+    const identity = lifecyclemodelIdentity(payload);
+    return {
+      id: firstNonEmpty(row.id, identity.id),
+      version: firstNonEmpty(row.version, identity.version),
+    };
+  }
+  return {
+    id: firstNonEmpty(row.id),
+    version: firstNonEmpty(row.version),
+  };
+}
+
+export function materializeDatasetRows(inputPath: string, rawInput?: unknown): DatasetRowInput[] {
+  return readDatasetRowsInput(inputPath, rawInput).map((row, index) => {
+    const payload = unwrapDatasetPayload(row);
+    const kind = detectDatasetKind(row);
+    const identity = datasetIdentity(row, payload, kind);
+    return {
+      index,
+      row,
+      payload,
+      kind,
+      id: identity.id,
+      version: identity.version,
+    };
+  });
+}

--- a/src/lib/dataset-references-rewrite.ts
+++ b/src/lib/dataset-references-rewrite.ts
@@ -1,0 +1,355 @@
+import path from 'node:path';
+import { writeJsonArtifact, writeJsonLinesArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+import type { FetchLike } from './http.js';
+import {
+  cloneJson,
+  firstNonEmpty,
+  isRecord,
+  materializeDatasetRows,
+  unwrapDatasetPayload,
+  type DatasetKind,
+  type JsonObject,
+} from './dataset-local.js';
+import {
+  runLifecyclemodelSaveDraft,
+  type LifecyclemodelSaveDraftReport,
+} from './lifecyclemodel-save-draft-run.js';
+import { runProcessSaveDraft, type ProcessSaveDraftReport } from './process-save-draft-run.js';
+
+type ReferenceKind = 'flow';
+
+type ParsedReference = {
+  kind: ReferenceKind;
+  id: string;
+  version: string | null;
+};
+
+export type DatasetReferencesRewriteChange = {
+  row_index: number;
+  dataset_type: DatasetKind | null;
+  dataset_id: string | null;
+  dataset_version: string | null;
+  path: string;
+  field: '@refObjectId' | '@version' | '@flowUUID';
+  before: string | null;
+  after: string | null;
+};
+
+export type DatasetReferencesRewriteReport = {
+  generated_at_utc: string;
+  input_path: string;
+  out_dir: string;
+  mode: 'dry_run' | 'commit';
+  status: 'completed' | 'completed_with_failures';
+  from: ParsedReference;
+  to: ParsedReference;
+  filters: {
+    types: DatasetKind[];
+    scope: string | null;
+  };
+  counts: {
+    input_rows: number;
+    patched_rows: number;
+    changes: number;
+    process_rows: number;
+    lifecyclemodel_rows: number;
+  };
+  files: {
+    patched_rows: string;
+    rewrite_plan: string;
+    summary: string;
+  };
+  changes: DatasetReferencesRewriteChange[];
+  commit_reports: {
+    processes: ProcessSaveDraftReport | null;
+    lifecyclemodels: LifecyclemodelSaveDraftReport | null;
+  };
+};
+
+export type RunDatasetReferencesRewriteOptions = {
+  inputPath: string;
+  outDir: string;
+  from: string;
+  to: string;
+  types?: string[] | null;
+  scope?: string | null;
+  commit?: boolean | null;
+  rawInput?: unknown;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: FetchLike;
+  now?: Date;
+  runProcessSaveDraftImpl?: typeof runProcessSaveDraft;
+  runLifecyclemodelSaveDraftImpl?: typeof runLifecyclemodelSaveDraft;
+};
+
+function parseReference(value: string, label: string): ParsedReference {
+  const match = /^(flow):([^@\s]+)(?:@([^@\s]+))?$/u.exec(value.trim());
+  if (!match) {
+    throw new CliError(`Expected ${label} reference like flow:<id>@<version>.`, {
+      code: 'DATASET_REFERENCE_INVALID',
+      exitCode: 2,
+      details: value,
+    });
+  }
+  return {
+    kind: 'flow',
+    id: match[2],
+    version: match[3] ?? null,
+  };
+}
+
+function normalizeTypes(values: string[] | null | undefined): DatasetKind[] {
+  const raw = values && values.length > 0 ? values.flatMap((value) => value.split(',')) : [];
+  const normalized = raw
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean)
+    .map((value) => {
+      if (value === 'process' || value === 'processes') {
+        return 'process' as const;
+      }
+      if (
+        value === 'lifecyclemodel' ||
+        value === 'lifecyclemodels' ||
+        value === 'model' ||
+        value === 'models'
+      ) {
+        return 'lifecyclemodel' as const;
+      }
+      throw new CliError('Expected --type or --types to contain process and/or lifecyclemodel.', {
+        code: 'DATASET_REFERENCE_TYPES_INVALID',
+        exitCode: 2,
+        details: value,
+      });
+    });
+  return normalized.length > 0 ? [...new Set(normalized)] : ['process', 'lifecyclemodel'];
+}
+
+function joinPath(base: string, key: string | number): string {
+  return base ? `${base}.${String(key)}` : String(key);
+}
+
+function rewriteProcessReferences(
+  value: unknown,
+  from: ParsedReference,
+  to: ParsedReference,
+  pathPrefix: string,
+  change: (
+    path: string,
+    field: '@refObjectId' | '@version',
+    before: string | null,
+    after: string | null,
+  ) => void,
+): void {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      rewriteProcessReferences(item, from, to, joinPath(pathPrefix, index), change),
+    );
+    return;
+  }
+  if (!isRecord(value)) {
+    return;
+  }
+
+  const reference = value.referenceToFlowDataSet;
+  if (isRecord(reference) && reference['@refObjectId'] === from.id) {
+    const versionMatches = !from.version || reference['@version'] === from.version;
+    if (versionMatches) {
+      if (reference['@refObjectId'] !== to.id) {
+        change(
+          joinPath(pathPrefix, 'referenceToFlowDataSet.@refObjectId'),
+          '@refObjectId',
+          reference['@refObjectId'],
+          to.id,
+        );
+        reference['@refObjectId'] = to.id;
+      }
+      if (to.version && reference['@version'] !== to.version) {
+        change(
+          joinPath(pathPrefix, 'referenceToFlowDataSet.@version'),
+          '@version',
+          typeof reference['@version'] === 'string' ? reference['@version'] : null,
+          to.version,
+        );
+        reference['@version'] = to.version;
+      }
+    }
+  }
+
+  Object.entries(value).forEach(([key, child]) =>
+    rewriteProcessReferences(child, from, to, joinPath(pathPrefix, key), change),
+  );
+}
+
+function rewriteLifecyclemodelReferences(
+  value: unknown,
+  from: ParsedReference,
+  to: ParsedReference,
+  pathPrefix: string,
+  change: (path: string, field: '@flowUUID', before: string | null, after: string | null) => void,
+): void {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      rewriteLifecyclemodelReferences(item, from, to, joinPath(pathPrefix, index), change),
+    );
+    return;
+  }
+  if (!isRecord(value)) {
+    return;
+  }
+
+  if (value['@flowUUID'] === from.id && value['@flowUUID'] !== to.id) {
+    change(joinPath(pathPrefix, '@flowUUID'), '@flowUUID', value['@flowUUID'], to.id);
+    value['@flowUUID'] = to.id;
+  }
+
+  Object.entries(value).forEach(([key, child]) =>
+    rewriteLifecyclemodelReferences(child, from, to, joinPath(pathPrefix, key), change),
+  );
+}
+
+function buildFiles(outDir: string): DatasetReferencesRewriteReport['files'] {
+  return {
+    patched_rows: path.join(outDir, 'outputs', 'patched-rows.jsonl'),
+    rewrite_plan: path.join(outDir, 'outputs', 'rewrite-plan.json'),
+    summary: path.join(outDir, 'outputs', 'summary.json'),
+  };
+}
+
+export async function runDatasetReferencesRewrite(
+  options: RunDatasetReferencesRewriteOptions,
+): Promise<DatasetReferencesRewriteReport> {
+  if (!options.outDir) {
+    throw new CliError('Missing required --out-dir value.', {
+      code: 'DATASET_REFERENCES_REWRITE_OUT_DIR_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  const from = parseReference(options.from, '--from');
+  const to = parseReference(options.to, '--to');
+
+  const types = normalizeTypes(options.types);
+  const rows = materializeDatasetRows(options.inputPath, options.rawInput);
+  const outDir = path.resolve(options.outDir);
+  const files = buildFiles(outDir);
+  const changes: DatasetReferencesRewriteChange[] = [];
+  const patchedRows: JsonObject[] = [];
+  const processRows: JsonObject[] = [];
+  const lifecyclemodelRows: JsonObject[] = [];
+
+  rows.forEach((row) => {
+    const patched = cloneJson(row.row);
+    if (row.kind && types.includes(row.kind)) {
+      const payload = unwrapDatasetPayload(patched);
+      const addChange = (
+        pathValue: string,
+        field: '@refObjectId' | '@version' | '@flowUUID',
+        before: string | null,
+        after: string | null,
+      ): void => {
+        changes.push({
+          row_index: row.index,
+          dataset_type: row.kind,
+          dataset_id: row.id,
+          dataset_version: row.version,
+          path: pathValue,
+          field,
+          before,
+          after,
+        });
+      };
+      const beforeCount = changes.length;
+      if (row.kind === 'process') {
+        rewriteProcessReferences(payload, from, to, '', addChange);
+      } else if (row.kind === 'lifecyclemodel') {
+        rewriteLifecyclemodelReferences(payload, from, to, '', addChange);
+      }
+      if (changes.length > beforeCount) {
+        if (row.kind === 'process') {
+          processRows.push(patched);
+        } else if (row.kind === 'lifecyclemodel') {
+          lifecyclemodelRows.push(patched);
+        }
+      }
+    }
+    patchedRows.push(patched);
+  });
+
+  writeJsonLinesArtifact(files.patched_rows, patchedRows);
+  writeJsonArtifact(files.rewrite_plan, {
+    from,
+    to,
+    filters: {
+      types,
+      scope: firstNonEmpty(options.scope),
+    },
+    changes,
+  });
+
+  const commit = options.commit === true;
+  const processSaveDraftImpl = options.runProcessSaveDraftImpl ?? runProcessSaveDraft;
+  const lifecyclemodelSaveDraftImpl =
+    options.runLifecyclemodelSaveDraftImpl ?? runLifecyclemodelSaveDraft;
+  const processReport =
+    commit && processRows.length > 0
+      ? await processSaveDraftImpl({
+          inputPath: files.patched_rows,
+          rawInput: processRows,
+          outDir: path.join(outDir, 'process-save-draft'),
+          commit: true,
+          env: options.env,
+          fetchImpl: options.fetchImpl,
+        })
+      : null;
+  const lifecyclemodelReport =
+    commit && lifecyclemodelRows.length > 0
+      ? await lifecyclemodelSaveDraftImpl({
+          inputPath: files.patched_rows,
+          rawInput: lifecyclemodelRows,
+          outDir: path.join(outDir, 'lifecyclemodel-save-draft'),
+          commit: true,
+          env: options.env,
+          fetchImpl: options.fetchImpl,
+        })
+      : null;
+
+  const commitFailed =
+    processReport?.status === 'completed_with_failures' ||
+    lifecyclemodelReport?.status === 'completed_with_failures';
+  const report: DatasetReferencesRewriteReport = {
+    generated_at_utc: (options.now ?? new Date()).toISOString(),
+    input_path: path.resolve(options.inputPath),
+    out_dir: outDir,
+    mode: commit ? 'commit' : 'dry_run',
+    status: commitFailed ? 'completed_with_failures' : 'completed',
+    from,
+    to,
+    filters: {
+      types,
+      scope: firstNonEmpty(options.scope),
+    },
+    counts: {
+      input_rows: rows.length,
+      patched_rows: processRows.length + lifecyclemodelRows.length,
+      changes: changes.length,
+      process_rows: processRows.length,
+      lifecyclemodel_rows: lifecyclemodelRows.length,
+    },
+    files,
+    changes,
+    commit_reports: {
+      processes: processReport,
+      lifecyclemodels: lifecyclemodelReport,
+    },
+  };
+  writeJsonArtifact(files.summary, report);
+  return report;
+}
+
+export const __testInternals = {
+  normalizeTypes,
+  parseReference,
+  rewriteLifecyclemodelReferences,
+  rewriteProcessReferences,
+};

--- a/src/lib/dataset-validate.ts
+++ b/src/lib/dataset-validate.ts
@@ -1,0 +1,295 @@
+import path from 'node:path';
+import * as tidasSdk from '@tiangong-lca/tidas-sdk';
+import { writeJsonArtifact, writeJsonLinesArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+import { materializeDatasetRows, type DatasetKind, type DatasetRowInput } from './dataset-local.js';
+
+type SafeParseIssue = {
+  code?: string;
+  message?: string;
+  path?: Array<string | number>;
+};
+
+type SafeParseResult =
+  | {
+      success: true;
+      data?: unknown;
+    }
+  | {
+      success: false;
+      error?: {
+        issues?: SafeParseIssue[];
+      };
+    };
+
+type SafeParseSchema = {
+  safeParse: (value: unknown) => SafeParseResult;
+};
+
+type DatasetValidateType = 'auto' | DatasetKind;
+
+export type DatasetValidateIssue = {
+  path: string;
+  message: string;
+  code: string;
+};
+
+export type DatasetValidateRowReport = {
+  index: number;
+  id: string | null;
+  version: string | null;
+  type: DatasetKind | null;
+  status: 'valid' | 'invalid';
+  validator: string | null;
+  issue_count: number;
+  issues: DatasetValidateIssue[];
+};
+
+export type DatasetValidateReport = {
+  generated_at_utc: string;
+  input_path: string;
+  requested_type: DatasetValidateType;
+  status: 'completed' | 'completed_with_failures';
+  counts: {
+    total: number;
+    valid: number;
+    invalid: number;
+    by_type: Record<DatasetKind, number>;
+  };
+  files: {
+    report: string | null;
+    valid_rows: string | null;
+    invalid_rows: string | null;
+  };
+  rows: DatasetValidateRowReport[];
+};
+
+export type RunDatasetValidateOptions = {
+  inputPath: string;
+  type?: string | null;
+  outDir?: string | null;
+  rawInput?: unknown;
+  now?: Date;
+  schemas?: Partial<Record<DatasetKind, SafeParseSchema>>;
+};
+
+const DEFAULT_TYPE: DatasetValidateType = 'auto';
+
+const SCHEMA_EXPORTS: Record<DatasetKind, keyof typeof tidasSdk> = {
+  flow: 'FlowSchema' as keyof typeof tidasSdk,
+  process: 'ProcessSchema' as keyof typeof tidasSdk,
+  lifecyclemodel: 'LifeCycleModelSchema' as keyof typeof tidasSdk,
+};
+
+function normalizeType(value: string | null | undefined): DatasetValidateType {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) {
+    return DEFAULT_TYPE;
+  }
+  if (normalized === 'auto') {
+    return 'auto';
+  }
+  if (normalized === 'flow' || normalized === 'flows') {
+    return 'flow';
+  }
+  if (normalized === 'process' || normalized === 'processes') {
+    return 'process';
+  }
+  if (
+    normalized === 'lifecyclemodel' ||
+    normalized === 'lifecyclemodels' ||
+    normalized === 'model' ||
+    normalized === 'models'
+  ) {
+    return 'lifecyclemodel';
+  }
+  throw new CliError('Expected --type to be auto, flow, process, or lifecyclemodel.', {
+    code: 'DATASET_VALIDATE_TYPE_INVALID',
+    exitCode: 2,
+    details: value,
+  });
+}
+
+function normalizeIssuePath(pathParts: Array<string | number> | undefined): string {
+  if (!Array.isArray(pathParts) || pathParts.length === 0) {
+    return '<root>';
+  }
+  return pathParts.map((part) => String(part)).join('.');
+}
+
+function schemaForKind(
+  kind: DatasetKind,
+  schemas: Partial<Record<DatasetKind, SafeParseSchema>> | undefined,
+): { validator: string; schema: SafeParseSchema } {
+  if (schemas?.[kind]) {
+    return {
+      validator: 'injected',
+      schema: schemas[kind],
+    };
+  }
+
+  const exportName = SCHEMA_EXPORTS[kind];
+  const candidate = (tidasSdk as Record<string, unknown>)[exportName];
+  if (
+    !candidate ||
+    typeof candidate !== 'object' ||
+    typeof (candidate as SafeParseSchema).safeParse !== 'function'
+  ) {
+    throw new CliError(`${String(exportName)} is unavailable in @tiangong-lca/tidas-sdk.`, {
+      code: 'DATASET_VALIDATE_SCHEMA_UNAVAILABLE',
+      exitCode: 2,
+      details: { type: kind },
+    });
+  }
+
+  return {
+    validator: `@tiangong-lca/tidas-sdk/${String(exportName)}`,
+    schema: candidate as SafeParseSchema,
+  };
+}
+
+function buildUnsupportedTypeReport(row: DatasetRowInput): DatasetValidateRowReport {
+  return {
+    index: row.index,
+    id: row.id,
+    version: row.version,
+    type: row.kind,
+    status: 'invalid',
+    validator: null,
+    issue_count: 1,
+    issues: [
+      {
+        path: '<root>',
+        message: 'Could not detect dataset type. Use --type or provide a recognized TIDAS wrapper.',
+        code: 'dataset_type_unknown',
+      },
+    ],
+  };
+}
+
+function validateRow(
+  row: DatasetRowInput,
+  requestedType: DatasetValidateType,
+  schemas: Partial<Record<DatasetKind, SafeParseSchema>> | undefined,
+): DatasetValidateRowReport {
+  const kind = requestedType === 'auto' ? row.kind : requestedType;
+  if (!kind) {
+    return buildUnsupportedTypeReport(row);
+  }
+
+  const { validator, schema } = schemaForKind(kind, schemas);
+  const outcome = schema.safeParse(row.payload);
+  if (outcome.success) {
+    return {
+      index: row.index,
+      id: row.id,
+      version: row.version,
+      type: kind,
+      status: 'valid',
+      validator,
+      issue_count: 0,
+      issues: [],
+    };
+  }
+
+  const issues = (outcome.error?.issues ?? []).map((issue) => ({
+    path: normalizeIssuePath(issue.path),
+    message: issue.message ?? 'Validation failed',
+    code: issue.code ?? 'custom',
+  }));
+
+  return {
+    index: row.index,
+    id: row.id,
+    version: row.version,
+    type: kind,
+    status: 'invalid',
+    validator,
+    issue_count: issues.length,
+    issues,
+  };
+}
+
+function buildFiles(outDir: string | null | undefined): DatasetValidateReport['files'] {
+  if (!outDir) {
+    return {
+      report: null,
+      valid_rows: null,
+      invalid_rows: null,
+    };
+  }
+
+  const resolved = path.resolve(outDir);
+  return {
+    report: path.join(resolved, 'outputs', 'validation-report.json'),
+    valid_rows: path.join(resolved, 'outputs', 'valid-rows.jsonl'),
+    invalid_rows: path.join(resolved, 'outputs', 'invalid-rows.jsonl'),
+  };
+}
+
+function summarizeByType(rows: DatasetValidateRowReport[]): Record<DatasetKind, number> {
+  return {
+    flow: rows.filter((row) => row.type === 'flow').length,
+    process: rows.filter((row) => row.type === 'process').length,
+    lifecyclemodel: rows.filter((row) => row.type === 'lifecyclemodel').length,
+  };
+}
+
+export async function runDatasetValidate(
+  options: RunDatasetValidateOptions,
+): Promise<DatasetValidateReport> {
+  const requestedType = normalizeType(options.type);
+  const rows = materializeDatasetRows(options.inputPath, options.rawInput);
+  const reports = rows.map((row) => validateRow(row, requestedType, options.schemas));
+  const invalidRows = reports.filter((row) => row.status === 'invalid');
+  const files = buildFiles(options.outDir);
+
+  const report: DatasetValidateReport = {
+    generated_at_utc: (options.now ?? new Date()).toISOString(),
+    input_path: path.resolve(options.inputPath),
+    requested_type: requestedType,
+    status: invalidRows.length > 0 ? 'completed_with_failures' : 'completed',
+    counts: {
+      total: reports.length,
+      valid: reports.length - invalidRows.length,
+      invalid: invalidRows.length,
+      by_type: summarizeByType(reports),
+    },
+    files,
+    rows: reports,
+  };
+
+  if (files.report) {
+    writeJsonArtifact(files.report, report);
+  }
+  if (files.valid_rows) {
+    writeJsonLinesArtifact(
+      files.valid_rows,
+      rows.filter((_, index) => reports[index]?.status === 'valid').map((row) => row.row),
+    );
+  }
+  if (files.invalid_rows) {
+    writeJsonLinesArtifact(
+      files.invalid_rows,
+      rows.flatMap((row, index) =>
+        reports[index]?.status === 'invalid'
+          ? [
+              {
+                row: row.row,
+                validation: reports[index],
+              },
+            ]
+          : [],
+      ),
+    );
+  }
+
+  return report;
+}
+
+export const __testInternals = {
+  SCHEMA_EXPORTS,
+  normalizeType,
+  schemaForKind,
+  validateRow,
+};

--- a/src/lib/lifecyclemodel-graph.ts
+++ b/src/lib/lifecyclemodel-graph.ts
@@ -1,0 +1,373 @@
+import path from 'node:path';
+import { writeJsonArtifact, writeJsonLinesArtifact, writeTextArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+import {
+  firstNonEmpty,
+  isRecord,
+  materializeDatasetRows,
+  trimToken,
+  type JsonObject,
+} from './dataset-local.js';
+import { deriveLifecyclemodelJsonTg } from './lifecyclemodel-bundle-save.js';
+
+export type LifecyclemodelGraphFormat = 'json' | 'dot' | 'svg' | 'all';
+
+export type LifecyclemodelGraphFinding = {
+  severity: 'error' | 'warning';
+  code: string;
+  model_index: number;
+  model_id: string | null;
+  path: string;
+  message: string;
+};
+
+export type LifecyclemodelGraphModelReport = {
+  index: number;
+  id: string | null;
+  version: string | null;
+  node_count: number;
+  edge_count: number;
+  finding_count: number;
+  files: {
+    graph_json: string | null;
+    dot: string | null;
+    svg: string | null;
+  };
+};
+
+export type LifecyclemodelGraphReport = {
+  generated_at_utc: string;
+  input_path: string;
+  out_dir: string;
+  format: LifecyclemodelGraphFormat;
+  check_connections: boolean;
+  status: 'completed' | 'completed_with_findings';
+  counts: {
+    models: number;
+    nodes: number;
+    edges: number;
+    findings: number;
+  };
+  files: {
+    report: string;
+    findings: string;
+  };
+  models: LifecyclemodelGraphModelReport[];
+  findings: LifecyclemodelGraphFinding[];
+};
+
+export type RunLifecyclemodelGraphOptions = {
+  inputPath: string;
+  outDir: string;
+  format?: string | null;
+  checkConnections?: boolean | null;
+  rawInput?: unknown;
+  now?: Date;
+};
+
+type XflowNode = {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  data: JsonObject;
+};
+
+type XflowEdge = {
+  id: string;
+  source: { cell?: string };
+  target: { cell?: string };
+  data: JsonObject;
+};
+
+function normalizeFormat(value: string | null | undefined): LifecyclemodelGraphFormat {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) {
+    return 'all';
+  }
+  if (
+    normalized === 'json' ||
+    normalized === 'dot' ||
+    normalized === 'svg' ||
+    normalized === 'all'
+  ) {
+    return normalized;
+  }
+  throw new CliError('Expected --format to be json, dot, svg, or all.', {
+    code: 'LIFECYCLEMODEL_GRAPH_FORMAT_INVALID',
+    exitCode: 2,
+    details: value,
+  });
+}
+
+function asArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (value === undefined || value === null) {
+    return [];
+  }
+  return [value];
+}
+
+function normalizeNodes(jsonTg: JsonObject): XflowNode[] {
+  const xflow = isRecord(jsonTg.xflow) ? jsonTg.xflow : {};
+  return asArray(xflow.nodes)
+    .filter(isRecord)
+    .map((node, index) => ({
+      id: firstNonEmpty(node.id, `node-${index + 1}`)!,
+      x: typeof node.x === 'number' ? node.x : index * 320,
+      y: typeof node.y === 'number' ? node.y : 0,
+      width: typeof node.width === 'number' ? node.width : 260,
+      height: typeof node.height === 'number' ? node.height : 90,
+      data: isRecord(node.data) ? node.data : {},
+    }));
+}
+
+function normalizeEdges(jsonTg: JsonObject): XflowEdge[] {
+  const xflow = isRecord(jsonTg.xflow) ? jsonTg.xflow : {};
+  return asArray(xflow.edges)
+    .filter(isRecord)
+    .map((edge, index) => ({
+      id: firstNonEmpty(edge.id, `edge-${index + 1}`)!,
+      source: isRecord(edge.source) ? edge.source : {},
+      target: isRecord(edge.target) ? edge.target : {},
+      data: isRecord(edge.data) ? edge.data : {},
+    }));
+}
+
+function labelFromNode(node: XflowNode): string {
+  const label = node.data.label;
+  if (typeof label === 'string') {
+    return label;
+  }
+  if (isRecord(label) && Array.isArray(label.baseName)) {
+    const first = label.baseName.find(isRecord);
+    const text = isRecord(first) ? trimToken(first['#text']) : null;
+    if (text) {
+      return text;
+    }
+  }
+  return firstNonEmpty(node.data.id, node.id)!;
+}
+
+function escapeDot(value: string): string {
+  return value.replace(/\\/gu, '\\\\').replace(/"/gu, '\\"');
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/gu, '&amp;')
+    .replace(/</gu, '&lt;')
+    .replace(/>/gu, '&gt;')
+    .replace(/"/gu, '&quot;');
+}
+
+function buildDot(modelId: string | null, nodes: XflowNode[], edges: XflowEdge[]): string {
+  const lines = ['digraph lifecyclemodel {', '  rankdir=LR;', '  node [shape=box];'];
+  if (modelId) {
+    lines.push(`  label="${escapeDot(modelId)}";`);
+  }
+  nodes.forEach((node) => {
+    lines.push(`  "${escapeDot(node.id)}" [label="${escapeDot(labelFromNode(node))}"];`);
+  });
+  edges.forEach((edge) => {
+    const source = firstNonEmpty(edge.source.cell, 'unknown-source')!;
+    const target = firstNonEmpty(edge.target.cell, 'unknown-target')!;
+    const connection = isRecord(edge.data.connection) ? edge.data.connection : {};
+    const outputExchange = isRecord(connection.outputExchange) ? connection.outputExchange : {};
+    const flowUuid = firstNonEmpty(outputExchange['@flowUUID'], edge.id);
+    lines.push(
+      `  "${escapeDot(source)}" -> "${escapeDot(target)}" [label="${escapeDot(flowUuid ?? '')}"];`,
+    );
+  });
+  lines.push('}');
+  return `${lines.join('\n')}\n`;
+}
+
+function buildSvg(nodes: XflowNode[], edges: XflowEdge[]): string {
+  const padding = 32;
+  const maxX = Math.max(...nodes.map((node) => node.x + node.width), 320);
+  const maxY = Math.max(...nodes.map((node) => node.y + node.height), 180);
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  const lines = [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${maxX + padding * 2}" height="${
+      maxY + padding * 2
+    }" viewBox="0 0 ${maxX + padding * 2} ${maxY + padding * 2}">`,
+    '<defs><marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L0,6 L9,3 z" fill="#444"/></marker></defs>',
+    '<rect width="100%" height="100%" fill="#fff"/>',
+  ];
+
+  edges.forEach((edge) => {
+    const source = nodeById.get(firstNonEmpty(edge.source.cell, '') ?? '');
+    const target = nodeById.get(firstNonEmpty(edge.target.cell, '') ?? '');
+    if (!source || !target) {
+      return;
+    }
+    const x1 = padding + source.x + source.width;
+    const y1 = padding + source.y + source.height / 2;
+    const x2 = padding + target.x;
+    const y2 = padding + target.y + target.height / 2;
+    lines.push(
+      `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="#444" stroke-width="2" marker-end="url(#arrow)"/>`,
+    );
+  });
+
+  nodes.forEach((node) => {
+    const x = padding + node.x;
+    const y = padding + node.y;
+    lines.push(
+      `<rect x="${x}" y="${y}" width="${node.width}" height="${node.height}" rx="4" fill="#f8fafc" stroke="#334155"/>`,
+      `<text x="${x + 12}" y="${y + 28}" font-family="Arial, sans-serif" font-size="14" fill="#111827">${escapeXml(
+        labelFromNode(node),
+      )}</text>`,
+      `<text x="${x + 12}" y="${y + 52}" font-family="Arial, sans-serif" font-size="12" fill="#475569">${escapeXml(
+        firstNonEmpty(node.data.id, node.id)!,
+      )}</text>`,
+    );
+  });
+
+  lines.push('</svg>');
+  return `${lines.join('\n')}\n`;
+}
+
+function checkEdges(
+  modelIndex: number,
+  modelId: string | null,
+  nodes: XflowNode[],
+  edges: XflowEdge[],
+): LifecyclemodelGraphFinding[] {
+  const nodeIds = new Set(nodes.map((node) => node.id));
+  const findings: LifecyclemodelGraphFinding[] = [];
+  edges.forEach((edge, index) => {
+    const source = firstNonEmpty(edge.source.cell);
+    const target = firstNonEmpty(edge.target.cell);
+    if (!source || !nodeIds.has(source)) {
+      findings.push({
+        severity: 'error',
+        code: 'missing_source_process_instance',
+        model_index: modelIndex,
+        model_id: modelId,
+        path: `xflow.edges.${index}.source.cell`,
+        message: `Edge ${edge.id} references missing source process instance ${source ?? '<empty>'}.`,
+      });
+    }
+    if (!target || !nodeIds.has(target)) {
+      findings.push({
+        severity: 'error',
+        code: 'missing_target_process_instance',
+        model_index: modelIndex,
+        model_id: modelId,
+        path: `xflow.edges.${index}.target.cell`,
+        message: `Edge ${edge.id} references missing target process instance ${target ?? '<empty>'}.`,
+      });
+    }
+  });
+  return findings;
+}
+
+function safeStem(index: number, id: string | null): string {
+  const base = id ? id.replace(/[^A-Za-z0-9_.-]+/gu, '_') : `model-${index + 1}`;
+  return `${String(index + 1).padStart(3, '0')}-${base}`;
+}
+
+function wants(
+  format: LifecyclemodelGraphFormat,
+  target: Exclude<LifecyclemodelGraphFormat, 'all'>,
+): boolean {
+  return format === 'all' || format === target;
+}
+
+export async function runLifecyclemodelGraph(
+  options: RunLifecyclemodelGraphOptions,
+): Promise<LifecyclemodelGraphReport> {
+  if (!options.outDir) {
+    throw new CliError('Missing required --out-dir value.', {
+      code: 'LIFECYCLEMODEL_GRAPH_OUT_DIR_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  const format = normalizeFormat(options.format);
+  const outDir = path.resolve(options.outDir);
+  const rows = materializeDatasetRows(options.inputPath, options.rawInput);
+  const findings: LifecyclemodelGraphFinding[] = [];
+  const models: LifecyclemodelGraphModelReport[] = [];
+
+  rows.forEach((row, index) => {
+    const graph = deriveLifecyclemodelJsonTg(row.payload);
+    const nodes = normalizeNodes(graph);
+    const edges = normalizeEdges(graph);
+    const modelFindings =
+      options.checkConnections === true ? checkEdges(index, row.id, nodes, edges) : [];
+    findings.push(...modelFindings);
+    const stem = safeStem(index, row.id);
+    const graphJsonPath = wants(format, 'json')
+      ? path.join(outDir, 'graphs', `${stem}.json`)
+      : null;
+    const dotPath = wants(format, 'dot') ? path.join(outDir, 'graphs', `${stem}.dot`) : null;
+    const svgPath = wants(format, 'svg') ? path.join(outDir, 'graphs', `${stem}.svg`) : null;
+
+    if (graphJsonPath) {
+      writeJsonArtifact(graphJsonPath, graph);
+    }
+    if (dotPath) {
+      writeTextArtifact(dotPath, buildDot(row.id, nodes, edges));
+    }
+    if (svgPath) {
+      writeTextArtifact(svgPath, buildSvg(nodes, edges));
+    }
+
+    models.push({
+      index,
+      id: row.id,
+      version: row.version,
+      node_count: nodes.length,
+      edge_count: edges.length,
+      finding_count: modelFindings.length,
+      files: {
+        graph_json: graphJsonPath,
+        dot: dotPath,
+        svg: svgPath,
+      },
+    });
+  });
+
+  const files = {
+    report: path.join(outDir, 'outputs', 'graph-report.json'),
+    findings: path.join(outDir, 'outputs', 'findings.jsonl'),
+  };
+  const report: LifecyclemodelGraphReport = {
+    generated_at_utc: (options.now ?? new Date()).toISOString(),
+    input_path: path.resolve(options.inputPath),
+    out_dir: outDir,
+    format,
+    check_connections: options.checkConnections === true,
+    status: findings.length > 0 ? 'completed_with_findings' : 'completed',
+    counts: {
+      models: models.length,
+      nodes: models.reduce((sum, model) => sum + model.node_count, 0),
+      edges: models.reduce((sum, model) => sum + model.edge_count, 0),
+      findings: findings.length,
+    },
+    files,
+    models,
+    findings,
+  };
+  writeJsonArtifact(files.report, report);
+  writeJsonLinesArtifact(files.findings, findings);
+  return report;
+}
+
+export const __testInternals = {
+  asArray,
+  buildDot,
+  buildSvg,
+  checkEdges,
+  labelFromNode,
+  normalizeFormat,
+  normalizeNodes,
+  normalizeEdges,
+  safeStem,
+};

--- a/src/lib/lifecyclemodel-save-draft-run.ts
+++ b/src/lib/lifecyclemodel-save-draft-run.ts
@@ -1,0 +1,398 @@
+import path from 'node:path';
+import * as tidasSdk from '@tiangong-lca/tidas-sdk';
+import { writeJsonArtifact, writeJsonLinesArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+import type { FetchLike } from './http.js';
+import {
+  firstNonEmpty,
+  isRecord,
+  materializeDatasetRows,
+  type JsonObject,
+} from './dataset-local.js';
+import {
+  syncLifecyclemodelBundleRecord,
+  type LifecyclemodelBundleWriteResult,
+  type LifecyclemodelPublishMetadata,
+} from './lifecyclemodel-bundle-save.js';
+import { buildRunId, resolveRunLayout } from './run.js';
+
+type SafeParseIssue = {
+  code?: string;
+  message?: string;
+  path?: Array<string | number>;
+};
+
+type SafeParseResult =
+  | {
+      success: true;
+      data?: unknown;
+    }
+  | {
+      success: false;
+      error?: {
+        issues?: SafeParseIssue[];
+      };
+    };
+
+type SafeParseSchema = {
+  safeParse: (value: unknown) => SafeParseResult;
+};
+
+export type LifecyclemodelPayloadValidationIssue = {
+  path: string;
+  message: string;
+  code: string;
+};
+
+export type LifecyclemodelPayloadValidationResult =
+  | {
+      ok: true;
+      validator: string;
+      issue_count: 0;
+      issues: [];
+    }
+  | {
+      ok: false;
+      validator: string;
+      issue_count: number;
+      issues: LifecyclemodelPayloadValidationIssue[];
+    };
+
+type LifecyclemodelSaveDraftCandidate = {
+  id: string | null;
+  version: string | null;
+  payload: JsonObject;
+  metadata: LifecyclemodelPublishMetadata | null;
+  validation?: LifecyclemodelPayloadValidationResult;
+  error?: { message: string };
+};
+
+export type LifecyclemodelSaveDraftModelReport = {
+  id: string | null;
+  version: string | null;
+  status: 'prepared' | 'executed' | 'failed';
+  validation?: LifecyclemodelPayloadValidationResult;
+  execution?: LifecyclemodelBundleWriteResult;
+  error?: { message: string };
+};
+
+export type LifecyclemodelSaveDraftReport = {
+  generated_at_utc: string;
+  input_path: string;
+  out_dir: string;
+  commit: boolean;
+  mode: 'dry_run' | 'commit';
+  status: 'completed' | 'completed_with_failures';
+  counts: {
+    selected: number;
+    prepared: number;
+    executed: number;
+    failed: number;
+  };
+  files: {
+    normalized_input: string;
+    selected_lifecyclemodels: string;
+    progress_jsonl: string;
+    failures_jsonl: string;
+    summary_json: string;
+  };
+  lifecyclemodels: LifecyclemodelSaveDraftModelReport[];
+};
+
+export type RunLifecyclemodelSaveDraftOptions = {
+  inputPath: string;
+  outDir?: string | null;
+  commit?: boolean | null;
+  rawInput?: unknown;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: FetchLike;
+  timeoutMs?: number;
+  now?: Date;
+  validateLifecyclemodelPayloadImpl?: (
+    payload: JsonObject,
+  ) => LifecyclemodelPayloadValidationResult;
+};
+
+const VALIDATOR_NAME = '@tiangong-lca/tidas-sdk/LifeCycleModelSchema';
+
+function normalizeIssuePath(pathParts: Array<string | number> | undefined): string {
+  if (!Array.isArray(pathParts) || pathParts.length === 0) {
+    return '<root>';
+  }
+  return pathParts.map((part) => String(part)).join('.');
+}
+
+function getLifecyclemodelSchema(
+  sdk: { LifeCycleModelSchema?: unknown } = tidasSdk,
+): SafeParseSchema {
+  const schema = sdk.LifeCycleModelSchema as SafeParseSchema | undefined;
+  if (!schema?.safeParse) {
+    throw new Error(`${VALIDATOR_NAME} is unavailable in the published CLI runtime.`);
+  }
+  return schema;
+}
+
+export function validateLifecyclemodelPayload(
+  payload: JsonObject,
+  schema: SafeParseSchema = getLifecyclemodelSchema(),
+): LifecyclemodelPayloadValidationResult {
+  const outcome = schema.safeParse(payload);
+  if (outcome.success) {
+    return {
+      ok: true,
+      validator: VALIDATOR_NAME,
+      issue_count: 0,
+      issues: [],
+    };
+  }
+
+  const issues = (outcome.error?.issues ?? []).map((issue) => ({
+    path: normalizeIssuePath(issue.path),
+    message: issue.message ?? 'Validation failed',
+    code: issue.code ?? 'custom',
+  }));
+
+  return {
+    ok: false,
+    validator: VALIDATOR_NAME,
+    issue_count: issues.length,
+    issues,
+  };
+}
+
+function summarizeValidation(result: LifecyclemodelPayloadValidationResult): string {
+  if (result.ok) {
+    return 'local LifeCycleModelSchema validation passed';
+  }
+  const preview = result.issues
+    .slice(0, 3)
+    .map((issue) => `${issue.path}: ${issue.message}`)
+    .join('; ');
+  return `local LifeCycleModelSchema validation failed with ${result.issue_count} issue(s)${
+    preview ? ` (${preview})` : ''
+  }`;
+}
+
+function extractMetadata(row: JsonObject): LifecyclemodelPublishMetadata | null {
+  const metadata: LifecyclemodelPublishMetadata = {};
+  const jsonTg = isRecord(row.json_tg) ? row.json_tg : isRecord(row.jsonTg) ? row.jsonTg : null;
+  if (jsonTg) {
+    metadata.json_tg = jsonTg;
+  }
+  if (Array.isArray(row.processMutations)) {
+    metadata.processMutations = row.processMutations.filter(isRecord);
+  } else if (Array.isArray(row.process_mutations)) {
+    metadata.processMutations = row.process_mutations.filter(isRecord);
+  }
+  if (typeof row.ruleVerification === 'boolean') {
+    metadata.ruleVerification = row.ruleVerification;
+  } else if (typeof row.rule_verification === 'boolean') {
+    metadata.ruleVerification = row.rule_verification;
+  }
+
+  return Object.keys(metadata).length > 0 ? metadata : null;
+}
+
+function candidateError(message: string): { message: string } {
+  return { message };
+}
+
+function buildCandidate(
+  row: JsonObject,
+  payload: JsonObject,
+  validate: (payload: JsonObject) => LifecyclemodelPayloadValidationResult,
+): LifecyclemodelSaveDraftCandidate {
+  const root = isRecord(payload.lifeCycleModelDataSet) ? payload.lifeCycleModelDataSet : payload;
+  const information = isRecord(root.lifeCycleModelInformation)
+    ? root.lifeCycleModelInformation
+    : {};
+  const dataSetInformation = isRecord(information.dataSetInformation)
+    ? information.dataSetInformation
+    : {};
+  const administrativeInformation = isRecord(root.administrativeInformation)
+    ? root.administrativeInformation
+    : {};
+  const publicationAndOwnership = isRecord(administrativeInformation.publicationAndOwnership)
+    ? administrativeInformation.publicationAndOwnership
+    : {};
+  const id = firstNonEmpty(row.id, dataSetInformation['common:UUID']);
+  const version = firstNonEmpty(
+    row.version,
+    publicationAndOwnership['common:dataSetVersion'],
+    '01.01.000',
+  );
+
+  if (!id) {
+    return {
+      id: null,
+      version,
+      payload,
+      metadata: extractMetadata(row),
+      error: candidateError(
+        'Lifecyclemodel payload missing lifeCycleModelInformation.dataSetInformation.common:UUID.',
+      ),
+    };
+  }
+
+  const validation = validate(payload);
+  if (!validation.ok) {
+    return {
+      id,
+      version,
+      payload,
+      metadata: extractMetadata(row),
+      validation,
+      error: candidateError(summarizeValidation(validation)),
+    };
+  }
+
+  return {
+    id,
+    version,
+    payload,
+    metadata: extractMetadata(row),
+    validation,
+  };
+}
+
+function defaultOutDir(inputPath: string, commit: boolean, now: Date): string {
+  const runId = buildRunId({
+    namespace: 'lifecyclemodel_save_draft',
+    operation: commit ? 'commit' : 'dry_run',
+    now,
+  });
+  return resolveRunLayout(
+    path.join(path.dirname(inputPath), 'artifacts'),
+    'lifecyclemodel_save_draft',
+    runId,
+  ).runRoot;
+}
+
+function buildFiles(outDir: string): LifecyclemodelSaveDraftReport['files'] {
+  const outputDir = path.join(outDir, 'outputs', 'save-draft-bundle');
+  return {
+    normalized_input: path.join(outDir, 'inputs', 'normalized-input.json'),
+    selected_lifecyclemodels: path.join(outputDir, 'selected-lifecyclemodels.jsonl'),
+    progress_jsonl: path.join(outputDir, 'progress.jsonl'),
+    failures_jsonl: path.join(outputDir, 'failures.jsonl'),
+    summary_json: path.join(outputDir, 'summary.json'),
+  };
+}
+
+function compactCandidate(candidate: LifecyclemodelSaveDraftCandidate): JsonObject {
+  return {
+    id: candidate.id,
+    version: candidate.version,
+    payload: candidate.payload,
+    metadata: candidate.metadata,
+    ...(candidate.validation ? { validation: candidate.validation } : {}),
+    ...(candidate.error ? { error: candidate.error } : {}),
+  };
+}
+
+function serializeError(error: unknown): { message: string } {
+  return {
+    message: error instanceof Error ? error.message : String(error),
+  };
+}
+
+export async function runLifecyclemodelSaveDraft(
+  options: RunLifecyclemodelSaveDraftOptions,
+): Promise<LifecyclemodelSaveDraftReport> {
+  const now = options.now ?? new Date();
+  const inputPath = path.resolve(options.inputPath);
+  const commit = options.commit === true;
+  const outDir = path.resolve(options.outDir ?? defaultOutDir(inputPath, commit, now));
+  const validate = options.validateLifecyclemodelPayloadImpl ?? validateLifecyclemodelPayload;
+  const datasetRows = materializeDatasetRows(inputPath, options.rawInput);
+  const candidates = datasetRows.map((row) => buildCandidate(row.row, row.payload, validate));
+  const files = buildFiles(outDir);
+
+  if (commit && (!options.env || !options.fetchImpl)) {
+    throw new CliError(
+      'Lifecyclemodel save-draft commit requires env and fetch runtime bindings.',
+      {
+        code: 'LIFECYCLEMODEL_SAVE_DRAFT_RUNTIME_REQUIRED',
+        exitCode: 2,
+      },
+    );
+  }
+
+  writeJsonArtifact(files.normalized_input, {
+    input_kind: 'rows_file',
+    input_path: inputPath,
+    row_count: candidates.length,
+  });
+  writeJsonLinesArtifact(files.selected_lifecyclemodels, candidates.map(compactCandidate));
+
+  const reports: LifecyclemodelSaveDraftModelReport[] = [];
+  for (const candidate of candidates) {
+    const report: LifecyclemodelSaveDraftModelReport = {
+      id: candidate.id,
+      version: candidate.version,
+      status: 'prepared',
+      ...(candidate.validation ? { validation: candidate.validation } : {}),
+    };
+
+    if (candidate.error) {
+      report.status = 'failed';
+      report.error = candidate.error;
+      reports.push(report);
+      continue;
+    }
+
+    if (!commit) {
+      reports.push(report);
+      continue;
+    }
+
+    try {
+      report.execution = await syncLifecyclemodelBundleRecord({
+        id: candidate.id!,
+        version: candidate.version!,
+        payload: candidate.payload,
+        metadata: candidate.metadata,
+        env: options.env!,
+        fetchImpl: options.fetchImpl!,
+        timeoutMs: options.timeoutMs,
+      });
+      report.status = 'executed';
+    } catch (error) {
+      report.status = 'failed';
+      report.error = serializeError(error);
+    }
+    reports.push(report);
+  }
+
+  const failures = reports.filter((report) => report.status === 'failed');
+  writeJsonLinesArtifact(files.progress_jsonl, reports);
+  writeJsonLinesArtifact(files.failures_jsonl, failures);
+
+  const report: LifecyclemodelSaveDraftReport = {
+    generated_at_utc: now.toISOString(),
+    input_path: inputPath,
+    out_dir: outDir,
+    commit,
+    mode: commit ? 'commit' : 'dry_run',
+    status: failures.length > 0 ? 'completed_with_failures' : 'completed',
+    counts: {
+      selected: candidates.length,
+      prepared: reports.filter((entry) => entry.status === 'prepared').length,
+      executed: reports.filter((entry) => entry.status === 'executed').length,
+      failed: failures.length,
+    },
+    files,
+    lifecyclemodels: reports,
+  };
+  writeJsonArtifact(files.summary_json, report);
+  return report;
+}
+
+export const __testInternals = {
+  buildCandidate,
+  getLifecyclemodelSchema,
+  normalizeIssuePath,
+  serializeError,
+  summarizeValidation,
+  validateLifecyclemodelPayload,
+};

--- a/src/lib/user-api-key.ts
+++ b/src/lib/user-api-key.ts
@@ -50,7 +50,7 @@ export function requireUserApiKeyCredentials(apiKey: string): UserApiKeyCredenti
   const credentials = decodeUserApiKey(apiKey);
   if (!credentials) {
     throw new CliError(
-      'TIANGONG_LCA_API_KEY is invalid. Generate a new user API key from the TianGong account page.',
+      'TIANGONG_LCA_API_KEY is invalid. Generate a new user API key from the TianGong user API key page.',
       {
         code: 'USER_API_KEY_INVALID',
         exitCode: 2,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -405,6 +405,382 @@ test('executeCli returns help for the lifecyclemodel namespace and implemented s
   assert.doesNotMatch(lifecyclemodelOrchestrateHelp.stdout, /Planned command/u);
 });
 
+test('executeCli exposes dataset and lifecyclemodel friction-fix commands', async () => {
+  const datasetHelp = await executeCli(['dataset'], makeDeps());
+  assert.equal(datasetHelp.exitCode, 0);
+  assert.match(datasetHelp.stdout, /tiangong-lca dataset <subcommand>/u);
+  assert.match(datasetHelp.stdout, /validate/u);
+  assert.match(datasetHelp.stdout, /references rewrite/u);
+
+  const datasetValidateHelp = await executeCli(['dataset', 'validate', '--help'], makeDeps());
+  assert.equal(datasetValidateHelp.exitCode, 0);
+  assert.match(datasetValidateHelp.stdout, /tiangong-lca dataset validate --input <file>/u);
+  assert.doesNotMatch(datasetValidateHelp.stdout, /Planned command/u);
+
+  const datasetReferencesHelp = await executeCli(
+    ['dataset', 'references', 'rewrite', '--help'],
+    makeDeps(),
+  );
+  assert.equal(datasetReferencesHelp.exitCode, 0);
+  assert.match(datasetReferencesHelp.stdout, /tiangong-lca dataset references rewrite/u);
+  assert.match(datasetReferencesHelp.stdout, /--commit/u);
+  assert.doesNotMatch(datasetReferencesHelp.stdout, /Planned command/u);
+
+  const lifecyclemodelSaveDraftHelp = await executeCli(
+    ['lifecyclemodel', 'save-draft', '--help'],
+    makeDeps(),
+  );
+  assert.equal(lifecyclemodelSaveDraftHelp.exitCode, 0);
+  assert.match(
+    lifecyclemodelSaveDraftHelp.stdout,
+    /tiangong-lca lifecyclemodel save-draft --input <file>/u,
+  );
+  assert.doesNotMatch(lifecyclemodelSaveDraftHelp.stdout, /Planned command/u);
+
+  const lifecyclemodelGraphHelp = await executeCli(
+    ['lifecyclemodel', 'graph', '--help'],
+    makeDeps(),
+  );
+  assert.equal(lifecyclemodelGraphHelp.exitCode, 0);
+  assert.match(lifecyclemodelGraphHelp.stdout, /tiangong-lca lifecyclemodel graph --input <file>/u);
+  assert.match(lifecyclemodelGraphHelp.stdout, /--check-connections/u);
+  assert.doesNotMatch(lifecyclemodelGraphHelp.stdout, /Planned command/u);
+});
+
+test('executeCli dispatches dataset and lifecyclemodel friction-fix commands', async () => {
+  const datasetValidate = await executeCli(
+    [
+      'dataset',
+      'validate',
+      '--json',
+      '--input',
+      'rows.jsonl',
+      '--type',
+      'process',
+      '--out-dir',
+      'validate-out',
+    ],
+    {
+      ...makeDeps(),
+      runDatasetValidateImpl: async (options) => {
+        assert.equal(options.inputPath, 'rows.jsonl');
+        assert.equal(options.type, 'process');
+        assert.equal(options.outDir, 'validate-out');
+        return {
+          generated_at_utc: '2026-05-05T00:00:00.000Z',
+          input_path: 'rows.jsonl',
+          requested_type: 'auto',
+          status: 'completed',
+          counts: {
+            total: 1,
+            valid: 1,
+            invalid: 0,
+            by_type: { flow: 0, process: 1, lifecyclemodel: 0 },
+          },
+          files: { report: null, valid_rows: null, invalid_rows: null },
+          rows: [],
+        };
+      },
+    },
+  );
+  assert.equal(datasetValidate.exitCode, 0);
+
+  const datasetValidateFailure = await executeCli(
+    ['dataset', 'validate', '--json', '--input', 'rows.jsonl'],
+    {
+      ...makeDeps(),
+      runDatasetValidateImpl: async () => ({
+        generated_at_utc: '2026-05-05T00:00:00.000Z',
+        input_path: 'rows.jsonl',
+        requested_type: 'auto',
+        status: 'completed_with_failures',
+        counts: {
+          total: 1,
+          valid: 0,
+          invalid: 1,
+          by_type: { flow: 0, process: 1, lifecyclemodel: 0 },
+        },
+        files: { report: null, valid_rows: null, invalid_rows: null },
+        rows: [],
+      }),
+    },
+  );
+  assert.equal(datasetValidateFailure.exitCode, 1);
+
+  const datasetValidateParseError = await executeCli(['dataset', 'validate', '--wat'], makeDeps());
+  assert.equal(datasetValidateParseError.exitCode, 2);
+  assert.match(datasetValidateParseError.stderr, /Unknown option/u);
+
+  const datasetRewrite = await executeCli(
+    [
+      'dataset',
+      'references',
+      'rewrite',
+      '--json',
+      '--input',
+      'rows.jsonl',
+      '--from',
+      'flow:old@01.00.000',
+      '--to',
+      'flow:new@01.01.000',
+      '--type',
+      'process',
+      '--types',
+      'lifecyclemodel',
+      '--scope',
+      'current',
+      '--out-dir',
+      'rewrite-out',
+    ],
+    {
+      ...makeDeps(),
+      runDatasetReferencesRewriteImpl: async (options) => {
+        assert.equal(options.inputPath, 'rows.jsonl');
+        assert.equal(options.from, 'flow:old@01.00.000');
+        assert.equal(options.to, 'flow:new@01.01.000');
+        assert.deepEqual(options.types, ['process', 'lifecyclemodel']);
+        assert.equal(options.scope, 'current');
+        assert.equal(options.outDir, 'rewrite-out');
+        assert.equal(options.commit, false);
+        return {
+          generated_at_utc: '2026-05-05T00:00:00.000Z',
+          input_path: 'rows.jsonl',
+          out_dir: 'rewrite-out',
+          mode: 'dry_run',
+          status: 'completed',
+          from: { kind: 'flow', id: 'old', version: '01.00.000' },
+          to: { kind: 'flow', id: 'new', version: '01.01.000' },
+          filters: { types: ['process'], scope: null },
+          counts: {
+            input_rows: 1,
+            patched_rows: 1,
+            changes: 1,
+            process_rows: 1,
+            lifecyclemodel_rows: 0,
+          },
+          files: { patched_rows: '', rewrite_plan: '', summary: '' },
+          changes: [],
+          commit_reports: { processes: null, lifecyclemodels: null },
+        };
+      },
+    },
+  );
+  assert.equal(datasetRewrite.exitCode, 0);
+
+  const datasetRewriteFailure = await executeCli(
+    [
+      'dataset',
+      'references',
+      'rewrite',
+      '--json',
+      '--input',
+      'rows.jsonl',
+      '--from',
+      'flow:old',
+      '--to',
+      'flow:new',
+      '--out-dir',
+      'rewrite-out',
+    ],
+    {
+      ...makeDeps(),
+      runDatasetReferencesRewriteImpl: async () => ({
+        generated_at_utc: '2026-05-05T00:00:00.000Z',
+        input_path: 'rows.jsonl',
+        out_dir: 'rewrite-out',
+        mode: 'commit',
+        status: 'completed_with_failures',
+        from: { kind: 'flow', id: 'old', version: null },
+        to: { kind: 'flow', id: 'new', version: null },
+        filters: { types: ['process', 'lifecyclemodel'], scope: null },
+        counts: {
+          input_rows: 1,
+          patched_rows: 1,
+          changes: 1,
+          process_rows: 1,
+          lifecyclemodel_rows: 0,
+        },
+        files: { patched_rows: '', rewrite_plan: '', summary: '' },
+        changes: [],
+        commit_reports: { processes: null, lifecyclemodels: null },
+      }),
+    },
+  );
+  assert.equal(datasetRewriteFailure.exitCode, 1);
+
+  const datasetReferencesRootHelp = await executeCli(['dataset', 'references'], makeDeps());
+  assert.equal(datasetReferencesRootHelp.exitCode, 0);
+  assert.match(datasetReferencesRootHelp.stdout, /tiangong-lca dataset references rewrite/u);
+
+  const invalidDatasetReferenceAction = await executeCli(
+    ['dataset', 'references', 'scan'],
+    makeDeps(),
+  );
+  assert.equal(invalidDatasetReferenceAction.exitCode, 2);
+  assert.match(invalidDatasetReferenceAction.stderr, /must be 'rewrite'/u);
+
+  const datasetReferencesModeError = await executeCli(
+    [
+      'dataset',
+      'references',
+      'rewrite',
+      '--input',
+      'rows.jsonl',
+      '--from',
+      'flow:old',
+      '--to',
+      'flow:new',
+      '--out-dir',
+      'rewrite-out',
+      '--commit',
+      '--dry-run',
+    ],
+    makeDeps(),
+  );
+  assert.equal(datasetReferencesModeError.exitCode, 2);
+  assert.match(datasetReferencesModeError.stderr, /Cannot pass both/u);
+
+  const datasetReferencesParseError = await executeCli(
+    ['dataset', 'references', 'rewrite', '--wat'],
+    makeDeps(),
+  );
+  assert.equal(datasetReferencesParseError.exitCode, 2);
+  assert.match(datasetReferencesParseError.stderr, /Unknown option/u);
+
+  const lifecyclemodelSaveDraft = await executeCli(
+    ['lifecyclemodel', 'save-draft', '--json', '--input', 'models.jsonl', '--out-dir', 'save-out'],
+    {
+      ...makeDeps(),
+      runLifecyclemodelSaveDraftImpl: async (options) => {
+        assert.equal(options.inputPath, 'models.jsonl');
+        assert.equal(options.outDir, 'save-out');
+        assert.equal(options.commit, false);
+        return {
+          generated_at_utc: '2026-05-05T00:00:00.000Z',
+          input_path: 'models.jsonl',
+          out_dir: 'save-out',
+          commit: false,
+          mode: 'dry_run',
+          status: 'completed',
+          counts: { selected: 1, prepared: 1, executed: 0, failed: 0 },
+          files: {
+            normalized_input: '',
+            selected_lifecyclemodels: '',
+            progress_jsonl: '',
+            failures_jsonl: '',
+            summary_json: '',
+          },
+          lifecyclemodels: [],
+        };
+      },
+    },
+  );
+  assert.equal(lifecyclemodelSaveDraft.exitCode, 0);
+
+  const lifecyclemodelSaveDraftFailure = await executeCli(
+    ['lifecyclemodel', 'save-draft', '--json', '--input', 'models.jsonl'],
+    {
+      ...makeDeps(),
+      runLifecyclemodelSaveDraftImpl: async () => ({
+        generated_at_utc: '2026-05-05T00:00:00.000Z',
+        input_path: 'models.jsonl',
+        out_dir: 'save-out',
+        commit: false,
+        mode: 'dry_run',
+        status: 'completed_with_failures',
+        counts: { selected: 1, prepared: 0, executed: 0, failed: 1 },
+        files: {
+          normalized_input: '',
+          selected_lifecyclemodels: '',
+          progress_jsonl: '',
+          failures_jsonl: '',
+          summary_json: '',
+        },
+        lifecyclemodels: [],
+      }),
+    },
+  );
+  assert.equal(lifecyclemodelSaveDraftFailure.exitCode, 1);
+
+  const lifecyclemodelSaveDraftModeError = await executeCli(
+    ['lifecyclemodel', 'save-draft', '--input', 'models.jsonl', '--commit', '--dry-run'],
+    makeDeps(),
+  );
+  assert.equal(lifecyclemodelSaveDraftModeError.exitCode, 2);
+  assert.match(lifecyclemodelSaveDraftModeError.stderr, /Cannot pass both/u);
+
+  const lifecyclemodelSaveDraftParseError = await executeCli(
+    ['lifecyclemodel', 'save-draft', '--wat'],
+    makeDeps(),
+  );
+  assert.equal(lifecyclemodelSaveDraftParseError.exitCode, 2);
+  assert.match(lifecyclemodelSaveDraftParseError.stderr, /Unknown option/u);
+
+  const lifecyclemodelGraph = await executeCli(
+    [
+      'lifecyclemodel',
+      'graph',
+      '--json',
+      '--input',
+      'models.jsonl',
+      '--out-dir',
+      'graph-out',
+      '--format',
+      'dot',
+      '--check-connections',
+    ],
+    {
+      ...makeDeps(),
+      runLifecyclemodelGraphImpl: async (options) => {
+        assert.equal(options.inputPath, 'models.jsonl');
+        assert.equal(options.outDir, 'graph-out');
+        assert.equal(options.format, 'dot');
+        assert.equal(options.checkConnections, true);
+        return {
+          generated_at_utc: '2026-05-05T00:00:00.000Z',
+          input_path: 'models.jsonl',
+          out_dir: 'graph-out',
+          format: 'dot',
+          check_connections: true,
+          status: 'completed',
+          counts: { models: 1, nodes: 1, edges: 0, findings: 0 },
+          files: { report: '', findings: '' },
+          models: [],
+          findings: [],
+        };
+      },
+    },
+  );
+  assert.equal(lifecyclemodelGraph.exitCode, 0);
+
+  const lifecyclemodelGraphFindings = await executeCli(
+    ['lifecyclemodel', 'graph', '--json', '--input', 'models.jsonl', '--out-dir', 'graph-out'],
+    {
+      ...makeDeps(),
+      runLifecyclemodelGraphImpl: async () => ({
+        generated_at_utc: '2026-05-05T00:00:00.000Z',
+        input_path: 'models.jsonl',
+        out_dir: 'graph-out',
+        format: 'all',
+        check_connections: false,
+        status: 'completed_with_findings',
+        counts: { models: 1, nodes: 1, edges: 1, findings: 1 },
+        files: { report: '', findings: '' },
+        models: [],
+        findings: [],
+      }),
+    },
+  );
+  assert.equal(lifecyclemodelGraphFindings.exitCode, 1);
+
+  const lifecyclemodelGraphParseError = await executeCli(
+    ['lifecyclemodel', 'graph', '--wat'],
+    makeDeps(),
+  );
+  assert.equal(lifecyclemodelGraphParseError.exitCode, 2);
+  assert.match(lifecyclemodelGraphParseError.stderr, /Unknown option/u);
+});
+
 test('executeCli executes lifecyclemodel auto-build with injected implementation', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-auto-build-cli-'));
   const inputPath = path.join(dir, 'request.json');

--- a/test/dataset-references-rewrite.test.ts
+++ b/test/dataset-references-rewrite.test.ts
@@ -1,0 +1,314 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  __testInternals,
+  runDatasetReferencesRewrite,
+} from '../src/lib/dataset-references-rewrite.js';
+
+function writeJsonl(filePath: string, rows: unknown[]): void {
+  writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`, 'utf8');
+}
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+function readJsonl(filePath: string): unknown[] {
+  return readFileSync(filePath, 'utf8')
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+test('runDatasetReferencesRewrite patches process and lifecyclemodel flow references locally', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-dataset-references-'));
+  const inputPath = path.join(dir, 'rows.jsonl');
+  const outDir = path.join(dir, 'out');
+  writeJsonl(inputPath, [
+    {
+      id: 'proc-1',
+      version: '01.00.000',
+      json_ordered: {
+        processDataSet: {
+          exchanges: {
+            exchange: [
+              {
+                referenceToFlowDataSet: {
+                  '@refObjectId': 'old-flow',
+                  '@version': '01.00.000',
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    {
+      id: 'lm-1',
+      version: '01.00.000',
+      json_ordered: {
+        lifeCycleModelDataSet: {
+          lifeCycleModelInformation: {
+            technology: {
+              processes: {
+                processInstance: {
+                  '@dataSetInternalID': '1',
+                  connections: {
+                    outputExchange: {
+                      '@flowUUID': 'old-flow',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  ]);
+
+  try {
+    const report = await runDatasetReferencesRewrite({
+      inputPath,
+      outDir,
+      from: 'flow:old-flow@01.00.000',
+      to: 'flow:new-flow@01.01.000',
+      now: new Date('2026-05-05T00:00:00.000Z'),
+    });
+
+    assert.equal(report.status, 'completed');
+    assert.deepEqual(report.counts, {
+      input_rows: 2,
+      patched_rows: 2,
+      changes: 3,
+      process_rows: 1,
+      lifecyclemodel_rows: 1,
+    });
+    assert.equal(existsSync(report.files.summary), true);
+    assert.deepEqual(readJson(report.files.summary), report);
+
+    const patchedRows = readJsonl(report.files.patched_rows) as Array<{
+      json_ordered: Record<string, unknown>;
+    }>;
+    assert.equal(
+      (
+        (
+          (
+            (patchedRows[0]?.json_ordered.processDataSet as Record<string, unknown>)
+              .exchanges as Record<string, unknown>
+          ).exchange as Array<Record<string, unknown>>
+        )[0]?.referenceToFlowDataSet as Record<string, unknown>
+      )['@refObjectId'],
+      'new-flow',
+    );
+    assert.match(JSON.stringify(patchedRows[1]), /new-flow/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runDatasetReferencesRewrite accepts comma-separated type aliases', () => {
+  assert.deepEqual(__testInternals.normalizeTypes(['process,lifecyclemodel']), [
+    'process',
+    'lifecyclemodel',
+  ]);
+});
+
+test('runDatasetReferencesRewrite validates flags and supports commit delegates', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-dataset-references-commit-'));
+  const inputPath = path.join(dir, 'rows.jsonl');
+  const outDir = path.join(dir, 'out');
+  writeJsonl(inputPath, [
+    {
+      id: 'proc-commit',
+      version: '01.00.000',
+      json_ordered: {
+        processDataSet: {
+          exchanges: {
+            exchange: {
+              referenceToFlowDataSet: {
+                '@refObjectId': 'old-flow',
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      id: 'lm-commit',
+      version: '01.00.000',
+      json_ordered: {
+        lifeCycleModelDataSet: {
+          lifeCycleModelInformation: {
+            technology: {
+              processes: {
+                processInstance: {
+                  connections: {
+                    outputExchange: {
+                      '@flowUUID': 'old-flow',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    { id: 'flow-skip', json_ordered: { flowDataSet: {} } },
+  ]);
+
+  try {
+    await assert.rejects(
+      () =>
+        runDatasetReferencesRewrite({
+          inputPath,
+          outDir,
+          from: 'bad-reference',
+          to: 'flow:new-flow',
+        }),
+      /Expected --from reference/u,
+    );
+    await assert.rejects(
+      () =>
+        runDatasetReferencesRewrite({
+          inputPath,
+          outDir: '',
+          from: 'flow:old-flow',
+          to: 'flow:new-flow',
+        }),
+      /Missing required --out-dir/u,
+    );
+    assert.throws(
+      () => __testInternals.normalizeTypes(['process,unknown']),
+      /Expected --type or --types/u,
+    );
+
+    const processCalls: unknown[] = [];
+    const lifecyclemodelCalls: unknown[] = [];
+    const report = await runDatasetReferencesRewrite({
+      inputPath,
+      outDir,
+      from: 'flow:old-flow',
+      to: 'flow:new-flow',
+      commit: true,
+      scope: ' current scope ',
+      env: { TEST: '1' },
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        text: async () => '{}',
+      }),
+      runProcessSaveDraftImpl: async (options) => {
+        processCalls.push(options);
+        return {
+          generated_at_utc: '2026-05-05T00:00:00.000Z',
+          input_path: options.inputPath,
+          input_kind: 'rows_file',
+          out_dir: options.outDir ?? '',
+          commit: true,
+          mode: 'commit',
+          status: 'completed',
+          counts: { selected: 1, prepared: 0, executed: 1, failed: 0 },
+          files: {
+            normalized_input: '',
+            selected_processes: '',
+            progress_jsonl: '',
+            failures_jsonl: '',
+            summary_json: '',
+          },
+          processes: [],
+        };
+      },
+      runLifecyclemodelSaveDraftImpl: async (options) => {
+        lifecyclemodelCalls.push(options);
+        return {
+          generated_at_utc: '2026-05-05T00:00:00.000Z',
+          input_path: options.inputPath,
+          out_dir: options.outDir ?? '',
+          commit: true,
+          mode: 'commit',
+          status: 'completed_with_failures',
+          counts: { selected: 1, prepared: 0, executed: 0, failed: 1 },
+          files: {
+            normalized_input: '',
+            selected_lifecyclemodels: '',
+            progress_jsonl: '',
+            failures_jsonl: '',
+            summary_json: '',
+          },
+          lifecyclemodels: [],
+        };
+      },
+      now: new Date('2026-05-05T00:00:00.000Z'),
+    });
+
+    assert.equal(report.status, 'completed_with_failures');
+    assert.equal(report.filters.scope, 'current scope');
+    assert.equal(report.counts.process_rows, 1);
+    assert.equal(report.counts.lifecyclemodel_rows, 1);
+    assert.equal(processCalls.length, 1);
+    assert.equal(lifecyclemodelCalls.length, 1);
+
+    const generatedNow = await runDatasetReferencesRewrite({
+      inputPath,
+      outDir: path.join(dir, 'generated-now-out'),
+      from: 'flow:old-flow',
+      to: 'flow:new-flow',
+      types: ['process'],
+    });
+    assert.equal(generatedNow.status, 'completed');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('reference rewrite internals cover no-op and nested fallback branches', () => {
+  const from = __testInternals.parseReference('flow:old-flow', '--from');
+  const to = __testInternals.parseReference('flow:old-flow', '--to');
+  const processPayload = {
+    array: [
+      null,
+      {
+        referenceToFlowDataSet: {
+          '@refObjectId': 'old-flow',
+          '@version': '01.00.000',
+        },
+      },
+    ],
+  };
+  const processVersionPayload = {
+    referenceToFlowDataSet: {
+      '@refObjectId': 'old-flow',
+      '@version': 1,
+    },
+  };
+  const lifecyclemodelPayload = [{ '@flowUUID': 'old-flow' }, 1];
+  const changes: unknown[] = [];
+
+  __testInternals.rewriteProcessReferences(processPayload, from, to, '', (...args) =>
+    changes.push(args),
+  );
+  __testInternals.rewriteLifecyclemodelReferences(lifecyclemodelPayload, from, to, '', (...args) =>
+    changes.push(args),
+  );
+
+  assert.equal(changes.length, 0);
+
+  __testInternals.rewriteProcessReferences(
+    processVersionPayload,
+    from,
+    __testInternals.parseReference('flow:new-flow@01.00.000', '--to'),
+    '',
+    (...args) => changes.push(args),
+  );
+  assert.deepEqual(
+    changes.find((change) => Array.isArray(change) && change[1] === '@version'),
+    ['referenceToFlowDataSet.@version', '@version', null, '01.00.000'],
+  );
+});

--- a/test/dataset-validate.test.ts
+++ b/test/dataset-validate.test.ts
@@ -1,0 +1,302 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  __testInternals,
+  runDatasetValidate,
+  type RunDatasetValidateOptions,
+} from '../src/lib/dataset-validate.js';
+import {
+  datasetIdentity,
+  datasetRoot,
+  detectDatasetKind,
+  firstNonEmpty,
+  materializeDatasetRows,
+  readDatasetRowsInput,
+  trimToken,
+  unwrapDatasetPayload,
+} from '../src/lib/dataset-local.js';
+
+function writeJsonl(filePath: string, rows: unknown[]): void {
+  writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`, 'utf8');
+}
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+function readJsonl(filePath: string): unknown[] {
+  return readFileSync(filePath, 'utf8')
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+const schemas = {
+  flow: {
+    safeParse: (value: unknown) => ({ success: !(value as { invalid?: boolean }).invalid }),
+  },
+  process: {
+    safeParse: (value: unknown) => ({
+      success: !(value as { invalid?: boolean }).invalid,
+      error: { issues: [{ path: ['invalid'], message: 'marked invalid', code: 'custom' }] },
+    }),
+  },
+  lifecyclemodel: {
+    safeParse: (value: unknown) => ({ success: !(value as { invalid?: boolean }).invalid }),
+  },
+} satisfies RunDatasetValidateOptions['schemas'];
+
+test('runDatasetValidate validates local rows and writes split artifacts', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-dataset-validate-'));
+  const inputPath = path.join(dir, 'rows.jsonl');
+  const outDir = path.join(dir, 'out');
+  writeJsonl(inputPath, [
+    {
+      id: 'proc-ok',
+      version: '01.01.000',
+      json_ordered: { processDataSet: {} },
+    },
+    {
+      id: 'proc-bad',
+      version: '01.01.000',
+      json_ordered: { processDataSet: {}, invalid: true },
+    },
+    {
+      id: 'flow-ok',
+      version: '01.01.000',
+      json_ordered: { flowDataSet: {} },
+    },
+  ]);
+
+  try {
+    const report = await runDatasetValidate({
+      inputPath,
+      outDir,
+      type: 'auto',
+      schemas,
+      now: new Date('2026-05-05T00:00:00.000Z'),
+    });
+
+    assert.equal(report.status, 'completed_with_failures');
+    assert.deepEqual(report.counts, {
+      total: 3,
+      valid: 2,
+      invalid: 1,
+      by_type: {
+        flow: 1,
+        process: 2,
+        lifecyclemodel: 0,
+      },
+    });
+    assert.equal(existsSync(report.files.report ?? ''), true);
+    assert.deepEqual(readJson(report.files.report ?? ''), report);
+    assert.equal(readJsonl(report.files.valid_rows ?? '').length, 2);
+    assert.equal(readJsonl(report.files.invalid_rows ?? '').length, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('dataset local helpers cover input parsing, wrappers, identities, and errors', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-dataset-local-'));
+  const jsonPath = path.join(dir, 'rows.json');
+  const jsonlPath = path.join(dir, 'rows.jsonl');
+  const badJsonlPath = path.join(dir, 'bad.jsonl');
+  const primitiveJsonlPath = path.join(dir, 'primitive.jsonl');
+  writeFileSync(
+    jsonPath,
+    JSON.stringify({
+      rows: [
+        {
+          jsonOrdered: {
+            flowDataSet: {
+              flowInformation: {
+                dataSetInformation: { 'common:UUID': 'flow-from-payload' },
+              },
+              administrativeInformation: {
+                publicationAndOwnership: { 'common:dataSetVersion': '01.00.000' },
+              },
+            },
+          },
+        },
+      ],
+    }),
+    'utf8',
+  );
+  writeJsonl(jsonlPath, [
+    {
+      process: {
+        processDataSet: {
+          processInformation: {
+            dataSetInformation: { 'common:UUID': 'proc-from-wrapper' },
+          },
+          administrativeInformation: {
+            publicationAndOwnership: { 'common:dataSetVersion': '01.02.000' },
+          },
+        },
+      },
+    },
+    {
+      lifecyclemodel: {
+        lifeCycleModelDataSet: {
+          lifeCycleModelInformation: {
+            dataSetInformation: { 'common:UUID': 'lm-from-wrapper' },
+          },
+          administrativeInformation: {
+            publicationAndOwnership: { 'common:dataSetVersion': '01.03.000' },
+          },
+        },
+      },
+    },
+  ]);
+  writeFileSync(badJsonlPath, '{bad-json}\n', 'utf8');
+  writeFileSync(primitiveJsonlPath, '1\n', 'utf8');
+
+  try {
+    assert.equal(trimToken(123), null);
+    assert.equal(trimToken(' value '), 'value');
+    assert.equal(firstNonEmpty(null, ' ', 'winner'), 'winner');
+    assert.equal(firstNonEmpty(null, undefined, ''), null);
+
+    assert.equal(readDatasetRowsInput(jsonPath).length, 1);
+    assert.equal(
+      readDatasetRowsInput('memory', { rows: [{ payload: { processDataSet: {} } }] }).length,
+      1,
+    );
+    assert.deepEqual(readDatasetRowsInput('memory', { id: 'single-row' }), [{ id: 'single-row' }]);
+    assert.throws(() => readDatasetRowsInput('', []), /Missing required --input value/u);
+    assert.throws(
+      () => readDatasetRowsInput(path.join(dir, 'missing.jsonl')),
+      /Input file not found/u,
+    );
+    assert.throws(() => readDatasetRowsInput(badJsonlPath), /invalid JSONL/u);
+    assert.throws(() => readDatasetRowsInput(primitiveJsonlPath), /Expected JSON object rows/u);
+    assert.throws(
+      () => readDatasetRowsInput('memory', { rows: [1] }),
+      /Expected JSON object rows/u,
+    );
+
+    const materialized = materializeDatasetRows(jsonlPath);
+    const materializedFlow = materializeDatasetRows(jsonPath);
+    assert.equal(materializedFlow[0]?.id, 'flow-from-payload');
+    assert.equal(materializedFlow[0]?.version, '01.00.000');
+    assert.equal(materialized[0]?.kind, 'process');
+    assert.equal(materialized[0]?.id, 'proc-from-wrapper');
+    assert.equal(materialized[1]?.kind, 'lifecyclemodel');
+    assert.equal(materialized[1]?.version, '01.03.000');
+    assert.equal(detectDatasetKind({ flow: {} }), 'flow');
+    assert.equal(detectDatasetKind({ process: {} }), 'process');
+    assert.equal(detectDatasetKind({ lifecyclemodel: {} }), 'lifecyclemodel');
+    assert.equal(detectDatasetKind({ unknown: true }), null);
+    assert.deepEqual(datasetIdentity({ id: 'row-id', version: 'row-version' }, {}, null), {
+      id: 'row-id',
+      version: 'row-version',
+    });
+    assert.deepEqual(datasetIdentity({}, { flowDataSet: {} }, 'flow'), {
+      id: null,
+      version: null,
+    });
+    assert.deepEqual(datasetRoot({ processDataSet: { id: 'wrapped-process' } }, 'process'), {
+      id: 'wrapped-process',
+    });
+    assert.deepEqual(
+      datasetRoot({ lifeCycleModelDataSet: { id: 'wrapped-model' } }, 'lifecyclemodel'),
+      { id: 'wrapped-model' },
+    );
+    assert.deepEqual(datasetRoot({ id: 'unwrapped-flow' }, 'flow'), { id: 'unwrapped-flow' });
+    assert.deepEqual(datasetRoot({ id: 'unwrapped-process' }, 'process'), {
+      id: 'unwrapped-process',
+    });
+    assert.deepEqual(datasetRoot({ id: 'unwrapped-model' }, 'lifecyclemodel'), {
+      id: 'unwrapped-model',
+    });
+    assert.deepEqual(unwrapDatasetPayload({ json: { flowDataSet: {} } }), { flowDataSet: {} });
+    assert.deepEqual(unwrapDatasetPayload({ payload: { processDataSet: {} } }), {
+      processDataSet: {},
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runDatasetValidate covers aliases, unsupported rows, default schemas, and no-output mode', async () => {
+  const noOutput = await runDatasetValidate({
+    inputPath: 'memory',
+    rawInput: [{ id: 'unknown-row' }],
+    now: new Date('2026-05-05T00:00:00.000Z'),
+  });
+  assert.equal(noOutput.status, 'completed_with_failures');
+  assert.deepEqual(noOutput.files, { report: null, valid_rows: null, invalid_rows: null });
+  assert.equal(noOutput.rows[0]?.issues[0]?.code, 'dataset_type_unknown');
+
+  const aliases = await runDatasetValidate({
+    inputPath: 'memory',
+    rawInput: [{ json_ordered: { processDataSet: {} } }],
+    type: 'processes',
+    schemas,
+  });
+  assert.equal(aliases.requested_type, 'process');
+  assert.equal(aliases.rows[0]?.status, 'valid');
+
+  const modelAlias = await runDatasetValidate({
+    inputPath: 'memory',
+    rawInput: [{ json_ordered: { lifeCycleModelDataSet: {} } }],
+    type: 'models',
+    schemas,
+  });
+  assert.equal(modelAlias.requested_type, 'lifecyclemodel');
+
+  const defaultSchema = await runDatasetValidate({
+    inputPath: 'memory',
+    rawInput: [{ json_ordered: { flowDataSet: {} } }],
+    type: 'flow',
+  });
+  assert.equal(defaultSchema.requested_type, 'flow');
+  assert.equal(defaultSchema.rows[0]?.validator?.includes('FlowSchema'), true);
+
+  const fallbackIssue = await runDatasetValidate({
+    inputPath: 'memory',
+    rawInput: [{ json_ordered: { processDataSet: { invalid: true } } }],
+    type: 'process',
+    schemas: {
+      process: {
+        safeParse: () => ({ success: false, error: { issues: [{}] } }),
+      },
+    },
+  });
+  assert.deepEqual(fallbackIssue.rows[0]?.issues, [
+    { path: '<root>', message: 'Validation failed', code: 'custom' },
+  ]);
+
+  const issueLessFailure = await runDatasetValidate({
+    inputPath: 'memory',
+    rawInput: [{ json_ordered: { processDataSet: { invalid: true } } }],
+    type: 'process',
+    schemas: {
+      process: {
+        safeParse: () => ({ success: false }),
+      },
+    },
+  });
+  assert.equal(issueLessFailure.rows[0]?.issue_count, 0);
+
+  await assert.rejects(
+    () => runDatasetValidate({ inputPath: 'memory', rawInput: [], type: 'bad-type' }),
+    /Expected --type/u,
+  );
+
+  const originalLifecyclemodelExport = __testInternals.SCHEMA_EXPORTS.lifecyclemodel;
+  try {
+    __testInternals.SCHEMA_EXPORTS.lifecyclemodel = 'MissingSchemaForTest' as never;
+    assert.throws(
+      () => __testInternals.schemaForKind('lifecyclemodel', undefined),
+      /MissingSchemaForTest is unavailable/u,
+    );
+  } finally {
+    __testInternals.SCHEMA_EXPORTS.lifecyclemodel = originalLifecyclemodelExport;
+  }
+});

--- a/test/lifecyclemodel-graph.test.ts
+++ b/test/lifecyclemodel-graph.test.ts
@@ -1,0 +1,218 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { __testInternals, runLifecyclemodelGraph } from '../src/lib/lifecyclemodel-graph.js';
+
+function writeJsonl(filePath: string, rows: unknown[]): void {
+  writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`, 'utf8');
+}
+
+function readJsonl(filePath: string): unknown[] {
+  return readFileSync(filePath, 'utf8')
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function makeLifecyclemodelWithDanglingEdge(): Record<string, unknown> {
+  return {
+    lifeCycleModelDataSet: {
+      lifeCycleModelInformation: {
+        dataSetInformation: {
+          'common:UUID': 'lm-graph-1',
+        },
+        technology: {
+          processes: {
+            processInstance: {
+              '@dataSetInternalID': '1',
+              referenceToProcess: {
+                '@refObjectId': 'proc-1',
+                '@version': '01.01.000',
+                name: {
+                  baseName: [{ '#text': 'Process 1' }],
+                },
+              },
+              connections: {
+                outputExchange: {
+                  '@flowUUID': 'flow-1',
+                  downstreamProcess: {
+                    '@id': 'missing-node',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+test('runLifecyclemodelGraph writes graph files and flags unresolved connections', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-graph-'));
+  const inputPath = path.join(dir, 'lifecyclemodels.jsonl');
+  const outDir = path.join(dir, 'out');
+  writeJsonl(inputPath, [
+    {
+      id: 'lm-graph-1',
+      version: '01.01.000',
+      json_ordered: makeLifecyclemodelWithDanglingEdge(),
+    },
+  ]);
+
+  try {
+    const report = await runLifecyclemodelGraph({
+      inputPath,
+      outDir,
+      format: 'all',
+      checkConnections: true,
+      now: new Date('2026-05-05T00:00:00.000Z'),
+    });
+
+    assert.equal(report.status, 'completed_with_findings');
+    assert.equal(report.counts.models, 1);
+    assert.equal(report.counts.nodes, 1);
+    assert.equal(report.counts.edges, 1);
+    assert.equal(report.counts.findings, 1);
+    assert.equal(report.findings[0]?.code, 'missing_target_process_instance');
+    assert.equal(existsSync(report.models[0]?.files.graph_json ?? ''), true);
+    assert.equal(existsSync(report.models[0]?.files.dot ?? ''), true);
+    assert.equal(existsSync(report.models[0]?.files.svg ?? ''), true);
+    assert.equal(readJsonl(report.files.findings).length, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelGraph validates required flags and supports json-only output', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-graph-json-'));
+  const inputPath = path.join(dir, 'lifecyclemodels.json');
+  const outDir = path.join(dir, 'out');
+  writeFileSync(
+    inputPath,
+    JSON.stringify({ rows: [{ json_ordered: { lifeCycleModelDataSet: {} } }] }),
+    'utf8',
+  );
+
+  try {
+    await assert.rejects(
+      () => runLifecyclemodelGraph({ inputPath, outDir: '', format: 'json' }),
+      /Missing required --out-dir/u,
+    );
+    await assert.rejects(
+      () => runLifecyclemodelGraph({ inputPath, outDir, format: 'bad' }),
+      /Expected --format/u,
+    );
+
+    const report = await runLifecyclemodelGraph({
+      inputPath,
+      outDir,
+      format: 'json',
+      now: new Date('2026-05-05T00:00:00.000Z'),
+    });
+
+    assert.equal(report.status, 'completed');
+    assert.equal(report.models[0]?.files.dot, null);
+    assert.equal(report.models[0]?.files.svg, null);
+    assert.equal(existsSync(report.models[0]?.files.graph_json ?? ''), true);
+    assert.equal(readJsonl(report.files.findings).length, 0);
+
+    const dotOnlyReport = await runLifecyclemodelGraph({
+      inputPath,
+      outDir: path.join(dir, 'dot-out'),
+      format: 'dot',
+    });
+    assert.equal(dotOnlyReport.models[0]?.files.graph_json, null);
+    assert.equal(existsSync(dotOnlyReport.models[0]?.files.dot ?? ''), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('lifecyclemodel graph internals cover fallback graph rendering branches', () => {
+  assert.deepEqual(__testInternals.asArray(undefined), []);
+  assert.deepEqual(__testInternals.asArray('one'), ['one']);
+  assert.equal(__testInternals.normalizeFormat(null), 'all');
+  assert.equal(__testInternals.safeStem(0, 'bad id/with spaces'), '001-bad_id_with_spaces');
+  assert.deepEqual(__testInternals.normalizeNodes({}), []);
+  assert.deepEqual(__testInternals.normalizeEdges({}), []);
+
+  const nodes = __testInternals.normalizeNodes({
+    xflow: {
+      nodes: [
+        {
+          data: {
+            label: { baseName: [{ '#text': 'Localized Label' }] },
+          },
+        },
+      ],
+    },
+  });
+  const fallbackLabelNodes = __testInternals.normalizeNodes({
+    xflow: {
+      nodes: [{ data: { label: { baseName: ['bad'] } } }, {}],
+    },
+  });
+  const edges = __testInternals.normalizeEdges({
+    xflow: {
+      edges: [
+        {
+          source: { cell: 'missing-source' },
+          target: { cell: '' },
+          data: { connection: { outputExchange: { '@flowUUID': 'flow-1' } } },
+        },
+      ],
+    },
+  });
+
+  assert.equal(__testInternals.labelFromNode(nodes[0]!), 'Localized Label');
+  assert.equal(__testInternals.labelFromNode(fallbackLabelNodes[0]!), 'node-1');
+  assert.equal(__testInternals.labelFromNode(fallbackLabelNodes[1]!), 'node-2');
+  assert.match(__testInternals.buildDot('model"1', nodes, edges), /model\\"1/u);
+  assert.match(__testInternals.buildSvg(nodes, edges), /Localized Label/u);
+  const connectedNodes = __testInternals.normalizeNodes({
+    xflow: {
+      nodes: [
+        {
+          id: 'source',
+          x: 1,
+          y: 2,
+          width: 100,
+          height: 50,
+          data: { id: 'source', label: 'Source label' },
+        },
+        { id: 'target', x: 200, y: 20, width: 100, height: 50, data: { id: 'target' } },
+      ],
+    },
+  });
+  const connectedEdges = __testInternals.normalizeEdges({
+    xflow: {
+      edges: [
+        { id: 'edge-1', source: { cell: 'source' }, target: { cell: 'target' } },
+        { id: '', source: {}, target: {} },
+        { source: 'bad-source', target: 'bad-target', data: 'bad-data' },
+      ],
+    },
+  });
+  assert.match(__testInternals.buildSvg(connectedNodes, connectedEdges), /<line x1=/u);
+  assert.match(
+    __testInternals.buildDot(null, connectedNodes, [
+      ...connectedEdges,
+      { id: '', source: {}, target: {}, data: {} },
+    ]),
+    /unknown-source/u,
+  );
+  const findings = __testInternals.checkEdges(0, 'lm-1', nodes, edges);
+  assert.deepEqual(
+    findings.map((finding) => finding.code),
+    ['missing_source_process_instance', 'missing_target_process_instance'],
+  );
+  const emptyFindings = __testInternals.checkEdges(0, null, [], connectedEdges);
+  assert.equal(
+    emptyFindings.some((finding) => /<empty>/u.test(finding.message)),
+    true,
+  );
+});

--- a/test/lifecyclemodel-save-draft-run.test.ts
+++ b/test/lifecyclemodel-save-draft-run.test.ts
@@ -254,7 +254,8 @@ test('runLifecyclemodelSaveDraft records candidate failures and default output l
 
     assert.equal(report.status, 'completed_with_failures');
     assert.equal(report.counts.failed, 2);
-    assert.match(report.out_dir, /artifacts\/lifecyclemodel_save_draft/u);
+    assert.equal(path.basename(path.dirname(report.out_dir)), 'lifecyclemodel_save_draft');
+    assert.equal(path.basename(path.dirname(path.dirname(report.out_dir))), 'artifacts');
     assert.equal(readJsonl(report.files.failures_jsonl).length, 2);
 
     const missingIdCandidate = __testInternals.buildCandidate(
@@ -308,6 +309,7 @@ test('runLifecyclemodelSaveDraft records candidate failures and default output l
 
     const validPayload = __testInternals.validateLifecyclemodelPayload(
       makeSchemaValidLifecyclemodel(),
+      { safeParse: () => ({ success: true }) },
     );
     assert.equal(validPayload.ok, true);
     assert.equal(

--- a/test/lifecyclemodel-save-draft-run.test.ts
+++ b/test/lifecyclemodel-save-draft-run.test.ts
@@ -1,0 +1,408 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import type { FetchLike } from '../src/lib/http.js';
+import {
+  __testInternals,
+  runLifecyclemodelSaveDraft,
+} from '../src/lib/lifecyclemodel-save-draft-run.js';
+import {
+  buildSupabaseTestEnv,
+  isSupabaseAuthTokenUrl,
+  makeSupabaseAuthResponse,
+} from './helpers/supabase-auth.js';
+
+function writeJsonl(filePath: string, rows: unknown[]): void {
+  writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`, 'utf8');
+}
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+function readJsonl(filePath: string): unknown[] {
+  return readFileSync(filePath, 'utf8')
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function makeLifecyclemodel(id: string): Record<string, unknown> {
+  return {
+    lifeCycleModelDataSet: {
+      lifeCycleModelInformation: {
+        dataSetInformation: {
+          'common:UUID': id,
+        },
+      },
+      administrativeInformation: {
+        publicationAndOwnership: {
+          'common:dataSetVersion': '01.01.000',
+        },
+      },
+    },
+  };
+}
+
+function makeGlobalReference(id: string): Record<string, unknown> {
+  return {
+    '@type': 'contact data set',
+    '@refObjectId': id,
+    '@version': '01.00.000',
+    '@uri': `https://example.com/${id}`,
+    'common:shortDescription': { '#text': 'Reference', '@xml:lang': 'en' },
+  };
+}
+
+function makeMultilangText(text: string): Record<string, unknown> {
+  return { '#text': text, '@xml:lang': 'en' };
+}
+
+function makeSchemaValidLifecyclemodel(): Record<string, unknown> {
+  const id = '123e4567-e89b-12d3-a456-426614174000';
+  const reference = makeGlobalReference(id);
+  const text = makeMultilangText('Lifecycle model');
+
+  return {
+    lifeCycleModelDataSet: {
+      '@xmlns': 'http://eplca.jrc.ec.europa.eu/ILCD/LifeCycleModel/2017',
+      '@xmlns:acme': 'http://acme.com/custom',
+      '@xmlns:common': 'http://lca.jrc.it/ILCD/Common',
+      '@xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+      '@locations': '../ILCDLocations.xml',
+      '@version': '1.1',
+      '@xsi:schemaLocation':
+        'http://eplca.jrc.ec.europa.eu/ILCD/LifeCycleModel/2017 ../../schemas/ILCD_LifeCycleModelDataSet.xsd',
+      lifeCycleModelInformation: {
+        dataSetInformation: {
+          'common:UUID': id,
+          name: {
+            baseName: text,
+            treatmentStandardsRoutes: text,
+            mixAndLocationTypes: text,
+          },
+          classificationInformation: {
+            'common:classification': {
+              'common:class': [
+                { '@level': '0', '@classId': '0', '#text': 'Root' },
+                { '@level': '1', '@classId': '1', '#text': 'One' },
+                { '@level': '2', '@classId': '2', '#text': 'Two' },
+                { '@level': '3', '@classId': '3', '#text': 'Three' },
+              ],
+            },
+          },
+        },
+        quantitativeReference: {
+          referenceToReferenceProcess: '1',
+        },
+        technology: {
+          processes: {},
+        },
+      },
+      modellingAndValidation: {
+        validation: {
+          review: {
+            'common:referenceToNameOfReviewerAndInstitution': reference,
+          },
+        },
+        complianceDeclarations: {
+          compliance: {
+            'common:referenceToComplianceSystem': reference,
+            'common:approvalOfOverallCompliance': 'Not defined',
+            'common:nomenclatureCompliance': 'Not defined',
+            'common:methodologicalCompliance': 'Not defined',
+            'common:reviewCompliance': 'Not defined',
+            'common:documentationCompliance': 'Not defined',
+            'common:qualityCompliance': 'Not defined',
+          },
+        },
+      },
+      administrativeInformation: {
+        'common:commissionerAndGoal': {
+          'common:referenceToCommissioner': reference,
+        },
+        dataEntryBy: {
+          'common:timeStamp': '2026-05-05T00:00:00.000Z',
+          'common:referenceToDataSetFormat': reference,
+        },
+        publicationAndOwnership: {
+          'common:dataSetVersion': '01.01.000',
+          'common:permanentDataSetURI': 'https://example.com/lifecyclemodel',
+          'common:referenceToOwnershipOfDataSet': reference,
+          'common:copyright': 'false',
+          'common:licenseType': 'Other',
+        },
+      },
+    },
+  };
+}
+
+const VALIDATION_OK = () => ({
+  ok: true as const,
+  validator: 'test-validator',
+  issue_count: 0 as const,
+  issues: [] as [],
+});
+
+function makeResponse(options: { ok: boolean; status: number; body?: string }) {
+  return {
+    ok: options.ok,
+    status: options.status,
+    headers: {
+      get(name: string): string | null {
+        return name.toLowerCase() === 'content-type' ? 'application/json' : null;
+      },
+    },
+    async text(): Promise<string> {
+      return options.body ?? '';
+    },
+  };
+}
+
+function withSupabaseAuthBootstrap(fetchImpl: FetchLike): FetchLike {
+  return async (url, init) => {
+    if (isSupabaseAuthTokenUrl(String(url))) {
+      return makeSupabaseAuthResponse();
+    }
+
+    return fetchImpl(String(url), init);
+  };
+}
+
+test('runLifecyclemodelSaveDraft prepares dry-run bundle artifacts from local rows', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-save-draft-'));
+  const inputPath = path.join(dir, 'lifecyclemodels.jsonl');
+  const outDir = path.join(dir, 'out');
+  writeJsonl(inputPath, [
+    {
+      id: 'lm-1',
+      version: '01.01.000',
+      json_ordered: makeLifecyclemodel('lm-1'),
+      json_tg: { xflow: { nodes: [], edges: [] } },
+      rule_verification: true,
+    },
+  ]);
+
+  try {
+    const report = await runLifecyclemodelSaveDraft({
+      inputPath,
+      outDir,
+      now: new Date('2026-05-05T00:00:00.000Z'),
+      validateLifecyclemodelPayloadImpl: VALIDATION_OK,
+    });
+
+    assert.equal(report.status, 'completed');
+    assert.equal(report.mode, 'dry_run');
+    assert.deepEqual(report.counts, {
+      selected: 1,
+      prepared: 1,
+      executed: 0,
+      failed: 0,
+    });
+    assert.equal(existsSync(report.files.summary_json), true);
+    assert.deepEqual(readJson(report.files.summary_json), report);
+    assert.equal(readJsonl(report.files.selected_lifecyclemodels).length, 1);
+    assert.equal(readJsonl(report.files.progress_jsonl).length, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelSaveDraft records candidate failures and default output layout', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-save-draft-failures-'));
+  const inputPath = path.join(dir, 'lifecyclemodels.jsonl');
+  writeJsonl(inputPath, [
+    {
+      json_ordered: {
+        lifeCycleModelDataSet: {
+          administrativeInformation: {
+            publicationAndOwnership: {
+              'common:dataSetVersion': '01.02.000',
+            },
+          },
+        },
+      },
+      jsonTg: { xflow: { nodes: [] } },
+      processMutations: [{ id: 'mutation-1' }, 1],
+      ruleVerification: false,
+    },
+    {
+      id: 'lm-invalid',
+      json_ordered: makeLifecyclemodel('lm-invalid'),
+      process_mutations: [{ id: 'mutation-2' }],
+      rule_verification: true,
+    },
+  ]);
+
+  try {
+    const report = await runLifecyclemodelSaveDraft({
+      inputPath,
+      now: new Date('2026-05-05T00:00:00.000Z'),
+      validateLifecyclemodelPayloadImpl: (payload) =>
+        payload === makeLifecyclemodel('never')
+          ? VALIDATION_OK()
+          : {
+              ok: false,
+              validator: 'test-validator',
+              issue_count: 1,
+              issues: [{ path: '<root>', message: '', code: '' }],
+            },
+    });
+
+    assert.equal(report.status, 'completed_with_failures');
+    assert.equal(report.counts.failed, 2);
+    assert.match(report.out_dir, /artifacts\/lifecyclemodel_save_draft/u);
+    assert.equal(readJsonl(report.files.failures_jsonl).length, 2);
+
+    const missingIdCandidate = __testInternals.buildCandidate(
+      { json_tg: { xflow: {} }, processMutations: [{}], ruleVerification: true },
+      { lifeCycleModelDataSet: {} },
+      VALIDATION_OK,
+    );
+    assert.equal(missingIdCandidate.metadata?.ruleVerification, true);
+
+    const invalidPayload = __testInternals.validateLifecyclemodelPayload({});
+    assert.equal(invalidPayload.ok, false);
+    const fallbackInvalidPayload = __testInternals.validateLifecyclemodelPayload(
+      {},
+      { safeParse: () => ({ success: false, error: { issues: [{}] } }) },
+    );
+    assert.deepEqual(fallbackInvalidPayload.issues, [
+      { path: '<root>', message: 'Validation failed', code: 'custom' },
+    ]);
+    assert.equal(
+      __testInternals.validateLifecyclemodelPayload({}, { safeParse: () => ({ success: false }) })
+        .issue_count,
+      0,
+    );
+    assert.equal(__testInternals.normalizeIssuePath(undefined), '<root>');
+    assert.throws(
+      () => __testInternals.getLifecyclemodelSchema({}),
+      /LifeCycleModelSchema is unavailable/u,
+    );
+    assert.deepEqual(__testInternals.serializeError('string failure'), {
+      message: 'string failure',
+    });
+    assert.equal(
+      __testInternals.summarizeValidation({
+        ok: false,
+        validator: 'test-validator',
+        issue_count: 0,
+        issues: [],
+      }),
+      'local LifeCycleModelSchema validation failed with 0 issue(s)',
+    );
+    const unwrappedCandidate = __testInternals.buildCandidate(
+      { id: 'lm-unwrapped' },
+      {
+        lifeCycleModelInformation: {
+          dataSetInformation: { 'common:UUID': 'lm-unwrapped' },
+        },
+      },
+      VALIDATION_OK,
+    );
+    assert.equal(unwrappedCandidate.id, 'lm-unwrapped');
+
+    const validPayload = __testInternals.validateLifecyclemodelPayload(
+      makeSchemaValidLifecyclemodel(),
+    );
+    assert.equal(validPayload.ok, true);
+    assert.equal(
+      __testInternals.summarizeValidation(VALIDATION_OK()),
+      'local LifeCycleModelSchema validation passed',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runLifecyclemodelSaveDraft validates commit runtime and executes remote writes', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-save-draft-commit-'));
+  const inputPath = path.join(dir, 'lifecyclemodels.jsonl');
+  const outDir = path.join(dir, 'out');
+  writeJsonl(inputPath, [
+    {
+      id: 'lm-commit',
+      version: '01.01.000',
+      json_ordered: makeLifecyclemodel('lm-commit'),
+    },
+  ]);
+
+  try {
+    await assert.rejects(
+      () =>
+        runLifecyclemodelSaveDraft({
+          inputPath,
+          outDir,
+          commit: true,
+          validateLifecyclemodelPayloadImpl: VALIDATION_OK,
+        }),
+      /commit requires env and fetch runtime bindings/u,
+    );
+
+    const observed: string[] = [];
+    const fetchImpl = withSupabaseAuthBootstrap(async (url) => {
+      observed.push(String(url));
+      if (observed.length === 1) {
+        return makeResponse({ ok: true, status: 200, body: '[]' });
+      }
+      return makeResponse({ ok: true, status: 200, body: '{"ok":true}' });
+    });
+
+    const report = await runLifecyclemodelSaveDraft({
+      inputPath,
+      outDir,
+      commit: true,
+      env: buildSupabaseTestEnv({
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
+        TIANGONG_LCA_API_KEY: 'key',
+      }),
+      fetchImpl,
+      validateLifecyclemodelPayloadImpl: VALIDATION_OK,
+      now: new Date('2026-05-05T00:00:00.000Z'),
+    });
+
+    assert.equal(report.status, 'completed');
+    assert.equal(report.counts.executed, 1);
+    assert.match(observed[0] ?? '', /\/rest\/v1\/lifecyclemodels/u);
+    assert.match(observed[1] ?? '', /save_lifecycle_model_bundle/u);
+
+    const failingFetch = withSupabaseAuthBootstrap(async () =>
+      makeResponse({ ok: true, status: 200, body: 'not-json' }),
+    );
+    const failed = await runLifecyclemodelSaveDraft({
+      inputPath,
+      outDir: path.join(dir, 'failed-out'),
+      commit: true,
+      env: buildSupabaseTestEnv({
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co/functions/v1',
+        TIANGONG_LCA_API_KEY: 'key',
+      }),
+      fetchImpl: failingFetch,
+      validateLifecyclemodelPayloadImpl: VALIDATION_OK,
+    });
+    assert.equal(failed.status, 'completed_with_failures');
+    assert.equal(failed.lifecyclemodels[0]?.status, 'failed');
+
+    await assert.rejects(
+      () =>
+        runLifecyclemodelSaveDraft({
+          inputPath,
+          commit: true,
+          validateLifecyclemodelPayloadImpl: VALIDATION_OK,
+        }),
+      /commit requires env and fetch runtime bindings/u,
+    );
+
+    const defaultValidator = await runLifecyclemodelSaveDraft({
+      inputPath,
+      outDir: path.join(dir, 'default-validator-out'),
+    });
+    assert.equal(defaultValidator.status, 'completed_with_failures');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/user-api-key.test.ts
+++ b/test/user-api-key.test.ts
@@ -14,7 +14,7 @@ function encodeUserApiKey(payload: unknown): string {
   return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64');
 }
 
-test('decodeUserApiKey accepts the TianGong account-page payload shape', () => {
+test('decodeUserApiKey accepts the TianGong user API key payload shape', () => {
   const apiKey = encodeUserApiKey({
     email: ' user@example.com ',
     password: ' secret-password ',


### PR DESCRIPTION
Closes tiangong-lca/tiangong-cli#99

## Summary
- Add local dataset validation and reference rewrite commands for flow/process/lifecyclemodel rows.
- Add lifecyclemodel save-draft and graph commands for local review and controlled remote writes.
- Wire the new command surfaces into tiangong-lca with strict parsing, docpact coverage, and 100% coverage tests.

## Validation
- node --import tsx --test test/lifecyclemodel-save-draft-run.test.ts
- npm run lint
- npm run prepush:gate
- npm run lint:prettier

## Follow-ups
- Project sync blocked: ProjectV2 #1 could not be resolved for owner tiangong-lca from this token/session.
- Local docpact reproduction was blocked because this checkout does not have `docpact` or `cargo`; CI reruns the docpact gate from the workflow environment.

## Workspace Integration
- Requires later lca-workspace submodule pointer update after the PR is merged and the target commit is eligible for root integration.
