### PR TITLE
feat: add dataset evidence search artifacts

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-23"
-lastReviewedCommit: "b5f9d561e9fca8d67189fa2dc7c4397f5d553e07"
+lastReviewedAt: "2026-05-27"
+lastReviewedCommit: "906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: b5f9d561e9fca8d67189fa2dc7c4397f5d553e07
+lastReviewedAt: 2026-05-27
+lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -18,8 +18,8 @@ checkPaths:
   - src/**
   - scripts/**
   - .github/workflows/**
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: b5f9d561e9fca8d67189fa2dc7c4397f5d553e07
+lastReviewedAt: 2026-05-27
+lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ tiangong-lca process resume-build --run-dir /abs/path/to/process-run --json
 tiangong-lca process publish-build --run-dir /abs/path/to/process-run --json
 tiangong-lca process batch-build --input ./examples/process-batch-build.request.json --out-dir /abs/path/to/process-batch --json
 tiangong-lca dataset validate --input ./rows.jsonl --type auto --out-dir /abs/path/to/dataset-validate --json
+tiangong-lca dataset evidence-search plan --query "中国2026年电力结构数据" --out-dir /abs/path/to/evidence-search --json
+tiangong-lca dataset evidence-search run --input ./evidence-search.request.json --results ./search-results.json --out-dir /abs/path/to/evidence-search --json
 tiangong-lca dataset references rewrite --input ./rows.jsonl --from flow:<old-id>@<old-version> --to flow:<new-id>@<new-version> --out-dir /abs/path/to/dataset-rewrite --json
 tiangong-lca lifecyclemodel auto-build --input ./examples/lifecyclemodel-auto-build.request.json --out-dir /abs/path/to/lifecyclemodel-run --json
 tiangong-lca lifecyclemodel validate-build --run-dir /abs/path/to/lifecyclemodel-run --json
@@ -297,6 +299,8 @@ For `process publish-build`, canonical process payloads are validated locally wi
 For `publish run`, `verification-report.json` is written next to `publish-report.json` and summarizes the publish ruleset status, blockers, failed entries, deferred entries, and executed entries.
 
 For `lifecyclemodel save-draft`, canonical lifecyclemodel payloads are validated locally with `LifeCycleModelSchema` before any `--commit` write. Schema-invalid rows remain in `outputs/save-draft-bundle/failures.jsonl` instead of being persisted.
+
+For `dataset evidence-search`, `plan` creates the field-level query matrix and search budget. `run` accepts normalized external search results from browser/web-search tools or a generic JSON provider endpoint, then writes `outputs/evidence-search-plan.json`, `outputs/evidence-search-results.jsonl`, `outputs/evidence-search-report.json`, and `outputs/evidence-search-declaration.json` when evidence is absent or only partial. The CLI records scope and normalization; Codex/skills still own semantic judgement and source selection.
 
 For `dataset references rewrite`, `--commit` executes the state-aware save-draft path for patched process and lifecyclemodel rows; without `--commit`, the command only writes local rewrite artifacts.
 

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -340,6 +340,7 @@ tiangong-lca admin embedding-run
 tiangong-lca search flow --input ./request.json --json
 tiangong-lca publish run --input ./publish-request.json --dry-run
 tiangong-lca validation run --input-dir ./tidas-package --engine auto
+tiangong-lca dataset evidence-search plan --query "中国2026年电力结构数据" --out-dir ./evidence-search --json
 tiangong-lca admin embedding-run --input ./jobs.json --dry-run
 ```
 
@@ -368,6 +369,50 @@ tiangong-lca admin embedding-run --input ./jobs.json --dry-run
 ```
 
 更完整的请求体示例：
+
+### 4.3.2 `dataset evidence-search` 的最小 contract
+
+`dataset evidence-search` 固定的是字段级证据检索留痕契约，不是答案生成器。
+
+它负责：
+
+- `plan` 生成 query matrix、source tier 和预算；
+- `run` 接收 browser/web-search 工具导出的规范化结果，或调用一个通用 JSON provider endpoint；
+- 去重、打分、归类 source tier；
+- 记录 evidence-search report；
+- 当没有足够证据，或当前年只能找到阶段性/预测性证据时，写出 declaration。
+
+它不负责判断 LCA 字段最终该写什么。Codex/skill 必须读取 evidence-search artifacts 后，再结合 TIDAS/ILCD/PEF 语境和 process/flow review 规则做语义判断。
+
+最小请求体：
+
+```json
+{
+  "question": "中国2026年电力结构数据",
+  "field": {
+    "dataset_type": "process",
+    "field_path": "/processInformation/time/referenceYear"
+  },
+  "preferred_domains": ["stats.gov.cn", "nea.gov.cn", "chinapower.org.cn"],
+  "required_evidence": {
+    "temporal_scope": "2026 full-year electricity generation mix",
+    "require_complete_year": true
+  },
+  "budget": {
+    "max_queries": 8,
+    "max_results_per_query": 8
+  }
+}
+```
+
+输出：
+
+```text
+outputs/evidence-search-plan.json
+outputs/evidence-search-results.jsonl
+outputs/evidence-search-report.json
+outputs/evidence-search-declaration.json
+```
 
 ```json
 {
@@ -852,6 +897,7 @@ TIANGONG_LCA_COVERAGE=0
 | --- | --- | --- | --- | --- |
 | `doctor` | 无 |
 | `search flow | process | lifecyclemodel` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY`（`TIANGONG_LCA_REGION` 可选） |
+| `dataset evidence-search` | 默认无；若使用 `--provider-url`，认证由 `--provider-key` 显式传入 |
 | `admin embedding-run` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY`（`TIANGONG_LCA_REGION` 可选） |
 | `process get` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` |
 | `process identity-preflight` | 默认无；若启用 `--remote-candidates` 或输入 `remote_candidate_search.enabled=true`，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY`（`TIANGONG_LCA_REGION` 可选） |

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -17,8 +17,8 @@ checkPaths:
   - package.json
   - src/**
   - test/**
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: b5f9d561e9fca8d67189fa2dc7c4397f5d553e07
+lastReviewedAt: 2026-05-27
+lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
+++ b/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
@@ -15,8 +15,8 @@ checkPaths:
   - src/lib/user-api-key.ts
   - src/lib/supabase-session.ts
   - src/lib/supabase-client.ts
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: b5f9d561e9fca8d67189fa2dc7c4397f5d553e07
+lastReviewedAt: 2026-05-27
+lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
+++ b/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - src/lib/supabase-client.ts
   - src/lib/tidas-sdk-package-validator.ts
   - test/**
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: b5f9d561e9fca8d67189fa2dc7c4397f5d553e07
+lastReviewedAt: 2026-05-27
+lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: b5f9d561e9fca8d67189fa2dc7c4397f5d553e07
+lastReviewedAt: 2026-05-27
+lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: b5f9d561e9fca8d67189fa2dc7c4397f5d553e07
+lastReviewedAt: 2026-05-27
+lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: b5f9d561e9fca8d67189fa2dc7c4397f5d553e07
+lastReviewedAt: 2026-05-27
+lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -19,8 +19,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: b5f9d561e9fca8d67189fa2dc7c4397f5d553e07
+lastReviewedAt: 2026-05-27
+lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -227,6 +227,11 @@ import {
   type RunDatasetBilingualExtractOptions,
   type RunDatasetBilingualValidateOptions,
 } from './lib/dataset-bilingual.js';
+import {
+  runDatasetEvidenceSearch,
+  type EvidenceSearchReport,
+  type RunDatasetEvidenceSearchOptions,
+} from './lib/dataset-evidence-search.js';
 
 export type CliDeps = {
   env: NodeJS.ProcessEnv;
@@ -363,6 +368,9 @@ export type CliDeps = {
   runDatasetBilingualValidateImpl?: (
     options: RunDatasetBilingualValidateOptions,
   ) => Promise<DatasetBilingualValidateReport>;
+  runDatasetEvidenceSearchImpl?: (
+    options: RunDatasetEvidenceSearchOptions,
+  ) => Promise<EvidenceSearchReport>;
 };
 
 export type CliResult = {
@@ -395,7 +403,7 @@ Implemented Commands:
   doctor     show environment diagnostics
   search     flow | process | lifecyclemodel
   process    get | list | identity-preflight | build-plan | scope-statistics | dedup-review | auto-build | resume-build | publish-build | complete-required-fields | save-draft | batch-build | refresh-references | verify-rows
-  dataset    validate | verify-remote | bilingual extract/apply/validate | references rewrite/refresh-remote
+  dataset    validate | verify-remote | bilingual extract/apply/validate | evidence-search plan/run | references rewrite/refresh-remote
   flow       get | list | identity-preflight | build-plan | fetch-rows | materialize-decisions | remediate | publish-version | publish-reviewed-data | build-alias-map | scan-process-flow-refs | plan-process-flow-repairs | apply-process-flow-repairs | regen-product | validate-processes
   lifecyclemodel auto-build | validate-build | publish-build | save-draft | graph | build-resulting-process | publish-resulting-process | orchestrate
   review     process | flow | lifecyclemodel
@@ -432,6 +440,8 @@ Examples:
   tiangong-lca dataset bilingual extract --input ./rows/processes.jsonl --type process --out-dir ./translation
   tiangong-lca dataset bilingual apply --input ./rows/processes.jsonl --translations ./translation/trans-reviewed.jsonl --out ./rows/processes.translated.jsonl
   tiangong-lca dataset bilingual validate --input ./rows/processes.translated.jsonl --type process --out-dir ./translation-validate
+  tiangong-lca dataset evidence-search plan --query "中国2026年电力结构数据" --out-dir ./evidence-search
+  tiangong-lca dataset evidence-search run --input ./evidence-search.request.json --results ./search-results.json --out-dir ./evidence-search
   tiangong-lca dataset references rewrite --input ./rows.jsonl --from flow:<old-id>@<old-version> --to flow:<new-id>@<new-version> --out-dir /abs/path/to/dataset-rewrite
   tiangong-lca lifecyclemodel auto-build --input ./lifecyclemodel-auto-build.request.json --out-dir /abs/path/to/lifecyclemodel-run
   tiangong-lca lifecyclemodel validate-build --run-dir /abs/path/to/lifecyclemodel-run
@@ -574,6 +584,7 @@ Implemented Subcommands:
   bilingual extract    Extract bilingual translation units from local rows
   bilingual apply      Apply reviewed bilingual translations back to local rows
   bilingual validate   Validate bilingual rows with deterministic scans and schema/review gates
+  evidence-search      Plan or record field-level public evidence retrieval
   references rewrite   Rewrite flow references in local process and lifecyclemodel rows
   references refresh-remote Refresh local TIDAS reference versions to latest reachable remote rows
 
@@ -583,6 +594,8 @@ Examples:
   tiangong-lca dataset bilingual extract --input ./rows.jsonl --type process --out-dir ./translation --help
   tiangong-lca dataset bilingual apply --input ./rows.jsonl --translations ./trans-reviewed.jsonl --out ./rows.translated.jsonl --help
   tiangong-lca dataset bilingual validate --input ./rows.translated.jsonl --type process --out-dir ./translation-validate --help
+  tiangong-lca dataset evidence-search plan --query "中国2026年电力结构数据" --out-dir ./evidence-search --help
+  tiangong-lca dataset evidence-search run --input ./request.json --results ./search-results.json --out-dir ./evidence-search --help
   tiangong-lca dataset references rewrite --input ./rows.jsonl --from flow:<old-id>@<old-version> --to flow:<new-id>@<new-version> --out-dir ./dataset-rewrite --help
   tiangong-lca dataset references refresh-remote --input ./rows.jsonl --out ./rows.refreshed.jsonl --out-dir ./dataset-reference-refresh --help
 `.trim();
@@ -702,6 +715,39 @@ Outputs written under --out-dir:
   - outputs/bilingual-findings.jsonl
   - schema/outputs/validation-report.json
   - review/process/... and/or review/flow/... when applicable
+`.trim();
+}
+
+function renderDatasetEvidenceSearchHelp(): string {
+  return `Usage:
+  tiangong-lca dataset evidence-search <plan|run> [options]
+
+Plan:
+  tiangong-lca dataset evidence-search plan --query <text> --out-dir <dir>
+
+Run:
+  tiangong-lca dataset evidence-search run --input <request.json> --results <search-results.json> --out-dir <dir>
+  tiangong-lca dataset evidence-search run --query <text> --provider-url <url> --out-dir <dir>
+
+Options:
+  --query <text>             Evidence question when no --input is supplied
+  --input <file>             JSON request with question, field, budget, preferred_domains, and required_evidence
+  --results <file>           Normalized external search results JSON/JSONL captured from web/search tools
+  --provider-url <url>       Optional generic JSON search provider endpoint
+  --provider-key <key>       Optional bearer token for --provider-url
+  --profile <profile>        shallow | balanced | deep (default: balanced)
+  --max-queries <n>          Override query budget
+  --max-results-per-query <n> Override per-query result budget
+  --timeout-ms <n>           Provider request timeout in milliseconds
+  --out-dir <dir>            Artifact directory
+  --json                     Print compact JSON
+  -h, --help
+
+Outputs written under --out-dir:
+  - outputs/evidence-search-plan.json
+  - outputs/evidence-search-results.jsonl
+  - outputs/evidence-search-report.json
+  - outputs/evidence-search-declaration.json when evidence is absent or only partial
 `.trim();
 }
 
@@ -2249,6 +2295,72 @@ function parseDatasetBilingualValidateFlags(args: string[]): {
     inputPath: typeof values.input === 'string' ? values.input : '',
     type: typeof values.type === 'string' ? values.type : undefined,
     outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : null,
+  };
+}
+
+function parseDatasetEvidenceSearchFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  query: string | null;
+  inputPath: string | null;
+  resultsPath: string | null;
+  providerUrl: string | null;
+  providerKey: string | null;
+  profile: string | null;
+  outDir: string | null;
+  maxQueries: number | null;
+  maxResultsPerQuery: number | null;
+  timeoutMs: number | null;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        query: { type: 'string' },
+        input: { type: 'string' },
+        results: { type: 'string' },
+        'provider-url': { type: 'string' },
+        'provider-key': { type: 'string' },
+        profile: { type: 'string' },
+        'out-dir': { type: 'string' },
+        'max-queries': { type: 'string' },
+        'max-results-per-query': { type: 'string' },
+        'timeout-ms': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  const readNumber = (value: unknown): number | null => {
+    if (typeof value !== 'string') {
+      return null;
+    }
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : Number.NaN;
+  };
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    query: typeof values.query === 'string' ? values.query : null,
+    inputPath: typeof values.input === 'string' ? values.input : null,
+    resultsPath: typeof values.results === 'string' ? values.results : null,
+    providerUrl: typeof values['provider-url'] === 'string' ? values['provider-url'] : null,
+    providerKey: typeof values['provider-key'] === 'string' ? values['provider-key'] : null,
+    profile: typeof values.profile === 'string' ? values.profile : null,
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : null,
+    maxQueries: readNumber(values['max-queries']),
+    maxResultsPerQuery: readNumber(values['max-results-per-query']),
+    timeoutMs: readNumber(values['timeout-ms']),
   };
 }
 
@@ -4597,6 +4709,7 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
     const datasetBilingualApplyImpl = deps.runDatasetBilingualApplyImpl ?? runDatasetBilingualApply;
     const datasetBilingualValidateImpl =
       deps.runDatasetBilingualValidateImpl ?? runDatasetBilingualValidate;
+    const datasetEvidenceSearchImpl = deps.runDatasetEvidenceSearchImpl ?? runDatasetEvidenceSearch;
 
     if (flags.version) {
       return { exitCode: 0, stdout: `${loadCliPackageVersion(import.meta.url)}\n`, stderr: '' };
@@ -4755,6 +4868,43 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
         code: 'INVALID_ARGS',
         exitCode: 2,
       });
+    }
+
+    if (command === 'dataset' && subcommand === 'evidence-search') {
+      const action = commandArgs[0] ?? '';
+      if (!action || action === '--help' || action === '-h') {
+        return { exitCode: 0, stdout: `${renderDatasetEvidenceSearchHelp()}\n`, stderr: '' };
+      }
+      if (action !== 'plan' && action !== 'run') {
+        throw new CliError("dataset evidence-search action must be 'plan' or 'run'.", {
+          code: 'INVALID_ARGS',
+          exitCode: 2,
+        });
+      }
+
+      const datasetFlags = parseDatasetEvidenceSearchFlags(commandArgs.slice(1));
+      if (datasetFlags.help) {
+        return { exitCode: 0, stdout: `${renderDatasetEvidenceSearchHelp()}\n`, stderr: '' };
+      }
+      const report = await datasetEvidenceSearchImpl({
+        mode: action,
+        query: datasetFlags.query,
+        inputPath: datasetFlags.inputPath,
+        resultsPath: datasetFlags.resultsPath,
+        providerUrl: datasetFlags.providerUrl,
+        providerKey: datasetFlags.providerKey,
+        profile: datasetFlags.profile,
+        outDir: datasetFlags.outDir,
+        maxQueries: datasetFlags.maxQueries,
+        maxResultsPerQuery: datasetFlags.maxResultsPerQuery,
+        timeoutMs: datasetFlags.timeoutMs,
+        fetchImpl: deps.fetchImpl,
+      });
+      return {
+        exitCode: report.status === 'completed_no_sufficient_evidence' ? 1 : 0,
+        stdout: stringifyJson(report, datasetFlags.json),
+        stderr: '',
+      };
     }
 
     if (command === 'dataset' && subcommand === 'references') {

--- a/src/lib/dataset-evidence-search.ts
+++ b/src/lib/dataset-evidence-search.ts
@@ -1,0 +1,878 @@
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+import { writeJsonArtifact, writeJsonLinesArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+import type { FetchLike } from './http.js';
+import { postJson } from './http.js';
+import { readJsonInput } from './io.js';
+
+type JsonObject = Record<string, unknown>;
+
+export type EvidenceSearchMode = 'plan' | 'run';
+export type EvidenceSearchProfile = 'shallow' | 'balanced' | 'deep';
+export type EvidenceSearchStatus =
+  | 'planned'
+  | 'completed_with_evidence'
+  | 'completed_with_partial_evidence'
+  | 'completed_no_sufficient_evidence';
+
+export type EvidenceSearchBudget = {
+  max_queries: number;
+  max_results_per_query: number;
+  max_provider_calls: number;
+};
+
+export type EvidenceSearchQuery = {
+  query_id: string;
+  text: string;
+  purpose: string;
+  source_tier: string;
+  priority: number;
+  expected_terms: string[];
+};
+
+export type EvidenceSearchResult = {
+  query_id: string | null;
+  query: string | null;
+  provider: string;
+  rank: number;
+  title: string;
+  url: string;
+  snippet: string | null;
+  published_at: string | null;
+  source_domain: string | null;
+  source_tier: string;
+  matched_terms: string[];
+  score: number;
+};
+
+export type EvidenceSearchDeclaration = {
+  schema_version: 1;
+  generated_at_utc: string;
+  question: string;
+  declaration_type: 'no_sufficient_evidence' | 'partial_temporal_evidence';
+  statement: string;
+  search_scope: {
+    query_count: number;
+    provider_count: number;
+    normalized_result_count: number;
+    authoritative_result_count: number;
+    required_complete_year: boolean;
+    requested_year: number | null;
+    temporal_coverage_status: string;
+  };
+  limits: string[];
+};
+
+export type EvidenceSearchReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  mode: EvidenceSearchMode;
+  status: EvidenceSearchStatus;
+  question: string;
+  field: {
+    dataset_type: string | null;
+    field_path: string | null;
+  };
+  profile: EvidenceSearchProfile;
+  budget: EvidenceSearchBudget;
+  plan: {
+    query_count: number;
+    queries: EvidenceSearchQuery[];
+  };
+  run: {
+    provider_count: number;
+    provider_call_count: number;
+    normalized_result_count: number;
+    authoritative_result_count: number;
+    high_confidence_result_count: number;
+    stop_reason: string;
+  };
+  evidence_quality: {
+    sufficient: boolean;
+    temporal_coverage_status: string;
+    requested_year: number | null;
+    required_complete_year: boolean;
+  };
+  files: {
+    plan: string | null;
+    results: string | null;
+    report: string | null;
+    declaration: string | null;
+  };
+};
+
+export type RunDatasetEvidenceSearchOptions = {
+  mode: EvidenceSearchMode;
+  query?: string | null;
+  inputPath?: string | null;
+  resultsPath?: string | null;
+  providerUrl?: string | null;
+  providerKey?: string | null;
+  profile?: string | null;
+  outDir?: string | null;
+  maxQueries?: number | null;
+  maxResultsPerQuery?: number | null;
+  timeoutMs?: number | null;
+  rawInput?: unknown;
+  rawResults?: unknown;
+  now?: Date;
+  fetchImpl?: FetchLike;
+};
+
+type EvidenceSearchRequest = {
+  question: string;
+  field: {
+    dataset_type: string | null;
+    field_path: string | null;
+  };
+  profile: EvidenceSearchProfile;
+  budget: EvidenceSearchBudget;
+  preferred_domains: string[];
+  required_terms: string[];
+  required_complete_year: boolean;
+  requested_year: number | null;
+};
+
+type ProviderQueryResult = {
+  provider: string;
+  query_id: string | null;
+  query: string | null;
+  items: unknown[];
+};
+
+const DEFAULT_BUDGETS: Record<EvidenceSearchProfile, EvidenceSearchBudget> = {
+  shallow: {
+    max_queries: 4,
+    max_results_per_query: 5,
+    max_provider_calls: 4,
+  },
+  balanced: {
+    max_queries: 8,
+    max_results_per_query: 8,
+    max_provider_calls: 8,
+  },
+  deep: {
+    max_queries: 14,
+    max_results_per_query: 10,
+    max_provider_calls: 14,
+  },
+};
+
+const PUBLIC_OFFICIAL_DOMAINS = [
+  'gov.cn',
+  'stats.gov.cn',
+  'nea.gov.cn',
+  'ndrc.gov.cn',
+  'samr.gov.cn',
+];
+
+const ELECTRICITY_TERMS = [
+  '中国',
+  '全国',
+  '2026',
+  '电力',
+  '电源',
+  '结构',
+  '数据',
+  '发电',
+  '发电量',
+  '装机',
+  '火电',
+  '水电',
+  '核电',
+  '风电',
+  '太阳能',
+  '非化石',
+  'coal',
+  'hydro',
+  'nuclear',
+  'wind',
+  'solar',
+  'generation',
+  'electricity',
+  'mix',
+];
+
+function nowIso(now: Date = new Date()): string {
+  return now.toISOString();
+}
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function trimToken(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function normalizeProfile(value: string | null | undefined): EvidenceSearchProfile {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) {
+    return 'balanced';
+  }
+  if (normalized === 'shallow' || normalized === 'balanced' || normalized === 'deep') {
+    return normalized;
+  }
+  throw new CliError("--profile must be 'shallow', 'balanced', or 'deep'.", {
+    code: 'EVIDENCE_SEARCH_PROFILE_INVALID',
+    exitCode: 2,
+    details: value,
+  });
+}
+
+function readPositiveInteger(value: unknown, fallback: number, label: string): number {
+  if (value === undefined || value === null || value === '') {
+    return fallback;
+  }
+  const numberValue = typeof value === 'number' ? value : Number(value);
+  if (!Number.isInteger(numberValue) || numberValue < 1) {
+    throw new CliError(`${label} must be a positive integer.`, {
+      code: 'EVIDENCE_SEARCH_BUDGET_INVALID',
+      exitCode: 2,
+      details: value,
+    });
+  }
+  return numberValue;
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((item) => trimToken(item)).filter((item): item is string => item !== null);
+}
+
+function readBoolean(value: unknown): boolean {
+  return value === true;
+}
+
+function readRequestedYear(question: string, request: JsonObject): number | null {
+  const rawTemporal = isRecord(request.required_evidence)
+    ? trimToken(request.required_evidence.temporal_scope)
+    : null;
+  const source = rawTemporal ? `${question} ${rawTemporal}` : question;
+  const match = /(?:19|20)\d{2}/u.exec(source);
+  return match ? Number(match[0]) : null;
+}
+
+function requestRequiresCompleteYear(request: JsonObject): boolean {
+  if (!isRecord(request.required_evidence)) {
+    return false;
+  }
+  return (
+    readBoolean(request.required_evidence.require_complete_year) ||
+    trimToken(request.required_evidence.temporal_coverage)?.toLowerCase() === 'annual_complete'
+  );
+}
+
+function normalizeDomain(url: string): string | null {
+  try {
+    return new URL(url).hostname.toLowerCase().replace(/^www\./u, '');
+  } catch {
+    return null;
+  }
+}
+
+function domainMatches(domain: string | null, candidate: string): boolean {
+  if (!domain) {
+    return false;
+  }
+  const normalized = candidate.toLowerCase().replace(/^www\./u, '');
+  return domain === normalized || domain.endsWith(`.${normalized}`);
+}
+
+function classifySourceTier(domain: string | null, preferredDomains: string[]): string {
+  if (preferredDomains.some((preferred) => domainMatches(domain, preferred))) {
+    return 'preferred_domain';
+  }
+  if (PUBLIC_OFFICIAL_DOMAINS.some((official) => domainMatches(domain, official))) {
+    return 'official_statistics';
+  }
+  if (domainMatches(domain, 'cec.org.cn') || domainMatches(domain, 'chinapower.org.cn')) {
+    return 'industry_association';
+  }
+  if (domainMatches(domain, 'iea.org') || domainMatches(domain, 'ember-energy.org')) {
+    return 'international_statistics';
+  }
+  return 'open_web';
+}
+
+function extractTerms(question: string, configuredTerms: string[]): string[] {
+  const terms = new Set<string>();
+  for (const term of configuredTerms) {
+    terms.add(term.toLowerCase());
+  }
+  for (const term of ELECTRICITY_TERMS) {
+    if (question.toLowerCase().includes(term.toLowerCase())) {
+      terms.add(term.toLowerCase());
+    }
+  }
+  const latinTerms = question.match(/[a-z0-9][a-z0-9-]{2,}/giu) ?? [];
+  for (const term of latinTerms) {
+    terms.add(term.toLowerCase());
+  }
+  return [...terms];
+}
+
+function dedupeStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const normalized = value.replace(/\s+/gu, ' ').trim();
+    const key = normalized.toLowerCase();
+    if (normalized && !seen.has(key)) {
+      seen.add(key);
+      result.push(normalized);
+    }
+  }
+  return result;
+}
+
+function buildQueryTexts(request: EvidenceSearchRequest): string[] {
+  const yearText = request.requested_year ? String(request.requested_year) : '';
+  const preferredQueries = request.preferred_domains.map(
+    (domain) => `site:${domain} ${request.question}`,
+  );
+  const generated = [
+    request.question,
+    `site:stats.gov.cn ${request.question}`,
+    `site:nea.gov.cn ${request.question}`,
+    yearText
+      ? `国家统计局 ${yearText} 发电量 火电 水电 核电 风电 太阳能`
+      : '国家统计局 发电量 火电 水电 核电 风电 太阳能',
+    yearText
+      ? `国家能源局 ${yearText} 全国电力统计数据 发电装机容量 火电 水电 风电 太阳能`
+      : '国家能源局 全国电力统计数据 发电装机容量 火电 水电 风电 太阳能',
+    yearText
+      ? `中电联 ${yearText} 电力供需形势 非化石能源 发电量 占比`
+      : '中电联 电力供需形势 非化石能源 发电量 占比',
+    yearText
+      ? `China ${yearText} electricity generation mix coal hydro nuclear wind solar`
+      : 'China electricity generation mix coal hydro nuclear wind solar',
+    yearText
+      ? `China ${yearText} installed power capacity mix thermal hydro nuclear wind solar`
+      : 'China installed power capacity mix thermal hydro nuclear wind solar',
+    ...preferredQueries,
+  ];
+  return dedupeStrings(generated).slice(0, request.budget.max_queries);
+}
+
+function buildSearchPlan(request: EvidenceSearchRequest): EvidenceSearchQuery[] {
+  const expectedTerms = extractTerms(request.question, request.required_terms);
+  return buildQueryTexts(request).map((text, index) => ({
+    query_id: `q${String(index + 1).padStart(2, '0')}`,
+    text,
+    purpose: index === 0 ? 'broad_discovery' : 'source_targeted_discovery',
+    source_tier: text.startsWith('site:') ? 'targeted' : 'general',
+    priority: index + 1,
+    expected_terms: expectedTerms,
+  }));
+}
+
+function normalizeRequest(options: RunDatasetEvidenceSearchOptions): EvidenceSearchRequest {
+  const rawInput = options.rawInput ?? (options.inputPath ? readJsonInput(options.inputPath) : {});
+  const input = isRecord(rawInput) ? rawInput : {};
+  const question = trimToken(options.query) ?? trimToken(input.question);
+  if (!question) {
+    throw new CliError('Evidence search requires --query or input.question.', {
+      code: 'EVIDENCE_SEARCH_QUESTION_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  const profile = normalizeProfile(options.profile ?? trimToken(input.profile));
+  const defaultBudget = DEFAULT_BUDGETS[profile];
+  const budgetInput = isRecord(input.budget) ? input.budget : {};
+  const maxQueries = readPositiveInteger(
+    options.maxQueries ?? budgetInput.max_queries,
+    defaultBudget.max_queries,
+    '--max-queries',
+  );
+  const maxResultsPerQuery = readPositiveInteger(
+    options.maxResultsPerQuery ?? budgetInput.max_results_per_query,
+    defaultBudget.max_results_per_query,
+    '--max-results-per-query',
+  );
+  const budget = {
+    max_queries: maxQueries,
+    max_results_per_query: maxResultsPerQuery,
+    max_provider_calls: maxQueries,
+  };
+  const fieldInput = isRecord(input.field) ? input.field : {};
+
+  return {
+    question,
+    field: {
+      dataset_type: trimToken(fieldInput.dataset_type),
+      field_path: trimToken(fieldInput.field_path),
+    },
+    profile,
+    budget,
+    preferred_domains: readStringArray(input.preferred_domains),
+    required_terms: readStringArray(input.required_terms),
+    required_complete_year: requestRequiresCompleteYear(input),
+    requested_year: readRequestedYear(question, input),
+  };
+}
+
+function readResultsInput(resultsPath: string, rawResults?: unknown): unknown {
+  if (rawResults !== undefined) {
+    return rawResults;
+  }
+  const text = readFileSync(resultsPath, 'utf8');
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return [];
+  }
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    try {
+      return JSON.parse(trimmed);
+    } catch (error) {
+      throw new CliError(`Search results file is not valid JSON: ${resultsPath}`, {
+        code: 'EVIDENCE_SEARCH_RESULTS_INVALID_JSON',
+        exitCode: 2,
+        details: String(error),
+      });
+    }
+  }
+  return trimmed
+    .split(/\r?\n/u)
+    .map((line, index) => {
+      try {
+        return JSON.parse(line);
+      } catch (error) {
+        throw new CliError(`Search results file has invalid JSONL at line ${index + 1}.`, {
+          code: 'EVIDENCE_SEARCH_RESULTS_INVALID_JSONL',
+          exitCode: 2,
+          details: String(error),
+        });
+      }
+    })
+    .filter((item) => item !== null);
+}
+
+function extractItems(value: JsonObject): unknown[] {
+  for (const key of ['items', 'results', 'data', 'web_results']) {
+    const candidate = value[key];
+    if (Array.isArray(candidate)) {
+      return candidate;
+    }
+  }
+  return [];
+}
+
+function normalizeResultGroups(rawResults: unknown): ProviderQueryResult[] {
+  const root = rawResults;
+  if (isRecord(root) && Array.isArray(root.queries)) {
+    return root.queries.filter(isRecord).map((queryGroup) => ({
+      provider: trimToken(queryGroup.provider) ?? 'external',
+      query_id: trimToken(queryGroup.query_id),
+      query: trimToken(queryGroup.query ?? queryGroup.text),
+      items: extractItems(queryGroup),
+    }));
+  }
+  const rows = Array.isArray(root) ? root : [root];
+  if (rows.every(isRecord) && rows.some((row) => extractItems(row).length > 0)) {
+    return rows.filter(isRecord).map((queryGroup) => ({
+      provider: trimToken(queryGroup.provider) ?? 'external',
+      query_id: trimToken(queryGroup.query_id),
+      query: trimToken(queryGroup.query ?? queryGroup.text),
+      items: extractItems(queryGroup),
+    }));
+  }
+  return [
+    {
+      provider: 'external',
+      query_id: null,
+      query: null,
+      items: rows,
+    },
+  ];
+}
+
+function normalizeOneResult(options: {
+  item: unknown;
+  group: ProviderQueryResult;
+  rank: number;
+  terms: string[];
+  preferredDomains: string[];
+}): EvidenceSearchResult | null {
+  if (!isRecord(options.item)) {
+    return null;
+  }
+  const title = trimToken(options.item.title ?? options.item.name);
+  const url = trimToken(options.item.url ?? options.item.link ?? options.item.href);
+  if (!title || !url) {
+    return null;
+  }
+  const snippet = trimToken(
+    options.item.snippet ?? options.item.description ?? options.item.summary ?? options.item.text,
+  );
+  const publishedAt = trimToken(
+    options.item.published_at ?? options.item.publishedAt ?? options.item.date,
+  );
+  const sourceText = `${title} ${snippet ?? ''}`.toLowerCase();
+  const matchedTerms = options.terms.filter((term) => sourceText.includes(term));
+  const domain = normalizeDomain(url);
+  const sourceTier = classifySourceTier(domain, options.preferredDomains);
+  const authorityScore =
+    sourceTier === 'official_statistics'
+      ? 4
+      : sourceTier === 'preferred_domain' || sourceTier === 'industry_association'
+        ? 3
+        : sourceTier === 'international_statistics'
+          ? 2
+          : 1;
+  const termScore = Math.min(matchedTerms.length, 6);
+  return {
+    query_id: options.group.query_id,
+    query: options.group.query,
+    provider: options.group.provider,
+    rank: options.rank,
+    title,
+    url,
+    snippet,
+    published_at: publishedAt,
+    source_domain: domain,
+    source_tier: sourceTier,
+    matched_terms: matchedTerms,
+    score: authorityScore + termScore,
+  };
+}
+
+function normalizeResults(options: {
+  rawResults: unknown;
+  terms: string[];
+  preferredDomains: string[];
+  maxResultsPerQuery: number;
+}): EvidenceSearchResult[] {
+  const byUrl = new Map<string, EvidenceSearchResult>();
+  for (const group of normalizeResultGroups(options.rawResults)) {
+    group.items.slice(0, options.maxResultsPerQuery).forEach((item, index) => {
+      const result = normalizeOneResult({
+        item,
+        group,
+        rank: index + 1,
+        terms: options.terms,
+        preferredDomains: options.preferredDomains,
+      });
+      if (!result) {
+        return;
+      }
+      const previous = byUrl.get(result.url);
+      if (!previous || result.score > previous.score) {
+        byUrl.set(result.url, result);
+      }
+    });
+  }
+  return [...byUrl.values()].sort(
+    (left, right) => right.score - left.score || left.rank - right.rank,
+  );
+}
+
+async function fetchProviderResults(options: {
+  providerUrl: string;
+  providerKey: string | null;
+  plan: EvidenceSearchQuery[];
+  request: EvidenceSearchRequest;
+  timeoutMs: number;
+  fetchImpl: FetchLike;
+}): Promise<{ rawResults: ProviderQueryResult[]; callCount: number }> {
+  const rawResults: ProviderQueryResult[] = [];
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (options.providerKey) {
+    headers.Authorization = `Bearer ${options.providerKey}`;
+  }
+  for (const query of options.plan.slice(0, options.request.budget.max_provider_calls)) {
+    const payload = await postJson({
+      url: options.providerUrl,
+      headers,
+      body: {
+        query: query.text,
+        query_id: query.query_id,
+        limit: options.request.budget.max_results_per_query,
+        context: {
+          question: options.request.question,
+          field: options.request.field,
+          expected_terms: query.expected_terms,
+        },
+      },
+      timeoutMs: options.timeoutMs,
+      fetchImpl: options.fetchImpl,
+    });
+    rawResults.push({
+      provider: options.providerUrl,
+      query_id: query.query_id,
+      query: query.text,
+      items: isRecord(payload) ? extractItems(payload) : Array.isArray(payload) ? payload : [],
+    });
+  }
+  return { rawResults, callCount: rawResults.length };
+}
+
+function temporalCoverageStatus(request: EvidenceSearchRequest, now: Date): string {
+  if (!request.required_complete_year || !request.requested_year) {
+    return 'not_required';
+  }
+  const currentYear = now.getUTCFullYear();
+  if (request.requested_year > currentYear) {
+    return 'future_year';
+  }
+  if (request.requested_year === currentYear && now.getUTCMonth() < 11) {
+    return 'incomplete_current_year';
+  }
+  return 'complete_year_possible';
+}
+
+function buildDeclaration(options: {
+  generatedAt: string;
+  request: EvidenceSearchRequest;
+  queryCount: number;
+  providerCount: number;
+  resultCount: number;
+  authoritativeResultCount: number;
+  temporalStatus: string;
+  partial: boolean;
+}): EvidenceSearchDeclaration {
+  const declarationType = options.partial ? 'partial_temporal_evidence' : 'no_sufficient_evidence';
+  const statement =
+    declarationType === 'partial_temporal_evidence'
+      ? 'The configured search found current-year or forecast evidence, but not complete annual evidence for the requested year.'
+      : 'Within the configured search scope, query matrix, source policy, and budget, no sufficient evidence was found for the requested field.';
+  return {
+    schema_version: 1,
+    generated_at_utc: options.generatedAt,
+    question: options.request.question,
+    declaration_type: declarationType,
+    statement,
+    search_scope: {
+      query_count: options.queryCount,
+      provider_count: options.providerCount,
+      normalized_result_count: options.resultCount,
+      authoritative_result_count: options.authoritativeResultCount,
+      required_complete_year: options.request.required_complete_year,
+      requested_year: options.request.requested_year,
+      temporal_coverage_status: options.temporalStatus,
+    },
+    limits: [
+      'The command records deterministic search scope and result normalization; it does not prove that the open web contains no undiscoverable source.',
+      'Browser-only, paywalled, login-protected, or unindexed sources require separate readback or manual evidence capture.',
+      'A no-evidence or partial-evidence declaration is valid only for the configured query matrix, provider set, and budget.',
+    ],
+  };
+}
+
+function buildReport(options: {
+  generatedAt: string;
+  mode: EvidenceSearchMode;
+  request: EvidenceSearchRequest;
+  plan: EvidenceSearchQuery[];
+  results: EvidenceSearchResult[];
+  providerCount: number;
+  providerCallCount: number;
+  files: EvidenceSearchReport['files'];
+  now: Date;
+}): EvidenceSearchReport {
+  const authoritativeResultCount = options.results.filter((result) =>
+    ['official_statistics', 'preferred_domain', 'industry_association'].includes(
+      result.source_tier,
+    ),
+  ).length;
+  const highConfidenceResultCount = options.results.filter((result) => result.score >= 7).length;
+  const temporalStatus = temporalCoverageStatus(options.request, options.now);
+  const hasEvidence = authoritativeResultCount > 0 || highConfidenceResultCount > 0;
+  const partial =
+    hasEvidence && ['future_year', 'incomplete_current_year'].includes(temporalStatus);
+  const sufficient = hasEvidence && !partial;
+  const status: EvidenceSearchStatus =
+    options.mode === 'plan'
+      ? 'planned'
+      : sufficient
+        ? 'completed_with_evidence'
+        : partial
+          ? 'completed_with_partial_evidence'
+          : 'completed_no_sufficient_evidence';
+  const stopReason =
+    options.mode === 'plan'
+      ? 'plan_only'
+      : sufficient
+        ? 'sufficient_authoritative_evidence_found'
+        : partial
+          ? 'complete_annual_scope_not_available'
+          : 'budget_exhausted_without_sufficient_evidence';
+
+  return {
+    schema_version: 1,
+    generated_at_utc: options.generatedAt,
+    mode: options.mode,
+    status,
+    question: options.request.question,
+    field: options.request.field,
+    profile: options.request.profile,
+    budget: options.request.budget,
+    plan: {
+      query_count: options.plan.length,
+      queries: options.plan,
+    },
+    run: {
+      provider_count: options.providerCount,
+      provider_call_count: options.providerCallCount,
+      normalized_result_count: options.results.length,
+      authoritative_result_count: authoritativeResultCount,
+      high_confidence_result_count: highConfidenceResultCount,
+      stop_reason: stopReason,
+    },
+    evidence_quality: {
+      sufficient,
+      temporal_coverage_status: temporalStatus,
+      requested_year: options.request.requested_year,
+      required_complete_year: options.request.required_complete_year,
+    },
+    files: options.files,
+  };
+}
+
+export async function runDatasetEvidenceSearch(
+  options: RunDatasetEvidenceSearchOptions,
+): Promise<EvidenceSearchReport> {
+  const request = normalizeRequest(options);
+  const plan = buildSearchPlan(request);
+  const generatedAt = nowIso(options.now);
+  const now = options.now ?? new Date();
+  const outputDir = options.outDir ? path.resolve(options.outDir) : null;
+  const planFile = outputDir ? path.join(outputDir, 'outputs', 'evidence-search-plan.json') : null;
+  const resultsFile = outputDir
+    ? path.join(outputDir, 'outputs', 'evidence-search-results.jsonl')
+    : null;
+  const reportFile = outputDir
+    ? path.join(outputDir, 'outputs', 'evidence-search-report.json')
+    : null;
+  const declarationFile = outputDir
+    ? path.join(outputDir, 'outputs', 'evidence-search-declaration.json')
+    : null;
+
+  if (planFile) {
+    writeJsonArtifact(planFile, {
+      schema_version: 1,
+      generated_at_utc: generatedAt,
+      question: request.question,
+      field: request.field,
+      profile: request.profile,
+      budget: request.budget,
+      queries: plan,
+    });
+  }
+
+  let rawResults: unknown = [];
+  let providerCount = 0;
+  let providerCallCount = 0;
+
+  if (options.mode === 'run') {
+    if (options.resultsPath) {
+      rawResults = readResultsInput(options.resultsPath, options.rawResults);
+      providerCount += 1;
+    }
+    if (options.providerUrl) {
+      if (!options.fetchImpl) {
+        throw new CliError('Evidence search provider mode requires fetchImpl.', {
+          code: 'EVIDENCE_SEARCH_FETCH_IMPL_REQUIRED',
+          exitCode: 2,
+        });
+      }
+      const providerResults = await fetchProviderResults({
+        providerUrl: options.providerUrl,
+        providerKey: options.providerKey ?? null,
+        plan,
+        request,
+        timeoutMs: options.timeoutMs ?? 30_000,
+        fetchImpl: options.fetchImpl,
+      });
+      rawResults = [...normalizeResultGroups(rawResults), ...providerResults.rawResults];
+      providerCount += 1;
+      providerCallCount += providerResults.callCount;
+    }
+    if (!options.resultsPath && !options.providerUrl) {
+      throw new CliError('dataset evidence-search run requires --results or --provider-url.', {
+        code: 'EVIDENCE_SEARCH_PROVIDER_REQUIRED',
+        exitCode: 2,
+      });
+    }
+  }
+
+  const terms = extractTerms(request.question, request.required_terms);
+  const results =
+    options.mode === 'run'
+      ? normalizeResults({
+          rawResults,
+          terms,
+          preferredDomains: request.preferred_domains,
+          maxResultsPerQuery: request.budget.max_results_per_query,
+        })
+      : [];
+  if (resultsFile) {
+    writeJsonLinesArtifact(resultsFile, results);
+  }
+
+  const preliminaryReport = buildReport({
+    generatedAt,
+    mode: options.mode,
+    request,
+    plan,
+    results,
+    providerCount,
+    providerCallCount,
+    files: {
+      plan: planFile,
+      results: resultsFile,
+      report: reportFile,
+      declaration: null,
+    },
+    now,
+  });
+
+  let finalDeclarationFile: string | null = null;
+  if (
+    outputDir &&
+    options.mode === 'run' &&
+    preliminaryReport.status !== 'completed_with_evidence'
+  ) {
+    const declaration = buildDeclaration({
+      generatedAt,
+      request,
+      queryCount: plan.length,
+      providerCount,
+      resultCount: results.length,
+      authoritativeResultCount: preliminaryReport.run.authoritative_result_count,
+      temporalStatus: preliminaryReport.evidence_quality.temporal_coverage_status,
+      partial: preliminaryReport.status === 'completed_with_partial_evidence',
+    });
+    finalDeclarationFile = writeJsonArtifact(declarationFile!, declaration);
+  }
+
+  const report = {
+    ...preliminaryReport,
+    files: {
+      ...preliminaryReport.files,
+      declaration: finalDeclarationFile,
+    },
+  };
+  if (reportFile) {
+    writeJsonArtifact(reportFile, report);
+  }
+  return report;
+}
+
+export const __testInternals = {
+  buildSearchPlan,
+  classifySourceTier,
+  normalizeResults,
+  normalizeRequest,
+  temporalCoverageStatus,
+};

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -455,6 +455,15 @@ test('executeCli exposes dataset and lifecyclemodel friction-fix commands', asyn
   assert.match(datasetReferencesHelp.stdout, /--commit/u);
   assert.doesNotMatch(datasetReferencesHelp.stdout, /Planned command/u);
 
+  const datasetEvidenceHelp = await executeCli(
+    ['dataset', 'evidence-search', 'plan', '--help'],
+    makeDeps(),
+  );
+  assert.equal(datasetEvidenceHelp.exitCode, 0);
+  assert.match(datasetEvidenceHelp.stdout, /tiangong-lca dataset evidence-search <plan\|run>/u);
+  assert.match(datasetEvidenceHelp.stdout, /--provider-url/u);
+  assert.doesNotMatch(datasetEvidenceHelp.stdout, /Planned command/u);
+
   const lifecyclemodelSaveDraftHelp = await executeCli(
     ['lifecyclemodel', 'save-draft', '--help'],
     makeDeps(),
@@ -668,6 +677,175 @@ test('executeCli dispatches dataset and lifecyclemodel friction-fix commands', a
   );
   assert.equal(datasetReferencesModeError.exitCode, 2);
   assert.match(datasetReferencesModeError.stderr, /Cannot pass both/u);
+
+  const datasetEvidencePlan = await executeCli(
+    [
+      'dataset',
+      'evidence-search',
+      'plan',
+      '--json',
+      '--query',
+      '中国2026年电力结构数据',
+      '--profile',
+      'shallow',
+      '--max-queries',
+      '2',
+      '--max-results-per-query',
+      '3',
+      '--out-dir',
+      'evidence-out',
+    ],
+    {
+      ...makeDeps(),
+      runDatasetEvidenceSearchImpl: async (options) => {
+        assert.equal(options.mode, 'plan');
+        assert.equal(options.query, '中国2026年电力结构数据');
+        assert.equal(options.profile, 'shallow');
+        assert.equal(options.maxQueries, 2);
+        assert.equal(options.maxResultsPerQuery, 3);
+        assert.equal(options.outDir, 'evidence-out');
+        return {
+          schema_version: 1,
+          generated_at_utc: '2026-05-27T00:00:00.000Z',
+          mode: 'plan',
+          status: 'planned',
+          question: '中国2026年电力结构数据',
+          field: { dataset_type: null, field_path: null },
+          profile: 'shallow',
+          budget: { max_queries: 2, max_results_per_query: 3, max_provider_calls: 2 },
+          plan: { query_count: 0, queries: [] },
+          run: {
+            provider_count: 0,
+            provider_call_count: 0,
+            normalized_result_count: 0,
+            authoritative_result_count: 0,
+            high_confidence_result_count: 0,
+            stop_reason: 'plan_only',
+          },
+          evidence_quality: {
+            sufficient: false,
+            temporal_coverage_status: 'not_required',
+            requested_year: null,
+            required_complete_year: false,
+          },
+          files: { plan: null, results: null, report: null, declaration: null },
+        };
+      },
+    },
+  );
+  assert.equal(datasetEvidencePlan.exitCode, 0);
+
+  const datasetEvidenceNumericFallback = await executeCli(
+    ['dataset', 'evidence-search', 'plan', '--query', 'x', '--max-queries', 'nope'],
+    {
+      ...makeDeps(),
+      runDatasetEvidenceSearchImpl: async (options) => {
+        assert.equal(Number.isNaN(options.maxQueries), true);
+        return {
+          schema_version: 1,
+          generated_at_utc: '2026-05-27T00:00:00.000Z',
+          mode: 'plan',
+          status: 'planned',
+          question: 'x',
+          field: { dataset_type: null, field_path: null },
+          profile: 'balanced',
+          budget: { max_queries: 1, max_results_per_query: 1, max_provider_calls: 1 },
+          plan: { query_count: 0, queries: [] },
+          run: {
+            provider_count: 0,
+            provider_call_count: 0,
+            normalized_result_count: 0,
+            authoritative_result_count: 0,
+            high_confidence_result_count: 0,
+            stop_reason: 'plan_only',
+          },
+          evidence_quality: {
+            sufficient: false,
+            temporal_coverage_status: 'not_required',
+            requested_year: null,
+            required_complete_year: false,
+          },
+          files: { plan: null, results: null, report: null, declaration: null },
+        };
+      },
+    },
+  );
+  assert.equal(datasetEvidenceNumericFallback.exitCode, 0);
+
+  const datasetEvidenceRun = await executeCli(
+    [
+      'dataset',
+      'evidence-search',
+      'run',
+      '--json',
+      '--input',
+      'request.json',
+      '--results',
+      'results.json',
+      '--provider-url',
+      'https://search.example/query',
+      '--provider-key',
+      'secret',
+      '--timeout-ms',
+      '25',
+    ],
+    {
+      ...makeDeps(),
+      runDatasetEvidenceSearchImpl: async (options) => {
+        assert.equal(options.mode, 'run');
+        assert.equal(options.inputPath, 'request.json');
+        assert.equal(options.resultsPath, 'results.json');
+        assert.equal(options.providerUrl, 'https://search.example/query');
+        assert.equal(options.providerKey, 'secret');
+        assert.equal(options.timeoutMs, 25);
+        return {
+          schema_version: 1,
+          generated_at_utc: '2026-05-27T00:00:00.000Z',
+          mode: 'run',
+          status: 'completed_no_sufficient_evidence',
+          question: 'x',
+          field: { dataset_type: null, field_path: null },
+          profile: 'balanced',
+          budget: { max_queries: 1, max_results_per_query: 1, max_provider_calls: 1 },
+          plan: { query_count: 0, queries: [] },
+          run: {
+            provider_count: 1,
+            provider_call_count: 0,
+            normalized_result_count: 0,
+            authoritative_result_count: 0,
+            high_confidence_result_count: 0,
+            stop_reason: 'budget_exhausted_without_sufficient_evidence',
+          },
+          evidence_quality: {
+            sufficient: false,
+            temporal_coverage_status: 'not_required',
+            requested_year: null,
+            required_complete_year: false,
+          },
+          files: { plan: null, results: null, report: null, declaration: null },
+        };
+      },
+    },
+  );
+  assert.equal(datasetEvidenceRun.exitCode, 1);
+
+  const datasetEvidenceRootHelp = await executeCli(['dataset', 'evidence-search'], makeDeps());
+  assert.equal(datasetEvidenceRootHelp.exitCode, 0);
+  assert.match(datasetEvidenceRootHelp.stdout, /evidence-search <plan\|run>/u);
+
+  const invalidDatasetEvidenceAction = await executeCli(
+    ['dataset', 'evidence-search', 'scan'],
+    makeDeps(),
+  );
+  assert.equal(invalidDatasetEvidenceAction.exitCode, 2);
+  assert.match(invalidDatasetEvidenceAction.stderr, /must be 'plan' or 'run'/u);
+
+  const datasetEvidenceParseError = await executeCli(
+    ['dataset', 'evidence-search', 'plan', '--wat'],
+    makeDeps(),
+  );
+  assert.equal(datasetEvidenceParseError.exitCode, 2);
+  assert.match(datasetEvidenceParseError.stderr, /Unknown option/u);
 
   const datasetReferencesParseError = await executeCli(
     ['dataset', 'references', 'rewrite', '--wat'],

--- a/test/dataset-evidence-search.test.ts
+++ b/test/dataset-evidence-search.test.ts
@@ -1,0 +1,538 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { CliError } from '../src/lib/errors.js';
+import { __testInternals, runDatasetEvidenceSearch } from '../src/lib/dataset-evidence-search.js';
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+function readJsonl(filePath: string): unknown[] {
+  return readFileSync(filePath, 'utf8')
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+const chinaPowerRequest = {
+  question: '中国2026年电力结构数据',
+  field: {
+    dataset_type: 'process',
+    field_path: '/processInformation/time/referenceYear',
+  },
+  preferred_domains: ['chinapower.org.cn'],
+  required_terms: ['发电量', '火电', '风电', '太阳能'],
+  required_evidence: {
+    temporal_scope: '2026 full-year electricity generation mix',
+    require_complete_year: true,
+  },
+  budget: {
+    max_queries: 5,
+    max_results_per_query: 3,
+  },
+};
+
+test('dataset evidence-search plan writes a deterministic query matrix', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-evidence-plan-'));
+  try {
+    const report = await runDatasetEvidenceSearch({
+      mode: 'plan',
+      rawInput: chinaPowerRequest,
+      outDir: dir,
+      now: new Date('2026-05-27T00:00:00.000Z'),
+    });
+
+    assert.equal(report.status, 'planned');
+    assert.equal(report.question, '中国2026年电力结构数据');
+    assert.equal(report.plan.query_count, 5);
+    assert.equal(report.evidence_quality.temporal_coverage_status, 'incomplete_current_year');
+    assert.equal(existsSync(report.files.plan ?? ''), true);
+    assert.equal(existsSync(report.files.results ?? ''), true);
+    assert.deepEqual(
+      (readJson(report.files.plan ?? '') as { queries: unknown[] }).queries.length,
+      5,
+    );
+    assert.deepEqual(readJsonl(report.files.results ?? ''), []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('dataset evidence-search run records partial current-year evidence and declaration', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-evidence-run-'));
+  const resultsPath = path.join(dir, 'search-results.json');
+  writeFileSync(
+    resultsPath,
+    JSON.stringify({
+      queries: [
+        {
+          provider: 'web.run',
+          query_id: 'q01',
+          query: '中国2026年电力结构数据',
+          items: [
+            {
+              title: '国家能源局发布2026年1-4月份全国电力统计数据',
+              url: 'https://www.nea.gov.cn/20260525/c509435a0f09497cb3d2ca361fa262de/c.html',
+              snippet:
+                '截至4月底，全国累计发电装机容量39.9亿千瓦，其中太阳能发电装机容量12.5亿千瓦，风电装机容量6.6亿千瓦。',
+              published_at: '2026-05-25',
+            },
+            {
+              title: '中电联发布2026年一季度全国电力供需形势分析预测报告',
+              url: 'https://chinapower.org.cn/detail/457464.html',
+              snippet: '一季度全口径非化石能源发电量占总发电量比重为40.5%，煤电发电量占比为53.5%。',
+              published_at: '2026-04-28',
+            },
+          ],
+        },
+      ],
+    }),
+    'utf8',
+  );
+
+  try {
+    const report = await runDatasetEvidenceSearch({
+      mode: 'run',
+      rawInput: chinaPowerRequest,
+      resultsPath,
+      outDir: dir,
+      now: new Date('2026-05-27T00:00:00.000Z'),
+    });
+
+    assert.equal(report.status, 'completed_with_partial_evidence');
+    assert.equal(report.run.provider_count, 1);
+    assert.equal(report.run.normalized_result_count, 2);
+    assert.equal(report.run.authoritative_result_count, 2);
+    assert.equal(report.run.stop_reason, 'complete_annual_scope_not_available');
+    assert.equal(existsSync(report.files.declaration ?? ''), true);
+    const declaration = readJson(report.files.declaration ?? '') as { declaration_type: string };
+    assert.equal(declaration.declaration_type, 'partial_temporal_evidence');
+    const normalized = readJsonl(report.files.results ?? '') as Array<{ source_tier: string }>;
+    assert.deepEqual(
+      normalized.map((result) => result.source_tier),
+      ['official_statistics', 'preferred_domain'],
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('dataset evidence-search run can call a generic JSON provider endpoint', async () => {
+  const captured: Array<{ url: string; init?: RequestInit }> = [];
+  const report = await runDatasetEvidenceSearch({
+    mode: 'run',
+    query: 'China 2025 electricity generation mix',
+    providerUrl: 'https://search.example/query',
+    providerKey: 'provider-token',
+    maxQueries: 2,
+    maxResultsPerQuery: 2,
+    timeoutMs: 20,
+    now: new Date('2026-05-27T00:00:00.000Z'),
+    fetchImpl: async (url, init) => {
+      captured.push({ url, init });
+      return {
+        ok: true,
+        status: 200,
+        headers: {
+          get: () => 'application/json',
+        },
+        text: async () =>
+          JSON.stringify({
+            items: [
+              {
+                title: 'China electricity generation mix 2025',
+                link: 'https://stats.gov.cn/electricity-2025',
+                description: '2025 electricity generation coal hydro nuclear wind solar data.',
+              },
+            ],
+          }),
+      };
+    },
+  });
+
+  assert.equal(report.status, 'completed_with_evidence');
+  assert.equal(report.run.provider_call_count, 2);
+  assert.equal(captured.length, 2);
+  assert.equal(captured[0]?.url, 'https://search.example/query');
+  assert.deepEqual(captured[0]?.init?.headers, {
+    'Content-Type': 'application/json',
+    Authorization: 'Bearer provider-token',
+  });
+  assert.equal(JSON.parse(String(captured[0]?.init?.body)).limit, 2);
+});
+
+test('dataset evidence-search validates required inputs and unsupported modes', async () => {
+  await assert.rejects(
+    () =>
+      runDatasetEvidenceSearch({
+        mode: 'plan',
+        rawInput: {},
+      }),
+    /requires --query or input.question/u,
+  );
+
+  const primitiveInputReport = await runDatasetEvidenceSearch({
+    mode: 'plan',
+    query: 'fallback question',
+    rawInput: 'not-an-object',
+  });
+  assert.equal(primitiveInputReport.question, 'fallback question');
+
+  await assert.rejects(
+    () =>
+      runDatasetEvidenceSearch({
+        mode: 'plan',
+        query: 'x',
+        profile: 'wide',
+      }),
+    /--profile/u,
+  );
+
+  await assert.rejects(
+    () =>
+      runDatasetEvidenceSearch({
+        mode: 'run',
+        query: 'x',
+      }),
+    /requires --results or --provider-url/u,
+  );
+
+  await assert.rejects(
+    () =>
+      runDatasetEvidenceSearch({
+        mode: 'run',
+        query: 'x',
+        providerUrl: 'https://search.example/query',
+      }),
+    (error: unknown) => {
+      assert.equal(error instanceof CliError, true);
+      assert.equal((error as CliError).code, 'EVIDENCE_SEARCH_FETCH_IMPL_REQUIRED');
+      return true;
+    },
+  );
+
+  await assert.rejects(
+    () =>
+      runDatasetEvidenceSearch({
+        mode: 'plan',
+        query: 'x',
+        maxQueries: 0,
+      }),
+    /positive integer/u,
+  );
+});
+
+test('dataset evidence-search normalizes JSONL result files and insufficient evidence', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-evidence-jsonl-'));
+  const resultsPath = path.join(dir, 'results.jsonl');
+  writeFileSync(
+    resultsPath,
+    `${JSON.stringify({
+      title: 'Unrelated page',
+      url: 'https://example.com/page',
+      snippet: 'No relevant statistics here.',
+    })}\n`,
+    'utf8',
+  );
+
+  try {
+    const report = await runDatasetEvidenceSearch({
+      mode: 'run',
+      query: 'China 2024 electricity generation mix',
+      resultsPath,
+      outDir: dir,
+      now: new Date('2026-05-27T00:00:00.000Z'),
+    });
+
+    assert.equal(report.status, 'completed_no_sufficient_evidence');
+    assert.equal(report.run.normalized_result_count, 1);
+    assert.equal(report.files.declaration?.endsWith('evidence-search-declaration.json'), true);
+    const declaration = readJson(report.files.declaration ?? '') as { declaration_type: string };
+    assert.equal(declaration.declaration_type, 'no_sufficient_evidence');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('dataset evidence-search normalizes mixed result shapes and keeps strongest duplicate', async () => {
+  const report = await runDatasetEvidenceSearch({
+    mode: 'run',
+    query: 'China electricity mix',
+    profile: 'deep',
+    resultsPath: 'ignored-results.json',
+    rawInput: {
+      field: 'not-object',
+      preferred_domains: 'not-array',
+      required_terms: [null, 'solar'],
+      budget: {
+        max_queries: '3',
+        max_results_per_query: '4',
+      },
+    },
+    rawResults: [
+      {
+        provider: 'mixed-provider',
+        text: 'China electricity mix',
+        data: [
+          'not-a-result',
+          { title: 'Missing URL' },
+          {
+            title: 'Bad URL result',
+            url: 'not a url',
+            text: 'solar electricity mix',
+          },
+          {
+            name: 'China electricity generation mix from NBS',
+            href: 'https://www.stats.gov.cn/china-electricity',
+            summary: 'Coal hydro nuclear wind solar generation mix data.',
+            date: '2026-01-01',
+          },
+          {
+            title: 'Duplicate lower score',
+            url: 'https://example.com/duplicate',
+            snippet: 'misc',
+          },
+          {
+            title: 'Duplicate stronger score',
+            url: 'https://example.com/duplicate',
+            snippet: 'solar electricity generation mix data',
+          },
+        ],
+      },
+    ],
+    now: new Date('2026-05-27T00:00:00.000Z'),
+  });
+
+  assert.equal(report.status, 'completed_with_evidence');
+  assert.equal(report.profile, 'deep');
+  assert.equal(report.budget.max_queries, 3);
+  assert.equal(report.budget.max_results_per_query, 4);
+  assert.equal(report.run.provider_count, 1);
+  assert.equal(report.run.normalized_result_count, 2);
+  assert.equal(report.files.report, null);
+
+  const normalized = __testInternals.normalizeResults({
+    rawResults: [
+      {
+        provider: 'mixed-provider',
+        text: 'China electricity mix',
+        data: [
+          { title: 'Bad URL result', url: 'not a url', text: 'solar electricity mix' },
+          {
+            name: 'China electricity generation mix from IEA',
+            href: 'https://reports.iea.org/china-electricity',
+            summary: 'Coal hydro nuclear wind solar generation mix data.',
+            date: '2026-01-01',
+          },
+          { title: 'Duplicate lower score', url: 'https://example.com/duplicate', snippet: 'misc' },
+          {
+            title: 'Duplicate stronger score',
+            url: 'https://example.com/duplicate',
+            snippet: 'solar electricity generation mix data',
+          },
+        ],
+      },
+      {
+        provider: 'tie-provider',
+        results: [
+          { title: 'Later equal score', url: 'https://example.org/later' },
+          { title: 'Earlier equal score', url: 'https://example.org/earlier' },
+        ],
+      },
+      {
+        query: 'fallback provider row',
+        web_results: [{ title: 'Fallback provider row', url: 'https://example.net/row' }],
+      },
+    ],
+    terms: ['solar', 'electricity', 'generation', 'mix'],
+    preferredDomains: [],
+    maxResultsPerQuery: 4,
+  });
+  assert.deepEqual(
+    normalized.map((result) => [result.url, result.source_tier]),
+    [
+      ['https://reports.iea.org/china-electricity', 'international_statistics'],
+      ['https://example.com/duplicate', 'open_web'],
+      ['not a url', 'open_web'],
+      ['https://example.org/later', 'open_web'],
+      ['https://example.net/row', 'open_web'],
+      ['https://example.org/earlier', 'open_web'],
+    ],
+  );
+
+  const queryGroupFallbacks = __testInternals.normalizeResults({
+    rawResults: {
+      queries: [
+        {
+          provider: '   ',
+          query_id: '   ',
+          text: 'query group fallback text',
+          results: [{ title: 'Fallback query group', url: 'https://example.net/query-group' }],
+        },
+        'ignored',
+      ],
+    },
+    terms: [],
+    preferredDomains: [],
+    maxResultsPerQuery: 2,
+  });
+  assert.deepEqual(queryGroupFallbacks[0], {
+    query_id: null,
+    query: 'query group fallback text',
+    provider: 'external',
+    rank: 1,
+    title: 'Fallback query group',
+    url: 'https://example.net/query-group',
+    snippet: null,
+    published_at: null,
+    source_domain: 'example.net',
+    source_tier: 'open_web',
+    matched_terms: [],
+    score: 1,
+  });
+});
+
+test('dataset evidence-search rejects invalid JSON and JSONL result files', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-evidence-invalid-'));
+  try {
+    const requestPath = path.join(dir, 'request.json');
+    const invalidJson = path.join(dir, 'invalid.json');
+    const invalidJsonl = path.join(dir, 'invalid.jsonl');
+    const emptyResults = path.join(dir, 'empty.jsonl');
+    writeFileSync(requestPath, JSON.stringify({ question: 'question from file' }), 'utf8');
+    writeFileSync(invalidJson, '{not-json', 'utf8');
+    writeFileSync(invalidJsonl, 'not-json\n', 'utf8');
+    writeFileSync(emptyResults, '\n  \n', 'utf8');
+
+    const fileInputReport = await runDatasetEvidenceSearch({
+      mode: 'plan',
+      inputPath: requestPath,
+    });
+    assert.equal(fileInputReport.question, 'question from file');
+
+    const emptyReport = await runDatasetEvidenceSearch({
+      mode: 'run',
+      query: 'China electricity mix',
+      resultsPath: emptyResults,
+    });
+    assert.equal(emptyReport.status, 'completed_no_sufficient_evidence');
+    assert.equal(emptyReport.run.normalized_result_count, 0);
+
+    await assert.rejects(
+      () =>
+        runDatasetEvidenceSearch({
+          mode: 'run',
+          query: 'China electricity mix',
+          resultsPath: invalidJson,
+        }),
+      /not valid JSON/u,
+    );
+    await assert.rejects(
+      () =>
+        runDatasetEvidenceSearch({
+          mode: 'run',
+          query: 'China electricity mix',
+          resultsPath: invalidJsonl,
+        }),
+      /invalid JSONL/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('dataset evidence-search provider supports array payloads without authorization', async () => {
+  const captured: Array<{ url: string; init?: RequestInit }> = [];
+  const report = await runDatasetEvidenceSearch({
+    mode: 'run',
+    query: 'China 2027 electricity mix',
+    rawInput: {
+      required_evidence: {
+        temporal_scope: '2027 full-year electricity generation mix',
+        temporal_coverage: 'annual_complete',
+      },
+    },
+    providerUrl: 'https://search.example/query',
+    maxQueries: 2,
+    fetchImpl: async (url, init) => {
+      captured.push({ url, init });
+      const responseText =
+        captured.length === 1
+          ? JSON.stringify([
+              {
+                title: 'China 2027 electricity generation mix forecast',
+                url: 'https://stats.gov.cn/forecast',
+                snippet: 'Forecast coal hydro nuclear wind solar electricity generation mix.',
+              },
+            ])
+          : JSON.stringify('unsupported provider payload');
+      return {
+        ok: true,
+        status: 200,
+        headers: {
+          get: () => 'application/json',
+        },
+        text: async () => responseText,
+      };
+    },
+    now: new Date('2026-05-27T00:00:00.000Z'),
+  });
+
+  assert.equal(report.status, 'completed_with_partial_evidence');
+  assert.equal(report.evidence_quality.temporal_coverage_status, 'future_year');
+  assert.equal(report.run.provider_call_count, 2);
+  assert.deepEqual(captured[0]?.init?.headers, {
+    'Content-Type': 'application/json',
+  });
+});
+
+test('dataset evidence-search internals classify domains and complete-year timing', () => {
+  assert.equal(__testInternals.classifySourceTier(null, []), 'open_web');
+  assert.equal(__testInternals.classifySourceTier('sub.stats.gov.cn', []), 'official_statistics');
+  assert.equal(__testInternals.classifySourceTier('www.cec.org.cn', []), 'industry_association');
+  assert.equal(
+    __testInternals.classifySourceTier('reports.iea.org', []),
+    'international_statistics',
+  );
+  assert.equal(
+    __testInternals.classifySourceTier('example.com', ['example.com']),
+    'preferred_domain',
+  );
+  assert.equal(__testInternals.classifySourceTier('example.com', []), 'open_web');
+  assert.equal(
+    __testInternals.temporalCoverageStatus(
+      {
+        question: 'x',
+        field: { dataset_type: null, field_path: null },
+        profile: 'balanced',
+        budget: { max_queries: 1, max_results_per_query: 1, max_provider_calls: 1 },
+        preferred_domains: [],
+        required_terms: [],
+        required_complete_year: false,
+        requested_year: null,
+      },
+      new Date('2026-05-27T00:00:00.000Z'),
+    ),
+    'not_required',
+  );
+  assert.equal(
+    __testInternals.temporalCoverageStatus(
+      {
+        question: 'x',
+        field: { dataset_type: null, field_path: null },
+        profile: 'balanced',
+        budget: { max_queries: 1, max_results_per_query: 1, max_provider_calls: 1 },
+        preferred_domains: [],
+        required_terms: [],
+        required_complete_year: true,
+        requested_year: 2025,
+      },
+      new Date('2026-05-27T00:00:00.000Z'),
+    ),
+    'complete_year_possible',
+  );
+});


### PR DESCRIPTION
## Summary
- add `dataset evidence-search plan|run` for field-level evidence retrieval artifacts
- normalize external/browser search results, source tiers, budgets, temporal completeness, and no/partial evidence declarations
- document the command surface and validation contract

## Validation
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npm run lint`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npm run test:coverage && PATH="/opt/homebrew/opt/node@24/bin:$PATH" npm run test:coverage:assert-full`
- `/Users/huimin/projets/workspace/scripts/docpact lint --root . --worktree --mode warn`

Closes #114