### PR TITLE
chore: harden cli release publishing

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-01"
-lastReviewedCommit: "8c8689ee7d13093b772ee285a87129fa3585ddc9"
+lastReviewedCommit: "2145810ec95300f99a17f39801a169f098c08797"
 
 catalog:
   repos:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,12 @@
 name: Publish Package
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Existing cli-v* tag to release with the current workflow definition.
+        required: true
+        type: string
   push:
     tags:
       - 'cli-v*'
@@ -9,14 +15,99 @@ permissions:
   contents: read
 
 jobs:
+  release-context:
+    name: Release Context
+    runs-on: ubuntu-latest
+    outputs:
+      release_base: ${{ steps.release.outputs.release_base }}
+      release_head: ${{ steps.release.outputs.release_head }}
+      should_release: ${{ steps.release.outputs.should_release }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch main and tags
+        run: |
+          git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+          git fetch --force origin '+refs/tags/*:refs/tags/*'
+
+      - name: Resolve release target
+        id: release
+        env:
+          REQUESTED_TAG_NAME: ${{ github.event.inputs.tag_name || '' }}
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_REPOSITORY}" != "tiangong-lca/tiangong-cli" ]; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping release outside canonical repository: ${GITHUB_REPOSITORY}."
+            exit 0
+          fi
+
+          read_package_version() {
+            git show "${1}:package.json" | node -e "const fs = require('fs'); const pkg = JSON.parse(fs.readFileSync(0, 'utf8')); console.log(pkg.version);"
+          }
+
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            tag_name="${REQUESTED_TAG_NAME}"
+            if [ -z "${tag_name}" ] || [[ "${tag_name}" != cli-v* ]]; then
+              echo "::error::workflow_dispatch tag_name must be an existing cli-v* tag."
+              exit 1
+            fi
+          else
+            tag_name="${GITHUB_REF_NAME}"
+          fi
+
+          if ! release_head="$(git rev-list -n 1 "${tag_name}" 2>/dev/null)"; then
+            echo "::error::Release tag ${tag_name} does not exist."
+            exit 1
+          fi
+
+          package_version="$(read_package_version "${release_head}")"
+          expected_tag="cli-v${package_version}"
+          if [ "${tag_name}" != "${expected_tag}" ]; then
+            echo "::error::Release tag ${tag_name} does not match package.json version ${package_version} at ${release_head}."
+            exit 1
+          fi
+
+          if ! git merge-base --is-ancestor "${release_head}" origin/main; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+            echo "release_head=${release_head}" >> "$GITHUB_OUTPUT"
+            echo "::notice::Release target ${tag_name} points to ${release_head}, which is not on origin/main. Skipping npm publish."
+            exit 0
+          fi
+
+          release_base="$(git rev-parse "${release_head}^")"
+
+          echo "release_base=${release_base}" >> "$GITHUB_OUTPUT"
+          echo "release_head=${release_head}" >> "$GITHUB_OUTPUT"
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
+          echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Release context"
+            echo "- tag: \`${tag_name}\`"
+            echo "- head: \`${release_head}\`"
+            echo "- base: \`${release_base}\`"
+            echo "- package version: \`${package_version}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   release-gate:
     name: Release Gate
+    needs: release-context
+    if: needs.release-context.outputs.should_release == 'true'
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
         with:
+          ref: ${{ needs.release-context.outputs.release_head }}
           fetch-depth: 0
 
       - name: Fetch main
@@ -31,8 +122,8 @@ jobs:
       - name: Run docpact release gate
         run: |
           set -euo pipefail
-          release_head="$(git rev-list -n 1 "$GITHUB_REF_NAME")"
-          release_base="$(git rev-parse "${release_head}^")"
+          release_head="${{ needs.release-context.outputs.release_head }}"
+          release_base="${{ needs.release-context.outputs.release_base }}"
           scripts/docpact-gate.sh --base "$release_base" --head "$release_head"
 
       - name: Set up Node.js
