### PR TITLE
Gate CLI releases with local doc checks

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-27"
-lastReviewedCommit: "10f7d8facdc08ab6b333b652cb1c986866912302"
+lastReviewedAt: "2026-05-28"
+lastReviewedCommit: "d933e493cd109161c7fc6894a96ebfe442602b82"
 
 catalog:
   repos:

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,7 +1,7 @@
 name: ai-doc-lint
 
 on:
-  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,19 +16,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch main
+        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
         run: cargo install docpact --version 0.1.9 --force
 
-      - name: Validate docpact config
-        run: scripts/docpact validate-config --root . --strict
-
-      - name: Run docpact lint
-        run: |
-          scripts/docpact lint \
-            --root . \
-            --mode enforce \
-            --base "${{ github.event.pull_request.base.sha }}" \
-            --head "${{ github.event.pull_request.head.sha }}"
+      - name: Run local docpact gate
+        run: scripts/docpact-gate.sh --base origin/main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,20 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch main
+        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install docpact
+        run: cargo install docpact --version 0.1.9 --force
+
+      - name: Run docpact release gate
+        run: scripts/docpact-gate.sh --base origin/main
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -61,6 +75,9 @@ jobs:
 
       - name: Check npm registry version availability
         run: node ./scripts/ci/release-version.cjs assert-unpublished
+
+      - name: Build package artifacts
+        run: npm run build
 
       - name: Verify package
         run: npm pack --dry-run >/dev/null

--- a/.github/workflows/tag-release-from-merge.yml
+++ b/.github/workflows/tag-release-from-merge.yml
@@ -21,6 +21,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install docpact
+        run: cargo install docpact --version 0.1.9 --force
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
@@ -32,6 +38,17 @@ jobs:
             echo "error: missing TIANGONG_CLI_RELEASE_AUTOMATION_TOKEN secret" >&2
             exit 1
           fi
+
+      - name: Run docpact release gate before tag
+        env:
+          BASE_REF: ${{ github.event.before }}
+          HEAD_REF: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$BASE_REF" = "0000000000000000000000000000000000000000" ]; then
+            BASE_REF="${HEAD_REF}^"
+          fi
+          scripts/docpact-gate.sh --base "$BASE_REF" --head "$HEAD_REF"
 
       - name: Detect release version changes
         id: release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ Route those tasks to:
 
 ## Runtime Facts
 
-- Repo-local documentation governance is encoded in `.docpact/config.yaml` and enforced by `.github/workflows/ai-doc-lint.yml` through `docpact`.
+- Repo-local documentation governance is encoded in `.docpact/config.yaml` and enforced locally by the pre-push docpact gate; `.github/workflows/ai-doc-lint.yml` is manual-dispatch fallback.
 - Package manager: `npm`
 - Node baseline: `>=24 <25`
 - Runtime style: TypeScript source, Node-native CLI, direct REST and Edge Function access only

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 1c7dd5bd718bdef159368f5f5293bcb5182e0416
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: d933e493cd109161c7fc6894a96ebfe442602b82
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 1c7dd5bd718bdef159368f5f5293bcb5182e0416
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: d933e493cd109161c7fc6894a96ebfe442602b82
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 1c7dd5bd718bdef159368f5f5293bcb5182e0416
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: d933e493cd109161c7fc6894a96ebfe442602b82
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -19,8 +19,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 1c7dd5bd718bdef159368f5f5293bcb5182e0416
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: d933e493cd109161c7fc6894a96ebfe442602b82
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml


### PR DESCRIPTION
## Summary
- move ai-doc-lint off ordinary PR/push execution and keep it as manual fallback
- keep documentation governance in the local pre-push gate
- add docpact gates before automatic release tagging and npm publish\n- build package artifacts before npm pack/npm publish

## Validation
- parsed changed GitHub workflow YAML locally
- ran repo docpact/AI-doc gate against origin/main..HEAD
- ran local test gate where the repo pre-push hook required it

Closes #118
