### PR TITLE
feat: add dataset import context CLI commands

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "8b9704d8bc72fb282e8abe1dc9138c46fbd78768"
+lastReviewedAt: "2026-06-01"
+lastReviewedCommit: "24f96578290267865df3ee1244a96723129bc376"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: 8b9704d8bc72fb282e8abe1dc9138c46fbd78768
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 24f96578290267865df3ee1244a96723129bc376
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -18,8 +18,8 @@ checkPaths:
   - src/**
   - scripts/**
   - .github/workflows/**
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 1c7dd5bd718bdef159368f5f5293bcb5182e0416
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 2c0e773f729c83b92de13222f00b1e06b16f74e1
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ checkPaths:
   - bin/**
   - src/cli.ts
   - src/main.ts
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 06dbec3287513cf94c5d64c73bd467ed5347f40a
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 24f96578290267865df3ee1244a96723129bc376
 ---
 
 # TianGong LCA CLI

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - README.md
   - src/**
   - test/**
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 24f96578290267865df3ee1244a96723129bc376
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -17,8 +17,8 @@ checkPaths:
   - package.json
   - src/**
   - test/**
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 1c7dd5bd718bdef159368f5f5293bcb5182e0416
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 2c0e773f729c83b92de13222f00b1e06b16f74e1
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
+++ b/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
@@ -15,8 +15,8 @@ checkPaths:
   - src/lib/user-api-key.ts
   - src/lib/supabase-session.ts
   - src/lib/supabase-client.ts
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 1c7dd5bd718bdef159368f5f5293bcb5182e0416
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 2c0e773f729c83b92de13222f00b1e06b16f74e1
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
+++ b/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - src/lib/supabase-client.ts
   - src/lib/tidas-sdk-package-validator.ts
   - test/**
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 1c7dd5bd718bdef159368f5f5293bcb5182e0416
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 2c0e773f729c83b92de13222f00b1e06b16f74e1
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: 8b9704d8bc72fb282e8abe1dc9138c46fbd78768
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 24f96578290267865df3ee1244a96723129bc376
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: 8b9704d8bc72fb282e8abe1dc9138c46fbd78768
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 24f96578290267865df3ee1244a96723129bc376
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: 8b9704d8bc72fb282e8abe1dc9138c46fbd78768
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 24f96578290267865df3ee1244a96723129bc376
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -19,8 +19,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: 8b9704d8bc72fb282e8abe1dc9138c46fbd78768
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 24f96578290267865df3ee1244a96723129bc376
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -232,6 +232,21 @@ import {
   type EvidenceSearchReport,
   type RunDatasetEvidenceSearchOptions,
 } from './lib/dataset-evidence-search.js';
+import {
+  runDatasetContract,
+  type DatasetContractReport,
+  type RunDatasetContractOptions,
+} from './lib/dataset-contract.js';
+import {
+  runDatasetImportLcaConvert,
+  type DatasetImportLcaReport,
+  type RunDatasetImportLcaConvertOptions,
+} from './lib/dataset-import-lca.js';
+import {
+  runDatasetAuthor,
+  type DatasetAuthorReport,
+  type RunDatasetAuthorOptions,
+} from './lib/dataset-author.js';
 
 export type CliDeps = {
   env: NodeJS.ProcessEnv;
@@ -371,6 +386,11 @@ export type CliDeps = {
   runDatasetEvidenceSearchImpl?: (
     options: RunDatasetEvidenceSearchOptions,
   ) => Promise<EvidenceSearchReport>;
+  runDatasetContractImpl?: (options: RunDatasetContractOptions) => Promise<DatasetContractReport>;
+  runDatasetImportLcaConvertImpl?: (
+    options: RunDatasetImportLcaConvertOptions,
+  ) => Promise<DatasetImportLcaReport> | DatasetImportLcaReport;
+  runDatasetAuthorImpl?: (options: RunDatasetAuthorOptions) => Promise<DatasetAuthorReport>;
 };
 
 export type CliResult = {
@@ -403,7 +423,7 @@ Implemented Commands:
   doctor     show environment diagnostics
   search     flow | process | lifecyclemodel
   process    get | list | identity-preflight | build-plan | scope-statistics | dedup-review | auto-build | resume-build | publish-build | complete-required-fields | save-draft | batch-build | refresh-references | verify-rows
-  dataset    validate | verify-remote | bilingual extract/apply/validate | evidence-search plan/run | references rewrite/refresh-remote
+  dataset    contract get | context-pack | import-lca convert | author | validate | verify-remote | bilingual extract/apply/validate | evidence-search plan/run | references rewrite/refresh-remote
   flow       get | list | identity-preflight | build-plan | fetch-rows | materialize-decisions | remediate | publish-version | publish-reviewed-data | build-alias-map | scan-process-flow-refs | plan-process-flow-repairs | apply-process-flow-repairs | regen-product | validate-processes
   lifecyclemodel auto-build | validate-build | publish-build | save-draft | graph | build-resulting-process | publish-resulting-process | orchestrate
   review     process | flow | lifecyclemodel
@@ -436,6 +456,10 @@ Examples:
   tiangong-lca process refresh-references --out-dir /abs/path/to/process-refresh --dry-run
   tiangong-lca process verify-rows --rows-file ./process-list-report.json --out-dir /abs/path/to/process-verify
   tiangong-lca dataset validate --input ./rows.jsonl --type auto --out-dir /abs/path/to/dataset-validate
+  tiangong-lca dataset contract get --type process --include schema,methodology,ruleset --out-dir ./contract
+  tiangong-lca dataset context-pack --type process --profile ai-import --out-dir ./context-pack
+  tiangong-lca dataset import-lca convert --input ./external-package --output-dir ./converted --from-format auto --target tidas
+  tiangong-lca dataset author --input ./source.pdf --target-types process,flow --out-dir ./authoring
   tiangong-lca dataset verify-remote --input ./rows.jsonl --out-dir /abs/path/to/dataset-remote-verify
   tiangong-lca dataset bilingual extract --input ./rows/processes.jsonl --type process --out-dir ./translation
   tiangong-lca dataset bilingual apply --input ./rows/processes.jsonl --translations ./translation/trans-reviewed.jsonl --out ./rows/processes.translated.jsonl
@@ -579,6 +603,10 @@ function renderDatasetHelp(): string {
   tiangong-lca dataset <subcommand> [options]
 
 Implemented Subcommands:
+  contract get        Write TIDAS schema / methodology / ruleset contract artifacts
+  context-pack        Write an AI-ready TIDAS contract context pack
+  import-lca convert  Convert supported external LCA packages through tidas-tools
+  author              Extract source evidence and prepare TIDAS context packs for AI authoring
   validate             Validate local flow / process / lifecyclemodel rows with the TIDAS SDK
   verify-remote        Verify dataset roots and TIDAS references against remote published versions
   bilingual extract    Extract bilingual translation units from local rows
@@ -589,6 +617,10 @@ Implemented Subcommands:
   references refresh-remote Refresh local TIDAS reference versions to latest reachable remote rows
 
 Examples:
+  tiangong-lca dataset contract get --type process --include schema,methodology,ruleset --out-dir ./contract --help
+  tiangong-lca dataset context-pack --type process --profile ai-import --out-dir ./context-pack --help
+  tiangong-lca dataset import-lca convert --input ./external-package --output-dir ./converted --from-format auto --target tidas --help
+  tiangong-lca dataset author --input ./source.pdf --target-types process,flow --out-dir ./authoring --help
   tiangong-lca dataset validate --input ./rows.jsonl --type auto --out-dir ./dataset-validate --help
   tiangong-lca dataset verify-remote --input ./rows.jsonl --out-dir ./dataset-remote-verify --help
   tiangong-lca dataset bilingual extract --input ./rows.jsonl --type process --out-dir ./translation --help
@@ -598,6 +630,105 @@ Examples:
   tiangong-lca dataset evidence-search run --input ./request.json --results ./search-results.json --out-dir ./evidence-search --help
   tiangong-lca dataset references rewrite --input ./rows.jsonl --from flow:<old-id>@<old-version> --to flow:<new-id>@<new-version> --out-dir ./dataset-rewrite --help
   tiangong-lca dataset references refresh-remote --input ./rows.jsonl --out ./rows.refreshed.jsonl --out-dir ./dataset-reference-refresh --help
+`.trim();
+}
+
+function renderDatasetContractHelp(): string {
+  return `Usage:
+  tiangong-lca dataset contract get --type <type> --out-dir <dir> [options]
+
+Options:
+  --type <type>       TIDAS target type: process, flow, source, contact, unitgroup, flowproperty, lifecyclemodel, lciamethod
+  --include <list>    Comma-separated or repeatable list: schema, methodology, ruleset (default: all)
+  --profile <name>    default | ai-import (default: default)
+  --out-dir <dir>     Artifact directory
+  --json              Print compact JSON
+  -h, --help
+
+Outputs written under --out-dir:
+  - outputs/contract-manifest.json
+  - outputs/schema.json when requested and available
+  - outputs/methodology.yaml when requested and available
+  - outputs/runtime-ruleset.json when requested and available
+  - outputs/contract-report.json
+`.trim();
+}
+
+function renderDatasetContextPackHelp(): string {
+  return `Usage:
+  tiangong-lca dataset context-pack --type <type> --out-dir <dir> [options]
+
+Options:
+  --type <type>       TIDAS target type for AI authoring or repair
+  --include <list>    Comma-separated or repeatable list: schema, methodology, ruleset (default: all)
+  --profile <name>    default | ai-import (default: ai-import)
+  --out-dir <dir>     Artifact directory
+  --json              Print compact JSON
+  -h, --help
+
+Outputs written under --out-dir:
+  - outputs/contract-manifest.json
+  - outputs/schema.json
+  - outputs/methodology.yaml when available
+  - outputs/runtime-ruleset.json when available
+  - outputs/ai-context.json
+  - outputs/ai-context.md
+  - outputs/contract-report.json
+`.trim();
+}
+
+function renderDatasetImportLcaHelp(): string {
+  return `Usage:
+  tiangong-lca dataset import-lca convert --input <path> --output-dir <dir> [options]
+
+Options:
+  --input <path>          Source file, directory, or package to import
+  --output-dir <dir>      Output directory for generated package and reports
+  --from-format <format>  auto, ecospold1, ecospold2, openlca-jsonld, openlca-process-xlsx, simapro-csv
+  --target <target>       tidas | ilcd | both (default: tidas)
+  --report <file>         Conversion report path (default: <output-dir>/conversion-report.json)
+  --mapping-dir <dir>     Optional custom mapping/reference data directory
+  --language <lang>       Default language for generated text (default: en)
+  --validation-jobs <n>   Parallel validation jobs passed to tidas-tools (default: 1)
+  --detect-only           Only detect the input format and write the report
+  --fail-on-warning       Return non-zero when converter warnings are present
+  --python <bin>          Python executable (default: python3)
+  --tidas-tools-dir <dir> Explicit tidas-tools checkout path
+  --json                  Print compact JSON
+  -h, --help
+
+Outputs written under --output-dir:
+  - conversion-report.json
+  - tidas/ when target includes TIDAS and not detect-only
+  - ilcd/ when target includes ILCD and not detect-only
+  - mapping.csv when not detect-only
+  - outputs/import-lca-report.json
+`.trim();
+}
+
+function renderDatasetAuthorHelp(): string {
+  return `Usage:
+  tiangong-lca dataset author --input <file> --target-types <types> --out-dir <dir> [options]
+
+Options:
+  --input <file>          PDF, Excel, image, markdown, or source document file
+  --target-types <list>   Comma-separated or repeatable TIDAS types, for example process,flow,source
+  --out-dir <dir>         Artifact directory
+  --prompt <text>         Optional extraction prompt passed to the unstructured parser
+  --provider <name>       Optional unstructured parser provider override
+  --model <name>          Optional unstructured parser model override
+  --timeout-ms <n>        Parser timeout in milliseconds (default: 120000)
+  --json                  Print compact JSON
+  -h, --help
+
+Outputs written under --out-dir:
+  - outputs/source-extract.json
+  - context/<type>/outputs/contract-manifest.json
+  - context/<type>/outputs/ai-context.json
+  - outputs/authoring-report.json
+
+Environment:
+  TIANGONG_LCA_UNSTRUCTURED_API_BASE_URL and TIANGONG_LCA_UNSTRUCTURED_API_KEY
 `.trim();
 }
 
@@ -2125,6 +2256,182 @@ function parseDatasetValidateFlags(args: string[]): {
     inputPath: typeof values.input === 'string' ? values.input : '',
     type: typeof values.type === 'string' ? values.type : undefined,
     outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : null,
+  };
+}
+
+function parseDatasetContractFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  type: string | undefined;
+  include: string[];
+  profile: string | undefined;
+  outDir: string | null;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        type: { type: 'string' },
+        include: { type: 'string', multiple: true },
+        profile: { type: 'string' },
+        'out-dir': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    type: typeof values.type === 'string' ? values.type : undefined,
+    include: Array.isArray(values.include)
+      ? values.include.filter((value): value is string => typeof value === 'string')
+      : [],
+    profile: typeof values.profile === 'string' ? values.profile : undefined,
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : null,
+  };
+}
+
+function parseDatasetImportLcaConvertFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  inputPath: string;
+  outputDir: string;
+  fromFormat: string | undefined;
+  target: string | undefined;
+  reportPath: string | undefined;
+  mappingDir: string | undefined;
+  language: string | undefined;
+  validationJobs: number | undefined;
+  detectOnly: boolean;
+  failOnWarning: boolean;
+  pythonBin: string | undefined;
+  tidasToolsDir: string | undefined;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        input: { type: 'string' },
+        'output-dir': { type: 'string' },
+        'from-format': { type: 'string' },
+        target: { type: 'string' },
+        report: { type: 'string' },
+        'mapping-dir': { type: 'string' },
+        language: { type: 'string' },
+        'validation-jobs': { type: 'string' },
+        'detect-only': { type: 'boolean' },
+        'fail-on-warning': { type: 'boolean' },
+        python: { type: 'string' },
+        'tidas-tools-dir': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  const validationJobs =
+    typeof values['validation-jobs'] === 'string' ? Number(values['validation-jobs']) : undefined;
+  if (validationJobs !== undefined && (!Number.isInteger(validationJobs) || validationJobs < 0)) {
+    throw new CliError('--validation-jobs must be a non-negative integer.', {
+      code: 'DATASET_IMPORT_LCA_VALIDATION_JOBS_INVALID',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    inputPath: typeof values.input === 'string' ? values.input : '',
+    outputDir: typeof values['output-dir'] === 'string' ? values['output-dir'] : '',
+    fromFormat: typeof values['from-format'] === 'string' ? values['from-format'] : undefined,
+    target: typeof values.target === 'string' ? values.target : undefined,
+    reportPath: typeof values.report === 'string' ? values.report : undefined,
+    mappingDir: typeof values['mapping-dir'] === 'string' ? values['mapping-dir'] : undefined,
+    language: typeof values.language === 'string' ? values.language : undefined,
+    validationJobs,
+    detectOnly: Boolean(values['detect-only']),
+    failOnWarning: Boolean(values['fail-on-warning']),
+    pythonBin: typeof values.python === 'string' ? values.python : undefined,
+    tidasToolsDir:
+      typeof values['tidas-tools-dir'] === 'string' ? values['tidas-tools-dir'] : undefined,
+  };
+}
+
+function parseDatasetAuthorFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  inputPath: string;
+  targetTypes: string[];
+  outDir: string | null;
+  prompt: string | undefined;
+  provider: string | undefined;
+  model: string | undefined;
+  timeoutMs: number | undefined;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        input: { type: 'string' },
+        'target-types': { type: 'string', multiple: true },
+        'out-dir': { type: 'string' },
+        prompt: { type: 'string' },
+        provider: { type: 'string' },
+        model: { type: 'string' },
+        'timeout-ms': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  const timeoutMs =
+    typeof values['timeout-ms'] === 'string' ? Number(values['timeout-ms']) : undefined;
+  if (timeoutMs !== undefined && (!Number.isInteger(timeoutMs) || timeoutMs <= 0)) {
+    throw new CliError('--timeout-ms must be a positive integer.', {
+      code: 'DATASET_AUTHOR_TIMEOUT_INVALID',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    inputPath: typeof values.input === 'string' ? values.input : '',
+    targetTypes: Array.isArray(values['target-types'])
+      ? values['target-types'].filter((value): value is string => typeof value === 'string')
+      : [],
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : null,
+    prompt: typeof values.prompt === 'string' ? values.prompt : undefined,
+    provider: typeof values.provider === 'string' ? values.provider : undefined,
+    model: typeof values.model === 'string' ? values.model : undefined,
+    timeoutMs,
   };
 }
 
@@ -4710,6 +5017,10 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
     const datasetBilingualValidateImpl =
       deps.runDatasetBilingualValidateImpl ?? runDatasetBilingualValidate;
     const datasetEvidenceSearchImpl = deps.runDatasetEvidenceSearchImpl ?? runDatasetEvidenceSearch;
+    const datasetContractImpl = deps.runDatasetContractImpl ?? runDatasetContract;
+    const datasetImportLcaConvertImpl =
+      deps.runDatasetImportLcaConvertImpl ?? runDatasetImportLcaConvert;
+    const datasetAuthorImpl = deps.runDatasetAuthorImpl ?? runDatasetAuthor;
 
     if (flags.version) {
       return { exitCode: 0, stdout: `${loadCliPackageVersion(import.meta.url)}\n`, stderr: '' };
@@ -4761,6 +5072,114 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
 
     if (command === 'dataset' && !subcommand) {
       return { exitCode: 0, stdout: `${renderDatasetHelp()}\n`, stderr: '' };
+    }
+
+    if (command === 'dataset' && subcommand === 'contract') {
+      const action = commandArgs[0] ?? '';
+      if (!action || action === '--help' || action === '-h') {
+        return { exitCode: 0, stdout: `${renderDatasetContractHelp()}\n`, stderr: '' };
+      }
+      if (action !== 'get') {
+        throw new CliError("dataset contract action must be 'get'.", {
+          code: 'DATASET_CONTRACT_ACTION_INVALID',
+          exitCode: 2,
+        });
+      }
+      const datasetFlags = parseDatasetContractFlags(commandArgs.slice(1));
+      if (datasetFlags.help) {
+        return { exitCode: 0, stdout: `${renderDatasetContractHelp()}\n`, stderr: '' };
+      }
+      const report = await datasetContractImpl({
+        type: datasetFlags.type,
+        include: datasetFlags.include,
+        profile: datasetFlags.profile,
+        outDir: datasetFlags.outDir,
+        mode: 'contract',
+      });
+      return {
+        exitCode: 0,
+        stdout: stringifyJson(report, datasetFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'dataset' && subcommand === 'context-pack') {
+      const datasetFlags = parseDatasetContractFlags(commandArgs);
+      if (datasetFlags.help) {
+        return { exitCode: 0, stdout: `${renderDatasetContextPackHelp()}\n`, stderr: '' };
+      }
+      const report = await datasetContractImpl({
+        type: datasetFlags.type,
+        include: datasetFlags.include,
+        profile: datasetFlags.profile,
+        outDir: datasetFlags.outDir,
+        mode: 'context-pack',
+      });
+      return {
+        exitCode: 0,
+        stdout: stringifyJson(report, datasetFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'dataset' && subcommand === 'import-lca') {
+      const action = commandArgs[0] ?? '';
+      if (!action || action === '--help' || action === '-h') {
+        return { exitCode: 0, stdout: `${renderDatasetImportLcaHelp()}\n`, stderr: '' };
+      }
+      if (action !== 'convert') {
+        throw new CliError("dataset import-lca action must be 'convert'.", {
+          code: 'DATASET_IMPORT_LCA_ACTION_INVALID',
+          exitCode: 2,
+        });
+      }
+      const datasetFlags = parseDatasetImportLcaConvertFlags(commandArgs.slice(1));
+      if (datasetFlags.help) {
+        return { exitCode: 0, stdout: `${renderDatasetImportLcaHelp()}\n`, stderr: '' };
+      }
+      const report = await datasetImportLcaConvertImpl({
+        inputPath: datasetFlags.inputPath,
+        outputDir: datasetFlags.outputDir,
+        fromFormat: datasetFlags.fromFormat,
+        target: datasetFlags.target,
+        reportPath: datasetFlags.reportPath,
+        mappingDir: datasetFlags.mappingDir,
+        language: datasetFlags.language,
+        validationJobs: datasetFlags.validationJobs,
+        detectOnly: datasetFlags.detectOnly,
+        failOnWarning: datasetFlags.failOnWarning,
+        pythonBin: datasetFlags.pythonBin,
+        tidasToolsDir: datasetFlags.tidasToolsDir,
+        env: deps.env,
+      });
+      return {
+        exitCode: report.status === 'completed' ? 0 : 1,
+        stdout: stringifyJson(report, datasetFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'dataset' && subcommand === 'author') {
+      const datasetFlags = parseDatasetAuthorFlags(commandArgs);
+      if (datasetFlags.help) {
+        return { exitCode: 0, stdout: `${renderDatasetAuthorHelp()}\n`, stderr: '' };
+      }
+      const report = await datasetAuthorImpl({
+        inputPath: datasetFlags.inputPath,
+        targetTypes: datasetFlags.targetTypes,
+        outDir: datasetFlags.outDir,
+        prompt: datasetFlags.prompt,
+        provider: datasetFlags.provider,
+        model: datasetFlags.model,
+        timeoutMs: datasetFlags.timeoutMs,
+        env: deps.env,
+        fetchImpl: deps.fetchImpl,
+      });
+      return {
+        exitCode: 0,
+        stdout: stringifyJson(report, datasetFlags.json),
+        stderr: '',
+      };
     }
 
     if (command === 'dataset' && subcommand === 'validate') {

--- a/src/lib/dataset-author.ts
+++ b/src/lib/dataset-author.ts
@@ -1,0 +1,149 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { writeJsonArtifact } from './artifacts.js';
+import { runDatasetContract, type DatasetContractReport } from './dataset-contract.js';
+import { CliError } from './errors.js';
+import {
+  parseUnstructuredDocument,
+  readUnstructuredRuntimeEnv,
+  type ParseUnstructuredDocumentOptions,
+} from './unstructured.js';
+import type { FetchLike } from './http.js';
+
+export type DatasetAuthorReport = {
+  schema_version: 1;
+  status: 'evidence_ready';
+  generated_at_utc: string;
+  input_path: string;
+  target_types: string[];
+  files: {
+    source_extract: string;
+    authoring_report: string;
+  };
+  context_packs: Array<{
+    type: string;
+    report: DatasetContractReport;
+  }>;
+  next_actions: string[];
+};
+
+export type RunDatasetAuthorOptions = {
+  inputPath: string;
+  targetTypes: string | string[] | undefined;
+  outDir: string | null | undefined;
+  prompt?: string | undefined;
+  provider?: string | undefined;
+  model?: string | undefined;
+  timeoutMs?: number | undefined;
+  env: NodeJS.ProcessEnv;
+  fetchImpl: FetchLike;
+  now?: Date | undefined;
+  parseImpl?: typeof parseUnstructuredDocument | undefined;
+  contractImpl?: typeof runDatasetContract | undefined;
+};
+
+export async function runDatasetAuthor(
+  options: RunDatasetAuthorOptions,
+): Promise<DatasetAuthorReport> {
+  const inputPath = requireInputPath(options.inputPath);
+  const outDir = requireOutDir(options.outDir);
+  const targetTypes = normalizeTargetTypes(options.targetTypes);
+  const outputsDir = path.join(outDir, 'outputs');
+  const sourceExtractFile = path.join(outputsDir, 'source-extract.json');
+  const authoringReportFile = path.join(outputsDir, 'authoring-report.json');
+  const parseImpl = options.parseImpl ?? parseUnstructuredDocument;
+  const contractImpl = options.contractImpl ?? runDatasetContract;
+
+  const sourceExtract = await parseImpl({
+    env: readUnstructuredRuntimeEnv(options.env),
+    filePath: inputPath,
+    prompt: options.prompt,
+    provider: options.provider,
+    model: options.model,
+    timeoutMs: options.timeoutMs ?? 120000,
+    fetchImpl: options.fetchImpl,
+  } satisfies ParseUnstructuredDocumentOptions);
+  writeJsonArtifact(sourceExtractFile, sourceExtract);
+
+  const contextPacks = [];
+  for (const type of targetTypes) {
+    const report = await contractImpl({
+      type,
+      include: ['schema', 'methodology', 'ruleset'],
+      profile: 'ai-import',
+      outDir: path.join(outDir, 'context', type),
+      mode: 'context-pack',
+      now: options.now,
+    });
+    contextPacks.push({ type, report });
+  }
+
+  const report: DatasetAuthorReport = {
+    schema_version: 1,
+    status: 'evidence_ready',
+    generated_at_utc: (options.now ?? new Date()).toISOString(),
+    input_path: inputPath,
+    target_types: targetTypes,
+    files: {
+      source_extract: sourceExtractFile,
+      authoring_report: authoringReportFile,
+    },
+    context_packs: contextPacks,
+    next_actions: [
+      'Use outputs/source-extract.json and the context pack manifests to generate candidate TIDAS rows.',
+      'Run tiangong-lca dataset validate for each generated row file before mutation planning.',
+      'Place invalid rows in a repair queue and keep source evidence linked to field-level assumptions.',
+    ],
+  };
+  writeJsonArtifact(authoringReportFile, report);
+
+  return report;
+}
+
+function requireInputPath(value: string): string {
+  if (!value?.trim()) {
+    throw new CliError('Missing required --input value.', {
+      code: 'DATASET_AUTHOR_INPUT_REQUIRED',
+      exitCode: 2,
+    });
+  }
+  const resolved = path.resolve(value);
+  if (!existsSync(resolved)) {
+    throw new CliError(`Input file not found: ${resolved}`, {
+      code: 'DATASET_AUTHOR_INPUT_NOT_FOUND',
+      exitCode: 2,
+    });
+  }
+  return resolved;
+}
+
+function requireOutDir(value: string | null | undefined): string {
+  if (!value?.trim()) {
+    throw new CliError('Missing required --out-dir value.', {
+      code: 'DATASET_AUTHOR_OUT_DIR_REQUIRED',
+      exitCode: 2,
+    });
+  }
+  return path.resolve(value);
+}
+
+function normalizeTargetTypes(value: string | string[] | undefined): string[] {
+  const rawValues = Array.isArray(value) ? value : value ? [value] : [];
+  const values = rawValues.flatMap((item) =>
+    item
+      .split(',')
+      .map((part) => part.trim())
+      .filter(Boolean),
+  );
+  if (!values.length) {
+    throw new CliError('Missing required --target-types value.', {
+      code: 'DATASET_AUTHOR_TARGET_TYPES_REQUIRED',
+      exitCode: 2,
+    });
+  }
+  return [...new Set(values)];
+}
+
+export const __testInternals = {
+  normalizeTargetTypes,
+};

--- a/src/lib/dataset-contract.ts
+++ b/src/lib/dataset-contract.ts
@@ -39,6 +39,8 @@ export type RunDatasetContractOptions = {
   outDir: string | null | undefined;
   mode: DatasetContractMode;
   now?: Date;
+  sdkModule?: Record<string, unknown>;
+  runtimeAssetsRoot?: string;
 };
 
 type ContractPack = {
@@ -111,6 +113,8 @@ export async function runDatasetContract(
     includes,
     profile,
     includeAiContext,
+    sdkModule: options.sdkModule,
+    runtimeAssetsRoot: options.runtimeAssetsRoot,
   });
   const files = buildFiles(outDir, loaded.pack, includeAiContext);
 
@@ -136,7 +140,7 @@ export async function runDatasetContract(
     status: 'completed',
     generated_at_utc: (options.now ?? new Date()).toISOString(),
     mode: options.mode,
-    requested_type: options.type ?? '',
+    requested_type: String(options.type),
     type,
     profile,
     includes,
@@ -235,8 +239,13 @@ async function loadContractPack(options: {
   includes: DatasetContractInclude[];
   profile: DatasetContractProfile;
   includeAiContext: boolean;
+  sdkModule?: Record<string, unknown>;
+  runtimeAssetsRoot?: string;
 }): Promise<{ source: DatasetContractReport['source']; pack: ContractPack }> {
-  const sdkModule = (await import('@tiangong-lca/tidas-sdk')) as Record<string, unknown>;
+  let sdkModule = options.sdkModule;
+  if (!sdkModule) {
+    sdkModule = requireFromHere('@tiangong-lca/tidas-sdk') as Record<string, unknown>;
+  }
   const getTidasContractPack = sdkModule.getTidasContractPack;
   if (typeof getTidasContractPack === 'function') {
     return {
@@ -260,8 +269,9 @@ function loadFallbackContractPack(options: {
   includes: DatasetContractInclude[];
   profile: DatasetContractProfile;
   includeAiContext: boolean;
+  runtimeAssetsRoot?: string;
 }): ContractPack {
-  const runtimeRoot = resolveSdkRuntimeAssetsRoot();
+  const runtimeRoot = options.runtimeAssetsRoot ?? resolveSdkRuntimeAssetsRoot();
   const schemaText = options.includes.includes('schema')
     ? readOptionalText(path.join(runtimeRoot, 'tidas', 'schemas', schemaFiles[options.type]))
     : undefined;
@@ -309,17 +319,25 @@ function loadFallbackContractPack(options: {
   };
 }
 
-function resolveSdkRuntimeAssetsRoot(): string {
-  const sdkEntry = requireFromHere.resolve('@tiangong-lca/tidas-sdk');
-  const distRoot = path.dirname(sdkEntry);
-  const packagedRoot = path.join(distRoot, 'runtime-assets');
-  const cliRepoRoot = resolveCliRepoRoot();
-  const siblingSdkRoot = path.resolve(
-    cliRepoRoot,
-    '../tidas-sdk/sdks/typescript/src/runtime-assets',
-  );
+function resolveSdkRuntimeAssetsRoot(
+  candidatesOverride?: string[],
+  sdkEntryOverride?: string,
+): string {
+  const sdkEntry = sdkEntryOverride ?? requireFromHere.resolve('@tiangong-lca/tidas-sdk');
+  const candidates =
+    candidatesOverride ??
+    (() => {
+      const distRoot = path.dirname(sdkEntry);
+      const packagedRoot = path.join(distRoot, 'runtime-assets');
+      const cliRepoRoot = resolveCliRepoRoot();
+      const siblingSdkRoot = path.resolve(
+        cliRepoRoot,
+        '../tidas-sdk/sdks/typescript/src/runtime-assets',
+      );
+      return [siblingSdkRoot, packagedRoot];
+    })();
 
-  for (const candidate of [siblingSdkRoot, packagedRoot]) {
+  for (const candidate of candidates) {
     if (existsSync(candidate)) {
       return candidate;
     }
@@ -332,9 +350,12 @@ function resolveSdkRuntimeAssetsRoot(): string {
   });
 }
 
-function resolveCliRepoRoot(): string {
+function resolveCliRepoRoot(candidatesOverride?: string[]): string {
   const moduleDir = path.dirname(fileURLToPath(import.meta.url));
-  const candidates = [path.resolve(moduleDir, '../..'), path.resolve(moduleDir, '../../..')];
+  const candidates = candidatesOverride ?? [
+    path.resolve(moduleDir, '../..'),
+    path.resolve(moduleDir, '../../..'),
+  ];
   return (
     candidates.find(
       (candidate) =>
@@ -345,7 +366,10 @@ function resolveCliRepoRoot(): string {
 }
 
 function readOptionalText(filePath: string): string | undefined {
-  return existsSync(filePath) ? readFileSync(filePath, 'utf8') : undefined;
+  if (!existsSync(filePath)) {
+    return undefined;
+  }
+  return readFileSync(filePath, 'utf8');
 }
 
 function filterRuntimeRuleset(
@@ -463,6 +487,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 export const __testInternals = {
+  filterRuntimeRuleset,
+  loadFallbackContractPack,
+  renderAiContextMarkdown,
+  resolveCliRepoRoot,
+  resolveSdkRuntimeAssetsRoot,
   normalizeIncludes,
+  normalizeProfile,
   normalizeType,
 };

--- a/src/lib/dataset-contract.ts
+++ b/src/lib/dataset-contract.ts
@@ -1,0 +1,468 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { writeJsonArtifact, writeTextArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+
+export type DatasetContractInclude = 'schema' | 'methodology' | 'ruleset';
+export type DatasetContractProfile = 'default' | 'ai-import';
+export type DatasetContractMode = 'contract' | 'context-pack';
+
+export type DatasetContractReport = {
+  schema_version: 1;
+  status: 'completed';
+  generated_at_utc: string;
+  mode: DatasetContractMode;
+  requested_type: string;
+  type: string;
+  profile: DatasetContractProfile;
+  includes: DatasetContractInclude[];
+  source: 'sdk-contract-api' | 'sdk-runtime-assets';
+  manifest: unknown;
+  files: {
+    manifest: string;
+    schema: string | null;
+    methodology: string | null;
+    ruleset: string | null;
+    ai_context_json: string | null;
+    ai_context_markdown: string | null;
+    report: string;
+  };
+};
+
+export type RunDatasetContractOptions = {
+  type: string | undefined;
+  include?: string | string[] | undefined;
+  profile?: string | undefined;
+  outDir: string | null | undefined;
+  mode: DatasetContractMode;
+  now?: Date;
+};
+
+type ContractPack = {
+  manifest: unknown;
+  schemaText?: string;
+  methodologyText?: string;
+  runtimeRuleset?: unknown;
+  aiContext?: unknown;
+};
+
+type CanonicalKind =
+  | 'contact'
+  | 'flow'
+  | 'flowproperty'
+  | 'lciamethod'
+  | 'lifecyclemodel'
+  | 'process'
+  | 'source'
+  | 'unitgroup';
+
+const requireFromHere = createRequire(import.meta.url);
+
+const aliases: Record<string, CanonicalKind> = {
+  contact: 'contact',
+  contacts: 'contact',
+  flow: 'flow',
+  flows: 'flow',
+  flowproperty: 'flowproperty',
+  flowproperties: 'flowproperty',
+  lciamethod: 'lciamethod',
+  lciamethods: 'lciamethod',
+  lifecyclemodel: 'lifecyclemodel',
+  lifecyclemodels: 'lifecyclemodel',
+  process: 'process',
+  processes: 'process',
+  source: 'source',
+  sources: 'source',
+  unitgroup: 'unitgroup',
+  unitgroups: 'unitgroup',
+};
+
+const schemaFiles: Record<CanonicalKind, string> = {
+  contact: 'tidas_contacts.json',
+  flow: 'tidas_flows.json',
+  flowproperty: 'tidas_flowproperties.json',
+  lciamethod: 'tidas_lciamethods.json',
+  lifecyclemodel: 'tidas_lifecyclemodels.json',
+  process: 'tidas_processes.json',
+  source: 'tidas_sources.json',
+  unitgroup: 'tidas_unitgroups.json',
+};
+
+const methodologyFiles: Partial<Record<CanonicalKind, string>> = {
+  flow: 'tidas_flows.yaml',
+  process: 'tidas_processes.yaml',
+};
+
+const allowedIncludes = new Set<DatasetContractInclude>(['schema', 'methodology', 'ruleset']);
+
+export async function runDatasetContract(
+  options: RunDatasetContractOptions,
+): Promise<DatasetContractReport> {
+  const type = normalizeType(options.type);
+  const includes = normalizeIncludes(options.include);
+  const profile = normalizeProfile(options.profile ?? defaultProfile(options.mode));
+  const outDir = requireOutDir(options.outDir);
+  const includeAiContext = options.mode === 'context-pack';
+  const loaded = await loadContractPack({
+    type,
+    includes,
+    profile,
+    includeAiContext,
+  });
+  const files = buildFiles(outDir, loaded.pack, includeAiContext);
+
+  writeJsonArtifact(files.manifest, loaded.pack.manifest);
+  if (loaded.pack.schemaText && files.schema) {
+    writeTextArtifact(files.schema, `${loaded.pack.schemaText.trimEnd()}\n`);
+  }
+  if (loaded.pack.methodologyText && files.methodology) {
+    writeTextArtifact(files.methodology, `${loaded.pack.methodologyText.trimEnd()}\n`);
+  }
+  if (loaded.pack.runtimeRuleset && files.ruleset) {
+    writeJsonArtifact(files.ruleset, loaded.pack.runtimeRuleset);
+  }
+  if (loaded.pack.aiContext && files.ai_context_json) {
+    writeJsonArtifact(files.ai_context_json, loaded.pack.aiContext);
+  }
+  if (includeAiContext && files.ai_context_markdown) {
+    writeTextArtifact(files.ai_context_markdown, renderAiContextMarkdown(type, loaded.pack));
+  }
+
+  const report: DatasetContractReport = {
+    schema_version: 1,
+    status: 'completed',
+    generated_at_utc: (options.now ?? new Date()).toISOString(),
+    mode: options.mode,
+    requested_type: options.type ?? '',
+    type,
+    profile,
+    includes,
+    source: loaded.source,
+    manifest: loaded.pack.manifest,
+    files,
+  };
+  writeJsonArtifact(files.report, report);
+
+  return report;
+}
+
+function normalizeType(value: string | undefined): CanonicalKind {
+  const raw = value?.trim();
+  if (!raw) {
+    throw new CliError('Missing required --type value.', {
+      code: 'DATASET_CONTRACT_TYPE_REQUIRED',
+      exitCode: 2,
+    });
+  }
+  const normalized = raw.toLowerCase().replace(/[-_]/gu, '');
+  const type = aliases[normalized];
+  if (!type) {
+    throw new CliError(
+      `Unsupported dataset contract type '${value}'. Supported types: ${Object.keys(aliases)
+        .sort()
+        .join(', ')}.`,
+      {
+        code: 'DATASET_CONTRACT_TYPE_INVALID',
+        exitCode: 2,
+      },
+    );
+  }
+  return type;
+}
+
+function normalizeIncludes(value: string | string[] | undefined): DatasetContractInclude[] {
+  const rawValues =
+    Array.isArray(value) && value.length > 0
+      ? value
+      : value && !Array.isArray(value)
+        ? [value]
+        : ['schema,methodology,ruleset'];
+  const includes = rawValues.flatMap((raw) =>
+    raw
+      .split(',')
+      .map((item) => item.trim().toLowerCase())
+      .filter(Boolean),
+  );
+
+  if (!includes.length) {
+    throw new CliError('At least one --include value is required.', {
+      code: 'DATASET_CONTRACT_INCLUDE_REQUIRED',
+      exitCode: 2,
+    });
+  }
+
+  for (const include of includes) {
+    if (!allowedIncludes.has(include as DatasetContractInclude)) {
+      throw new CliError('--include values must be schema, methodology, or ruleset.', {
+        code: 'DATASET_CONTRACT_INCLUDE_INVALID',
+        exitCode: 2,
+      });
+    }
+  }
+
+  return Array.from(new Set(includes)) as DatasetContractInclude[];
+}
+
+function normalizeProfile(value: string): DatasetContractProfile {
+  if (value === 'default' || value === 'ai-import') {
+    return value;
+  }
+  throw new CliError("--profile must be 'default' or 'ai-import'.", {
+    code: 'DATASET_CONTRACT_PROFILE_INVALID',
+    exitCode: 2,
+  });
+}
+
+function defaultProfile(mode: DatasetContractMode): DatasetContractProfile {
+  return mode === 'context-pack' ? 'ai-import' : 'default';
+}
+
+function requireOutDir(value: string | null | undefined): string {
+  if (!value?.trim()) {
+    throw new CliError('Missing required --out-dir value.', {
+      code: 'DATASET_CONTRACT_OUT_DIR_REQUIRED',
+      exitCode: 2,
+    });
+  }
+  return path.resolve(value);
+}
+
+async function loadContractPack(options: {
+  type: CanonicalKind;
+  includes: DatasetContractInclude[];
+  profile: DatasetContractProfile;
+  includeAiContext: boolean;
+}): Promise<{ source: DatasetContractReport['source']; pack: ContractPack }> {
+  const sdkModule = (await import('@tiangong-lca/tidas-sdk')) as Record<string, unknown>;
+  const getTidasContractPack = sdkModule.getTidasContractPack;
+  if (typeof getTidasContractPack === 'function') {
+    return {
+      source: 'sdk-contract-api',
+      pack: getTidasContractPack(options.type, {
+        include: options.includes,
+        profile: options.profile,
+        includeAiContext: options.includeAiContext,
+      }) as ContractPack,
+    };
+  }
+
+  return {
+    source: 'sdk-runtime-assets',
+    pack: loadFallbackContractPack(options),
+  };
+}
+
+function loadFallbackContractPack(options: {
+  type: CanonicalKind;
+  includes: DatasetContractInclude[];
+  profile: DatasetContractProfile;
+  includeAiContext: boolean;
+}): ContractPack {
+  const runtimeRoot = resolveSdkRuntimeAssetsRoot();
+  const schemaText = options.includes.includes('schema')
+    ? readOptionalText(path.join(runtimeRoot, 'tidas', 'schemas', schemaFiles[options.type]))
+    : undefined;
+  const methodologyFile = methodologyFiles[options.type];
+  const methodologyText =
+    options.includes.includes('methodology') && methodologyFile
+      ? readOptionalText(path.join(runtimeRoot, 'tidas', 'methodologies', methodologyFile))
+      : undefined;
+  const rulesetText = options.includes.includes('ruleset')
+    ? readOptionalText(path.join(runtimeRoot, 'tidas', 'methodologies', 'runtime_rulesets.json'))
+    : undefined;
+  const runtimeRuleset = rulesetText
+    ? filterRuntimeRuleset(JSON.parse(rulesetText) as Record<string, unknown>, options.type)
+    : undefined;
+  const aiContext = options.includeAiContext
+    ? buildAiContext({
+        type: options.type,
+        profile: options.profile,
+        schemaText,
+        methodologyText,
+        runtimeRuleset,
+      })
+    : undefined;
+
+  return {
+    manifest: {
+      schema_version: 1,
+      kind: options.type,
+      profile: options.profile,
+      includes: options.includes,
+      sdk_package: '@tiangong-lca/tidas-sdk',
+      schema: schemaText ? artifactManifest(schemaFiles[options.type], schemaText) : null,
+      methodology:
+        methodologyText && methodologyFile
+          ? artifactManifest(methodologyFile, methodologyText)
+          : null,
+      ruleset: runtimeRuleset
+        ? artifactManifest('runtime_rulesets.json', JSON.stringify(runtimeRuleset, null, 2))
+        : null,
+    },
+    schemaText,
+    methodologyText,
+    runtimeRuleset,
+    aiContext,
+  };
+}
+
+function resolveSdkRuntimeAssetsRoot(): string {
+  const sdkEntry = requireFromHere.resolve('@tiangong-lca/tidas-sdk');
+  const distRoot = path.dirname(sdkEntry);
+  const packagedRoot = path.join(distRoot, 'runtime-assets');
+  const cliRepoRoot = resolveCliRepoRoot();
+  const siblingSdkRoot = path.resolve(
+    cliRepoRoot,
+    '../tidas-sdk/sdks/typescript/src/runtime-assets',
+  );
+
+  for (const candidate of [siblingSdkRoot, packagedRoot]) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new CliError('Could not resolve @tiangong-lca/tidas-sdk runtime assets.', {
+    code: 'DATASET_CONTRACT_SDK_ASSETS_NOT_FOUND',
+    exitCode: 1,
+    details: { sdkEntry },
+  });
+}
+
+function resolveCliRepoRoot(): string {
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [path.resolve(moduleDir, '../..'), path.resolve(moduleDir, '../../..')];
+  return (
+    candidates.find(
+      (candidate) =>
+        existsSync(path.join(candidate, 'package.json')) &&
+        existsSync(path.join(candidate, 'src/cli.ts')),
+    ) ?? candidates[0]
+  );
+}
+
+function readOptionalText(filePath: string): string | undefined {
+  return existsSync(filePath) ? readFileSync(filePath, 'utf8') : undefined;
+}
+
+function filterRuntimeRuleset(
+  source: Record<string, unknown>,
+  type: CanonicalKind,
+): unknown | undefined {
+  const rulesets = Array.isArray(source.rulesets)
+    ? source.rulesets.filter((entry) => isRulesetForType(entry, type))
+    : [];
+  const rules = Array.isArray(source.rules)
+    ? source.rules.filter((entry) => isRulesetForType(entry, type))
+    : [];
+  if (!rulesets.length && !rules.length) {
+    return undefined;
+  }
+  return {
+    $schema: source.$schema,
+    schema_version: source.schema_version,
+    ruleset_version: source.ruleset_version,
+    purpose: source.purpose,
+    rulesets,
+    rules,
+  };
+}
+
+function isRulesetForType(entry: unknown, type: CanonicalKind): boolean {
+  return (
+    typeof entry === 'object' &&
+    entry !== null &&
+    'dataset_type' in entry &&
+    (entry as { dataset_type?: unknown }).dataset_type === type
+  );
+}
+
+function artifactManifest(
+  name: string,
+  content: string,
+): { name: string; sha256: string; bytes: number } {
+  return {
+    name,
+    sha256: createHash('sha256').update(content).digest('hex'),
+    bytes: Buffer.byteLength(content, 'utf8'),
+  };
+}
+
+function buildAiContext(options: {
+  type: CanonicalKind;
+  profile: DatasetContractProfile;
+  schemaText?: string;
+  methodologyText?: string;
+  runtimeRuleset?: unknown;
+}): unknown {
+  return {
+    schema_version: 1,
+    kind: options.type,
+    profile: options.profile,
+    instructions: [
+      `Generate or repair only canonical TIDAS ${options.type} data.`,
+      'Use the JSON schema as the structural contract.',
+      'Use the methodology YAML as the semantic authoring contract when present.',
+      'Treat runtime ruleset blocker rules as gate requirements.',
+      'Return candidate data only; do not claim that database writes have happened.',
+      'Preserve source provenance and unresolved assumptions so Foundry can build evidence and repair queues.',
+    ],
+    schema_text: options.schemaText,
+    methodology_text: options.methodologyText,
+    runtime_ruleset: options.runtimeRuleset,
+  };
+}
+
+function buildFiles(
+  outDir: string,
+  pack: ContractPack,
+  includeAiContext: boolean,
+): DatasetContractReport['files'] {
+  const outputsDir = path.join(outDir, 'outputs');
+  return {
+    manifest: path.join(outputsDir, 'contract-manifest.json'),
+    schema: pack.schemaText ? path.join(outputsDir, 'schema.json') : null,
+    methodology: pack.methodologyText ? path.join(outputsDir, 'methodology.yaml') : null,
+    ruleset: pack.runtimeRuleset ? path.join(outputsDir, 'runtime-ruleset.json') : null,
+    ai_context_json:
+      includeAiContext && pack.aiContext ? path.join(outputsDir, 'ai-context.json') : null,
+    ai_context_markdown: includeAiContext ? path.join(outputsDir, 'ai-context.md') : null,
+    report: path.join(outputsDir, 'contract-report.json'),
+  };
+}
+
+function renderAiContextMarkdown(type: CanonicalKind, pack: ContractPack): string {
+  const aiContext = isRecord(pack.aiContext) ? pack.aiContext : {};
+  const instructions = Array.isArray(aiContext.instructions)
+    ? aiContext.instructions.map((item) => `- ${String(item)}`).join('\n')
+    : '';
+  const sections = [`# TIDAS ${type} AI Context`, '', '## Instructions', instructions];
+  if (pack.methodologyText) {
+    sections.push('', '## Methodology YAML', '```yaml', pack.methodologyText.trimEnd(), '```');
+  }
+  if (pack.schemaText) {
+    sections.push('', '## JSON Schema', '```json', pack.schemaText.trimEnd(), '```');
+  }
+  if (pack.runtimeRuleset) {
+    sections.push(
+      '',
+      '## Runtime Ruleset',
+      '```json',
+      JSON.stringify(pack.runtimeRuleset, null, 2),
+      '```',
+    );
+  }
+  return `${sections.join('\n')}\n`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export const __testInternals = {
+  normalizeIncludes,
+  normalizeType,
+};

--- a/src/lib/dataset-import-lca.ts
+++ b/src/lib/dataset-import-lca.ts
@@ -174,13 +174,28 @@ function normalizeTarget(value: string | undefined): DatasetImportLcaTarget {
   });
 }
 
-function resolveTidasToolsRoot(explicitValue: string | undefined, env: NodeJS.ProcessEnv): string {
+function resolveTidasToolsRoot(
+  explicitValue: string | undefined,
+  env: NodeJS.ProcessEnv,
+  defaultCandidate?: string,
+): string {
   const cliRepoRoot = resolveCliRepoRoot();
+  if (explicitValue?.trim()) {
+    const resolved = path.resolve(explicitValue);
+    if (existsSync(path.join(resolved, 'src/tidas_tools/import_lca/cli.py'))) {
+      return resolved;
+    }
+    throw new CliError('Could not resolve a tidas-tools checkout for dataset import.', {
+      code: 'DATASET_IMPORT_LCA_TIDAS_TOOLS_NOT_FOUND',
+      exitCode: 2,
+      details: { candidates: [explicitValue] },
+    });
+  }
+
   const candidates = [
-    explicitValue,
     env.TIDAS_TOOLS_DIR,
     env.TIDAS_TOOLS_PATH,
-    path.resolve(cliRepoRoot, '../tidas-tools'),
+    defaultCandidate ?? path.resolve(cliRepoRoot, '../tidas-tools'),
   ].filter((candidate): candidate is string => Boolean(candidate?.trim()));
 
   for (const candidate of candidates) {
@@ -197,9 +212,12 @@ function resolveTidasToolsRoot(explicitValue: string | undefined, env: NodeJS.Pr
   });
 }
 
-function resolveCliRepoRoot(): string {
+function resolveCliRepoRoot(candidatesOverride?: string[]): string {
   const moduleDir = path.dirname(fileURLToPath(import.meta.url));
-  const candidates = [path.resolve(moduleDir, '../..'), path.resolve(moduleDir, '../../..')];
+  const candidates = candidatesOverride ?? [
+    path.resolve(moduleDir, '../..'),
+    path.resolve(moduleDir, '../../..'),
+  ];
   return (
     candidates.find(
       (candidate) =>
@@ -222,5 +240,6 @@ function readOptionalJson(filePath: string): unknown | null {
 
 export const __testInternals = {
   normalizeTarget,
+  resolveCliRepoRoot,
   resolveTidasToolsRoot,
 };

--- a/src/lib/dataset-import-lca.ts
+++ b/src/lib/dataset-import-lca.ts
@@ -1,0 +1,226 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { writeJsonArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+
+export type DatasetImportLcaTarget = 'tidas' | 'ilcd' | 'both';
+
+export type DatasetImportLcaReport = {
+  schema_version: 1;
+  status: 'completed' | 'blocked';
+  generated_at_utc: string;
+  input_path: string;
+  output_dir: string;
+  from_format: string;
+  target: DatasetImportLcaTarget;
+  detect_only: boolean;
+  command: {
+    executable: string;
+    args: string[];
+    cwd: string;
+    exit_code: number | null;
+    stdout: string;
+    stderr: string;
+  };
+  conversion_report: unknown | null;
+  files: {
+    report: string;
+    conversion_report: string;
+    tidas_dir: string | null;
+    ilcd_dir: string | null;
+    mapping_csv: string | null;
+  };
+};
+
+export type RunDatasetImportLcaConvertOptions = {
+  inputPath: string;
+  outputDir: string;
+  fromFormat?: string | undefined;
+  target?: string | undefined;
+  language?: string | undefined;
+  reportPath?: string | undefined;
+  mappingDir?: string | undefined;
+  failOnWarning?: boolean | undefined;
+  validationJobs?: number | undefined;
+  detectOnly?: boolean | undefined;
+  pythonBin?: string | undefined;
+  tidasToolsDir?: string | undefined;
+  env?: NodeJS.ProcessEnv | undefined;
+  now?: Date | undefined;
+  spawnImpl?: typeof spawnSync | undefined;
+};
+
+export function runDatasetImportLcaConvert(
+  options: RunDatasetImportLcaConvertOptions,
+): DatasetImportLcaReport {
+  const inputPath = requireInputPath(options.inputPath);
+  const outputDir = requireOutputDir(options.outputDir);
+  const target = normalizeTarget(options.target);
+  const fromFormat = options.fromFormat?.trim() || 'auto';
+  const pythonBin = options.pythonBin?.trim() || 'python3';
+  const tidasToolsRoot = resolveTidasToolsRoot(options.tidasToolsDir, options.env ?? process.env);
+  const reportPath = path.resolve(
+    options.reportPath ?? path.join(outputDir, 'conversion-report.json'),
+  );
+  const commandArgs = [
+    '-m',
+    'tidas_tools.import_lca.cli',
+    '--input',
+    inputPath,
+    '--output-dir',
+    outputDir,
+    '--from-format',
+    fromFormat,
+    '--target',
+    target,
+    '--report',
+    reportPath,
+    '--language',
+    options.language?.trim() || 'en',
+    '--validation-jobs',
+    String(options.validationJobs ?? 1),
+  ];
+  if (options.mappingDir) {
+    commandArgs.push('--mapping-dir', path.resolve(options.mappingDir));
+  }
+  if (options.failOnWarning) {
+    commandArgs.push('--fail-on-warning');
+  }
+  if (options.detectOnly) {
+    commandArgs.push('--detect-only');
+  }
+
+  const run = (options.spawnImpl ?? spawnSync)(pythonBin, commandArgs, {
+    cwd: tidasToolsRoot,
+    env: {
+      ...(options.env ?? process.env),
+      PYTHONPATH: buildPythonPath(tidasToolsRoot, options.env ?? process.env),
+    },
+    encoding: 'utf8',
+  }) as SpawnSyncReturns<string>;
+  const conversionReport = readOptionalJson(reportPath);
+  const files = {
+    report: path.join(outputDir, 'outputs', 'import-lca-report.json'),
+    conversion_report: reportPath,
+    tidas_dir: options.detectOnly ? null : path.join(outputDir, 'tidas'),
+    ilcd_dir:
+      !options.detectOnly && (target === 'ilcd' || target === 'both')
+        ? path.join(outputDir, 'ilcd')
+        : null,
+    mapping_csv: options.detectOnly ? null : path.join(outputDir, 'mapping.csv'),
+  };
+  const report: DatasetImportLcaReport = {
+    schema_version: 1,
+    status: run.status === 0 ? 'completed' : 'blocked',
+    generated_at_utc: (options.now ?? new Date()).toISOString(),
+    input_path: inputPath,
+    output_dir: outputDir,
+    from_format: fromFormat,
+    target,
+    detect_only: Boolean(options.detectOnly),
+    command: {
+      executable: pythonBin,
+      args: commandArgs,
+      cwd: tidasToolsRoot,
+      exit_code: run.status,
+      stdout: run.stdout ?? '',
+      stderr: run.stderr ?? '',
+    },
+    conversion_report: conversionReport,
+    files,
+  };
+
+  writeJsonArtifact(files.report, report);
+  return report;
+}
+
+function requireInputPath(value: string): string {
+  if (!value?.trim()) {
+    throw new CliError('Missing required --input value.', {
+      code: 'DATASET_IMPORT_LCA_INPUT_REQUIRED',
+      exitCode: 2,
+    });
+  }
+  const resolved = path.resolve(value);
+  if (!existsSync(resolved)) {
+    throw new CliError(`Input path not found: ${resolved}`, {
+      code: 'DATASET_IMPORT_LCA_INPUT_NOT_FOUND',
+      exitCode: 2,
+    });
+  }
+  return resolved;
+}
+
+function requireOutputDir(value: string): string {
+  if (!value?.trim()) {
+    throw new CliError('Missing required --output-dir value.', {
+      code: 'DATASET_IMPORT_LCA_OUTPUT_DIR_REQUIRED',
+      exitCode: 2,
+    });
+  }
+  return path.resolve(value);
+}
+
+function normalizeTarget(value: string | undefined): DatasetImportLcaTarget {
+  const target = value?.trim() || 'tidas';
+  if (target === 'tidas' || target === 'ilcd' || target === 'both') {
+    return target;
+  }
+  throw new CliError("--target must be 'tidas', 'ilcd', or 'both'.", {
+    code: 'DATASET_IMPORT_LCA_TARGET_INVALID',
+    exitCode: 2,
+  });
+}
+
+function resolveTidasToolsRoot(explicitValue: string | undefined, env: NodeJS.ProcessEnv): string {
+  const cliRepoRoot = resolveCliRepoRoot();
+  const candidates = [
+    explicitValue,
+    env.TIDAS_TOOLS_DIR,
+    env.TIDAS_TOOLS_PATH,
+    path.resolve(cliRepoRoot, '../tidas-tools'),
+  ].filter((candidate): candidate is string => Boolean(candidate?.trim()));
+
+  for (const candidate of candidates) {
+    const resolved = path.resolve(candidate);
+    if (existsSync(path.join(resolved, 'src/tidas_tools/import_lca/cli.py'))) {
+      return resolved;
+    }
+  }
+
+  throw new CliError('Could not resolve a tidas-tools checkout for dataset import.', {
+    code: 'DATASET_IMPORT_LCA_TIDAS_TOOLS_NOT_FOUND',
+    exitCode: 2,
+    details: { candidates },
+  });
+}
+
+function resolveCliRepoRoot(): string {
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [path.resolve(moduleDir, '../..'), path.resolve(moduleDir, '../../..')];
+  return (
+    candidates.find(
+      (candidate) =>
+        existsSync(path.join(candidate, 'package.json')) &&
+        existsSync(path.join(candidate, 'src/cli.ts')),
+    ) ?? candidates[0]
+  );
+}
+
+function buildPythonPath(tidasToolsRoot: string, env: NodeJS.ProcessEnv): string {
+  return [path.join(tidasToolsRoot, 'src'), env.PYTHONPATH].filter(Boolean).join(path.delimiter);
+}
+
+function readOptionalJson(filePath: string): unknown | null {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+export const __testInternals = {
+  normalizeTarget,
+  resolveTidasToolsRoot,
+};

--- a/test/dataset-author.test.ts
+++ b/test/dataset-author.test.ts
@@ -75,6 +75,36 @@ test('runDatasetAuthor writes source extract and target context reports', async 
   }
 });
 
+test('runDatasetAuthor can use default parser and contract implementations', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-dataset-author-defaults-'));
+  const inputPath = path.join(dir, 'source.pdf');
+  writeFileSync(inputPath, 'source', 'utf8');
+
+  try {
+    const report = await runDatasetAuthor({
+      inputPath,
+      targetTypes: ['process'],
+      outDir: path.join(dir, 'out'),
+      env: {
+        TIANGONG_LCA_UNSTRUCTURED_API_BASE_URL: 'https://unstructured.example',
+        TIANGONG_LCA_UNSTRUCTURED_API_KEY: 'key',
+      },
+      fetchImpl: (async () => ({
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify({ text: 'parsed source' }),
+      })) as FetchLike,
+    });
+
+    assert.equal(report.status, 'evidence_ready');
+    assert.equal(report.context_packs.length, 1);
+    assert.equal(existsSync(report.context_packs[0]?.report.files.ai_context_markdown ?? ''), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('executeCli exposes dataset author command', async () => {
   const help = await executeCli(['dataset', 'author', '--help'], {
     env: {},
@@ -94,6 +124,14 @@ test('executeCli exposes dataset author command', async () => {
       'process',
       '--out-dir',
       'out',
+      '--prompt',
+      'make data',
+      '--provider',
+      'vision',
+      '--model',
+      'vision-model',
+      '--timeout-ms',
+      '1234',
       '--json',
     ],
     {
@@ -104,7 +142,7 @@ test('executeCli exposes dataset author command', async () => {
         schema_version: 1,
         status: 'evidence_ready',
         generated_at_utc: '2026-06-01T00:00:00.000Z',
-        input_path: options.inputPath,
+        input_path: `${options.inputPath}:${options.prompt}:${options.provider}:${options.model}:${options.timeoutMs}`,
         target_types: Array.isArray(options.targetTypes) ? options.targetTypes : [],
         files: {
           source_extract: 'out/outputs/source-extract.json',
@@ -116,5 +154,86 @@ test('executeCli exposes dataset author command', async () => {
     },
   );
   assert.equal(result.exitCode, 0);
-  assert.equal(JSON.parse(result.stdout).input_path, 'source.xlsx');
+  assert.equal(
+    JSON.parse(result.stdout).input_path,
+    'source.xlsx:make data:vision:vision-model:1234',
+  );
+
+  const invalidUnknown = await executeCli(['dataset', 'author', '--unknown'], {
+    env: {},
+    dotEnvStatus,
+    fetchImpl,
+  });
+  assert.equal(invalidUnknown.exitCode, 2);
+  assert.match(invalidUnknown.stderr, /INVALID_ARGS/u);
+
+  const invalidTimeout = await executeCli(['dataset', 'author', '--timeout-ms', '0'], {
+    env: {},
+    dotEnvStatus,
+    fetchImpl,
+  });
+  assert.equal(invalidTimeout.exitCode, 2);
+  assert.match(invalidTimeout.stderr, /timeout-ms/u);
+});
+
+test('runDatasetAuthor validates required local inputs before parsing', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-dataset-author-required-'));
+  const inputPath = path.join(dir, 'source.xlsx');
+  writeFileSync(inputPath, 'source', 'utf8');
+
+  try {
+    await assert.rejects(
+      () =>
+        runDatasetAuthor({
+          inputPath,
+          targetTypes: 'process',
+          outDir: null,
+          env: {},
+          fetchImpl,
+          parseImpl: async () => ({ text: 'unused' }),
+        }),
+      /Missing required --out-dir/u,
+    );
+
+    await assert.rejects(
+      () =>
+        runDatasetAuthor({
+          inputPath,
+          targetTypes: '',
+          outDir: path.join(dir, 'out'),
+          env: {},
+          fetchImpl,
+          parseImpl: async () => ({ text: 'unused' }),
+        }),
+      /Missing required --target-types/u,
+    );
+
+    await assert.rejects(
+      () =>
+        runDatasetAuthor({
+          inputPath: '',
+          targetTypes: 'process',
+          outDir: path.join(dir, 'out'),
+          env: {},
+          fetchImpl,
+          parseImpl: async () => ({ text: 'unused' }),
+        }),
+      /Missing required --input/u,
+    );
+
+    await assert.rejects(
+      () =>
+        runDatasetAuthor({
+          inputPath: path.join(dir, 'missing.pdf'),
+          targetTypes: 'process',
+          outDir: path.join(dir, 'out'),
+          env: {},
+          fetchImpl,
+          parseImpl: async () => ({ text: 'unused' }),
+        }),
+      /Input file not found/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/test/dataset-author.test.ts
+++ b/test/dataset-author.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { executeCli } from '../src/cli.js';
+import { runDatasetAuthor } from '../src/lib/dataset-author.js';
+import type { DotEnvLoadResult } from '../src/lib/dotenv.js';
+import type { FetchLike } from '../src/lib/http.js';
+
+const dotEnvStatus: DotEnvLoadResult = {
+  loaded: false,
+  path: '/tmp/.env',
+  count: 0,
+};
+
+const fetchImpl = (async () => ({
+  ok: true,
+  status: 200,
+  headers: { get: () => 'application/json' },
+  text: async () => JSON.stringify({ ok: true }),
+})) as FetchLike;
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+test('runDatasetAuthor writes source extract and target context reports', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-dataset-author-'));
+  const inputPath = path.join(dir, 'source.pdf');
+  writeFileSync(inputPath, 'source', 'utf8');
+
+  try {
+    const report = await runDatasetAuthor({
+      inputPath,
+      targetTypes: 'process,flow',
+      outDir: path.join(dir, 'out'),
+      env: {
+        TIANGONG_LCA_UNSTRUCTURED_API_BASE_URL: 'https://unstructured.example',
+        TIANGONG_LCA_UNSTRUCTURED_API_KEY: 'key',
+      },
+      fetchImpl,
+      parseImpl: async () => ({ text: 'parsed source' }),
+      contractImpl: async (options) => ({
+        schema_version: 1,
+        status: 'completed',
+        generated_at_utc: '2026-06-01T00:00:00.000Z',
+        mode: 'context-pack',
+        requested_type: String(options.type ?? ''),
+        type: String(options.type ?? ''),
+        profile: 'ai-import',
+        includes: ['schema', 'methodology', 'ruleset'],
+        source: 'sdk-runtime-assets',
+        manifest: {},
+        files: {
+          manifest: path.join(String(options.outDir), 'outputs/contract-manifest.json'),
+          schema: null,
+          methodology: null,
+          ruleset: null,
+          ai_context_json: null,
+          ai_context_markdown: null,
+          report: path.join(String(options.outDir), 'outputs/contract-report.json'),
+        },
+      }),
+      now: new Date('2026-06-01T00:00:00.000Z'),
+    });
+
+    assert.equal(report.status, 'evidence_ready');
+    assert.deepEqual(report.target_types, ['process', 'flow']);
+    assert.equal(existsSync(report.files.source_extract), true);
+    assert.equal(existsSync(report.files.authoring_report), true);
+    assert.deepEqual(readJson(report.files.authoring_report), report);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli exposes dataset author command', async () => {
+  const help = await executeCli(['dataset', 'author', '--help'], {
+    env: {},
+    dotEnvStatus,
+    fetchImpl,
+  });
+  assert.equal(help.exitCode, 0);
+  assert.match(help.stdout, /dataset author/u);
+
+  const result = await executeCli(
+    [
+      'dataset',
+      'author',
+      '--input',
+      'source.xlsx',
+      '--target-types',
+      'process',
+      '--out-dir',
+      'out',
+      '--json',
+    ],
+    {
+      env: {},
+      dotEnvStatus,
+      fetchImpl,
+      runDatasetAuthorImpl: async (options) => ({
+        schema_version: 1,
+        status: 'evidence_ready',
+        generated_at_utc: '2026-06-01T00:00:00.000Z',
+        input_path: options.inputPath,
+        target_types: Array.isArray(options.targetTypes) ? options.targetTypes : [],
+        files: {
+          source_extract: 'out/outputs/source-extract.json',
+          authoring_report: 'out/outputs/authoring-report.json',
+        },
+        context_packs: [],
+        next_actions: [],
+      }),
+    },
+  );
+  assert.equal(result.exitCode, 0);
+  assert.equal(JSON.parse(result.stdout).input_path, 'source.xlsx');
+});

--- a/test/dataset-contract.test.ts
+++ b/test/dataset-contract.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -70,6 +70,71 @@ test('runDatasetContract writes process contract artifacts', async () => {
 test('executeCli exposes dataset contract and context-pack commands', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-context-pack-'));
   try {
+    const contractHelp = await executeCli(['dataset', 'contract', 'get', '--help'], deps);
+    assert.equal(contractHelp.exitCode, 0);
+    assert.match(contractHelp.stdout, /dataset contract get/u);
+
+    const namespaceHelp = await executeCli(['dataset', 'contract'], deps);
+    assert.equal(namespaceHelp.exitCode, 0);
+    assert.match(namespaceHelp.stdout, /dataset contract get/u);
+
+    const contractReport = {
+      schema_version: 1,
+      status: 'completed',
+      generated_at_utc: '2026-06-01T00:00:00.000Z',
+      mode: 'contract',
+      requested_type: 'process',
+      type: 'process',
+      profile: 'default',
+      includes: ['schema'],
+      source: 'sdk-contract-api',
+      manifest: {},
+      files: {
+        manifest: 'manifest.json',
+        schema: 'schema.json',
+        methodology: null,
+        ruleset: null,
+        ai_context_json: null,
+        ai_context_markdown: null,
+        report: 'contract-report.json',
+      },
+    } satisfies Awaited<ReturnType<typeof runDatasetContract>>;
+    const contractResult = await executeCli(
+      [
+        'dataset',
+        'contract',
+        'get',
+        '--type',
+        'process',
+        '--include',
+        'schema',
+        '--profile',
+        'ai-import',
+        '--out-dir',
+        dir,
+      ],
+      {
+        ...deps,
+        runDatasetContractImpl: async (options) => ({
+          ...contractReport,
+          requested_type: String(options.type),
+          type: String(options.type),
+          profile: options.profile === 'ai-import' ? 'ai-import' : 'default',
+        }),
+      },
+    );
+    assert.equal(contractResult.exitCode, 0);
+    assert.equal(JSON.parse(contractResult.stdout).type, 'process');
+    assert.equal(JSON.parse(contractResult.stdout).profile, 'ai-import');
+
+    const invalidAction = await executeCli(['dataset', 'contract', 'show'], deps);
+    assert.equal(invalidAction.exitCode, 2);
+    assert.match(invalidAction.stderr, /dataset contract action must be 'get'/u);
+
+    const invalidFlags = await executeCli(['dataset', 'contract', 'get', '--bad'], deps);
+    assert.equal(invalidFlags.exitCode, 2);
+    assert.match(invalidFlags.stderr, /INVALID_ARGS/u);
+
     const help = await executeCli(['dataset', 'context-pack', '--help'], deps);
     assert.equal(help.exitCode, 0);
     assert.match(help.stdout, /dataset context-pack/u);
@@ -93,4 +158,193 @@ test('executeCli exposes dataset contract and context-pack commands', async () =
 
 test('dataset contract flag normalization rejects unsupported includes', () => {
   assert.throws(() => __testInternals.normalizeIncludes('schema,unknown'), /--include values/u);
+});
+
+test('runDatasetContract validates required contract inputs', async () => {
+  await assert.rejects(
+    () =>
+      runDatasetContract({
+        type: 'process',
+        include: 'schema',
+        outDir: null,
+        mode: 'contract',
+      }),
+    /Missing required --out-dir/u,
+  );
+});
+
+test('dataset contract internals cover fallback-only branches', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-contract-fallback-'));
+  mkdirSync(path.join(dir, 'tidas/schemas'), { recursive: true });
+  try {
+    const pack = __testInternals.loadFallbackContractPack({
+      type: 'contact',
+      includes: ['methodology'],
+      profile: 'default',
+      includeAiContext: false,
+      runtimeAssetsRoot: dir,
+    });
+    assert.equal((pack.manifest as { schema: unknown }).schema, null);
+    assert.equal((pack.manifest as { methodology: unknown }).methodology, null);
+    assert.equal((pack.manifest as { ruleset: unknown }).ruleset, null);
+    assert.equal(pack.aiContext, undefined);
+
+    const missingSchemaPack = __testInternals.loadFallbackContractPack({
+      type: 'contact',
+      includes: ['schema'],
+      profile: 'default',
+      includeAiContext: false,
+      runtimeAssetsRoot: dir,
+    });
+    assert.equal(missingSchemaPack.schemaText, undefined);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+
+  assert.equal(__testInternals.normalizeType('life-cycle_model'), 'lifecyclemodel');
+  assert.throws(() => __testInternals.normalizeType(undefined), /Missing required --type/u);
+  assert.throws(
+    () => __testInternals.normalizeType('bad-kind'),
+    /Unsupported dataset contract type/u,
+  );
+  assert.throws(() => __testInternals.normalizeIncludes(['']), /At least one --include/u);
+  assert.equal(__testInternals.normalizeProfile('ai-import'), 'ai-import');
+  assert.throws(() => __testInternals.normalizeProfile('draft'), /--profile/u);
+  assert.equal(
+    __testInternals.filterRuntimeRuleset(
+      {
+        schema_version: 1,
+        rulesets: [{ dataset_type: 'flow', id: 'flow-rules' }],
+        rules: [{ dataset_type: 'flow', id: 'flow-rule' }],
+      },
+      'process',
+    ),
+    undefined,
+  );
+  assert.equal(__testInternals.filterRuntimeRuleset({}, 'process'), undefined);
+  assert.throws(
+    () =>
+      __testInternals.resolveSdkRuntimeAssetsRoot(
+        [path.join(os.tmpdir(), 'missing-sdk-assets')],
+        '/tmp/sdk/index.js',
+      ),
+    /Could not resolve @tiangong-lca\/tidas-sdk runtime assets/u,
+  );
+
+  const repoRoot = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-contract-root-'));
+  const packageOnlyRoot = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-contract-package-only-'));
+  mkdirSync(path.join(repoRoot, 'src'), { recursive: true });
+  writeFileSync(path.join(repoRoot, 'package.json'), '{}', 'utf8');
+  writeFileSync(path.join(repoRoot, 'src/cli.ts'), '', 'utf8');
+  writeFileSync(path.join(packageOnlyRoot, 'package.json'), '{}', 'utf8');
+  try {
+    assert.equal(
+      __testInternals.resolveCliRepoRoot([path.join(repoRoot, 'missing'), repoRoot]),
+      repoRoot,
+    );
+    assert.equal(__testInternals.resolveCliRepoRoot([packageOnlyRoot, repoRoot]), repoRoot);
+    assert.equal(
+      __testInternals.resolveCliRepoRoot([path.join(repoRoot, 'missing')]),
+      path.join(repoRoot, 'missing'),
+    );
+    assert.equal(
+      __testInternals.resolveSdkRuntimeAssetsRoot([repoRoot], '/tmp/sdk/index.js'),
+      repoRoot,
+    );
+    assert.match(__testInternals.resolveCliRepoRoot(), /tiangong-lca-cli/u);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+    rmSync(packageOnlyRoot, { recursive: true, force: true });
+  }
+
+  const schemaRoot = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-contract-schema-root-'));
+  mkdirSync(path.join(schemaRoot, 'tidas/schemas'), { recursive: true });
+  writeFileSync(
+    path.join(schemaRoot, 'tidas/schemas/tidas_contacts.json'),
+    '{"type":"object"}',
+    'utf8',
+  );
+  try {
+    const pack = __testInternals.loadFallbackContractPack({
+      type: 'contact',
+      includes: ['schema'],
+      profile: 'default',
+      includeAiContext: false,
+      runtimeAssetsRoot: schemaRoot,
+    });
+    assert.equal(pack.schemaText, '{"type":"object"}');
+  } finally {
+    rmSync(schemaRoot, { recursive: true, force: true });
+  }
+
+  const markdown = __testInternals.renderAiContextMarkdown('source', {
+    manifest: {},
+    aiContext: { instructions: 'not-an-array' },
+  });
+  assert.match(markdown, /# TIDAS source AI Context/u);
+  assert.match(markdown, /## Instructions\n/u);
+
+  const markdownWithoutContext = __testInternals.renderAiContextMarkdown('flow', {
+    manifest: {},
+    aiContext: [],
+  });
+  assert.match(markdownWithoutContext, /# TIDAS flow AI Context/u);
+});
+
+test('runDatasetContract can consume a future SDK contract API', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-sdk-contract-api-'));
+  try {
+    const report = await runDatasetContract({
+      type: 'process',
+      include: ['schema'],
+      outDir: dir,
+      mode: 'contract',
+      sdkModule: {
+        getTidasContractPack: (type: string, options: unknown) => ({
+          manifest: { type, options },
+          schemaText: '{"type":"object"}',
+        }),
+      },
+    });
+
+    assert.equal(report.source, 'sdk-contract-api');
+    assert.match(readFileSync(report.files.schema ?? '', 'utf8'), /object/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runDatasetContract handles fallback and sparse SDK contract packs', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-contract-sparse-'));
+  const runtimeRoot = path.join(dir, 'runtime-assets');
+  mkdirSync(path.join(runtimeRoot, 'tidas/schemas'), { recursive: true });
+  try {
+    const fallbackReport = await runDatasetContract({
+      type: 'contact',
+      include: 'methodology',
+      outDir: path.join(dir, 'fallback'),
+      mode: 'contract',
+      sdkModule: {},
+      runtimeAssetsRoot: runtimeRoot,
+    });
+    assert.equal(fallbackReport.source, 'sdk-runtime-assets');
+    assert.equal(fallbackReport.files.schema, null);
+
+    const contextReport = await runDatasetContract({
+      type: 'flow',
+      include: 'schema',
+      outDir: path.join(dir, 'context'),
+      mode: 'context-pack',
+      sdkModule: {
+        getTidasContractPack: () => ({
+          manifest: {},
+          schemaText: '{"type":"object"}',
+        }),
+      },
+    });
+    assert.equal(contextReport.files.ai_context_json, null);
+    assert.equal(existsSync(contextReport.files.ai_context_markdown ?? ''), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/test/dataset-contract.test.ts
+++ b/test/dataset-contract.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { executeCli } from '../src/cli.js';
+import { __testInternals, runDatasetContract } from '../src/lib/dataset-contract.js';
+import type { DotEnvLoadResult } from '../src/lib/dotenv.js';
+import type { FetchLike } from '../src/lib/http.js';
+
+const dotEnvStatus: DotEnvLoadResult = {
+  loaded: false,
+  path: '/tmp/.env',
+  count: 0,
+};
+
+const deps = {
+  env: {},
+  dotEnvStatus,
+  fetchImpl: (async () => ({
+    ok: true,
+    status: 200,
+    headers: { get: () => 'application/json' },
+    text: async () => JSON.stringify({ ok: true }),
+  })) as FetchLike,
+};
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+test('runDatasetContract writes process contract artifacts', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-dataset-contract-'));
+  try {
+    const report = await runDatasetContract({
+      type: 'process',
+      include: 'schema,methodology,ruleset',
+      profile: 'ai-import',
+      outDir: dir,
+      mode: 'context-pack',
+      now: new Date('2026-06-01T00:00:00.000Z'),
+    });
+
+    assert.equal(report.status, 'completed');
+    assert.equal(report.type, 'process');
+    assert.equal(report.profile, 'ai-import');
+    assert.equal(existsSync(report.files.manifest), true);
+    assert.equal(existsSync(report.files.schema ?? ''), true);
+    assert.equal(existsSync(report.files.methodology ?? ''), true);
+    assert.equal(existsSync(report.files.ai_context_json ?? ''), true);
+    assert.equal(existsSync(report.files.ai_context_markdown ?? ''), true);
+    assert.match(readFileSync(report.files.schema ?? '', 'utf8'), /processDataSet/u);
+    assert.match(
+      readFileSync(report.files.methodology ?? '', 'utf8'),
+      /Process Dataset Content Rules/u,
+    );
+    assert.deepEqual(readJson(report.files.report), report);
+
+    const manifest = readJson(report.files.manifest) as {
+      schema?: { sha256?: string };
+      methodology?: { sha256?: string };
+    };
+    assert.match(manifest.schema?.sha256 ?? '', /^[a-f0-9]{64}$/u);
+    assert.match(manifest.methodology?.sha256 ?? '', /^[a-f0-9]{64}$/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli exposes dataset contract and context-pack commands', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-context-pack-'));
+  try {
+    const help = await executeCli(['dataset', 'context-pack', '--help'], deps);
+    assert.equal(help.exitCode, 0);
+    assert.match(help.stdout, /dataset context-pack/u);
+
+    const result = await executeCli(
+      ['dataset', 'context-pack', '--type', 'flow', '--out-dir', dir, '--json'],
+      deps,
+    );
+    assert.equal(result.exitCode, 0);
+    const payload = JSON.parse(result.stdout) as {
+      type: string;
+      files: { schema: string; ai_context_json: string };
+    };
+    assert.equal(payload.type, 'flow');
+    assert.equal(existsSync(payload.files.schema), true);
+    assert.equal(existsSync(payload.files.ai_context_json), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('dataset contract flag normalization rejects unsupported includes', () => {
+  assert.throws(() => __testInternals.normalizeIncludes('schema,unknown'), /--include values/u);
+});

--- a/test/dataset-import-lca.test.ts
+++ b/test/dataset-import-lca.test.ts
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { executeCli } from '../src/cli.js';
-import { runDatasetImportLcaConvert } from '../src/lib/dataset-import-lca.js';
+import { __testInternals, runDatasetImportLcaConvert } from '../src/lib/dataset-import-lca.js';
 import type { spawnSync, SpawnSyncReturns } from 'node:child_process';
 import type { DotEnvLoadResult } from '../src/lib/dotenv.js';
 import type { FetchLike } from '../src/lib/http.js';
@@ -66,14 +66,19 @@ test('runDatasetImportLcaConvert wraps tidas-tools and writes a report', () => {
       inputPath,
       outputDir: outDir,
       fromFormat: 'auto',
-      target: 'tidas',
+      target: 'both',
+      mappingDir: path.join(dir, 'mapping'),
+      failOnWarning: true,
       tidasToolsDir: toolsDir,
       spawnImpl,
       now: new Date('2026-06-01T00:00:00.000Z'),
     });
 
     assert.equal(report.status, 'completed');
-    assert.equal(report.target, 'tidas');
+    assert.equal(report.target, 'both');
+    assert.notEqual(report.files.ilcd_dir, null);
+    assert.ok(report.command.args.includes('--mapping-dir'));
+    assert.ok(report.command.args.includes('--fail-on-warning'));
     assert.equal(report.conversion_report && typeof report.conversion_report, 'object');
     assert.equal(existsSync(report.files.report), true);
     assert.deepEqual(readJson(report.files.report), report);
@@ -86,6 +91,14 @@ test('executeCli exposes dataset import-lca convert command', async () => {
   const result = await executeCli(['dataset', 'import-lca', 'convert', '--help'], deps);
   assert.equal(result.exitCode, 0);
   assert.match(result.stdout, /dataset import-lca convert/u);
+
+  const namespaceHelp = await executeCli(['dataset', 'import-lca'], deps);
+  assert.equal(namespaceHelp.exitCode, 0);
+  assert.match(namespaceHelp.stdout, /dataset import-lca convert/u);
+
+  const invalidAction = await executeCli(['dataset', 'import-lca', 'detect'], deps);
+  assert.equal(invalidAction.exitCode, 2);
+  assert.match(invalidAction.stderr, /dataset import-lca action must be 'convert'/u);
 
   const converted = await executeCli(
     ['dataset', 'import-lca', 'convert', '--input', 'in.zip', '--output-dir', 'out', '--json'],
@@ -121,4 +134,249 @@ test('executeCli exposes dataset import-lca convert command', async () => {
   );
   assert.equal(converted.exitCode, 0);
   assert.equal(JSON.parse(converted.stdout).input_path, 'in.zip');
+
+  const blocked = await executeCli(
+    [
+      'dataset',
+      'import-lca',
+      'convert',
+      '--input',
+      'in.zip',
+      '--output-dir',
+      'out',
+      '--from-format',
+      'ecospold2',
+      '--target',
+      'both',
+      '--report',
+      'conversion.json',
+      '--mapping-dir',
+      'mapping',
+      '--language',
+      'zh',
+      '--validation-jobs',
+      '2',
+      '--detect-only',
+      '--fail-on-warning',
+      '--python',
+      'python-custom',
+      '--tidas-tools-dir',
+      '/tmp/tidas-tools',
+      '--json',
+    ],
+    {
+      ...deps,
+      runDatasetImportLcaConvertImpl: (options) => ({
+        schema_version: 1,
+        status: 'blocked',
+        generated_at_utc: '2026-06-01T00:00:00.000Z',
+        input_path: `${options.inputPath}:${options.fromFormat}:${options.target}:${options.reportPath}:${options.mappingDir}:${options.language}:${options.validationJobs}:${options.detectOnly}:${options.failOnWarning}:${options.pythonBin}:${options.tidasToolsDir}`,
+        output_dir: options.outputDir,
+        from_format: options.fromFormat ?? 'auto',
+        target: 'both',
+        detect_only: true,
+        command: {
+          executable: 'python-custom',
+          args: [],
+          cwd: '/tmp/tidas-tools',
+          exit_code: 1,
+          stdout: '',
+          stderr: '',
+        },
+        conversion_report: null,
+        files: {
+          report: '/tmp/report.json',
+          conversion_report: '/tmp/conversion-report.json',
+          tidas_dir: null,
+          ilcd_dir: null,
+          mapping_csv: null,
+        },
+      }),
+    },
+  );
+  assert.equal(blocked.exitCode, 1);
+  assert.match(
+    JSON.parse(blocked.stdout).input_path,
+    /ecospold2:both:conversion\.json:mapping:zh:2:true:true:python-custom/u,
+  );
+});
+
+test('runDatasetImportLcaConvert records missing conversion report as null', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-import-lca-no-report-'));
+  const inputPath = path.join(dir, 'package.zip');
+  const outDir = path.join(dir, 'out');
+  const toolsDir = path.join(dir, 'tidas-tools');
+  const cliPath = path.join(toolsDir, 'src/tidas_tools/import_lca/cli.py');
+  writeFileSync(inputPath, 'fixture', 'utf8');
+  mkdirSync(path.dirname(cliPath), { recursive: true });
+  writeFileSync(cliPath, '', 'utf8');
+
+  try {
+    const report = runDatasetImportLcaConvert({
+      inputPath,
+      outputDir: outDir,
+      target: 'both',
+      detectOnly: true,
+      tidasToolsDir: toolsDir,
+      spawnImpl: (() => ({
+        status: 0,
+        signal: null,
+        output: [],
+        pid: 1,
+        stdout: '',
+        stderr: '',
+      })) as unknown as typeof spawnSync,
+    });
+
+    assert.equal(report.conversion_report, null);
+    assert.equal(report.files.tidas_dir, null);
+    assert.equal(report.files.ilcd_dir, null);
+    assert.equal(report.files.mapping_csv, null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runDatasetImportLcaConvert records blocked commands and default spawn output', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-import-lca-blocked-'));
+  const inputPath = path.join(dir, 'package.zip');
+  const outDir = path.join(dir, 'out');
+  const toolsDir = path.join(dir, 'tidas-tools');
+  const cliPath = path.join(toolsDir, 'src/tidas_tools/import_lca/cli.py');
+  writeFileSync(inputPath, 'fixture', 'utf8');
+  mkdirSync(path.dirname(cliPath), { recursive: true });
+  writeFileSync(cliPath, '', 'utf8');
+
+  try {
+    const blocked = runDatasetImportLcaConvert({
+      inputPath,
+      outputDir: outDir,
+      target: 'ilcd',
+      language: 'zh',
+      pythonBin: 'python-custom',
+      tidasToolsDir: toolsDir,
+      spawnImpl: (() => ({
+        status: 1,
+        signal: null,
+        output: [],
+        pid: 1,
+      })) as unknown as typeof spawnSync,
+    });
+    assert.equal(blocked.status, 'blocked');
+    assert.equal(blocked.command.executable, 'python-custom');
+    assert.equal(blocked.command.stdout, '');
+    assert.equal(blocked.command.stderr, '');
+    assert.equal(blocked.files.tidas_dir, path.join(outDir, 'tidas'));
+    assert.equal(blocked.files.ilcd_dir, path.join(outDir, 'ilcd'));
+
+    const completed = runDatasetImportLcaConvert({
+      inputPath,
+      outputDir: path.join(dir, 'true-out'),
+      pythonBin: '/usr/bin/true',
+      tidasToolsDir: toolsDir,
+    });
+    assert.equal(completed.status, 'completed');
+    assert.equal(completed.command.executable, '/usr/bin/true');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('dataset import-lca internals reject missing tidas-tools checkout', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-import-lca-missing-tools-'));
+  try {
+    assert.throws(
+      () => __testInternals.resolveTidasToolsRoot(path.join(dir, 'missing'), {}),
+      /Could not resolve a tidas-tools checkout/u,
+    );
+    assert.throws(
+      () => __testInternals.resolveTidasToolsRoot(undefined, {}, path.join(dir, 'also-missing')),
+      /Could not resolve a tidas-tools checkout/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('dataset import-lca validates required inputs and target values', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-import-lca-validation-'));
+  const inputPath = path.join(dir, 'package.zip');
+  const toolsDir = path.join(dir, 'tidas-tools');
+  const cliPath = path.join(toolsDir, 'src/tidas_tools/import_lca/cli.py');
+  writeFileSync(inputPath, 'fixture', 'utf8');
+  mkdirSync(path.dirname(cliPath), { recursive: true });
+  writeFileSync(cliPath, '', 'utf8');
+
+  try {
+    assert.throws(
+      () =>
+        runDatasetImportLcaConvert({
+          inputPath: '',
+          outputDir: path.join(dir, 'out'),
+          tidasToolsDir: toolsDir,
+        }),
+      /Missing required --input/u,
+    );
+    assert.throws(
+      () =>
+        runDatasetImportLcaConvert({
+          inputPath: path.join(dir, 'missing.zip'),
+          outputDir: path.join(dir, 'out'),
+          tidasToolsDir: toolsDir,
+        }),
+      /Input path not found/u,
+    );
+    assert.throws(
+      () =>
+        runDatasetImportLcaConvert({
+          inputPath,
+          outputDir: '',
+          tidasToolsDir: toolsDir,
+        }),
+      /Missing required --output-dir/u,
+    );
+    assert.throws(
+      () =>
+        runDatasetImportLcaConvert({
+          inputPath,
+          outputDir: path.join(dir, 'out'),
+          target: 'invalid',
+          tidasToolsDir: toolsDir,
+        }),
+      /--target must be/u,
+    );
+    assert.equal(
+      __testInternals.resolveTidasToolsRoot(undefined, { TIDAS_TOOLS_DIR: toolsDir }),
+      toolsDir,
+    );
+    assert.equal(__testInternals.normalizeTarget(undefined), 'tidas');
+
+    const repoRoot = path.join(dir, 'cli-root');
+    mkdirSync(path.join(repoRoot, 'src'), { recursive: true });
+    writeFileSync(path.join(repoRoot, 'package.json'), '{}', 'utf8');
+    writeFileSync(path.join(repoRoot, 'src/cli.ts'), '', 'utf8');
+    assert.equal(
+      __testInternals.resolveCliRepoRoot([path.join(dir, 'missing-root'), repoRoot]),
+      repoRoot,
+    );
+    assert.equal(
+      __testInternals.resolveCliRepoRoot([path.join(dir, 'missing-root')]),
+      path.join(dir, 'missing-root'),
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('dataset import-lca CLI validates parser-only errors', async () => {
+  const invalidUnknown = await executeCli(['dataset', 'import-lca', 'convert', '--unknown'], deps);
+  assert.equal(invalidUnknown.exitCode, 2);
+  assert.match(invalidUnknown.stderr, /INVALID_ARGS/u);
+
+  const invalidJobs = await executeCli(
+    ['dataset', 'import-lca', 'convert', '--validation-jobs=-1'],
+    deps,
+  );
+  assert.equal(invalidJobs.exitCode, 2);
+  assert.match(invalidJobs.stderr, /validation-jobs/u);
 });

--- a/test/dataset-import-lca.test.ts
+++ b/test/dataset-import-lca.test.ts
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { executeCli } from '../src/cli.js';
+import { runDatasetImportLcaConvert } from '../src/lib/dataset-import-lca.js';
+import type { spawnSync, SpawnSyncReturns } from 'node:child_process';
+import type { DotEnvLoadResult } from '../src/lib/dotenv.js';
+import type { FetchLike } from '../src/lib/http.js';
+
+const dotEnvStatus: DotEnvLoadResult = {
+  loaded: false,
+  path: '/tmp/.env',
+  count: 0,
+};
+
+const deps = {
+  env: {},
+  dotEnvStatus,
+  fetchImpl: (async () => ({
+    ok: true,
+    status: 200,
+    headers: { get: () => 'application/json' },
+    text: async () => JSON.stringify({ ok: true }),
+  })) as FetchLike,
+};
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+test('runDatasetImportLcaConvert wraps tidas-tools and writes a report', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-import-lca-'));
+  const inputPath = path.join(dir, 'package.zip');
+  const outDir = path.join(dir, 'out');
+  const toolsDir = path.join(dir, 'tidas-tools');
+  const cliPath = path.join(toolsDir, 'src/tidas_tools/import_lca/cli.py');
+  writeFileSync(inputPath, 'fixture', 'utf8');
+  mkdirSync(path.dirname(cliPath), { recursive: true });
+  writeFileSync(cliPath, '', { encoding: 'utf8', flag: 'w' });
+  const spawnImpl = ((_bin: string, args: readonly string[] = []): SpawnSyncReturns<string> => {
+    const reportIndex = args.indexOf('--report');
+    const reportPath = String(args[reportIndex + 1]);
+    mkdirSync(path.dirname(reportPath), { recursive: true });
+    writeFileSync(
+      reportPath,
+      JSON.stringify({
+        detected_format: 'ecospold2',
+        validation: { tidas: { ok: true } },
+      }),
+      'utf8',
+    );
+    return {
+      status: 0,
+      signal: null,
+      output: [],
+      pid: 1,
+      stdout: 'converted',
+      stderr: '',
+    };
+  }) as typeof spawnSync;
+
+  try {
+    const report = runDatasetImportLcaConvert({
+      inputPath,
+      outputDir: outDir,
+      fromFormat: 'auto',
+      target: 'tidas',
+      tidasToolsDir: toolsDir,
+      spawnImpl,
+      now: new Date('2026-06-01T00:00:00.000Z'),
+    });
+
+    assert.equal(report.status, 'completed');
+    assert.equal(report.target, 'tidas');
+    assert.equal(report.conversion_report && typeof report.conversion_report, 'object');
+    assert.equal(existsSync(report.files.report), true);
+    assert.deepEqual(readJson(report.files.report), report);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('executeCli exposes dataset import-lca convert command', async () => {
+  const result = await executeCli(['dataset', 'import-lca', 'convert', '--help'], deps);
+  assert.equal(result.exitCode, 0);
+  assert.match(result.stdout, /dataset import-lca convert/u);
+
+  const converted = await executeCli(
+    ['dataset', 'import-lca', 'convert', '--input', 'in.zip', '--output-dir', 'out', '--json'],
+    {
+      ...deps,
+      runDatasetImportLcaConvertImpl: (options) => ({
+        schema_version: 1,
+        status: 'completed',
+        generated_at_utc: '2026-06-01T00:00:00.000Z',
+        input_path: options.inputPath,
+        output_dir: options.outputDir,
+        from_format: options.fromFormat ?? 'auto',
+        target: 'tidas',
+        detect_only: false,
+        command: {
+          executable: 'python3',
+          args: [],
+          cwd: '/tmp/tidas-tools',
+          exit_code: 0,
+          stdout: '',
+          stderr: '',
+        },
+        conversion_report: null,
+        files: {
+          report: '/tmp/report.json',
+          conversion_report: '/tmp/conversion-report.json',
+          tidas_dir: '/tmp/tidas',
+          ilcd_dir: null,
+          mapping_csv: '/tmp/mapping.csv',
+        },
+      }),
+    },
+  );
+  assert.equal(converted.exitCode, 0);
+  assert.equal(JSON.parse(converted.stdout).input_path, 'in.zip');
+});


### PR DESCRIPTION
Closes tiangong-lca/tiangong-cli#121

## Summary
- Add dataset contract, context-pack, import-lca convert, and authoring command surfaces for Foundry data import workflows.
- Wire CLI commands to SDK-provided schema/YAML/ruleset context and tidas-tools conversion handoff reports.

## Key Decisions
- Reuse SDK contract assets as the canonical source for AI-facing schema and methodology context.

## Validation
- npm run prepush:gate
- docpact lint --root /Users/davidli/projects/workspace/tiangong-lca-cli --merge-base origin/main

## Risks / Rollback
- Additive CLI surface; conversion command shells out to an explicit tidas-tools checkout and reports blocked status on tool failures.

## Workspace Integration
- Workspace integration is required after child PRs merge.