### PR TITLE
chore: move cli push tests to local and release gates

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-27"
-lastReviewedCommit: "1c7dd5bd718bdef159368f5f5293bcb5182e0416"
+lastReviewedCommit: "10f7d8facdc08ab6b333b652cb1c986866912302"
 
 catalog:
   repos:

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,4 +2,9 @@
 set -eu
 
 repo_root="$(git rev-parse --show-toplevel)"
-exec "$repo_root/scripts/docpact-gate.sh" "$@"
+cd "$repo_root"
+
+"$repo_root/scripts/docpact-gate.sh" "$@"
+
+echo "Running local test gate: npm run prepush:gate"
+npm run prepush:gate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,8 +9,30 @@ permissions:
   contents: read
 
 jobs:
+  release-gate:
+    name: Release Gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run full pre-publish gate
+        run: npm run prepush:gate
+
   npm-publish:
     name: Publish npm package
+    needs: release-gate
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -41,9 +63,7 @@ jobs:
         run: node ./scripts/ci/release-version.cjs assert-unpublished
 
       - name: Verify package
-        run: |
-          npm run prepush:gate
-          npm pack --dry-run >/dev/null
+        run: npm pack --dry-run >/dev/null
 
       - name: Publish to npm
         run: npm publish --access public --provenance

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,10 +1,7 @@
 name: quality-gate
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   quality-gate:

--- a/.github/workflows/tag-release-from-merge.yml
+++ b/.github/workflows/tag-release-from-merge.yml
@@ -47,6 +47,14 @@ jobs:
         if: steps.release.outputs.any_changed != 'true'
         run: echo "No package version changes detected on main."
 
+      - name: Install dependencies
+        if: steps.release.outputs.cli_changed == 'true'
+        run: npm ci
+
+      - name: Run release gate before tag
+        if: steps.release.outputs.cli_changed == 'true'
+        run: npm run prepush:gate
+
       - name: Check npm registry version availability
         if: steps.release.outputs.cli_changed == 'true'
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,8 +110,8 @@ Route those tasks to:
 - `publish run` emits `verification-report.json` next to `publish-report.json`; this is the deterministic publish ruleset summary for failed/deferred/executed outcomes.
 - `src/lib/runtime-rulesets.ts` is the CLI-local runtime activation layer for stable ruleset ids, methodology rule ids, severity, and blocker semantics used by review, dedup, and publish gate artifacts.
 - The canonical minimum validation command is `npm run lint`
-- The authoritative full gate is `npm run prepush:gate`
-- Release tagging is guarded in `.github/workflows/tag-release-from-merge.yml` so only the upstream repository can execute the merge-tag flow.
+- The authoritative full gate is `npm run prepush:gate`; the local pre-push hook runs it after docpact.
+- Release tagging is guarded in `.github/workflows/tag-release-from-merge.yml` so only the upstream repository can execute the merge-tag flow, and it runs the release gate only when a package version change will create a tag.
 - Coverage for `src/**/*.ts` is expected to stay at `100%` statements, branches, functions, and lines
 
 ## Hard Boundaries
