### PR TITLE
feat: add deep validation fallback for CLI schema checks

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-10"
-lastReviewedCommit: "ea4e5b546ffdd4d5b57d266a58a3d3d5d83c8e5b"
+lastReviewedAt: "2026-05-22"
+lastReviewedCommit: "1e1119bdc91b82e3e5f360ba53610fe07479faad"
 
 catalog:
   repos:
@@ -59,6 +59,7 @@ ownership:
           - src/lib/review-*.ts
           - src/lib/run.ts
           - src/lib/state-lock.ts
+          - src/lib/tidas-sdk-validation.ts
           - src/lib/tidas-sdk-package-validator.ts
           - src/lib/validation.ts
       ownerRepo: cli
@@ -195,6 +196,7 @@ routing:
         - docs/IMPLEMENTATION_GUIDE_CN.md
     tidas-sdk-validation:
       paths:
+        - src/lib/tidas-sdk-validation.ts
         - src/lib/tidas-sdk-package-validator.ts
         - src/lib/validation.ts
         - test/fixtures/tidas-sdk/**
@@ -378,6 +380,8 @@ rules:
         kind: command-logic
       - path: src/lib/state-lock.ts
         kind: artifact-runtime
+      - path: src/lib/tidas-sdk-validation.ts
+        kind: validation-runtime
       - path: src/lib/tidas-sdk-package-validator.ts
         kind: validation-runtime
       - path: src/lib/validation.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: ea4e5b546ffdd4d5b57d266a58a3d3d5d83c8e5b
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 1e1119bdc91b82e3e5f360ba53610fe07479faad
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -18,8 +18,8 @@ checkPaths:
   - src/**
   - scripts/**
   - .github/workflows/**
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: a9a2a0507ea237b9e64b86ea2f79613c9be57ae5
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 1e1119bdc91b82e3e5f360ba53610fe07479faad
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - README.md
   - src/**
   - test/**
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: a9a2a0507ea237b9e64b86ea2f79613c9be57ae5
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 1e1119bdc91b82e3e5f360ba53610fe07479faad
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -17,8 +17,8 @@ checkPaths:
   - package.json
   - src/**
   - test/**
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: a9a2a0507ea237b9e64b86ea2f79613c9be57ae5
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 1e1119bdc91b82e3e5f360ba53610fe07479faad
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
+++ b/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
@@ -15,8 +15,8 @@ checkPaths:
   - src/lib/user-api-key.ts
   - src/lib/supabase-session.ts
   - src/lib/supabase-client.ts
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 06dbec3287513cf94c5d64c73bd467ed5347f40a
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 1e1119bdc91b82e3e5f360ba53610fe07479faad
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
+++ b/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - src/lib/supabase-client.ts
   - src/lib/tidas-sdk-package-validator.ts
   - test/**
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 06dbec3287513cf94c5d64c73bd467ed5347f40a
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 1e1119bdc91b82e3e5f360ba53610fe07479faad
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: e362b575b7baa15bbb9d4e0f697e46570ac8365d
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 1e1119bdc91b82e3e5f360ba53610fe07479faad
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: ea4e5b546ffdd4d5b57d266a58a3d3d5d83c8e5b
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 1e1119bdc91b82e3e5f360ba53610fe07479faad
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: ea4e5b546ffdd4d5b57d266a58a3d3d5d83c8e5b
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 1e1119bdc91b82e3e5f360ba53610fe07479faad
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -19,8 +19,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: ea4e5b546ffdd4d5b57d266a58a3d3d5d83c8e5b
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 1e1119bdc91b82e3e5f360ba53610fe07479faad
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/src/lib/dataset-validate.ts
+++ b/src/lib/dataset-validate.ts
@@ -3,28 +3,12 @@ import * as tidasSdk from '@tiangong-lca/tidas-sdk';
 import { writeJsonArtifact, writeJsonLinesArtifact } from './artifacts.js';
 import { CliError } from './errors.js';
 import { materializeDatasetRows, type DatasetKind, type DatasetRowInput } from './dataset-local.js';
-
-type SafeParseIssue = {
-  code?: string;
-  message?: string;
-  path?: Array<string | number>;
-};
-
-type SafeParseResult =
-  | {
-      success: true;
-      data?: unknown;
-    }
-  | {
-      success: false;
-      error?: {
-        issues?: SafeParseIssue[];
-      };
-    };
-
-type SafeParseSchema = {
-  safeParse: (value: unknown) => SafeParseResult;
-};
+import {
+  normalizeIssuePath,
+  type SafeParseSchema,
+  type SdkValidationFactory,
+  validateSchemaWithDeepFallback,
+} from './tidas-sdk-validation.js';
 
 type DatasetValidateType = 'auto' | DatasetKind;
 
@@ -81,6 +65,12 @@ const SCHEMA_EXPORTS: Record<DatasetKind, keyof typeof tidasSdk> = {
   lifecyclemodel: 'LifeCycleModelSchema' as keyof typeof tidasSdk,
 };
 
+const ENTITY_FACTORY_EXPORTS: Record<DatasetKind, keyof typeof tidasSdk> = {
+  flow: 'createFlow' as keyof typeof tidasSdk,
+  process: 'createProcess' as keyof typeof tidasSdk,
+  lifecyclemodel: 'createLifeCycleModel' as keyof typeof tidasSdk,
+};
+
 function normalizeType(value: string | null | undefined): DatasetValidateType {
   const normalized = value?.trim().toLowerCase();
   if (!normalized) {
@@ -110,21 +100,15 @@ function normalizeType(value: string | null | undefined): DatasetValidateType {
   });
 }
 
-function normalizeIssuePath(pathParts: Array<string | number> | undefined): string {
-  if (!Array.isArray(pathParts) || pathParts.length === 0) {
-    return '<root>';
-  }
-  return pathParts.map((part) => String(part)).join('.');
-}
-
 function schemaForKind(
   kind: DatasetKind,
   schemas: Partial<Record<DatasetKind, SafeParseSchema>> | undefined,
-): { validator: string; schema: SafeParseSchema } {
+): { validator: string; schema: SafeParseSchema; createEntity: SdkValidationFactory | null } {
   if (schemas?.[kind]) {
     return {
       validator: 'injected',
       schema: schemas[kind],
+      createEntity: null,
     };
   }
 
@@ -142,9 +126,14 @@ function schemaForKind(
     });
   }
 
+  const factoryName = ENTITY_FACTORY_EXPORTS[kind];
+  const createEntity = (tidasSdk as Record<string, unknown>)[factoryName];
+
   return {
     validator: `@tiangong-lca/tidas-sdk/${String(exportName)}`,
     schema: candidate as SafeParseSchema,
+    createEntity:
+      typeof createEntity === 'function' ? (createEntity as SdkValidationFactory) : null,
   };
 }
 
@@ -177,8 +166,8 @@ function validateRow(
     return buildUnsupportedTypeReport(row);
   }
 
-  const { validator, schema } = schemaForKind(kind, schemas);
-  const outcome = schema.safeParse(row.payload);
+  const { validator, schema, createEntity } = schemaForKind(kind, schemas);
+  const outcome = validateSchemaWithDeepFallback(schema, row.payload, createEntity);
   if (outcome.success) {
     return {
       index: row.index,
@@ -192,7 +181,7 @@ function validateRow(
     };
   }
 
-  const issues = (outcome.error?.issues ?? []).map((issue) => ({
+  const issues = outcome.issues.map((issue) => ({
     path: normalizeIssuePath(issue.path),
     message: issue.message ?? 'Validation failed',
     code: issue.code ?? 'custom',
@@ -288,6 +277,7 @@ export async function runDatasetValidate(
 }
 
 export const __testInternals = {
+  ENTITY_FACTORY_EXPORTS,
   SCHEMA_EXPORTS,
   normalizeType,
   schemaForKind,

--- a/src/lib/flow-regen-product.ts
+++ b/src/lib/flow-regen-product.ts
@@ -17,6 +17,10 @@ import {
   type FlowRecord,
   type JsonRecord,
 } from './flow-governance.js';
+import {
+  type SdkValidationEntity,
+  validateEntityWithDeepFallback,
+} from './tidas-sdk-validation.js';
 import { resolveRepoRootFrom } from './validation.js';
 
 const EMERGY_TEXT_KEYWORDS = [
@@ -306,11 +310,6 @@ export type FlowApplyProcessFlowRepairsReport = {
   files: ApplyStageFiles;
 };
 
-type ProcessSdkValidationEntity = {
-  validateEnhanced?: () => unknown;
-  validate?: () => unknown;
-};
-
 type ProcessSdkModule = {
   createProcess?: (
     data?: unknown,
@@ -319,7 +318,7 @@ type ProcessSdkModule = {
       throwOnError?: boolean;
       deepValidation?: boolean;
     },
-  ) => ProcessSdkValidationEntity;
+  ) => SdkValidationEntity;
   location?: string;
 };
 
@@ -1327,17 +1326,7 @@ function evaluateProcessSdkValidation(
   createProcess: NonNullable<ProcessSdkModule['createProcess']>,
 ): string | null {
   try {
-    const entity = createProcess(payload, {
-      mode: 'strict',
-      throwOnError: false,
-      deepValidation: true,
-    });
-    const validation =
-      typeof entity?.validateEnhanced === 'function'
-        ? entity.validateEnhanced()
-        : typeof entity?.validate === 'function'
-          ? entity.validate()
-          : null;
+    const validation = validateEntityWithDeepFallback(payload, createProcess);
 
     if (isRecord(validation) && validation.success === true) {
       return null;

--- a/src/lib/flow-remediate.ts
+++ b/src/lib/flow-remediate.ts
@@ -11,6 +11,10 @@ import {
   normalizeText,
   type JsonRecord,
 } from './flow-governance.js';
+import {
+  type SdkValidationEntity,
+  validateEntityWithDeepFallback,
+} from './tidas-sdk-validation.js';
 
 const CONTACT_UUID = 'f4b4c314-8c4c-4c83-968f-5b3c7724f6a8';
 const CONTACT_VERSION = '01.00.000';
@@ -74,10 +78,6 @@ type FlowValidationResult =
       issues: FlowValidationIssue[];
     };
 
-type FlowSdkValidationEntity = {
-  validate?: () => unknown;
-};
-
 type FlowSdkModule = {
   createFlow?: (
     data?: unknown,
@@ -86,7 +86,7 @@ type FlowSdkModule = {
       throwOnError?: boolean;
       deepValidation?: boolean;
     },
-  ) => FlowSdkValidationEntity;
+  ) => SdkValidationEntity;
 };
 
 type FlowRemediationFiles = {
@@ -699,19 +699,17 @@ function validate_flow_payload(
   }
 
   try {
-    const entity = sdkModule.createFlow(payload, {
-      mode: 'strict',
-      throwOnError: false,
-      deepValidation: true,
-    });
-    if (!entity || typeof entity.validate !== 'function') {
-      throw new CliError('Resolved tidas-sdk flow entity does not expose validate().', {
-        code: 'FLOW_REMEDIATE_SDK_INVALID',
-        exitCode: 2,
-        details: sdkModule.location ?? null,
-      });
+    const result = validateEntityWithDeepFallback(payload, sdkModule.createFlow);
+    if (!result) {
+      throw new CliError(
+        'Resolved tidas-sdk flow entity does not expose validateEnhanced() or validate().',
+        {
+          code: 'FLOW_REMEDIATE_SDK_INVALID',
+          exitCode: 2,
+          details: sdkModule.location ?? null,
+        },
+      );
     }
-    const result = entity.validate();
     if (isRecord(result) && result.success === true) {
       return { success: true };
     }

--- a/src/lib/lifecyclemodel-save-draft-run.ts
+++ b/src/lib/lifecyclemodel-save-draft-run.ts
@@ -15,28 +15,12 @@ import {
   type LifecyclemodelPublishMetadata,
 } from './lifecyclemodel-bundle-save.js';
 import { buildRunId, resolveRunLayout } from './run.js';
-
-type SafeParseIssue = {
-  code?: string;
-  message?: string;
-  path?: Array<string | number>;
-};
-
-type SafeParseResult =
-  | {
-      success: true;
-      data?: unknown;
-    }
-  | {
-      success: false;
-      error?: {
-        issues?: SafeParseIssue[];
-      };
-    };
-
-type SafeParseSchema = {
-  safeParse: (value: unknown) => SafeParseResult;
-};
+import {
+  normalizeIssuePath,
+  type SafeParseSchema,
+  type SdkValidationFactory,
+  validateSchemaWithDeepFallback,
+} from './tidas-sdk-validation.js';
 
 export type LifecyclemodelPayloadValidationIssue = {
   path: string;
@@ -115,13 +99,6 @@ export type RunLifecyclemodelSaveDraftOptions = {
 
 const VALIDATOR_NAME = '@tiangong-lca/tidas-sdk/LifeCycleModelSchema';
 
-function normalizeIssuePath(pathParts: Array<string | number> | undefined): string {
-  if (!Array.isArray(pathParts) || pathParts.length === 0) {
-    return '<root>';
-  }
-  return pathParts.map((part) => String(part)).join('.');
-}
-
 function getLifecyclemodelSchema(
   sdk: { LifeCycleModelSchema?: unknown } = tidasSdk,
 ): SafeParseSchema {
@@ -132,11 +109,24 @@ function getLifecyclemodelSchema(
   return schema;
 }
 
+function getLifecyclemodelFactory(
+  sdk: { createLifeCycleModel?: unknown } = tidasSdk,
+): SdkValidationFactory | null {
+  const createLifeCycleModel = sdk.createLifeCycleModel;
+  return typeof createLifeCycleModel === 'function'
+    ? (createLifeCycleModel as SdkValidationFactory)
+    : null;
+}
+
 export function validateLifecyclemodelPayload(
   payload: JsonObject,
-  schema: SafeParseSchema = getLifecyclemodelSchema(),
+  schema?: SafeParseSchema,
+  createEntity?: SdkValidationFactory | null,
 ): LifecyclemodelPayloadValidationResult {
-  const outcome = schema.safeParse(payload);
+  const activeSchema = schema ?? getLifecyclemodelSchema();
+  const activeCreateEntity =
+    createEntity === undefined && schema === undefined ? getLifecyclemodelFactory() : createEntity;
+  const outcome = validateSchemaWithDeepFallback(activeSchema, payload, activeCreateEntity);
   if (outcome.success) {
     return {
       ok: true,
@@ -146,7 +136,7 @@ export function validateLifecyclemodelPayload(
     };
   }
 
-  const issues = (outcome.error?.issues ?? []).map((issue) => ({
+  const issues = outcome.issues.map((issue) => ({
     path: normalizeIssuePath(issue.path),
     message: issue.message ?? 'Validation failed',
     code: issue.code ?? 'custom',
@@ -390,6 +380,7 @@ export async function runLifecyclemodelSaveDraft(
 
 export const __testInternals = {
   buildCandidate,
+  getLifecyclemodelFactory,
   getLifecyclemodelSchema,
   normalizeIssuePath,
   serializeError,

--- a/src/lib/process-payload-validation.ts
+++ b/src/lib/process-payload-validation.ts
@@ -1,28 +1,12 @@
 import * as tidasSdk from '@tiangong-lca/tidas-sdk';
+import {
+  normalizeIssuePath,
+  type SafeParseSchema,
+  type SdkValidationFactory,
+  validateSchemaWithDeepFallback,
+} from './tidas-sdk-validation.js';
 
 type JsonObject = Record<string, unknown>;
-
-type SafeParseIssue = {
-  code?: string;
-  message?: string;
-  path?: Array<string | number>;
-};
-
-type SafeParseResult =
-  | {
-      success: true;
-      data?: unknown;
-    }
-  | {
-      success: false;
-      error?: {
-        issues?: SafeParseIssue[];
-      };
-    };
-
-type SafeParseSchema = {
-  safeParse: (value: unknown) => SafeParseResult;
-};
 
 const PROCESS_SCHEMA_VALIDATOR = '@tiangong-lca/tidas-sdk/ProcessSchema';
 
@@ -54,11 +38,11 @@ function getProcessSchema(): SafeParseSchema {
   return schema;
 }
 
-function normalizeIssuePath(pathParts: Array<string | number> | undefined): string {
-  if (!Array.isArray(pathParts) || pathParts.length === 0) {
-    return '<root>';
-  }
-  return pathParts.map((part) => String(part)).join('.');
+function getProcessFactory(
+  sdk: { createProcess?: unknown } = tidasSdk,
+): SdkValidationFactory | null {
+  const createProcess = sdk.createProcess;
+  return typeof createProcess === 'function' ? (createProcess as SdkValidationFactory) : null;
 }
 
 export function summarizeProcessPayloadValidation(result: ProcessPayloadValidationResult): string {
@@ -73,9 +57,12 @@ export function summarizeProcessPayloadValidation(result: ProcessPayloadValidati
   return `local ProcessSchema validation failed with ${result.issue_count} issue(s)${preview ? ` (${preview})` : ''}`;
 }
 
-export function validateProcessPayload(payload: JsonObject): ProcessPayloadValidationResult {
-  const schema = getProcessSchema();
-  const outcome = schema.safeParse(payload);
+export function validateProcessPayload(
+  payload: JsonObject,
+  schema: SafeParseSchema = getProcessSchema(),
+  createEntity: SdkValidationFactory | null = getProcessFactory(),
+): ProcessPayloadValidationResult {
+  const outcome = validateSchemaWithDeepFallback(schema, payload, createEntity);
 
   if (outcome.success) {
     return {
@@ -86,7 +73,7 @@ export function validateProcessPayload(payload: JsonObject): ProcessPayloadValid
     };
   }
 
-  const issues = (outcome.error?.issues ?? []).map((issue) => ({
+  const issues = outcome.issues.map((issue) => ({
     path: normalizeIssuePath(issue.path),
     message: issue.message ?? 'Validation failed',
     code: issue.code ?? 'custom',
@@ -99,3 +86,7 @@ export function validateProcessPayload(payload: JsonObject): ProcessPayloadValid
     issues,
   };
 }
+
+export const __testInternals = {
+  getProcessFactory,
+};

--- a/src/lib/tidas-sdk-package-validator.ts
+++ b/src/lib/tidas-sdk-package-validator.ts
@@ -1,5 +1,11 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
+import {
+  type SafeParseIssue,
+  type SafeParseSchema,
+  type SdkValidationFactory,
+  validateSchemaWithDeepFallback,
+} from './tidas-sdk-validation.js';
 
 type JsonObject = Record<string, unknown>;
 
@@ -37,28 +43,6 @@ export type PackageValidationReport = {
   issues: ValidationIssue[];
 };
 
-type SafeParseIssue = {
-  code?: string;
-  message?: string;
-  path?: Array<string | number>;
-};
-
-type SafeParseResult =
-  | {
-      success: true;
-      data?: unknown;
-    }
-  | {
-      success: false;
-      error?: {
-        issues?: SafeParseIssue[];
-      };
-    };
-
-type SafeParseSchema = {
-  safeParse: (value: unknown) => SafeParseResult;
-};
-
 type SupportedCategory =
   | 'contacts'
   | 'flowproperties'
@@ -78,6 +62,14 @@ type TidasSdkPublicModule = {
   ProcessSchema?: SafeParseSchema;
   SourceSchema?: SafeParseSchema;
   UnitGroupSchema?: SafeParseSchema;
+  createContact?: SdkValidationFactory;
+  createFlowProperty?: SdkValidationFactory;
+  createFlow?: SdkValidationFactory;
+  createLCIAMethod?: SdkValidationFactory;
+  createLifeCycleModel?: SdkValidationFactory;
+  createProcess?: SdkValidationFactory;
+  createSource?: SdkValidationFactory;
+  createUnitGroup?: SdkValidationFactory;
 };
 
 const SUPPORTED_CATEGORIES: SupportedCategory[] = [
@@ -100,6 +92,17 @@ const CATEGORY_SCHEMA_EXPORTS: Record<SupportedCategory, keyof TidasSdkPublicMod
   processes: 'ProcessSchema',
   sources: 'SourceSchema',
   unitgroups: 'UnitGroupSchema',
+};
+
+const CATEGORY_FACTORY_EXPORTS: Record<SupportedCategory, keyof TidasSdkPublicModule> = {
+  contacts: 'createContact',
+  flowproperties: 'createFlowProperty',
+  flows: 'createFlow',
+  lciamethods: 'createLCIAMethod',
+  lifecyclemodels: 'createLifeCycleModel',
+  processes: 'createProcess',
+  sources: 'createSource',
+  unitgroups: 'createUnitGroup',
 };
 
 const CHINESE_CHARACTER_RE = /[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]/u;
@@ -678,14 +681,15 @@ function collectSchemaIssues(
   jsonItem: unknown,
   category: SupportedCategory,
   filePath: string,
+  createEntity: SdkValidationFactory | null = null,
 ): ValidationIssue[] {
   try {
-    const result = schema.safeParse(jsonItem);
+    const result = validateSchemaWithDeepFallback(schema, jsonItem, createEntity);
     if (result.success) {
       return [];
     }
 
-    const rawIssues = Array.isArray(result.error?.issues) ? result.error.issues : [];
+    const rawIssues = result.issues;
     if (rawIssues.length === 0) {
       return [createValidationErrorIssue(category, filePath, 'Schema validation failed')];
     }
@@ -700,6 +704,7 @@ function categoryValidate(
   jsonFilePath: string,
   category: SupportedCategory,
   schema: SafeParseSchema,
+  createEntity: SdkValidationFactory | null = null,
   emitLogs = true,
 ): CategoryValidationReport {
   const issues: ValidationIssue[] = [];
@@ -720,7 +725,7 @@ function categoryValidate(
     }
 
     const itemIssues = dedupeIssues([
-      ...collectSchemaIssues(schema, jsonItem, category, fullPath),
+      ...collectSchemaIssues(schema, jsonItem, category, fullPath, createEntity),
       ...collectFlowSchemaGapIssues(jsonItem, category, fullPath),
       ...collectLocalizedTextIssues(jsonItem, category, fullPath),
       ...collectClassificationIssues(jsonItem, category, fullPath),
@@ -756,8 +761,14 @@ function isSafeParseSchema(value: unknown): value is SafeParseSchema {
 
 function resolveCategorySchemas(
   moduleExports: TidasSdkPublicModule,
-): Map<SupportedCategory, SafeParseSchema> | null {
-  const schemas = new Map<SupportedCategory, SafeParseSchema>();
+): Map<
+  SupportedCategory,
+  { schema: SafeParseSchema; createEntity: SdkValidationFactory | null }
+> | null {
+  const schemas = new Map<
+    SupportedCategory,
+    { schema: SafeParseSchema; createEntity: SdkValidationFactory | null }
+  >();
 
   for (const category of SUPPORTED_CATEGORIES) {
     const exportName = CATEGORY_SCHEMA_EXPORTS[category];
@@ -765,7 +776,12 @@ function resolveCategorySchemas(
     if (!isSafeParseSchema(schema)) {
       return null;
     }
-    schemas.set(category, schema);
+    const factoryName = CATEGORY_FACTORY_EXPORTS[category];
+    const createEntity = moduleExports[factoryName];
+    schemas.set(category, {
+      schema,
+      createEntity: typeof createEntity === 'function' ? createEntity : null,
+    });
   }
 
   return schemas;
@@ -788,12 +804,20 @@ export function createTidasSdkPackageValidator(
     validatePackageDir(inputDir: string, emitLogs = false): PackageValidationReport {
       const categoryReports = SUPPORTED_CATEGORIES.flatMap((category) => {
         const categoryDir = path.join(inputDir, category);
-        const schema = schemas.get(category);
-        if (!schema || !existsSync(categoryDir)) {
+        const validator = schemas.get(category);
+        if (!validator || !existsSync(categoryDir)) {
           return [];
         }
 
-        return [categoryValidate(categoryDir, category, schema, emitLogs)];
+        return [
+          categoryValidate(
+            categoryDir,
+            category,
+            validator.schema,
+            validator.createEntity,
+            emitLogs,
+          ),
+        ];
       });
 
       return buildPackageReport(inputDir, categoryReports);
@@ -825,5 +849,6 @@ export const __testInternals = {
   collectClassificationIssues,
   collectSchemaIssues,
   categoryValidate,
+  CATEGORY_FACTORY_EXPORTS,
   resolveCategorySchemas,
 };

--- a/src/lib/tidas-sdk-validation.ts
+++ b/src/lib/tidas-sdk-validation.ts
@@ -1,0 +1,172 @@
+export type SafeParseIssue = {
+  code?: string;
+  message?: string;
+  path?: Array<string | number>;
+};
+
+export type SafeParseResult =
+  | {
+      success: true;
+      data?: unknown;
+    }
+  | {
+      success: false;
+      error?: {
+        issues?: SafeParseIssue[];
+      };
+    };
+
+export type SafeParseSchema = {
+  safeParse: (value: unknown) => SafeParseResult;
+};
+
+export type EntityValidationConfig = {
+  mode: 'strict';
+  throwOnError: false;
+  deepValidation: boolean;
+};
+
+export type SdkValidationEntity = {
+  validateEnhanced?: () => unknown;
+  validate?: () => unknown;
+};
+
+export type SdkValidationFactory = (
+  data?: unknown,
+  validationConfig?: EntityValidationConfig,
+) => SdkValidationEntity | unknown;
+
+export type SchemaValidationOutcome =
+  | {
+      success: true;
+      issues: [];
+      result: SafeParseResult;
+    }
+  | {
+      success: false;
+      issues: SafeParseIssue[];
+      result: unknown;
+    };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isIssueLike(value: unknown): value is SafeParseIssue {
+  return isRecord(value);
+}
+
+function issueArray(value: unknown): SafeParseIssue[] {
+  return Array.isArray(value) ? value.filter(isIssueLike) : [];
+}
+
+export function validationSucceeded(result: unknown): boolean {
+  return isRecord(result) && result.success === true;
+}
+
+export function validationIssues(result: unknown): SafeParseIssue[] {
+  if (!isRecord(result)) {
+    return [];
+  }
+
+  const error = isRecord(result.error) ? result.error : null;
+  const errorIssues = issueArray(error?.issues);
+  if (errorIssues.length > 0) {
+    return errorIssues;
+  }
+
+  return issueArray(result.validationIssues);
+}
+
+export function normalizeIssuePath(
+  pathParts: Array<string | number> | undefined,
+  separator = '.',
+): string {
+  if (!Array.isArray(pathParts) || pathParts.length === 0) {
+    return '<root>';
+  }
+  return pathParts.map((part) => String(part)).join(separator);
+}
+
+export function runEntityValidation(entity: unknown): unknown | null {
+  if (!isRecord(entity)) {
+    return null;
+  }
+
+  if (typeof entity.validateEnhanced === 'function') {
+    return entity.validateEnhanced();
+  }
+
+  if (typeof entity.validate === 'function') {
+    return entity.validate();
+  }
+
+  return null;
+}
+
+export function validateEntityWithDeepFallback(
+  payload: unknown,
+  createEntity: SdkValidationFactory,
+): unknown | null {
+  const fastEntity = createEntity(payload, {
+    mode: 'strict',
+    throwOnError: false,
+    deepValidation: false,
+  });
+  const fastResult = runEntityValidation(fastEntity);
+  if (validationSucceeded(fastResult)) {
+    return fastResult;
+  }
+
+  const deepEntity = createEntity(payload, {
+    mode: 'strict',
+    throwOnError: false,
+    deepValidation: true,
+  });
+  return runEntityValidation(deepEntity) ?? fastResult;
+}
+
+export function validateSchemaWithDeepFallback(
+  schema: SafeParseSchema,
+  payload: unknown,
+  createEntity?: SdkValidationFactory | null,
+): SchemaValidationOutcome {
+  const fastResult = schema.safeParse(payload);
+  if (fastResult.success) {
+    return {
+      success: true,
+      issues: [],
+      result: fastResult,
+    };
+  }
+
+  const fastIssues = validationIssues(fastResult);
+
+  if (!createEntity) {
+    return {
+      success: false,
+      issues: fastIssues,
+      result: fastResult,
+    };
+  }
+
+  try {
+    const deepResult = validateEntityWithDeepFallback(payload, createEntity);
+    const deepIssues = validationIssues(deepResult);
+    if (!validationSucceeded(deepResult) && (deepIssues.length > 0 || fastIssues.length === 0)) {
+      return {
+        success: false,
+        issues: deepIssues,
+        result: deepResult,
+      };
+    }
+  } catch {
+    // Keep the existing schema error path if SDK entity validation itself fails.
+  }
+
+  return {
+    success: false,
+    issues: fastIssues,
+    result: fastResult,
+  };
+}

--- a/test/dataset-validate.test.ts
+++ b/test/dataset-validate.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'no
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import * as tidasSdk from '@tiangong-lca/tidas-sdk';
 import {
   __testInternals,
   runDatasetValidate,
@@ -290,13 +291,39 @@ test('runDatasetValidate covers aliases, unsupported rows, default schemas, and 
   );
 
   const originalLifecyclemodelExport = __testInternals.SCHEMA_EXPORTS.lifecyclemodel;
+  const originalProcessFactoryExport = __testInternals.ENTITY_FACTORY_EXPORTS.process;
   try {
     __testInternals.SCHEMA_EXPORTS.lifecyclemodel = 'MissingSchemaForTest' as never;
     assert.throws(
       () => __testInternals.schemaForKind('lifecyclemodel', undefined),
       /MissingSchemaForTest is unavailable/u,
     );
+    __testInternals.ENTITY_FACTORY_EXPORTS.process = 'MissingFactoryForTest' as never;
+    assert.equal(__testInternals.schemaForKind('process', undefined).createEntity, null);
   } finally {
     __testInternals.SCHEMA_EXPORTS.lifecyclemodel = originalLifecyclemodelExport;
+    __testInternals.ENTITY_FACTORY_EXPORTS.process = originalProcessFactoryExport;
+  }
+});
+
+test('runDatasetValidate uses deep SDK fallback for default schema failures', async () => {
+  const originalSafeParse = tidasSdk.ProcessSchema.safeParse;
+  try {
+    tidasSdk.ProcessSchema.safeParse = (() => ({
+      success: false,
+      error: { issues: [{ path: ['fast'], message: 'fast issue', code: 'fast' }] },
+    })) as unknown as typeof originalSafeParse;
+
+    const report = await runDatasetValidate({
+      inputPath: 'memory',
+      rawInput: [{ json_ordered: { processDataSet: { invalid: true } } }],
+      type: 'process',
+    });
+
+    assert.equal(report.rows[0]?.status, 'invalid');
+    assert.equal(__testInternals.schemaForKind('process', undefined).createEntity !== null, true);
+    assert.equal((report.rows[0]?.issue_count ?? 0) > 0, true);
+  } finally {
+    tidasSdk.ProcessSchema.safeParse = originalSafeParse;
   }
 });

--- a/test/flow-regen-product.test.ts
+++ b/test/flow-regen-product.test.ts
@@ -1301,18 +1301,28 @@ test('flow regen-product merge, file-writing, and validator helper utilities cov
       version: '01.00.000',
       exchanges: [],
     });
+    const successConfigs: boolean[] = [];
     assert.equal(
-      __testInternals.evaluateProcessSdkValidation(payload, () => ({
-        validateEnhanced: () => ({ success: true }),
+      __testInternals.evaluateProcessSdkValidation(payload, (_data, config) => ({
+        validateEnhanced: () => {
+          successConfigs.push(config?.deepValidation ?? false);
+          return { success: true };
+        },
       })),
       null,
     );
+    assert.deepEqual(successConfigs, [false]);
+    const failureConfigs: boolean[] = [];
     assert.equal(
-      __testInternals.evaluateProcessSdkValidation(payload, () => ({
-        validate: () => ({ success: false, reason: 'bad' }),
+      __testInternals.evaluateProcessSdkValidation(payload, (_data, config) => ({
+        validate: () => {
+          failureConfigs.push(config?.deepValidation ?? false);
+          return { success: false, reason: config?.deepValidation ? 'deep bad' : 'bad' };
+        },
       })),
-      '{"success":false,"reason":"bad"}',
+      '{"success":false,"reason":"deep bad"}',
     );
+    assert.deepEqual(failureConfigs, [false, true]);
     assert.equal(
       __testInternals.evaluateProcessSdkValidation(payload, () => ({})),
       'Validator returned no result.',

--- a/test/flow-remediate.test.ts
+++ b/test/flow-remediate.test.ts
@@ -869,18 +869,24 @@ test('flow remediation sdk helpers cover resolution and validation error branche
     (error: unknown) => error instanceof CliError && error.code === 'FLOW_REMEDIATE_SDK_NOT_FOUND',
   );
 
+  const successConfigs: boolean[] = [];
   const successValidation = __testInternals.validate_flow_payload(
     { flowDataSet: {} },
     {
       loadSdkModule: () => ({
         location: 'mock',
-        createFlow: () => ({
+        createFlow: (_data, config) => ({
+          validateEnhanced: () => {
+            successConfigs.push(config?.deepValidation ?? false);
+            return { success: true };
+          },
           validate: () => ({ success: true }),
         }),
       }),
     },
   );
   assert.deepEqual(successValidation, { success: true });
+  assert.deepEqual(successConfigs, [false]);
 
   assert.throws(
     () =>
@@ -909,24 +915,35 @@ test('flow remediation sdk helpers cover resolution and validation error branche
     (error: unknown) => error instanceof CliError && error.code === 'FLOW_REMEDIATE_SDK_INVALID',
   );
 
+  const failedConfigs: boolean[] = [];
   const failedValidation = __testInternals.validate_flow_payload(
     { flowDataSet: {} },
     {
       loadSdkModule: () => ({
         location: 'mock',
-        createFlow: () => ({
-          validate: () => ({
-            success: false,
-            error: {
-              issues: [{ path: ['flowDataSet'], message: 'broken', code: 'custom' }],
-            },
-          }),
+        createFlow: (_data, config) => ({
+          validateEnhanced: () => {
+            failedConfigs.push(config?.deepValidation ?? false);
+            return {
+              success: false,
+              error: {
+                issues: [
+                  {
+                    path: [config?.deepValidation ? 'deepFlowDataSet' : 'flowDataSet'],
+                    message: 'broken',
+                    code: 'custom',
+                  },
+                ],
+              },
+            };
+          },
         }),
       }),
     },
   );
   assert.equal(failedValidation.success, false);
-  assert.equal(failedValidation.issues[0]?.path, 'flowDataSet');
+  assert.deepEqual(failedConfigs, [false, true]);
+  assert.equal(failedValidation.issues[0]?.path, 'deepFlowDataSet');
 
   const thrownValidation = __testInternals.validate_flow_payload(
     { flowDataSet: {} },

--- a/test/lifecyclemodel-save-draft-run.test.ts
+++ b/test/lifecyclemodel-save-draft-run.test.ts
@@ -316,6 +316,40 @@ test('runLifecyclemodelSaveDraft records candidate failures and default output l
       __testInternals.summarizeValidation(VALIDATION_OK()),
       'local LifeCycleModelSchema validation passed',
     );
+    assert.equal(__testInternals.getLifecyclemodelFactory({}), null);
+    assert.equal(
+      typeof __testInternals.getLifecyclemodelFactory({ createLifeCycleModel: () => ({}) }),
+      'function',
+    );
+
+    const deepFallbackPayload = __testInternals.validateLifecyclemodelPayload(
+      {},
+      {
+        safeParse: () => ({
+          success: false,
+          error: { issues: [{ path: ['fast'], message: 'fast issue', code: 'fast' }] },
+        }),
+      },
+      (_, config) => ({
+        validateEnhanced: () =>
+          config?.deepValidation
+            ? {
+                success: false,
+                error: {
+                  issues: [{ path: ['deep'], message: 'deep issue', code: 'deep' }],
+                },
+              }
+            : {
+                success: false,
+                error: {
+                  issues: [{ path: ['shallow'], message: 'shallow issue', code: 'shallow' }],
+                },
+              },
+      }),
+    );
+    assert.deepEqual(deepFallbackPayload.issues, [
+      { path: 'deep', message: 'deep issue', code: 'deep' },
+    ]);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/process-payload-validation.test.ts
+++ b/test/process-payload-validation.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import * as tidasSdk from '@tiangong-lca/tidas-sdk';
 import {
+  __testInternals,
   summarizeProcessPayloadValidation,
   validateProcessPayload,
 } from '../src/lib/process-payload-validation.js';
@@ -45,7 +46,7 @@ test('process payload validation summarizes ok and failure results with normaliz
         },
       }) as unknown as ReturnType<typeof originalSafeParse>) as typeof originalSafeParse;
 
-    const invalidResult = validateProcessPayload({});
+    const invalidResult = validateProcessPayload({}, undefined, null);
     assert.equal(invalidResult.ok, false);
     assert.equal(invalidResult.issue_count, 2);
     assert.deepEqual(invalidResult.issues, [
@@ -70,7 +71,7 @@ test('process payload validation summarizes ok and failure results with normaliz
         success: false,
         error: undefined,
       }) as unknown as ReturnType<typeof originalSafeParse>) as typeof originalSafeParse;
-    const emptyIssueResult = validateProcessPayload({});
+    const emptyIssueResult = validateProcessPayload({}, undefined, null);
     assert.equal(emptyIssueResult.ok, false);
     assert.equal(emptyIssueResult.issue_count, 0);
     assert.equal(
@@ -86,4 +87,48 @@ test('process payload validation summarizes ok and failure results with normaliz
   } finally {
     tidasSdk.ProcessSchema.safeParse = originalSafeParse;
   }
+});
+
+test('process payload validation falls back to deep SDK validation only after fast failure', () => {
+  const calls: boolean[] = [];
+  const schema = {
+    safeParse: () => ({
+      success: false as const,
+      error: {
+        issues: [{ path: ['fast'], message: 'fast issue', code: 'fast' }],
+      },
+    }),
+  };
+
+  const result = validateProcessPayload({}, schema, (_, config) => {
+    calls.push(config?.deepValidation ?? false);
+    return {
+      validateEnhanced: () =>
+        config?.deepValidation
+          ? {
+              success: false,
+              error: {
+                issues: [{ path: ['deep'], message: 'deep issue', code: 'deep' }],
+              },
+            }
+          : {
+              success: false,
+              error: {
+                issues: [{ path: ['shallow'], message: 'shallow issue', code: 'shallow' }],
+              },
+            },
+    };
+  });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(calls, [false, true]);
+  assert.deepEqual(result.issues, [
+    {
+      path: 'deep',
+      message: 'deep issue',
+      code: 'deep',
+    },
+  ]);
+  assert.equal(__testInternals.getProcessFactory({}), null);
+  assert.equal(typeof __testInternals.getProcessFactory({ createProcess: () => ({}) }), 'function');
 });

--- a/test/tidas-sdk-package-validator.test.ts
+++ b/test/tidas-sdk-package-validator.test.ts
@@ -66,6 +66,13 @@ test('createTidasSdkPackageValidator resolves complete schema exports and reject
   const resolved = __testInternals.resolveCategorySchemas(schemas);
   assert.ok(resolved instanceof Map);
   assert.equal(resolved?.size, 8);
+  assert.equal(resolved?.get('contacts')?.schema, schemas.ContactSchema);
+  assert.equal(resolved?.get('contacts')?.createEntity, null);
+  const resolvedWithFactory = __testInternals.resolveCategorySchemas({
+    ...schemas,
+    createContact: () => ({}),
+  });
+  assert.equal(typeof resolvedWithFactory?.get('contacts')?.createEntity, 'function');
   assert.equal(
     createTidasSdkPackageValidator(schemas, '@tiangong-lca/tidas-sdk')?.location,
     '@tiangong-lca/tidas-sdk',
@@ -822,6 +829,50 @@ test('collection helpers derive schema gaps, localized text issues, hierarchy is
     )[0]?.issue_code,
     'validation_error',
   );
+  assert.deepEqual(
+    __testInternals.collectSchemaIssues(
+      {
+        safeParse: () => ({
+          success: false,
+          error: {
+            issues: [{ code: 'fast', message: 'Fast issue', path: ['fast'] }],
+          },
+        }),
+      },
+      {},
+      'flows',
+      '/tmp/deep.json',
+      (_value: unknown, config?: { deepValidation?: boolean }) => ({
+        validateEnhanced: () =>
+          config?.deepValidation
+            ? {
+                success: false,
+                error: {
+                  issues: [{ code: 'deep', message: 'Deep issue', path: ['deep'] }],
+                },
+              }
+            : {
+                success: false,
+                error: {
+                  issues: [{ code: 'shallow', message: 'Shallow issue', path: ['shallow'] }],
+                },
+              },
+      }),
+    ),
+    [
+      {
+        issue_code: 'schema_error',
+        severity: 'error',
+        category: 'flows',
+        file_path: '/tmp/deep.json',
+        location: 'deep',
+        message: 'Schema Error at deep: Deep issue',
+        context: {
+          validator: 'deep',
+        },
+      },
+    ],
+  );
   assert.equal(
     __testInternals.collectSchemaIssues(
       {
@@ -914,6 +965,7 @@ test('categoryValidate logs pass and failure cases while deduping repeated schem
           };
         },
       },
+      null,
       true,
     );
 

--- a/test/tidas-sdk-validation.test.ts
+++ b/test/tidas-sdk-validation.test.ts
@@ -1,0 +1,163 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  normalizeIssuePath,
+  runEntityValidation,
+  validateEntityWithDeepFallback,
+  validateSchemaWithDeepFallback,
+  validationIssues,
+  validationSucceeded,
+  type SdkValidationFactory,
+} from '../src/lib/tidas-sdk-validation.js';
+
+test('tidas sdk validation helpers keep schema success on the fast path', () => {
+  let factoryCalls = 0;
+  const result = validateSchemaWithDeepFallback(
+    {
+      safeParse: () => ({ success: true, data: { ok: true } }),
+    },
+    { ok: true },
+    (() => {
+      factoryCalls += 1;
+      return { validateEnhanced: () => ({ success: true }) };
+    }) as SdkValidationFactory,
+  );
+
+  assert.equal(result.success, true);
+  assert.equal(factoryCalls, 0);
+  assert.deepEqual(result.issues, []);
+});
+
+test('tidas sdk validation helpers use deep entity issues after schema failure', () => {
+  const configs: boolean[] = [];
+  const result = validateSchemaWithDeepFallback(
+    {
+      safeParse: () => ({
+        success: false,
+        error: { issues: [{ path: ['fast'], message: 'fast issue', code: 'fast' }] },
+      }),
+    },
+    { invalid: true },
+    ((_, config) => {
+      configs.push(config?.deepValidation ?? false);
+      return {
+        validateEnhanced: () =>
+          config?.deepValidation
+            ? {
+                success: false,
+                error: {
+                  issues: [{ path: ['deep'], message: 'deep issue', code: 'deep' }],
+                },
+              }
+            : {
+                success: false,
+                error: {
+                  issues: [{ path: ['shallow'], message: 'shallow issue', code: 'shallow' }],
+                },
+              },
+      };
+    }) as SdkValidationFactory,
+  );
+
+  assert.equal(result.success, false);
+  assert.deepEqual(configs, [false, true]);
+  assert.deepEqual(result.issues, [{ path: ['deep'], message: 'deep issue', code: 'deep' }]);
+});
+
+test('tidas sdk validation helpers prefer empty deep failures when schema has no issues', () => {
+  const deepFailure = { success: false, error: { issues: [] } };
+  const result = validateSchemaWithDeepFallback(
+    {
+      safeParse: () => ({ success: false, error: { issues: [] } }),
+    },
+    { invalid: true },
+    ((_, config) => ({
+      validateEnhanced: () => (config?.deepValidation ? deepFailure : { success: false }),
+    })) as SdkValidationFactory,
+  );
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.issues, []);
+  assert.equal(result.result, deepFailure);
+});
+
+test('tidas sdk validation helpers preserve schema issues when entity fallback cannot help', () => {
+  const schemaFailure = {
+    path: ['schema'],
+    message: 'schema issue',
+    code: 'schema',
+  };
+  const thrown = validateSchemaWithDeepFallback(
+    {
+      safeParse: () => ({ success: false, error: { issues: [schemaFailure] } }),
+    },
+    {},
+    (() => {
+      throw new Error('entity unavailable');
+    }) as SdkValidationFactory,
+  );
+  assert.equal(thrown.success, false);
+  assert.deepEqual(thrown.issues, [schemaFailure]);
+
+  const noFactory = validateSchemaWithDeepFallback(
+    {
+      safeParse: () => ({ success: false, error: { issues: [schemaFailure] } }),
+    },
+    {},
+    null,
+  );
+  assert.equal(noFactory.success, false);
+  assert.deepEqual(noFactory.issues, [schemaFailure]);
+});
+
+test('tidas sdk validation helpers prefer validateEnhanced and fall back to validate', () => {
+  assert.deepEqual(runEntityValidation(null), null);
+  assert.deepEqual(runEntityValidation({}), null);
+  assert.deepEqual(runEntityValidation({ validate: () => ({ success: true, data: 1 }) }), {
+    success: true,
+    data: 1,
+  });
+  assert.deepEqual(
+    runEntityValidation({
+      validateEnhanced: () => ({ success: true, data: 2 }),
+      validate: () => ({ success: true, data: 1 }),
+    }),
+    { success: true, data: 2 },
+  );
+});
+
+test('tidas sdk validation helpers run deep validation only after entity failure', () => {
+  const successConfigs: boolean[] = [];
+  const success = validateEntityWithDeepFallback({}, ((_, config) => {
+    successConfigs.push(config?.deepValidation ?? false);
+    return { validateEnhanced: () => ({ success: true }) };
+  }) as SdkValidationFactory);
+  assert.deepEqual(successConfigs, [false]);
+  assert.deepEqual(success, { success: true });
+
+  const failureConfigs: boolean[] = [];
+  const failure = validateEntityWithDeepFallback({}, ((_, config) => {
+    failureConfigs.push(config?.deepValidation ?? false);
+    return config?.deepValidation
+      ? { validate: () => ({ success: false, validationIssues: [{ path: ['deep'] }] }) }
+      : { validate: () => ({ success: false, error: { issues: [{ path: ['fast'] }] } }) };
+  }) as SdkValidationFactory);
+  assert.deepEqual(failureConfigs, [false, true]);
+  assert.deepEqual(validationIssues(failure), [{ path: ['deep'] }]);
+});
+
+test('tidas sdk validation helpers normalize issue paths and results', () => {
+  assert.equal(validationSucceeded({ success: true }), true);
+  assert.equal(validationSucceeded({ success: false }), false);
+  assert.equal(validationSucceeded(null), false);
+  assert.deepEqual(validationIssues({ success: false, error: { issues: [null, { path: [] }] } }), [
+    { path: [] },
+  ]);
+  assert.deepEqual(validationIssues({ success: false, validationIssues: [{ path: ['x'] }] }), [
+    { path: ['x'] },
+  ]);
+  assert.deepEqual(validationIssues('failure'), []);
+  assert.equal(normalizeIssuePath(undefined), '<root>');
+  assert.equal(normalizeIssuePath([], '/'), '<root>');
+  assert.equal(normalizeIssuePath(['a', 0, 'b'], '/'), 'a/0/b');
+});


### PR DESCRIPTION
Closes tiangong-lca/tiangong-cli#102

## Summary
- Add a shared TIDAS SDK validation helper that keeps schema.safeParse() as the fast path and reruns entity validation with deepValidation=true only after failures.
- Wire the fallback into dataset validation, package validation, process/lifecyclemodel draft checks, and flow remediation/regeneration paths.

## Key Decisions
- Injected schemas keep their previous safeParse-only behavior; default SDK-backed validators can use entity fallback.
- Failure formatting remains on the existing CLI issue/result shapes, with deep SDK issues preferred only when they add actionable detail.

## Validation
- npm run prepush:gate
- /Users/davidli/projects/workspace/scripts/docpact lint --root . --staged

## Risks / Rollback
- Risk is limited to validation failure enrichment; successful validations stay on the existing fast path.

## Follow-ups
- After merge, prepare a CLI patch release and then update the root workspace submodule pointer.