### PR TITLE
chore: release CLI 0.0.8

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-01"
-lastReviewedCommit: "8e1009da9b30369a0afe0e77fd2d2cd82bdf752e"
+lastReviewedCommit: "9feee617010391dd3aa2ba185a670091ec06f13b"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 8e1009da9b30369a0afe0e77fd2d2cd82bdf752e
+lastReviewedCommit: 9feee617010391dd3aa2ba185a670091ec06f13b
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 8e1009da9b30369a0afe0e77fd2d2cd82bdf752e
+lastReviewedCommit: 9feee617010391dd3aa2ba185a670091ec06f13b
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 8e1009da9b30369a0afe0e77fd2d2cd82bdf752e
+lastReviewedCommit: 9feee617010391dd3aa2ba185a670091ec06f13b
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 8e1009da9b30369a0afe0e77fd2d2cd82bdf752e
+lastReviewedCommit: 9feee617010391dd3aa2ba185a670091ec06f13b
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 8e1009da9b30369a0afe0e77fd2d2cd82bdf752e
+lastReviewedCommit: 9feee617010391dd3aa2ba185a670091ec06f13b
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/cli",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.101.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Unified TianGong LCA CLI with direct REST adapters and low-entropy command surface.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #125

## Summary

- Bump `@tiangong-lca/cli` to 0.0.8.
- Refresh release/docpact review evidence for the merged import gate changes now on `main`.

## Validation

- `npm ci`
- `npm run prepush:gate` passed twice, including the push hook: 684 tests, 680 pass / 4 skipped, 100% coverage assertion.
- `node ./scripts/ci/release-version.cjs assert-unpublished --version 0.0.8`
- `npm pack --dry-run` produced the 0.0.8 tarball plan.

## Workspace Integration

After npm publish verification, bump the workspace CLI submodule pointer to the 0.0.8 release commit.