@@ -140,4 +140,4 @@ Install the versioned local hook once per checkout:
 ./scripts/install-git-hooks.sh
 ```
 
-The `pre-push` hook runs `scripts/docpact-gate.sh`, which delegates CLI lookup to `scripts/docpact` and performs strict config validation plus enforced lint before the push leaves the machine. The wrapper checks `DOCPACT_BIN`, Cargo install locations, Homebrew install locations, and then `PATH`, so local agent shells should not fail only because bare `docpact` is unavailable. The default comparison base is `origin/main`. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.
+The `pre-push` hook runs `scripts/docpact-gate.sh`, which delegates CLI lookup to `scripts/docpact` and performs strict config validation plus enforced lint before the push leaves the machine. It then runs `npm run prepush:gate` as the local test gate. The wrapper checks `DOCPACT_BIN`, Cargo install locations, Homebrew install locations, and then `PATH`, so local agent shells should not fail only because bare `docpact` is unavailable. The default comparison base is `origin/main`. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts. The GitHub `quality-gate` workflow is manual-dispatch only; publish and tag workflows still run release gates before release actions.

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -145,13 +145,13 @@ If a task changes output layout, locking, or local run roots, inspect these firs
 
 Repo-level maintenance gates are now split across:
 
-- `.github/workflows/quality-gate.yml`
+- `.github/workflows/quality-gate.yml` for manual remote reproduction of the local gate
 - `.github/workflows/ai-doc-lint.yml`
 - `.github/workflows/tag-release-from-merge.yml`
 
 Important constraints:
 
-- `npm run prepush:gate` remains the authoritative protected-branch proof for code changes
+- `npm run prepush:gate` remains the authoritative local proof for code changes and runs from the local pre-push hook
 - `ai-doc-lint` keeps the historical check identity, but its implementation should run `docpact`
 - `docpact` enforces that command-surface and release-gate changes also refresh or review the governed source docs
 - the merge-tag workflow is guarded so only the upstream repository can execute release tagging
@@ -171,4 +171,4 @@ Important constraints:
 
 ## Local Docpact Push Gate
 
-This repository has a versioned local `pre-push` hook under `.githooks/pre-push` that delegates to `scripts/docpact-gate.sh`. The gate resolves the CLI through `scripts/docpact`, so local agent shells do not need bare `docpact` on `PATH`. The hook is a local developer guard for docpact config validation and enforced doc-governance linting; CI remains the authoritative PR enforcement path.
+This repository has a versioned local `pre-push` hook under `.githooks/pre-push` that delegates to `scripts/docpact-gate.sh` and then runs `npm run prepush:gate`. The gate resolves the CLI through `scripts/docpact`, so local agent shells do not need bare `docpact` on `PATH`. The hook is the local guard for docpact config validation, enforced doc-governance linting, and the CLI test gate; ordinary GitHub push tests are replaced by this local gate plus release-time gates.

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -80,7 +80,9 @@ Facts that matter:
 
 - `npm run test:coverage` is the full coverage proof
 - `npm run test:coverage:assert-full` verifies the latest coverage artifact without rerunning coverage
-- `npm run prepush:gate` is the exact protected-branch gate
+- `npm run prepush:gate` is the exact local test gate
+- the local `pre-push` hook runs docpact first and then `npm run prepush:gate`
+- `.github/workflows/quality-gate.yml` is manual-dispatch only for remote reproduction, not an ordinary push-triggered test runner
 - `process save-draft`, `lifecyclemodel save-draft`, dataset governance commands, BuildPlan gates, publish schema/verification gates, and the newer process maintenance commands are expected to preserve `100%` coverage even when they add schema-validation, rewrite, or fallback branches
 - release-tag and docpact lint workflow changes should be described in the PR note when they alter the local or protected-branch proof
 
@@ -102,4 +104,4 @@ Install the versioned local hook once per checkout:
 ./scripts/install-git-hooks.sh
 ```
 
-The `pre-push` hook runs `scripts/docpact-gate.sh`, which delegates CLI lookup to `scripts/docpact` and performs strict config validation plus enforced lint before the push leaves the machine. The wrapper checks `DOCPACT_BIN`, Cargo install locations, Homebrew install locations, and then `PATH`, so local agent shells should not fail only because bare `docpact` is unavailable. The default comparison base is `origin/main`. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.
+The `pre-push` hook runs `scripts/docpact-gate.sh`, which delegates CLI lookup to `scripts/docpact` and performs strict config validation plus enforced lint before the push leaves the machine. It then runs `npm run prepush:gate` as the local test gate. The wrapper checks `DOCPACT_BIN`, Cargo install locations, Homebrew install locations, and then `PATH`, so local agent shells should not fail only because bare `docpact` is unavailable. The default comparison base is `origin/main`. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -51,7 +51,7 @@ Before starting a release:
 - work from the latest `main`
 - keep the release-prep change scoped to CLI package version metadata
 - confirm npm has not already published the target version
