### PR TITLE
Fix CLI release gate repo root test assumption

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-01"
-lastReviewedCommit: "9feee617010391dd3aa2ba185a670091ec06f13b"
+lastReviewedCommit: "8c8689ee7d13093b772ee285a87129fa3585ddc9"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 9feee617010391dd3aa2ba185a670091ec06f13b
+lastReviewedCommit: 8c8689ee7d13093b772ee285a87129fa3585ddc9
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 9feee617010391dd3aa2ba185a670091ec06f13b
+lastReviewedCommit: f281bb99a364bfcaca30702c72fbaa5402361b5f
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 9feee617010391dd3aa2ba185a670091ec06f13b
+lastReviewedCommit: 8c8689ee7d13093b772ee285a87129fa3585ddc9
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 9feee617010391dd3aa2ba185a670091ec06f13b
+lastReviewedCommit: 8c8689ee7d13093b772ee285a87129fa3585ddc9
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 9feee617010391dd3aa2ba185a670091ec06f13b
+lastReviewedCommit: 8c8689ee7d13093b772ee285a87129fa3585ddc9
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/test/dataset-contract.test.ts
+++ b/test/dataset-contract.test.ts
@@ -251,7 +251,7 @@ test('dataset contract internals cover fallback-only branches', () => {
       __testInternals.resolveSdkRuntimeAssetsRoot([repoRoot], '/tmp/sdk/index.js'),
       repoRoot,
     );
-    assert.match(__testInternals.resolveCliRepoRoot(), /tiangong-lca-cli/u);
+    assert.equal(__testInternals.resolveCliRepoRoot(), process.cwd());
   } finally {
     rmSync(repoRoot, { recursive: true, force: true });
     rmSync(packageOnlyRoot, { recursive: true, force: true });


### PR DESCRIPTION
Closes #127\n\n## Summary\n- Replace the release-gate-sensitive repo-root assertion with an environment-independent `process.cwd()` assertion.\n- Record docpact review evidence for the validation, release, and architecture docs touched by this release-gate fix.\n\n## Validation\n- `node --test --import tsx test/dataset-contract.test.ts`\n- `npm run prepush:gate`\n- pre-push hook: docpact gate + `npm run prepush:gate`\n\n## Release follow-up\n- Unblocks creating `cli-v0.0.8` after the original release workflow failed on this test assumption.