@@ -50,7 +141,10 @@ jobs:
 
   npm-publish:
     name: Publish npm package
-    needs: release-gate
+    needs:
+      - release-context
+      - release-gate
+    if: needs.release-context.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -59,6 +153,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-context.outputs.release_head }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -75,7 +171,7 @@ jobs:
         run: npm ci
 
       - name: Validate release tag
-        run: node ./scripts/ci/check-release-tag.cjs cli
+        run: node ./scripts/ci/check-release-tag.cjs cli "${{ needs.release-context.outputs.tag_name }}"
 
       - name: Check npm registry version availability
         run: node ./scripts/ci/release-version.cjs assert-unpublished

--- a/.github/workflows/tag-release-from-merge.yml
+++ b/.github/workflows/tag-release-from-merge.yml
@@ -87,11 +87,35 @@ jobs:
           TARGET_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
-            echo "error: tag ${TAG_NAME} already exists" >&2
+          existing_sha="$(
+            gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG_NAME}" \
+              --jq '.object.sha' 2>/dev/null || true
+          )"
+
+          if [ -n "$existing_sha" ]; then
+            if [ "$existing_sha" = "$TARGET_SHA" ]; then
+              echo "::notice::Tag ${TAG_NAME} already points to ${TARGET_SHA}; continuing."
+              {
+                echo "### Release tag"
+                echo "- tag: \`${TAG_NAME}\`"
+                echo "- target: \`${TARGET_SHA}\`"
+                echo "- created: \`false\`"
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+
+            echo "error: tag ${TAG_NAME} already points to ${existing_sha}, not ${TARGET_SHA}" >&2
             exit 1
           fi
+
           gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
             --method POST \
             -f ref="refs/tags/${TAG_NAME}" \
             -f sha="${TARGET_SHA}"
+
+          {
+            echo "### Release tag"
+            echo "- tag: \`${TAG_NAME}\`"
+            echo "- target: \`${TARGET_SHA}\`"
+            echo "- created: \`true\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ Route those tasks to:
 - `src/lib/runtime-rulesets.ts` is the CLI-local runtime activation layer for stable ruleset ids, methodology rule ids, severity, and blocker semantics used by review, dedup, and publish gate artifacts.
 - The canonical minimum validation command is `npm run lint`
 - The authoritative full gate is `npm run prepush:gate`; the local pre-push hook runs it after docpact.
-- Release tagging is guarded in `.github/workflows/tag-release-from-merge.yml` so only the upstream repository can execute the merge-tag flow, and it runs the release gate only when a package version change will create a tag.
+- Release tagging is guarded in `.github/workflows/tag-release-from-merge.yml` so only the upstream repository can execute the merge-tag flow, and it runs the release gate only when a package version change will create a `cli-v<version>` tag. `.github/workflows/publish.yml` publishes from that tag and also supports `workflow_dispatch` for existing-tag recovery/backfill.
 - Coverage for `src/**/*.ts` is expected to stay at `100%` statements, branches, functions, and lines
 
 ## Hard Boundaries

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -148,6 +148,7 @@ Repo-level maintenance gates are now split across:
 - `.github/workflows/quality-gate.yml` for manual remote reproduction of the local gate
 - `.github/workflows/ai-doc-lint.yml`
 - `.github/workflows/tag-release-from-merge.yml`
+- `.github/workflows/publish.yml`
 
 Important constraints:
 
@@ -155,6 +156,7 @@ Important constraints:
 - `ai-doc-lint` keeps the historical check identity, but its implementation should run `docpact`
 - `docpact` enforces that command-surface and release-gate changes also refresh or review the governed source docs
 - the merge-tag workflow is guarded so only the upstream repository can execute release tagging
+- the publish workflow releases from `cli-v<package.json version>` and supports manual dispatch for existing-tag recovery/backfill
 
 ## Cross-Repo Boundaries
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -85,6 +85,7 @@ Facts that matter:
 - `.github/workflows/quality-gate.yml` is manual-dispatch only for remote reproduction, not an ordinary push-triggered test runner
 - `process save-draft`, `lifecyclemodel save-draft`, dataset governance commands, BuildPlan gates, publish schema/verification gates, and the newer process maintenance commands are expected to preserve `100%` coverage even when they add schema-validation, rewrite, or fallback branches
 - release-tag and docpact lint workflow changes should be described in the PR note when they alter the local or protected-branch proof
+- `tag-release-from-merge.yml` is idempotent when the expected `cli-v*` tag already points at the merge commit, and `publish.yml` can be re-run with `workflow_dispatch` only for an existing `cli-v*` tag on `origin/main`
 
 If the task changes control flow, add or update tests instead of using coverage-ignore pragmas.
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -121,6 +121,12 @@ Expected result:
 
 - `Publish Package` finishes successfully
 
+If the tag exists but the publish workflow needs to be re-run with the current workflow definition, use the manual dispatch input:
+
+```bash
+gh workflow run publish.yml --repo tiangong-lca/tiangong-cli --field tag_name=cli-v<x.y.z>
+```
+
 ### 3. npm registry
 
 Confirm npm has the expected version:
@@ -169,6 +175,7 @@ For the CLI repo, that helper defaults to:
 - If the version bump PR is not merged, no release should happen.
 - If tag creation fails, fix the workflow or repository secret/config first. Do not manually continue the workspace bump.
 - If publish fails, inspect the failed GitHub Actions run and npm/Trusted Publisher configuration before retrying the release flow.
+- If the tag exists and points to the intended merge commit but publish did not run, re-run `publish.yml` with `tag_name=cli-v<x.y.z>`.
 - If npm does not show the expected version yet, wait for registry propagation before treating the release as failed.
 
 ## Operator Checklist

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -92,8 +92,8 @@ Leave the environment name unset unless the workflow is explicitly updated to us
 
 ## Operational Notes
 
-- `publish.yml` validates that the Git tag matches the package version before upload.
-- `tag-release-from-merge.yml` only creates a tag when `package.json` version changes on `main`, and it runs `npm run prepush:gate` before creating that tag.
+- `publish.yml` validates that the Git tag matches the package version before upload and supports `workflow_dispatch` for existing-tag recovery/backfill.
+- `tag-release-from-merge.yml` only creates a tag when `package.json` version changes on `main`, and it runs `npm run prepush:gate` before creating that tag. If the expected tag already points at the current merge commit, the tag step is idempotent; if it points elsewhere, the workflow fails.
 - The release-prep PR should update only the intended versioned release metadata for the CLI package.
 - Adding CLI command families such as dataset or lifecyclemodel maintenance commands does not require release setup changes by itself; those feature PRs are covered by the normal quality and docpact gates before a later version bump.
 


### PR DESCRIPTION
Closes #129

## Summary
- Add publish workflow release-context handling for tag push and manual existing-tag recovery.
- Make merge-driven cli-v* tag creation idempotent when the expected tag already points at the merge commit.

## Key Decisions
- Keep CLI releases merge-driven via tag-release-from-merge.yml, with workflow_dispatch only for existing cli-v* tags on origin/main.
- Validate manual/tag release targets against package.json.version before publishing.

## Validation
- git diff --check
- scripts/docpact validate-config --root . --strict
- scripts/docpact lint --root . --merge-base origin/main --mode enforce --format json
- Ruby YAML parse for .github/workflows/publish.yml and .github/workflows/tag-release-from-merge.yml
- node ./scripts/ci/check-release-tag.cjs cli cli-v0.0.8

## Risks / Rollback
- Low operational risk: manual dispatch cannot publish arbitrary tags and merge tag creation fails if the tag points elsewhere.

## Follow-ups
- Monitor the next merge-driven CLI release tag and publish run.

## Workspace Integration
- Requires later lca-workspace submodule pointer update after merge/release eligibility.