### PR TITLE
Gate build plans on unit-of-analysis artifacts

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-27"
-lastReviewedCommit: "906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5"
+lastReviewedCommit: "1c7dd5bd718bdef159368f5f5293bcb5182e0416"
 
 catalog:
   repos:

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-23"
-lastReviewedCommit: "b5f9d561e9fca8d67189fa2dc7c4397f5d553e07"
+lastReviewedAt: "2026-05-25"
+lastReviewedCommit: "906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: b5f9d561e9fca8d67189fa2dc7c4397f5d553e07
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
+lastReviewedCommit: 1c7dd5bd718bdef159368f5f5293bcb5182e0416
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -18,8 +18,8 @@ checkPaths:
   - src/**
   - scripts/**
   - .github/workflows/**
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: b5f9d561e9fca8d67189fa2dc7c4397f5d553e07
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -19,7 +19,7 @@ checkPaths:
   - scripts/**
   - .github/workflows/**
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
+lastReviewedCommit: 1c7dd5bd718bdef159368f5f5293bcb5182e0416
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - README.md
   - src/**
   - test/**
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: b5f9d561e9fca8d67189fa2dc7c4397f5d553e07
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -17,8 +17,8 @@ checkPaths:
   - package.json
   - src/**
   - test/**
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: b5f9d561e9fca8d67189fa2dc7c4397f5d553e07
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -18,7 +18,7 @@ checkPaths:
   - src/**
   - test/**
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
+lastReviewedCommit: 1c7dd5bd718bdef159368f5f5293bcb5182e0416
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
+++ b/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
@@ -16,7 +16,7 @@ checkPaths:
   - src/lib/supabase-session.ts
   - src/lib/supabase-client.ts
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
+lastReviewedCommit: 1c7dd5bd718bdef159368f5f5293bcb5182e0416
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
+++ b/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
@@ -15,8 +15,8 @@ checkPaths:
   - src/lib/user-api-key.ts
   - src/lib/supabase-session.ts
   - src/lib/supabase-client.ts
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: b5f9d561e9fca8d67189fa2dc7c4397f5d553e07
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
+++ b/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - src/lib/supabase-client.ts
   - src/lib/tidas-sdk-package-validator.ts
   - test/**
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: b5f9d561e9fca8d67189fa2dc7c4397f5d553e07
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
+++ b/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
@@ -17,7 +17,7 @@ checkPaths:
   - src/lib/tidas-sdk-package-validator.ts
   - test/**
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
+lastReviewedCommit: 1c7dd5bd718bdef159368f5f5293bcb5182e0416
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: b5f9d561e9fca8d67189fa2dc7c4397f5d553e07
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
+lastReviewedCommit: 1c7dd5bd718bdef159368f5f5293bcb5182e0416
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: b5f9d561e9fca8d67189fa2dc7c4397f5d553e07
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
+lastReviewedCommit: 1c7dd5bd718bdef159368f5f5293bcb5182e0416
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: b5f9d561e9fca8d67189fa2dc7c4397f5d553e07
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
+lastReviewedCommit: 1c7dd5bd718bdef159368f5f5293bcb5182e0416
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -19,8 +19,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: b5f9d561e9fca8d67189fa2dc7c4397f5d553e07
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
+lastReviewedCommit: 1c7dd5bd718bdef159368f5f5293bcb5182e0416
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/src/lib/process-auto-build.ts
+++ b/src/lib/process-auto-build.ts
@@ -789,6 +789,7 @@ function buildInitialProcessBuildPlan(
       field_bindings: [
         { field_path: 'target', source_id: `flow:${referenceFlowId}` },
         { field_path: 'identity_decision.decision', source_id: `flow:${referenceFlowId}` },
+        { field_path: 'unit_of_analysis', source_id: `flow:${referenceFlowId}` },
         { field_path: 'name_plan.base_name', source_id: `flow:${referenceFlowId}` },
         { field_path: 'target.geography', source_id: `flow:${referenceFlowId}` },
         { field_path: 'target.technology_route', source_id: `flow:${referenceFlowId}` },
@@ -796,6 +797,30 @@ function buildInitialProcessBuildPlan(
           field_path: 'quantitative_reference_plan.reference_flow_id',
           source_id: `flow:${referenceFlowId}`,
         },
+      ],
+    },
+    unit_of_analysis: {
+      target_kind: normalized.operation === 'treat' ? 'treatment' : 'process_from_flow_scaffold',
+      decision: 'manual_review',
+      functional_unit: {
+        what:
+          normalized.operation === 'treat'
+            ? `treat ${normalized.flow_summary.base_name ?? 'the reference flow'}`
+            : `produce ${normalized.flow_summary.base_name ?? 'the reference flow'}`,
+        how_much: `1 ${flowProperty.reference_unit ?? flowProperty.reference_property}`,
+        how_well: 'to be determined from source evidence before materialization',
+        how_long: 'not determined in the initial scaffold',
+      },
+      reference_flow: {
+        flow_identity: normalized.flow_summary.base_name ?? referenceFlowId,
+        reference_unit: flowProperty.reference_unit ?? flowProperty.reference_property,
+        reference_amount: 1,
+        flow_property: flowProperty.reference_property,
+      },
+      declared_unit_allowed: false,
+      scaling_evidence_status: 'source_required',
+      notes: [
+        'Initial scaffold only. A skill/Codex workflow must revise unit_of_analysis before build-plan materialize.',
       ],
     },
     name_plan: {
@@ -822,6 +847,7 @@ function buildInitialProcessBuildPlan(
     materialization_readiness: {
       status: 'scaffold_only',
       next_required_steps: [
+        'replace scaffold unit_of_analysis with a skill-authored decision artifact',
         'run process identity-preflight with local and remote candidates',
         'replace scaffold geography, technology, classification, exchange values, and annual volume with evidence-backed values',
         'run process build-plan validate/materialize before save-draft or publish-build',

--- a/src/lib/process-flow-build-plan.ts
+++ b/src/lib/process-flow-build-plan.ts
@@ -34,6 +34,11 @@ type BuildPlanDecision =
   | 'create_new'
   | 'block_duplicate'
   | 'manual_review';
+type UnitOfAnalysisDecision =
+  | 'ready_for_materialization'
+  | 'declared_unit_dataset'
+  | 'blocked_until_scaling_evidence'
+  | 'manual_review';
 
 type GateFinding = {
   code: string;
@@ -78,6 +83,7 @@ export type BuildPlanGateReport = {
   inputs: {
     plan_schema_version: number | string | null;
     identity_decision: BuildPlanDecision | null;
+    unit_of_analysis_decision: UnitOfAnalysisDecision | null;
   };
   required_fields: BuildPlanRequiredFields;
   schema_validation: SchemaValidationSummary;
@@ -110,6 +116,7 @@ type Evaluation = {
   blockers: GateFinding[];
   requiredFields: BuildPlanRequiredFields;
   decision: BuildPlanDecision | null;
+  unitOfAnalysisDecision: UnitOfAnalysisDecision | null;
 };
 
 type SchemaSpec = {
@@ -131,6 +138,18 @@ const ALL_DECISIONS = new Set<BuildPlanDecision>([
   'version_bump',
   'create_new',
   'block_duplicate',
+  'manual_review',
+]);
+
+const AUTOMATIC_UNIT_OF_ANALYSIS_DECISIONS = new Set<UnitOfAnalysisDecision>([
+  'ready_for_materialization',
+  'declared_unit_dataset',
+]);
+
+const ALL_UNIT_OF_ANALYSIS_DECISIONS = new Set<UnitOfAnalysisDecision>([
+  'ready_for_materialization',
+  'declared_unit_dataset',
+  'blocked_until_scaling_evidence',
   'manual_review',
 ]);
 
@@ -986,6 +1005,17 @@ function decisionFromPlan(plan: JsonObject): BuildPlanDecision | null {
   return raw && ALL_DECISIONS.has(raw as BuildPlanDecision) ? (raw as BuildPlanDecision) : null;
 }
 
+function unitOfAnalysisFromPlan(plan: JsonObject): JsonObject | null {
+  return valueAsObject(plan, ['unit_of_analysis', 'unitOfAnalysis']);
+}
+
+function unitOfAnalysisDecisionFromArtifact(artifact: JsonObject): UnitOfAnalysisDecision | null {
+  const raw = textToken(artifact.decision);
+  return raw && ALL_UNIT_OF_ANALYSIS_DECISIONS.has(raw as UnitOfAnalysisDecision)
+    ? (raw as UnitOfAnalysisDecision)
+    : null;
+}
+
 function buildPlanRuleset(plan: JsonObject, kind: BuildPlanKind): { id: string; version: string } {
   const ruleset = firstValue(plan, ['ruleset']);
   const id =
@@ -1006,6 +1036,7 @@ function requiredFieldSpecs(kind: BuildPlanKind): Array<{ path: string; aliases:
       path: 'identity_decision.decision',
       aliases: ['identity_decision.decision', 'identityDecision.decision', 'decision'],
     },
+    { path: 'unit_of_analysis', aliases: ['unit_of_analysis', 'unitOfAnalysis'] },
     { path: 'name_plan.base_name', aliases: ['name_plan.base_name', 'namePlan.baseName'] },
   ];
   const process = [
@@ -1046,6 +1077,121 @@ function makeFinding(
   return pathExpression
     ? { code, severity, message, path: pathExpression }
     : { code, severity, message };
+}
+
+function evaluateUnitOfAnalysis(plan: JsonObject): {
+  findings: GateFinding[];
+  blockers: GateFinding[];
+  decision: UnitOfAnalysisDecision | null;
+} {
+  const findings: GateFinding[] = [];
+  const blockers: GateFinding[] = [];
+  const artifact = unitOfAnalysisFromPlan(plan);
+  if (!artifact) {
+    blockers.push(
+      makeFinding(
+        'unit_of_analysis_missing',
+        'blocker',
+        'Build plan must include the skill-authored unit_of_analysis artifact.',
+        'unit_of_analysis',
+      ),
+    );
+    return { findings, blockers, decision: null };
+  }
+
+  const decision = unitOfAnalysisDecisionFromArtifact(artifact);
+  if (!decision) {
+    blockers.push(
+      makeFinding(
+        'unit_of_analysis_decision_missing',
+        'blocker',
+        'unit_of_analysis must include a supported decision.',
+        'unit_of_analysis.decision',
+      ),
+    );
+  } else if (!AUTOMATIC_UNIT_OF_ANALYSIS_DECISIONS.has(decision)) {
+    blockers.push(
+      makeFinding(
+        'unit_of_analysis_not_automatic',
+        'blocker',
+        `unit_of_analysis decision ${decision} cannot proceed to materialization.`,
+        'unit_of_analysis.decision',
+      ),
+    );
+  }
+
+  for (const spec of [
+    { path: 'unit_of_analysis.target_kind', aliases: ['target_kind', 'targetKind'] },
+    { path: 'unit_of_analysis.reference_flow', aliases: ['reference_flow', 'referenceFlow'] },
+    {
+      path: 'unit_of_analysis.reference_flow.reference_unit',
+      aliases: ['reference_flow.reference_unit', 'referenceFlow.referenceUnit'],
+    },
+    {
+      path: 'unit_of_analysis.reference_flow.reference_amount',
+      aliases: ['reference_flow.reference_amount', 'referenceFlow.referenceAmount'],
+    },
+    {
+      path: 'unit_of_analysis.reference_flow.flow_property',
+      aliases: ['reference_flow.flow_property', 'referenceFlow.flowProperty'],
+    },
+  ]) {
+    if (!pathIsSatisfied(artifact, spec.aliases)) {
+      blockers.push(
+        makeFinding(
+          'unit_of_analysis_required_field_missing',
+          'blocker',
+          `unit_of_analysis is missing ${spec.path}.`,
+          spec.path,
+        ),
+      );
+    }
+  }
+
+  const hasBasis =
+    pathIsSatisfied(artifact, ['functional_unit', 'functionalUnit']) ||
+    pathIsSatisfied(artifact, ['declared_unit', 'declaredUnit']);
+  if (!hasBasis) {
+    blockers.push(
+      makeFinding(
+        'unit_of_analysis_basis_missing',
+        'blocker',
+        'unit_of_analysis must describe either functional_unit or declared_unit.',
+        'unit_of_analysis.functional_unit',
+      ),
+    );
+  }
+
+  if (
+    decision === 'ready_for_materialization' &&
+    !pathIsSatisfied(artifact, [
+      'scaling_evidence',
+      'scalingEvidence',
+      'scaling_evidence_status',
+      'scalingEvidenceStatus',
+    ])
+  ) {
+    blockers.push(
+      makeFinding(
+        'scaling_evidence_missing',
+        'blocker',
+        'ready_for_materialization requires scaling evidence or an explicit scaling evidence status.',
+        'unit_of_analysis.scaling_evidence',
+      ),
+    );
+  }
+
+  if (blockers.length === 0) {
+    findings.push(
+      makeFinding(
+        'unit_of_analysis_contract_satisfied',
+        'info',
+        'unit_of_analysis artifact is present and complete enough for deterministic validation.',
+      ),
+    );
+  }
+
+  return { findings, blockers, decision };
 }
 
 function evaluateBuildPlan(plan: JsonObject, kind: BuildPlanKind): Evaluation {
@@ -1094,6 +1240,10 @@ function evaluateBuildPlan(plan: JsonObject, kind: BuildPlanKind): Evaluation {
       ),
     );
   }
+
+  const unitOfAnalysis = evaluateUnitOfAnalysis(plan);
+  findings.push(...unitOfAnalysis.findings);
+  blockers.push(...unitOfAnalysis.blockers);
 
   const bindingPaths = evidenceBindingPaths(plan);
   const required = requiredFieldSpecs(kind);
@@ -1145,6 +1295,7 @@ function evaluateBuildPlan(plan: JsonObject, kind: BuildPlanKind): Evaluation {
       missing,
     },
     decision,
+    unitOfAnalysisDecision: unitOfAnalysis.decision,
   };
 }
 
@@ -1308,6 +1459,7 @@ function makeReport(options: {
         textToken(options.evaluation.plan.schema_version) ??
         textToken(options.evaluation.plan.schemaVersion),
       identity_decision: options.evaluation.decision,
+      unit_of_analysis_decision: options.evaluation.unitOfAnalysisDecision,
     },
     required_fields: options.evaluation.requiredFields,
     schema_validation: options.schemaValidation,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2032,6 +2032,7 @@ test('executeCli executes process build-plan validate and materialize with injec
     inputs: {
       plan_schema_version: '1',
       identity_decision: 'create_new' as const,
+      unit_of_analysis_decision: 'ready_for_materialization' as const,
     },
     required_fields: {
       required: ['target'],
@@ -2175,6 +2176,7 @@ test('executeCli executes flow build-plan and maps blockers to exit code 1', asy
           inputs: {
             plan_schema_version: '1',
             identity_decision: 'manual_review',
+            unit_of_analysis_decision: 'manual_review',
           },
           required_fields: {
             required: ['target'],
@@ -2227,6 +2229,7 @@ test('executeCli executes flow build-plan and maps blockers to exit code 1', asy
           inputs: {
             plan_schema_version: '1',
             identity_decision: 'create_new',
+            unit_of_analysis_decision: 'declared_unit_dataset',
           },
           required_fields: {
             required: ['target'],

--- a/test/process-auto-build.test.ts
+++ b/test/process-auto-build.test.ts
@@ -496,6 +496,10 @@ test('process auto-build internals cover source-policy and empty-stage fallbacks
     ((fallbackPlan.name_plan as Record<string, unknown>) ?? {}).base_name,
     'Treatment process from reference flow',
   );
+  assert.equal(
+    ((fallbackPlan.unit_of_analysis as Record<string, unknown>) ?? {}).decision,
+    'manual_review',
+  );
 
   const arrayPropertyPlan = __testInternals.buildInitialProcessBuildPlan(
     {
@@ -667,6 +671,10 @@ test('runProcessAutoBuild writes the local artifact scaffold, state, and handoff
     assert.equal(
       ((buildPlan.quantitative_reference_plan as Record<string, unknown>) ?? {}).reference_flow_id,
       '4d8a3345-51fd-44ac-87e0-59bc8d3b0fdc',
+    );
+    assert.equal(
+      ((buildPlan.unit_of_analysis as Record<string, unknown>) ?? {}).decision,
+      'manual_review',
     );
 
     const runManifest = readJson(report.files.run_manifest);

--- a/test/process-flow-build-plan.test.ts
+++ b/test/process-flow-build-plan.test.ts
@@ -60,6 +60,7 @@ function processPlan(overrides: Record<string, unknown> = {}) {
       field_bindings: [
         { field_path: 'target' },
         { field_path: 'identity_decision.decision' },
+        { field_path: 'unit_of_analysis' },
         { field_path: 'name_plan.base_name' },
         { field_path: 'target.geography' },
         { field_path: 'target.technology_route' },
@@ -68,6 +69,23 @@ function processPlan(overrides: Record<string, unknown> = {}) {
     },
     name_plan: {
       base_name: '3kWp facade installation, multi-Si, laminated, integrated, at building {CN}',
+    },
+    unit_of_analysis: {
+      target_kind: 'countable_installation',
+      decision: 'ready_for_materialization',
+      functional_unit: {
+        what: 'provide installed photovoltaic generation capacity',
+        how_much: 'one 3 kWp facade-integrated installation',
+        how_well: 'multi-Si laminated facade-integrated photovoltaic technology',
+        how_long: 'service lifetime documented in source evidence',
+      },
+      reference_flow: {
+        flow_identity: '3 kWp facade-integrated photovoltaic installation',
+        reference_unit: 'unit',
+        reference_amount: 1,
+        flow_property: 'Number of items',
+      },
+      scaling_evidence_status: 'not_required_for_fixture',
     },
     quantitative_reference_plan: {
       reference_flow_id: '190f39ca-0ec8-5aab-b2d9-c91fc55ee58d',
@@ -94,6 +112,7 @@ function flowPlan(overrides: Record<string, unknown> = {}) {
       fieldBindings: [
         { fieldPath: 'target' },
         { fieldPath: 'identity_decision.decision' },
+        { fieldPath: 'unit_of_analysis' },
         { fieldPath: 'name_plan.base_name' },
         { fieldPath: 'target.flow_type' },
         { fieldPath: 'flow_property_plan.reference_property' },
@@ -102,6 +121,22 @@ function flowPlan(overrides: Record<string, unknown> = {}) {
     },
     namePlan: {
       baseName: 'Fluoroethylene carbonate',
+    },
+    unitOfAnalysis: {
+      targetKind: 'bulk_material',
+      decision: 'declared_unit_dataset',
+      declaredUnit: {
+        amount: 1,
+        unit: 'kg',
+        basis: 'flow reference property',
+      },
+      referenceFlow: {
+        flowIdentity: 'Fluoroethylene carbonate',
+        referenceUnit: 'kg',
+        referenceAmount: 1,
+        flowProperty: 'Mass',
+      },
+      scalingEvidenceStatus: 'not_required',
     },
     flowPropertyPlan: {
       referenceProperty: 'mass',
@@ -129,6 +164,7 @@ test('process build-plan validate passes and writes a gate report', async () => 
     assert.equal(report.ruleset_id, 'process-authoring/strict');
     assert.equal(report.inputs.plan_schema_version, '1');
     assert.equal(report.inputs.identity_decision, 'create_new');
+    assert.equal(report.inputs.unit_of_analysis_decision, 'ready_for_materialization');
     assert.equal(report.required_fields.missing.length, 0);
     assert.equal(
       report.files.materialized_artifact,
@@ -400,6 +436,96 @@ test('build-plan validation blocks unsupported or absent identity decisions', as
   assert.equal(absentDecision.inputs.identity_decision, null);
   assert.ok(
     absentDecision.blockers.some((finding) => finding.code === 'identity_decision_missing'),
+  );
+});
+
+test('build-plan validation requires a skill-authored unit-of-analysis artifact', async () => {
+  const missingArtifactPlan = processPlan() as Record<string, unknown>;
+  delete missingArtifactPlan.unit_of_analysis;
+  const missingArtifact = await runProcessBuildPlanValidate({
+    inputPath: '/tmp/process-build-plan.json',
+    rawInput: missingArtifactPlan,
+    now,
+  });
+  assert.equal(missingArtifact.status, 'blocked');
+  assert.equal(missingArtifact.inputs.unit_of_analysis_decision, null);
+  assert.ok(
+    missingArtifact.blockers.some((finding) => finding.code === 'unit_of_analysis_missing'),
+  );
+
+  const manualReview = await runProcessBuildPlanValidate({
+    inputPath: '/tmp/process-build-plan.json',
+    rawInput: processPlan({
+      unit_of_analysis: {
+        target_kind: 'countable_product',
+        decision: 'manual_review',
+        functional_unit: {
+          what: 'provide display service',
+        },
+        reference_flow: {
+          reference_unit: 'item',
+          reference_amount: 1,
+          flow_property: 'Number of items',
+        },
+        scaling_evidence_status: 'source_required',
+      },
+    }),
+    now,
+  });
+  assert.equal(manualReview.inputs.unit_of_analysis_decision, 'manual_review');
+  assert.ok(
+    manualReview.blockers.some((finding) => finding.code === 'unit_of_analysis_not_automatic'),
+  );
+
+  const incompleteArtifact = await runFlowBuildPlanValidate({
+    inputPath: '/tmp/flow-build-plan.json',
+    rawInput: flowPlan({
+      unitOfAnalysis: {
+        decision: 'unsupported',
+        referenceFlow: {
+          referenceUnit: 'kg',
+        },
+      },
+    }),
+    now,
+  });
+  assert.equal(incompleteArtifact.inputs.unit_of_analysis_decision, null);
+  assert.ok(
+    incompleteArtifact.blockers.some(
+      (finding) => finding.code === 'unit_of_analysis_decision_missing',
+    ),
+  );
+  assert.ok(
+    incompleteArtifact.blockers.some(
+      (finding) => finding.code === 'unit_of_analysis_required_field_missing',
+    ),
+  );
+  assert.ok(
+    incompleteArtifact.blockers.some(
+      (finding) => finding.code === 'unit_of_analysis_basis_missing',
+    ),
+  );
+
+  const missingScalingEvidence = await runProcessBuildPlanValidate({
+    inputPath: '/tmp/process-build-plan.json',
+    rawInput: processPlan({
+      unit_of_analysis: {
+        target_kind: 'countable_product',
+        decision: 'ready_for_materialization',
+        functional_unit: {
+          what: 'provide display service',
+        },
+        reference_flow: {
+          reference_unit: 'item',
+          reference_amount: 1,
+          flow_property: 'Number of items',
+        },
+      },
+    }),
+    now,
+  });
+  assert.ok(
+    missingScalingEvidence.blockers.some((finding) => finding.code === 'scaling_evidence_missing'),
   );
 });
 


### PR DESCRIPTION
Closes #111

## Summary
- require process/flow build plans to carry a skill-authored unit_of_analysis artifact
- block missing, incomplete, manual_review, and blocked_until_scaling_evidence unit decisions in the existing build-plan gate
- add unit_of_analysis scaffold output to process auto-build and expose unit_of_analysis_decision in gate reports

## Validation
- npm test -- --test-name-pattern "build-plan|process auto-build"
- PATH="/opt/homebrew/opt/node@24/bin:$PATH" npm run lint
- PATH="/opt/homebrew/opt/node@24/bin:$PATH" npm run test:coverage && PATH="/opt/homebrew/opt/node@24/bin:$PATH" npm run test:coverage:assert-full
- scripts/docpact lint --root . --worktree --mode warn

## Notes
- The CLI does not choose the industry unit basis. It only verifies the artifact supplied by the skill/workflow is present and ready for deterministic materialization.