-- confirm any command-surface feature PRs that will be included in the release have passed `npm run prepush:gate` and the docpact CI gate before preparing the version bump
+- confirm any command-surface feature PRs that will be included in the release have passed the local pre-push gate, including `npm run prepush:gate` and docpact, before preparing the version bump
 
 Useful commands:
 
@@ -76,7 +76,7 @@ npm pack --dry-run >/dev/null
    - `package.json`
    - `package-lock.json`
 3. Keep the PR focused on the release bump.
-4. Open a normal PR and wait for `quality-gate` to pass.
+4. Open a normal PR with local pre-push gate evidence. Use the manual `quality-gate` workflow only when remote reproduction is needed.
 5. Merge the PR into `main`.
 
 Release automation starts only after the version bump PR is merged into `main`.
@@ -101,6 +101,7 @@ gh api repos/tiangong-lca/tiangong-cli/git/ref/tags/cli-v<x.y.z>
 Expected result:
 
 - the workflow finishes successfully
+- `npm run prepush:gate` runs inside the tag workflow before tag creation when a CLI version change is detected
 - tag `cli-v<x.y.z>` exists
 
 ### 2. Publish workflow
@@ -182,4 +183,4 @@ For the CLI repo, that helper defaults to:
 
 ## Local Docpact Push Gate
 
-The repository now includes a local pre-push docpact gate in `scripts/docpact-gate.sh`. The gate resolves the CLI through `scripts/docpact`. It is a lightweight documentation-governance guard and does not replace the release or protected-branch validation gates.
+The repository now includes a local pre-push gate that runs `scripts/docpact-gate.sh` and then `npm run prepush:gate`. It is the ordinary local validation path; release workflows still run their own release gates before creating tags or publishing.

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -93,10 +93,10 @@ Leave the environment name unset unless the workflow is explicitly updated to us
 ## Operational Notes
 
 - `publish.yml` validates that the Git tag matches the package version before upload.
-- `tag-release-from-merge.yml` only creates a tag when `package.json` version changes on `main`.
+- `tag-release-from-merge.yml` only creates a tag when `package.json` version changes on `main`, and it runs `npm run prepush:gate` before creating that tag.
 - The release-prep PR should update only the intended versioned release metadata for the CLI package.
 - Adding CLI command families such as dataset or lifecyclemodel maintenance commands does not require release setup changes by itself; those feature PRs are covered by the normal quality and docpact gates before a later version bump.
 
 ## Local Docpact Push Gate
 
-The repository now includes a local pre-push docpact gate in `scripts/docpact-gate.sh`. The gate resolves the CLI through `scripts/docpact`. It is a lightweight documentation-governance guard and does not replace the release or protected-branch validation gates.
+The repository now includes a local pre-push gate that runs `scripts/docpact-gate.sh` and then `npm run prepush:gate`. It is the ordinary local validation path; release workflows still run release gates before tag creation or npm publishing.


### PR DESCRIPTION
Closes tiangong-lca/tiangong-cli#116

## Summary
- Make the standalone quality-gate workflow manual-only.
- Require npm prepush gate before npm publish and before auto tag creation when a package change will release.
- Run the same prepush gate from the local pre-push hook.

## Key Decisions
- Use local pre-push and release/tag workflows as validation gates instead of every push.

## Validation
- docpact gate passed during push.
- npm run prepush:gate passed locally: lint, build, 665 tests, and 100% coverage assertion.

## Risks / Rollback
- Release tagging and npm publish now fail before tag/publish if the local package gate fails.

## Workspace Integration
- Requires lca-workspace submodule pointer update after merge.