### PR TITLE
fix: replace review command surface with qa

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-01"
-lastReviewedCommit: "2145810ec95300f99a17f39801a169f098c08797"
+lastReviewedAt: "2026-06-02"
+lastReviewedCommit: "56757053fca9dc5f4c8120225ee35e2b4cc995ef"
 
 catalog:
   repos:

--- a/.env.example
+++ b/.env.example
@@ -48,8 +48,8 @@ TIANGONG_LCA_COVERAGE=0
 #   The CLI now loads `@tiangong-lca/tidas-sdk` directly from package
 #   dependencies instead of resolving a sibling checkout or CI-injected dist.
 
-# Public optional review-only: ignore this block unless `tiangong-lca review process`
-# or `tiangong-lca review flow` is called with `--enable-llm`.
+# Public optional QA-only: ignore this block unless `tiangong-lca qa process`
+# or `tiangong-lca qa flow` is called with `--enable-llm`.
 # When enabled, point `TIANGONG_LCA_REVIEW_LLM_BASE_URL` at an
 # OpenAI-compatible Responses API base URL. The CLI will call `<base_url>/responses`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 8c8689ee7d13093b772ee285a87129fa3585ddc9
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: 56757053fca9dc5f4c8120225ee35e2b4cc995ef
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -18,8 +18,8 @@ checkPaths:
   - src/**
   - scripts/**
   - .github/workflows/**
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 8e1009da9b30369a0afe0e77fd2d2cd82bdf752e
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: 56757053fca9dc5f4c8120225ee35e2b4cc995ef
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ TIANGONG_LCA_DISABLE_SESSION_CACHE=false
 TIANGONG_LCA_FORCE_REAUTH=false
 ```
 
-Optional LLM review env, only for `review process --enable-llm` or `review flow --enable-llm`:
+Optional LLM review env, only for `qa process --enable-llm` or `qa flow --enable-llm`:
 
 ```bash
 TIANGONG_LCA_REVIEW_LLM_BASE_URL=
@@ -177,11 +177,11 @@ Key outputs under `--out-dir`:
 - `outputs/materialized-process.json`
 - `outputs/materialized-flow.json`
 
-## Real DB Flow Review
+## Real DB Flow QA
 
 1. Search or otherwise collect exact flow refs.
-2. Materialize DB rows into local review input.
-3. Review the materialized rows.
+2. Materialize DB rows into local QA input.
+3. Run QA on the materialized rows.
 4. Materialize approved decisions into downstream artifacts.
 
 `flow fetch-rows` input:
@@ -225,19 +225,19 @@ tiangong-lca flow fetch-rows \
   --refs-file ./flow-refs.json \
   --out-dir ./flow-fetch
 
-tiangong-lca review flow \
-  --rows-file ./flow-fetch/review-input-rows.jsonl \
-  --out-dir ./flow-review
+tiangong-lca qa flow \
+  --rows-file ./flow-fetch/qa-input-rows.jsonl \
+  --out-dir ./flow-qa
 
 tiangong-lca flow materialize-decisions \
   --decision-file ./approved-decisions.json \
-  --flow-rows-file ./flow-fetch/review-input-rows.jsonl \
+  --flow-rows-file ./flow-fetch/qa-input-rows.jsonl \
   --out-dir ./flow-decisions
 ```
 
 Key `flow fetch-rows` outputs:
 
-- `review-input-rows.jsonl`
+- `qa-input-rows.jsonl`
 - `fetch-summary.json`
 - `missing-flow-refs.jsonl`
 - `ambiguous-flow-refs.jsonl`
@@ -272,8 +272,8 @@ tiangong-lca lifecyclemodel publish-build --run-dir /abs/path/to/lifecyclemodel-
 tiangong-lca lifecyclemodel save-draft --input ./lifecyclemodels.jsonl --out-dir /abs/path/to/lifecyclemodel-save-draft --dry-run --json
 tiangong-lca lifecyclemodel graph --input ./lifecyclemodels.jsonl --out-dir /abs/path/to/lifecyclemodel-graph --format all --json
 tiangong-lca lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir /abs/path/to/lifecyclemodel-recursive-run --json
-tiangong-lca review process --rows-file ./process-list-report.json --out-dir ./review
-tiangong-lca review process --run-root /abs/path/to/process-run --run-id <run_id> --out-dir ./review
+tiangong-lca qa process --rows-file ./process-list-report.json --out-dir ./process-qa
+tiangong-lca qa process --run-root /abs/path/to/process-run --run-id <run_id> --out-dir ./process-qa
 tiangong-lca process save-draft --input ./patched-processes.jsonl --out-dir /abs/path/to/process-save-draft --dry-run --json
 tiangong-lca process save-draft --input ./patched-processes.jsonl --out-dir /abs/path/to/process-save-draft --commit --json
 tiangong-lca flow publish-version --input-file ./ready-flows.jsonl --out-dir /abs/path/to/flow-publish --dry-run --json
@@ -284,7 +284,7 @@ tiangong-lca doctor --json
 
 For `publish run`, relative `out_dir` values from either the request body or `--out-dir` are resolved against the request file directory, not the shell `cwd`. Use an absolute path when you want a fixed destination independent of the request file location.
 
-For `review process`, `--rows-file` accepts either raw process rows as JSON/JSONL or the full JSON report emitted by `tiangong-lca process list --json`, as long as it contains a `rows` array.
+For `qa process`, `--rows-file` accepts either raw process rows as JSON/JSONL or the full JSON report emitted by `tiangong-lca process list --json`, as long as it contains a `rows` array.
 
 For `process identity-preflight` and `flow identity-preflight`, canonical TIDAS wrappers are schema-checked when present. Loose target objects are accepted for early planning and produce `schema_validation.status: "not_applicable"` until materialization. Candidate rows can be embedded in the request, loaded from repeatable `--candidate-input` local files/directories, or fetched through explicit `--remote-candidates` hybrid search; `identity-candidate-sources.json` records scanned files, remote endpoints, queries, filters, and row counts.
 
@@ -307,15 +307,15 @@ For `dataset references rewrite`, `--commit` executes the state-aware save-draft
 ## More Docs
 
 - `docs/IMPLEMENTATION_GUIDE_CN.md`: maintainer-facing command contract and implementation notes
-- `--help`: the canonical command surface for `tiangong-lca`, `tiangong-lca flow`, `tiangong-lca review`, `tiangong-lca process`, `tiangong-lca lifecyclemodel`, and `tiangong-lca publish`
+- `--help`: the canonical command surface for `tiangong-lca`, `tiangong-lca qa`, `tiangong-lca flow`, `tiangong-lca process`, `tiangong-lca lifecyclemodel`, and `tiangong-lca publish`
 - `tiangong-lca-skills`: use the skill-specific `SKILL.md` and wrapper docs for agent workflows; the CLI README only covers the public invocation contract
 
 ## Help
 
 ```bash
 tiangong-lca --help
+tiangong-lca qa --help
 tiangong-lca flow --help
-tiangong-lca review --help
 tiangong-lca process --help
 tiangong-lca lifecyclemodel --help
 tiangong-lca publish --help

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -97,9 +97,10 @@ tiangong-lca
     build-resulting-process
     publish-resulting-process
     orchestrate
-  review
+  qa
     process
     flow
+    lifecyclemodel
   publish
     run
   validation
@@ -146,8 +147,8 @@ tiangong-lca
 | `tiangong-lca lifecyclemodel build-resulting-process` | 本地 lifecycle model resulting process 聚合、内部 flow 抵消、artifact 输出 |
 | `tiangong-lca lifecyclemodel publish-resulting-process` | 读取 resulting-process run，生成 `publish-bundle.json` / `publish-intent.json` 本地交付物 |
 | `tiangong-lca lifecyclemodel orchestrate` | 递归装配的 plan / execute / publish-handoff 命令；写出 graph/lineage/publish bundle 工件，并只调用原生 CLI builder slices |
-| `tiangong-lca review process` | 本地 process review、artifact-first 报告输出、可选 CLI LLM 语义审核 |
-| `tiangong-lca review flow` | 本地 flow governance review、rows-file 物化、artifact-first 报告输出、可选 CLI LLM 语义审核 |
+| `tiangong-lca qa process` | 本地 process QA、artifact-first 报告输出、可选 CLI LLM 语义审核 |
+| `tiangong-lca qa flow` | 本地 flow governance QA、rows-file 物化、artifact-first 报告输出、可选 CLI LLM 语义审核 |
 | `tiangong-lca publish run` | 本地 publish 契约归一化、dry-run/commit、`verification-report.json` 与 `publish-report.json` 输出；当提供 Supabase runtime 时默认通过共享 dataset command executor 提交 `lifecyclemodels` / `processes` / `sources` |
 | `tiangong-lca validation run` | 本地 `@tiangong-lca/tidas-sdk` 直接依赖校验收口 |
 | `tiangong-lca admin embedding-run` | `embedding_ft` |
@@ -163,11 +164,11 @@ tiangong-lca
 - `tiangong-lca lifecyclemodel publish-resulting-process` 已可执行
 - `tiangong-lca lifecyclemodel orchestrate` 已可执行
 
-`tiangong-lca review ...` 也已经开始进入统一命令树，其中：
+`tiangong-lca qa ...` 也已经开始进入统一命令树，其中：
 
-- `tiangong-lca review process` 已可执行
-- `tiangong-lca review flow` 已可执行
-- `tiangong-lca review lifecyclemodel` 已可执行
+- `tiangong-lca qa process` 已可执行
+- `tiangong-lca qa flow` 已可执行
+- `tiangong-lca qa lifecyclemodel` 已可执行
 
 `tiangong-lca flow ...` 也已经开始承接 flow-governance 主链迁移，其中：
 
@@ -204,7 +205,7 @@ tiangong-lca
 - 已实现的 `process identity-preflight` 是本地只读、artifact-first 的生成前 gate；输入为 target + embedded candidates，并可通过 repeatable `--candidate-input` 读取 JSON/JSONL 文件或递归扫描本地目录。需要查正式库时，输入可设置 `remote_candidate_search`，CLI 也可传 `--remote-candidates --remote-query ... --remote-limit ...`，通过 `process_hybrid_search` 拉取远程候选并合并进入同一套 identity / exchange fingerprint 判定。输出 `identity-decision.json` / `identity-candidates.jsonl` / `identity-candidate-sources.json`；当 exact exchange fingerprint 与 reference/geography 等身份上下文同时命中时输出 `block_duplicate`，只有 inventory-only 弱命中时才进入 `manual_review`。
 - 已实现的 `process build-plan` 是 identity preflight 后、payload 生成前的本地 gate；输入为 BuildPlan，输出 `build-plan-gate-report.json`，并在 `materialize` 时输出 canonical `materialized-process.json`。如果 plan 内已提供 canonical payload，则直接校验该 payload；如果没有 payload，则从 name plan、quantitative reference、exchange plan、source evidence、modelling/admin 字段确定性生成 `processDataSet`。`annualSupplyOrProductionVolume` 使用 build plan/evidence 的显式源语言值；缺失时不再按 reference flow 自动伪造，必须回到证据或 AI 修复环节补齐后再入库。
 - 已实现的 `process auto-build` 在调用方显式提供的 run root 内保留旧 `cache/process_from_flow_state.json`、`cache/agent_handoff_summary.json` 等运行布局，不再推断 repo 本地 `./artifacts/...` 默认路径
-- `process auto-build` 当前只负责本地 request intake、flow 归一化、run scaffold、初始 `manifests/process-build-plan.json` 和 manifest/report 预写，不继续执行后续阶段。该 build plan 是 scaffold_only，后续必须由 identity preflight、evidence replacement、build-plan validate/materialize、schema/review gate 决定是否可写入。
+- `process auto-build` 当前只负责本地 request intake、flow 归一化、run scaffold、初始 `manifests/process-build-plan.json` 和 manifest/report 预写，不继续执行后续阶段。该 build plan 是 scaffold_only，后续必须由 identity preflight、evidence replacement、build-plan validate/materialize、schema/QA gate 决定是否可写入。
 - 已实现的 `process resume-build` 保留同一套 run 布局，并把本地 state-lock、run-manifest 校验、resume metadata/history、invocation index 更新统一收口到 CLI
 - `process resume-build` 当前只负责本地 resume handoff，不直接执行 route / split / exchange / QA / publish 阶段
 - 已实现的 `process publish-build` 继续保留同一套 run 布局，并把本地 publish-bundle/request/intent、state/invocation/handoff 更新统一收口到 CLI
@@ -227,10 +228,10 @@ tiangong-lca
 - `publish-resulting-process` 当前负责生成本地 publish handoff 产物，还没有把提交语义直接并入 `publish run`
 - 已实现的 `lifecyclemodel orchestrate` 把递归装配的 `plan | execute | publish` 三个动作统一收口到 CLI，并直接复用原生 `process auto-build`、`lifecyclemodel auto-build`、`lifecyclemodel build-resulting-process` slices
 - `lifecyclemodel orchestrate` 的 `process_builder` request schema 已删除旧 builder 控制项，只保留 CLI-native 本地构建字段，并在归一化阶段拒绝额外键；不再保留任何 Python fallback 配置面
-- 已实现的 `review process` 保留本地 artifact-first review contract，把规则核查、报告输出和可选 LLM 语义审核统一收口到 CLI；语义审核只使用 `TIANGONG_LCA_REVIEW_LLM_*`，不再透出 `OPENAI_*`
-- 已实现的 `review flow` 保留本地 artifact-first governance review contract，把 flow 摘要、相似对、规则 findings、可选 LLM findings 和双语 markdown 报告统一收口到 CLI；语义审核同样只使用 `TIANGONG_LCA_REVIEW_LLM_*`
+- 已实现的 `qa process` 保留本地 artifact-first QA contract，把规则核查、报告输出和可选 LLM 语义审核统一收口到 CLI；语义审核只使用 `TIANGONG_LCA_REVIEW_LLM_*`，不再透出 `OPENAI_*`
+- 已实现的 `qa flow` 保留本地 artifact-first governance QA contract，把 flow 摘要、相似对、规则 findings、可选 LLM findings 和双语 markdown 报告统一收口到 CLI；语义审核同样只使用 `TIANGONG_LCA_REVIEW_LLM_*`
 - review / dedup / publish 相关 gate 现在统一通过 `src/lib/runtime-rulesets.ts` 映射稳定 ruleset id、methodology rule id、severity 与 blocker 语义，供 Foundry / UI / publish handoff 不解析本地实现细节也能识别阻断原因
-- `review flow` 当前明确不支持 `--with-reference-context`，也还没有接入本地 registry enrichment；这部分仍需后续迁移切片单独落地
+- `qa flow` 当前明确不支持 `--with-reference-context`，也还没有接入本地 registry enrichment；这部分仍需后续迁移切片单独落地
 - 已实现的 `flow get` 保留 deterministic direct-read 边界，但内部执行已经收口到原生 `@supabase/supabase-js`；支持 `id` + 可选 `version/user_id/state_code` 读取；若精确版本 miss，则回退到最新可见版本；若出现多个同版本可见候选，则直接报 ambiguous
 - 已实现的 `flow list` 保留 deterministic direct-read 边界，但内部执行已经收口到原生 `@supabase/supabase-js`；支持稳定 `id/state_code/type_of_dataset` 过滤、显式 `order=id.asc,version.asc` 默认值，以及 `--all --page-size` 的 offset 分页
 - 已实现的 `flow identity-preflight` 是本地只读、artifact-first 的生成前 gate；输入为 target + embedded candidates，并可通过 repeatable `--candidate-input` 读取 JSON/JSONL 文件或递归扫描本地目录。需要查正式库时，输入可设置 `remote_candidate_search`，CLI 也可传 `--remote-candidates --remote-query ... --remote-limit ...`，通过 `flow_hybrid_search` 拉取远程候选；若 target 有 flow type，CLI 会作为 remote filter 写入请求。输出 `identity-decision.json` / `identity-candidates.jsonl` / `identity-candidate-sources.json`；对 type、reference property、unit、CAS/category 和 alias/name 等价的 flow 输出 `block_duplicate`，避免 process 引用新建同义 flow。
@@ -450,7 +451,7 @@ outputs/evidence-search-declaration.json
 
 它现在还不负责：
 
-- 把搜索结果直接物化为 `review flow` 的本地 rows 输入
+- 把搜索结果直接物化为 `qa flow` 的本地 rows 输入
 - 对 edge-function 返回做本地字段重命名或 UI 适配
 - 用搜索结果替代 deterministic `flow get` / `flow list` 详情读取
 - 任何 “synthetic rows” 自动补位
@@ -592,32 +593,32 @@ outputs/evidence-search-declaration.json
 - 重新实现历史 MCP transport
 - reference-model discovery
 
-`review process` 现在固定的是“本地 process review 契约层”。
+`qa process` 现在固定的是“本地 process QA 契约层”。
 
 它负责：
 
 - 从 `--run-root` 读取 `exports/processes/*.json`
-- 延续现有 v2.1 review 规则做基础信息核查、物料平衡核查和单位疑似问题记录
+- 延续现有 v2.1 QA 规则做基础信息核查、物料平衡核查和单位疑似问题记录
 - 写出中英文 markdown review、timing、unit issue log、summary 和 report
 - 在显式启用 `--enable-llm` 时，通过 CLI 的 `TIANGONG_LCA_REVIEW_LLM_*` 运行时做可选语义审核
 
 它现在还不负责：
 
-- flow governance review
-- lifecycle model review
+- flow governance QA
+- lifecycle model QA
 - 远端 remediation / publish
 - 任何 skill 私有的 `OPENAI_*` 调用路径
 
-`review flow` 现在固定的是“本地 flow governance review 契约层”。
+`qa flow` 现在固定的是“本地 flow governance QA 契约层”。
 
 它负责：
 
 - 接受且只接受一种输入模式：`--rows-file`、`--flows-dir`、`--run-root`
-- 在 `--rows-file` 模式下物化 `review-input/flows/*.json` 与 `review-input/materialization-summary.json`
+- 在 `--rows-file` 模式下物化 `qa-input/flows/*.json` 与 `qa-input/materialization-summary.json`
 - 输出 `rule_findings.jsonl`、`llm_findings.jsonl`、`findings.jsonl`
 - 输出 `flow_summaries.jsonl`、`similarity_pairs.jsonl`
-- 输出 `flow_review_summary.json`、`flow_review_zh.md`、`flow_review_en.md`、`flow_review_timing.md`
-- 输出 `flow_review_report.json`
+- 输出 `flow_qa_summary.json`、`flow_qa_zh.md`、`flow_qa_en.md`、`flow_qa_timing.md`
+- 输出 `flow_qa_report.json`
 - 在显式启用 `--enable-llm` 时，通过 CLI 的 `TIANGONG_LCA_REVIEW_LLM_*` 运行时做可选语义审核
 
 它现在还不负责：
@@ -851,7 +852,7 @@ TIANGONG_LCA_FORCE_REAUTH=false
 - `TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` 是 authenticated CLI 命令的必需项
 - `TIANGONG_LCA_SESSION_FILE`、`TIANGONG_LCA_DISABLE_SESSION_CACHE`、`TIANGONG_LCA_FORCE_REAUTH` 是可选 session cache 控制项
 
-按需启用的可选 review-only 变量：只有显式启用 `tiangong-lca review process --enable-llm` 或 `tiangong-lca review flow --enable-llm` 时才需要配置。`TIANGONG_LCA_REVIEW_LLM_BASE_URL` 应指向 OpenAI-compatible Responses API 根地址，CLI 会向 `<base_url>/responses` 发请求。
+按需启用的可选 QA-only 变量：只有显式启用 `tiangong-lca qa process --enable-llm` 或 `tiangong-lca qa flow --enable-llm` 时才需要配置。`TIANGONG_LCA_REVIEW_LLM_BASE_URL` 应指向 OpenAI-compatible Responses API 根地址，CLI 会向 `<base_url>/responses` 发请求。
 
 ```bash
 TIANGONG_LCA_REVIEW_LLM_BASE_URL=
@@ -886,8 +887,8 @@ TIANGONG_LCA_COVERAGE=0
 - internal/preparatory 和 test-only env 也要在 `.env.example` 里显式列出，避免代码与文档脱节
 - 不为了历史实现或未来猜测保留 alias
 - 不引入 `SUPABASE_URL`、`SUPABASE_KEY`、`TIANGONG_LCA_TIDAS_SDK_DIR` 这类额外兼容层；原生 Supabase client 一律从 `TIANGONG_LCA_API_BASE_URL` 派生，用户 session 一律从 `TIANGONG_LCA_API_KEY + TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` 换取，`@tiangong-lca/tidas-sdk` 一律走直接依赖
-- `review process` 的可选语义审核统一走 review-only 的 `TIANGONG_LCA_REVIEW_LLM_*`，不再引入 `OPENAI_*`
-- `review flow` 的可选语义审核也统一走 review-only 的 `TIANGONG_LCA_REVIEW_LLM_*`，不再引入 `OPENAI_*`
+- `qa process` 的可选语义审核统一走 QA-only 的 `TIANGONG_LCA_REVIEW_LLM_*`，不再引入 `OPENAI_*`
+- `qa flow` 的可选语义审核也统一走 QA-only 的 `TIANGONG_LCA_REVIEW_LLM_*`，不再引入 `OPENAI_*`
 - `publish run` / `validation run` 都是本地契约与执行收口，不新增远程 env
 - `TIANGONG_LCA_KB_SEARCH_*` 与 `TIANGONG_LCA_UNSTRUCTURED_*` 目前只属于 internal/preparatory 层，不属于公开命令契约
 
@@ -906,9 +907,9 @@ TIANGONG_LCA_COVERAGE=0
 | `lifecyclemodel auto-build | validate-build | publish-build | orchestrate` | 无 |
 | `lifecyclemodel build-resulting-process` | 本地运行默认无；若 request 开启 `process_sources.allow_remote_lookup=true`，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` |
 | `lifecyclemodel publish-resulting-process` | 无 |
-| `review process` | 纯规则 review 默认无；若显式开启 `--enable-llm`，则需要 `TIANGONG_LCA_REVIEW_LLM_BASE_URL`、`TIANGONG_LCA_REVIEW_LLM_API_KEY`、`TIANGONG_LCA_REVIEW_LLM_MODEL` |
-| `review flow` | 纯规则 review 默认无；若显式开启 `--enable-llm`，则需要 `TIANGONG_LCA_REVIEW_LLM_BASE_URL`、`TIANGONG_LCA_REVIEW_LLM_API_KEY`、`TIANGONG_LCA_REVIEW_LLM_MODEL` |
-| `review lifecyclemodel` | 无 |
+| `qa process` | 纯规则 QA 默认无；若显式开启 `--enable-llm`，则需要 `TIANGONG_LCA_REVIEW_LLM_BASE_URL`、`TIANGONG_LCA_REVIEW_LLM_API_KEY`、`TIANGONG_LCA_REVIEW_LLM_MODEL` |
+| `qa flow` | 纯规则 QA 默认无；若显式开启 `--enable-llm`，则需要 `TIANGONG_LCA_REVIEW_LLM_BASE_URL`、`TIANGONG_LCA_REVIEW_LLM_API_KEY`、`TIANGONG_LCA_REVIEW_LLM_MODEL` |
+| `qa lifecyclemodel` | 无 |
 | `flow get` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` |
 | `flow list` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` |
 | `flow identity-preflight` | 默认无；若启用 `--remote-candidates` 或输入 `remote_candidate_search.enabled=true`，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY`（`TIANGONG_LCA_REGION` 可选） |
@@ -1001,10 +1002,10 @@ CLI 现在额外有一条独立于质量门的 npm 发布链路：
   - `tiangong-lca lifecyclemodel publish-build`
   - skill 侧不再保留 shell 兼容壳或 Python / MCP runtime
 - `lifecycleinventory-review`
-  - `tiangong-lca review process`
-  - `tiangong-lca review lifecyclemodel`
+  - `tiangong-lca qa process`
+  - `tiangong-lca qa lifecyclemodel`
 - `flow-governance-review`
-  - `tiangong-lca review flow`
+  - `tiangong-lca qa flow`
   - `tiangong-lca flow get`
   - `tiangong-lca flow list`
   - `tiangong-lca flow remediate`

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -17,8 +17,8 @@ checkPaths:
   - package.json
   - src/**
   - test/**
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 8e1009da9b30369a0afe0e77fd2d2cd82bdf752e
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: 56757053fca9dc5f4c8120225ee35e2b4cc995ef
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
+++ b/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
@@ -15,8 +15,8 @@ checkPaths:
   - src/lib/user-api-key.ts
   - src/lib/supabase-session.ts
   - src/lib/supabase-client.ts
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 8e1009da9b30369a0afe0e77fd2d2cd82bdf752e
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: 56757053fca9dc5f4c8120225ee35e2b4cc995ef
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
+++ b/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - src/lib/supabase-client.ts
   - src/lib/tidas-sdk-package-validator.ts
   - test/**
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 8e1009da9b30369a0afe0e77fd2d2cd82bdf752e
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: 56757053fca9dc5f4c8120225ee35e2b4cc995ef
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -85,7 +85,7 @@ The widest feature families currently live in:
 
 - `src/lib/flow-*.ts`
 - `src/lib/dataset-*.ts`
-- `src/lib/review-*.ts`
+- `src/lib/*-qa.ts`
 - `src/lib/process-*.ts`
 - `src/lib/lifecyclemodel-*.ts`
 - `src/lib/publish.ts`
@@ -93,7 +93,7 @@ The widest feature families currently live in:
 
 These files own the public CLI semantics for those workflows.
 
-### Process maintenance and review commands
+### Process maintenance and QA commands
 
 Recent process maintenance commands extend the same native CLI layer instead of introducing a secondary orchestration surface:
 
@@ -105,7 +105,7 @@ Recent process maintenance commands extend the same native CLI layer instead of 
 - `src/lib/process-verify-rows.ts`
 - `src/lib/identity-preflight.ts`
 - `src/lib/process-flow-build-plan.ts`
-- `src/lib/review-process.ts`
+- `src/lib/process-qa.ts`
 - `src/lib/runtime-rulesets.ts`
 
 These modules share one contract:
@@ -116,8 +116,8 @@ These modules share one contract:
 - `process save-draft` validates canonical payloads with `ProcessSchema` before remote writes
 - `flow publish-version` and `process publish-build` validate canonical payloads with `FlowSchema` / `ProcessSchema` before publish planning or handoff artifacts proceed
 - `publish run` writes a deterministic `verification-report.json` next to the final publish report so downstream automation can read blockers without parsing execution details
-- `runtime-rulesets` maps CLI-local review, dedup, and publish findings to stable methodology rule ids so Foundry and UI handoffs can consume one ruleset profile contract
-- maintenance and review commands still emit artifact-first local outputs and remain covered by the strict `src/**/*.ts` coverage gate
+- `runtime-rulesets` maps CLI-local QA, dedup, and publish findings to stable methodology rule ids so Foundry and UI handoffs can consume one ruleset profile contract
+- maintenance and QA commands still emit artifact-first local outputs and remain covered by the strict `src/**/*.ts` coverage gate
 
 ### Dataset and lifecyclemodel governance commands
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 8c8689ee7d13093b772ee285a87129fa3585ddc9
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: 56757053fca9dc5f4c8120225ee35e2b4cc995ef
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 8c8689ee7d13093b772ee285a87129fa3585ddc9
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: 56757053fca9dc5f4c8120225ee35e2b4cc995ef
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -19,8 +19,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 8c8689ee7d13093b772ee285a87129fa3585ddc9
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: 56757053fca9dc5f4c8120225ee35e2b4cc995ef
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -126,16 +126,8 @@ import {
   type RunProcessIdentityPreflightOptions,
 } from './lib/identity-preflight.js';
 import { runPublish, type PublishReport, type RunPublishOptions } from './lib/publish.js';
-import {
-  runProcessQa,
-  type ProcessQaReport,
-  type RunProcessQaOptions,
-} from './lib/process-qa.js';
-import {
-  runFlowQa,
-  type FlowQaReport,
-  type RunFlowQaOptions,
-} from './lib/flow-qa.js';
+import { runProcessQa, type ProcessQaReport, type RunProcessQaOptions } from './lib/process-qa.js';
+import { runFlowQa, type FlowQaReport, type RunFlowQaOptions } from './lib/flow-qa.js';
 import {
   runLifecyclemodelQa,
   type LifecyclemodelQaReport,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -127,20 +127,20 @@ import {
 } from './lib/identity-preflight.js';
 import { runPublish, type PublishReport, type RunPublishOptions } from './lib/publish.js';
 import {
-  runProcessReview,
-  type ProcessReviewReport,
-  type RunProcessReviewOptions,
-} from './lib/review-process.js';
+  runProcessQa,
+  type ProcessQaReport,
+  type RunProcessQaOptions,
+} from './lib/process-qa.js';
 import {
-  runFlowReview,
-  type FlowReviewReport,
-  type RunFlowReviewOptions,
-} from './lib/review-flow.js';
+  runFlowQa,
+  type FlowQaReport,
+  type RunFlowQaOptions,
+} from './lib/flow-qa.js';
 import {
-  runLifecyclemodelReview,
-  type LifecyclemodelReviewReport,
-  type RunLifecyclemodelReviewOptions,
-} from './lib/review-lifecyclemodel.js';
+  runLifecyclemodelQa,
+  type LifecyclemodelQaReport,
+  type RunLifecyclemodelQaOptions,
+} from './lib/lifecyclemodel-qa.js';
 import {
   runFlowRemediate,
   type FlowRemediationReport,
@@ -319,11 +319,11 @@ export type CliDeps = {
   runProcessBuildPlanMaterializeImpl?: (
     options: RunProcessBuildPlanMaterializeOptions,
   ) => Promise<ProcessBuildPlanGateReport>;
-  runProcessReviewImpl?: (options: RunProcessReviewOptions) => Promise<ProcessReviewReport>;
-  runFlowReviewImpl?: (options: RunFlowReviewOptions) => Promise<FlowReviewReport>;
-  runLifecyclemodelReviewImpl?: (
-    options: RunLifecyclemodelReviewOptions,
-  ) => Promise<LifecyclemodelReviewReport>;
+  runProcessQaImpl?: (options: RunProcessQaOptions) => Promise<ProcessQaReport>;
+  runFlowQaImpl?: (options: RunFlowQaOptions) => Promise<FlowQaReport>;
+  runLifecyclemodelQaImpl?: (
+    options: RunLifecyclemodelQaOptions,
+  ) => Promise<LifecyclemodelQaReport>;
   runFlowRemediateImpl?: (options: RunFlowRemediateOptions) => Promise<FlowRemediationReport>;
   runFlowFetchRowsImpl?: (options: RunFlowFetchRowsOptions) => Promise<FlowFetchRowsReport>;
   runFlowMaterializeDecisionsImpl?: (
@@ -426,7 +426,7 @@ Implemented Commands:
   dataset    contract get | context-pack | import-lca convert | author | validate | verify-remote | bilingual extract/apply/validate | evidence-search plan/run | references rewrite/refresh-remote
   flow       get | list | identity-preflight | build-plan | fetch-rows | materialize-decisions | remediate | publish-version | publish-reviewed-data | build-alias-map | scan-process-flow-refs | plan-process-flow-repairs | apply-process-flow-repairs | regen-product | validate-processes
   lifecyclemodel auto-build | validate-build | publish-build | save-draft | graph | build-resulting-process | publish-resulting-process | orchestrate
-  review     process | flow | lifecyclemodel
+  qa         process | flow | lifecyclemodel
   publish    run
   validation run
   admin      embedding-run
@@ -478,7 +478,7 @@ Examples:
   tiangong-lca flow identity-preflight --input ./flow-preflight.json --out-dir ./flow-preflight
   tiangong-lca flow build-plan validate --input ./flow-build-plan.json --out-dir ./flow-build-plan
   tiangong-lca flow fetch-rows --refs-file ./flow-refs.json --out-dir ./flow-fetch
-  tiangong-lca flow materialize-decisions --decision-file ./approved-decisions.json --flow-rows-file ./review-input-rows.jsonl --out-dir ./flow-decisions
+  tiangong-lca flow materialize-decisions --decision-file ./approved-decisions.json --flow-rows-file ./qa-input-rows.jsonl --out-dir ./flow-decisions
   tiangong-lca flow remediate --input-file ./invalid-flows.jsonl --out-dir ./flow-remediation
   tiangong-lca flow publish-version --input-file ./ready-flows.jsonl --out-dir ./flow-publish --commit
   tiangong-lca flow publish-reviewed-data --flow-rows-file ./reviewed-flows.jsonl --original-flow-rows-file ./original-flows.jsonl --out-dir ./flow-publish-review
@@ -488,10 +488,10 @@ Examples:
   tiangong-lca flow apply-process-flow-repairs --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-repair-apply
   tiangong-lca flow regen-product --processes-file ./processes.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-regeneration --apply
   tiangong-lca flow validate-processes --original-processes-file ./before.jsonl --patched-processes-file ./after.jsonl --scope-flow-file ./flows.jsonl --out-dir ./flow-validation
-  tiangong-lca review process --rows-file ./processes.jsonl --out-dir ./review
-  tiangong-lca review process --run-root /abs/path/to/process-run --run-id <run_id> --out-dir ./review
-  tiangong-lca review flow --rows-file ./flows.json --out-dir ./review
-  tiangong-lca review lifecyclemodel --run-dir /abs/path/to/lifecyclemodel-run --out-dir ./lifecyclemodel-review
+  tiangong-lca qa process --rows-file ./processes.jsonl --out-dir ./qa
+  tiangong-lca qa process --run-root /abs/path/to/process-run --run-id <run_id> --out-dir ./qa
+  tiangong-lca qa flow --rows-file ./flows.json --out-dir ./qa
+  tiangong-lca qa lifecyclemodel --run-dir /abs/path/to/lifecyclemodel-run --out-dir ./lifecyclemodel-qa
   tiangong-lca publish run --input ./publish-request.json --dry-run
   tiangong-lca validation run --input-dir ./package --engine auto
   tiangong-lca admin embedding-run --input ./jobs.json
@@ -611,7 +611,7 @@ Implemented Subcommands:
   verify-remote        Verify dataset roots and TIDAS references against remote published versions
   bilingual extract    Extract bilingual translation units from local rows
   bilingual apply      Apply reviewed bilingual translations back to local rows
-  bilingual validate   Validate bilingual rows with deterministic scans and schema/review gates
+  bilingual validate   Validate bilingual rows with deterministic scans and schema/QA gates
   evidence-search      Plan or record field-level public evidence retrieval
   references rewrite   Rewrite flow references in local process and lifecyclemodel rows
   references refresh-remote Refresh local TIDAS reference versions to latest reachable remote rows
@@ -837,7 +837,7 @@ function renderDatasetBilingualValidateHelp(): string {
 Options:
   --input <file>   Local rows as JSON or JSONL
   --type <type>    auto | flow | process | lifecyclemodel (default: auto)
-  --out-dir <dir>  Artifact directory for scan, schema, and review outputs
+  --out-dir <dir>  Artifact directory for scan, schema, and QA outputs
   --json           Print compact JSON
   -h, --help
 
@@ -845,7 +845,7 @@ Outputs written under --out-dir:
   - outputs/bilingual-validate-report.json
   - outputs/bilingual-findings.jsonl
   - schema/outputs/validation-report.json
-  - review/process/... and/or review/flow/... when applicable
+  - qa/process/... and/or qa/flow/... when applicable
 `.trim();
 }
 
@@ -932,7 +932,7 @@ Implemented Subcommands:
   list         Enumerate flow datasets through direct Supabase access with deterministic filters
   identity-preflight Compare one target flow against local candidates before generation
   build-plan  Validate or materialize a flow build plan into gate artifacts
-  fetch-rows   Materialize real DB flow refs into local review-input rows and fetch artifacts
+  fetch-rows   Materialize real DB flow refs into local qa-input rows and fetch artifacts
   materialize-decisions Materialize approved merge decisions into canonical-map, rewrite-plan, and seed artifacts
   remediate    Deterministically repair invalid local flow rows and emit artifact-first outputs
   publish-version Publish remediated flow versions through the unified CLI surface
@@ -1103,7 +1103,7 @@ Required env:
 
 Outputs written under --out-dir:
   - resolved-flow-rows.jsonl
-  - review-input-rows.jsonl
+  - qa-input-rows.jsonl
   - fetch-summary.json
   - missing-flow-refs.jsonl
   - ambiguous-flow-refs.jsonl
@@ -1331,58 +1331,57 @@ Outputs written under --out-dir:
 `.trim();
 }
 
-function renderReviewHelp(): string {
+function renderQaHelp(): string {
   return `Usage:
-  tiangong-lca review <subcommand> [options]
+  tiangong-lca qa <subcommand> [options]
 
 Implemented Subcommands:
-  process      Review process build runs or rows-file snapshots and emit artifact-first findings
-  flow         Review local flow governance snapshots and emit artifact-first findings
-  lifecyclemodel Review one local lifecyclemodel build run and emit artifact-first findings
+  process      Run deterministic process QA for build runs or rows-file snapshots
+  flow         Run deterministic flow QA for local governance snapshots
+  lifecyclemodel Run deterministic lifecyclemodel QA for one local build run
 
 Examples:
-  tiangong-lca review --help
-  tiangong-lca review process --help
-  tiangong-lca review flow --help
-  tiangong-lca review lifecyclemodel --help
+  tiangong-lca qa process --help
+  tiangong-lca qa flow --help
+  tiangong-lca qa lifecyclemodel --help
 `.trim();
 }
 
-function renderReviewProcessHelp(): string {
+function renderQaProcessHelp(): string {
   return `Usage:
-  tiangong-lca review process (--rows-file <file> | --run-root <dir>) --out-dir <dir> [options]
+  tiangong-lca qa process (--rows-file <file> | --run-root <dir>) --out-dir <dir> [options]
 
 Options:
   --rows-file <file>        Process rows JSON/JSONL file; full process list reports with rows[] are also accepted
   --run-root <dir>          Process build run root containing exports/processes
-  --run-id <id>             Optional review run identifier; defaults to the rows-file name or run-root basename
-  --out-dir <dir>           Review artifact output directory
+  --run-id <id>             Optional QA run identifier; defaults to the rows-file name or run-root basename
+  --out-dir <dir>           QA artifact output directory
   --start-ts <iso>          Optional run start timestamp
   --end-ts <iso>            Optional run end timestamp
-  --logic-version <name>    Review logic version label (default: v2.1)
-  --enable-llm              Enable optional review-only semantic review via the CLI LLM client
-  --llm-model <name>        Override TIANGONG_LCA_REVIEW_LLM_MODEL for this review command
-  --llm-max-processes <n>   Cap how many process summaries are sent to the LLM (default: 8)
+  --logic-version <name>    QA logic version label (default: v2.1)
+  --enable-llm              Deprecated no-op; process semantic authoring now belongs in Foundry curation
+  --llm-model <name>        Deprecated no-op kept for older scripts
+  --llm-max-processes <n>   Deprecated no-op kept for older scripts
   --json                    Print compact JSON
   -h, --help
 `.trim();
 }
 
-function renderReviewFlowHelp(): string {
+function renderQaFlowHelp(): string {
   return `Usage:
-  tiangong-lca review flow (--rows-file <file> | --flows-dir <dir> | --run-root <dir>) --out-dir <dir> [options]
+  tiangong-lca qa flow (--rows-file <file> | --flows-dir <dir> | --run-root <dir>) --out-dir <dir> [options]
 
 Options:
-  --rows-file <file>        Flow rows JSON / JSONL file; the CLI materializes review-input/flows automatically
+  --rows-file <file>        Flow rows JSON / JSONL file; the CLI materializes qa-input/flows automatically
   --flows-dir <dir>         Directory containing per-flow JSON files
   --run-root <dir>          Existing run root containing cache/flows or exports/flows
   --run-id <id>             Optional run identifier override
-  --out-dir <dir>           Review artifact output directory
+  --out-dir <dir>           QA artifact output directory
   --start-ts <iso>          Optional run start timestamp
   --end-ts <iso>            Optional run end timestamp
-  --logic-version <name>    Review logic version label (default: flow-v1.0-cli)
-  --enable-llm              Enable optional review-only semantic review via the CLI LLM client
-  --llm-model <name>        Override TIANGONG_LCA_REVIEW_LLM_MODEL for this review command
+  --logic-version <name>    QA logic version label (default: flow-v1.0-cli)
+  --enable-llm              Enable optional QA-only semantic checks via the CLI LLM client
+  --llm-model <name>        Override TIANGONG_LCA_REVIEW_LLM_MODEL for this QA command
   --llm-max-flows <n>       Cap how many flow summaries are sent to the LLM (default: 120)
   --llm-batch-size <n>      Cap how many flow summaries each LLM batch sends (default: 20)
   --similarity-threshold <n> Similarity threshold for duplicate-candidate warnings (default: 0.92)
@@ -1392,23 +1391,23 @@ Options:
 `.trim();
 }
 
-function renderReviewLifecyclemodelHelp(): string {
+function renderQaLifecyclemodelHelp(): string {
   return `Usage:
-  tiangong-lca review lifecyclemodel --run-dir <dir> --out-dir <dir> [options]
+  tiangong-lca qa lifecyclemodel --run-dir <dir> --out-dir <dir> [options]
 
 Options:
   --run-dir <dir>          Existing lifecyclemodel auto-build run directory
-  --out-dir <dir>          Review artifact output directory
+  --out-dir <dir>          QA artifact output directory
   --start-ts <iso>         Optional run start timestamp
   --end-ts <iso>           Optional run end timestamp
-  --logic-version <name>   Review logic version label (default: lifecyclemodel-review-v1.0)
+  --logic-version <name>   QA logic version label (default: lifecyclemodel-qa-v1.0)
   --json                   Print compact JSON
   -h, --help
 
 This command:
   - reads one existing lifecyclemodel build run under models/*/tidas_bundle/lifecyclemodels
   - aggregates validate-build findings when reports/lifecyclemodel-validate-build-report.json is present
-  - emits artifact-first model summaries, findings, markdown review notes, and a structured report
+  - emits artifact-first model summaries, findings, markdown QA notes, and a structured report
 `.trim();
 }
 
@@ -3790,7 +3789,7 @@ function parseFlowListFlags(args: string[]): {
   };
 }
 
-function parseReviewProcessFlags(args: string[]): {
+function parseQaProcessFlags(args: string[]): {
   help: boolean;
   json: boolean;
   rowsFile: string | undefined;
@@ -3863,7 +3862,7 @@ function parseReviewProcessFlags(args: string[]): {
   };
 }
 
-function parseReviewFlowFlags(args: string[]): {
+function parseQaFlowFlags(args: string[]): {
   help: boolean;
   json: boolean;
   rowsFile: string | undefined;
@@ -3974,7 +3973,7 @@ function parseReviewFlowFlags(args: string[]): {
   };
 }
 
-function parseReviewLifecyclemodelFlags(args: string[]): {
+function parseQaLifecyclemodelFlags(args: string[]): {
   help: boolean;
   json: boolean;
   runDir: string;
@@ -4926,6 +4925,16 @@ function plannedCommand(command: string, subcommand?: string): CliResult {
   };
 }
 
+function removedReviewCommand(subcommand?: string): CliResult {
+  const suffix = subcommand ? ` ${subcommand}` : '';
+  const replacement = subcommand ? `qa ${subcommand}` : 'qa';
+  return {
+    exitCode: 2,
+    stdout: '',
+    stderr: `Command 'review${suffix}' was removed. Use 'tiangong-lca ${replacement}' instead.\n`,
+  };
+}
+
 function applyRemoteOverrides(
   env: NodeJS.ProcessEnv,
   overrides: Pick<ReturnType<typeof parseRemoteFlags>, 'apiBaseUrl' | 'apiKey' | 'region'>,
@@ -4981,9 +4990,9 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
       deps.runProcessBuildPlanValidateImpl ?? runProcessBuildPlanValidate;
     const processBuildPlanMaterializeImpl =
       deps.runProcessBuildPlanMaterializeImpl ?? runProcessBuildPlanMaterialize;
-    const processReviewImpl = deps.runProcessReviewImpl ?? runProcessReview;
-    const flowReviewImpl = deps.runFlowReviewImpl ?? runFlowReview;
-    const lifecyclemodelReviewImpl = deps.runLifecyclemodelReviewImpl ?? runLifecyclemodelReview;
+    const processQaImpl = deps.runProcessQaImpl ?? runProcessQa;
+    const flowQaImpl = deps.runFlowQaImpl ?? runFlowQa;
+    const lifecyclemodelQaImpl = deps.runLifecyclemodelQaImpl ?? runLifecyclemodelQa;
     const flowRemediateImpl = deps.runFlowRemediateImpl ?? runFlowRemediate;
     const flowFetchRowsImpl = deps.runFlowFetchRowsImpl ?? runFlowFetchRows;
     const flowMaterializeDecisionsImpl =
@@ -6416,89 +6425,93 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
       };
     }
 
-    if (command === 'review' && !subcommand) {
-      return { exitCode: 0, stdout: `${renderReviewHelp()}\n`, stderr: '' };
+    if (command === 'qa' && !subcommand) {
+      return { exitCode: 0, stdout: `${renderQaHelp()}\n`, stderr: '' };
     }
 
-    if (command === 'review' && subcommand === 'process') {
-      const reviewFlags = parseReviewProcessFlags(commandArgs);
-      if (reviewFlags.help) {
-        return { exitCode: 0, stdout: `${renderReviewProcessHelp()}\n`, stderr: '' };
+    if (command === 'qa' && subcommand === 'process') {
+      const qaFlags = parseQaProcessFlags(commandArgs);
+      if (qaFlags.help) {
+        return { exitCode: 0, stdout: `${renderQaProcessHelp()}\n`, stderr: '' };
       }
 
-      const report = await processReviewImpl({
-        rowsFile: reviewFlags.rowsFile,
-        runRoot: reviewFlags.runRoot,
-        runId: reviewFlags.runId,
-        outDir: reviewFlags.outDir,
-        startTs: reviewFlags.startTs,
-        endTs: reviewFlags.endTs,
-        logicVersion: reviewFlags.logicVersion,
-        enableLlm: reviewFlags.enableLlm,
-        llmModel: reviewFlags.llmModel,
-        llmMaxProcesses: reviewFlags.llmMaxProcesses,
+      const report = await processQaImpl({
+        rowsFile: qaFlags.rowsFile,
+        runRoot: qaFlags.runRoot,
+        runId: qaFlags.runId,
+        outDir: qaFlags.outDir,
+        startTs: qaFlags.startTs,
+        endTs: qaFlags.endTs,
+        logicVersion: qaFlags.logicVersion,
+        enableLlm: qaFlags.enableLlm,
+        llmModel: qaFlags.llmModel,
+        llmMaxProcesses: qaFlags.llmMaxProcesses,
         env: deps.env,
         fetchImpl: deps.fetchImpl,
       });
 
       return {
         exitCode: 0,
-        stdout: stringifyJson(report, reviewFlags.json),
+        stdout: stringifyJson(report, qaFlags.json),
         stderr: '',
       };
     }
 
-    if (command === 'review' && subcommand === 'flow') {
-      const reviewFlags = parseReviewFlowFlags(commandArgs);
-      if (reviewFlags.help) {
-        return { exitCode: 0, stdout: `${renderReviewFlowHelp()}\n`, stderr: '' };
+    if (command === 'qa' && subcommand === 'flow') {
+      const qaFlags = parseQaFlowFlags(commandArgs);
+      if (qaFlags.help) {
+        return { exitCode: 0, stdout: `${renderQaFlowHelp()}\n`, stderr: '' };
       }
 
-      const report = await flowReviewImpl({
-        rowsFile: reviewFlags.rowsFile,
-        flowsDir: reviewFlags.flowsDir,
-        runRoot: reviewFlags.runRoot,
-        runId: reviewFlags.runId,
-        outDir: reviewFlags.outDir,
-        startTs: reviewFlags.startTs,
-        endTs: reviewFlags.endTs,
-        logicVersion: reviewFlags.logicVersion,
-        enableLlm: reviewFlags.enableLlm,
-        llmModel: reviewFlags.llmModel,
-        llmMaxFlows: reviewFlags.llmMaxFlows,
-        llmBatchSize: reviewFlags.llmBatchSize,
-        similarityThreshold: reviewFlags.similarityThreshold,
-        methodologyId: reviewFlags.methodologyId,
+      const report = await flowQaImpl({
+        rowsFile: qaFlags.rowsFile,
+        flowsDir: qaFlags.flowsDir,
+        runRoot: qaFlags.runRoot,
+        runId: qaFlags.runId,
+        outDir: qaFlags.outDir,
+        startTs: qaFlags.startTs,
+        endTs: qaFlags.endTs,
+        logicVersion: qaFlags.logicVersion,
+        enableLlm: qaFlags.enableLlm,
+        llmModel: qaFlags.llmModel,
+        llmMaxFlows: qaFlags.llmMaxFlows,
+        llmBatchSize: qaFlags.llmBatchSize,
+        similarityThreshold: qaFlags.similarityThreshold,
+        methodologyId: qaFlags.methodologyId,
         env: deps.env,
         fetchImpl: deps.fetchImpl,
       });
 
       return {
         exitCode: 0,
-        stdout: stringifyJson(report, reviewFlags.json),
+        stdout: stringifyJson(report, qaFlags.json),
         stderr: '',
       };
     }
 
-    if (command === 'review' && subcommand === 'lifecyclemodel') {
-      const reviewFlags = parseReviewLifecyclemodelFlags(commandArgs);
-      if (reviewFlags.help) {
-        return { exitCode: 0, stdout: `${renderReviewLifecyclemodelHelp()}\n`, stderr: '' };
+    if (command === 'qa' && subcommand === 'lifecyclemodel') {
+      const qaFlags = parseQaLifecyclemodelFlags(commandArgs);
+      if (qaFlags.help) {
+        return { exitCode: 0, stdout: `${renderQaLifecyclemodelHelp()}\n`, stderr: '' };
       }
 
-      const report = await lifecyclemodelReviewImpl({
-        runDir: reviewFlags.runDir,
-        outDir: reviewFlags.outDir,
-        startTs: reviewFlags.startTs,
-        endTs: reviewFlags.endTs,
-        logicVersion: reviewFlags.logicVersion,
+      const report = await lifecyclemodelQaImpl({
+        runDir: qaFlags.runDir,
+        outDir: qaFlags.outDir,
+        startTs: qaFlags.startTs,
+        endTs: qaFlags.endTs,
+        logicVersion: qaFlags.logicVersion,
       });
 
       return {
         exitCode: 0,
-        stdout: stringifyJson(report, reviewFlags.json),
+        stdout: stringifyJson(report, qaFlags.json),
         stderr: '',
       };
+    }
+
+    if (command === 'review') {
+      return removedReviewCommand(subcommand ?? undefined);
     }
 
     return plannedCommand(command, subcommand ?? undefined);

--- a/src/lib/dataset-bilingual.ts
+++ b/src/lib/dataset-bilingual.ts
@@ -16,12 +16,12 @@ import {
   type DatasetValidateReport,
   type RunDatasetValidateOptions,
 } from './dataset-validate.js';
-import { runFlowReview, type FlowReviewReport, type RunFlowReviewOptions } from './review-flow.js';
+import { runFlowQa, type FlowQaReport, type RunFlowQaOptions } from './flow-qa.js';
 import {
-  runProcessReview,
-  type ProcessReviewReport,
-  type RunProcessReviewOptions,
-} from './review-process.js';
+  runProcessQa,
+  type ProcessQaReport,
+  type RunProcessQaOptions,
+} from './process-qa.js';
 
 type BilingualDatasetType = 'auto' | DatasetKind;
 type BilingualStatus = 'completed' | 'blocked';
@@ -128,7 +128,7 @@ export type DatasetBilingualValidateReport = {
     invalid: number;
     report_file: string | null;
   };
-  review_gate: {
+  qa_gate: {
     status: 'completed' | 'not_run';
     process_report_file: string | null;
     flow_report_file: string | null;
@@ -167,8 +167,8 @@ export type RunDatasetBilingualValidateOptions = {
   rawInput?: unknown;
   now?: Date;
   datasetValidateImpl?: (options: RunDatasetValidateOptions) => Promise<DatasetValidateReport>;
-  processReviewImpl?: (options: RunProcessReviewOptions) => Promise<ProcessReviewReport>;
-  flowReviewImpl?: (options: RunFlowReviewOptions) => Promise<FlowReviewReport>;
+  processQaImpl?: (options: RunProcessQaOptions) => Promise<ProcessQaReport>;
+  flowQaImpl?: (options: RunFlowQaOptions) => Promise<FlowQaReport>;
   schemas?: RunDatasetValidateOptions['schemas'];
 };
 
@@ -779,19 +779,19 @@ export async function runDatasetBilingualValidate(
     schemas: options.schemas,
   });
 
-  let processReport: ProcessReviewReport | null = null;
-  let flowReport: FlowReviewReport | null = null;
+  let processReport: ProcessQaReport | null = null;
+  let flowReport: FlowQaReport | null = null;
   if (options.outDir && (requestedType === 'process' || requestedType === 'auto')) {
     const processRows = rows.filter((row) => row.kind === 'process').map((row) => row.row);
     if (processRows.length > 0) {
       const processRowsFile = path.join(
         path.resolve(options.outDir),
-        'review-input-processes.jsonl',
+        'qa-input-processes.jsonl',
       );
       writeJsonLinesArtifact(processRowsFile, processRows);
-      processReport = await (options.processReviewImpl ?? runProcessReview)({
+      processReport = await (options.processQaImpl ?? runProcessQa)({
         rowsFile: processRowsFile,
-        outDir: path.join(path.resolve(options.outDir), 'review', 'process'),
+        outDir: path.join(path.resolve(options.outDir), 'qa', 'process'),
         now: () => options.now ?? new Date(),
       });
     }
@@ -799,11 +799,11 @@ export async function runDatasetBilingualValidate(
   if (options.outDir && (requestedType === 'flow' || requestedType === 'auto')) {
     const flowRows = rows.filter((row) => row.kind === 'flow').map((row) => row.row);
     if (flowRows.length > 0) {
-      const flowRowsFile = path.join(path.resolve(options.outDir), 'review-input-flows.jsonl');
+      const flowRowsFile = path.join(path.resolve(options.outDir), 'qa-input-flows.jsonl');
       writeJsonLinesArtifact(flowRowsFile, flowRows);
-      flowReport = await (options.flowReviewImpl ?? runFlowReview)({
+      flowReport = await (options.flowQaImpl ?? runFlowQa)({
         rowsFile: flowRowsFile,
-        outDir: path.join(path.resolve(options.outDir), 'review', 'flow'),
+        outDir: path.join(path.resolve(options.outDir), 'qa', 'flow'),
         now: () => options.now ?? new Date(),
       });
     }
@@ -830,7 +830,7 @@ export async function runDatasetBilingualValidate(
       invalid: schemaReport.counts.invalid,
       report_file: schemaReport.files.report,
     },
-    review_gate: {
+    qa_gate: {
       status: processReport || flowReport ? 'completed' : 'not_run',
       process_report_file: processReport?.files.report ?? null,
       flow_report_file: flowReport?.files.report ?? null,

--- a/src/lib/dataset-bilingual.ts
+++ b/src/lib/dataset-bilingual.ts
@@ -17,11 +17,7 @@ import {
   type RunDatasetValidateOptions,
 } from './dataset-validate.js';
 import { runFlowQa, type FlowQaReport, type RunFlowQaOptions } from './flow-qa.js';
-import {
-  runProcessQa,
-  type ProcessQaReport,
-  type RunProcessQaOptions,
-} from './process-qa.js';
+import { runProcessQa, type ProcessQaReport, type RunProcessQaOptions } from './process-qa.js';
 
 type BilingualDatasetType = 'auto' | DatasetKind;
 type BilingualStatus = 'completed' | 'blocked';
@@ -784,10 +780,7 @@ export async function runDatasetBilingualValidate(
   if (options.outDir && (requestedType === 'process' || requestedType === 'auto')) {
     const processRows = rows.filter((row) => row.kind === 'process').map((row) => row.row);
     if (processRows.length > 0) {
-      const processRowsFile = path.join(
-        path.resolve(options.outDir),
-        'qa-input-processes.jsonl',
-      );
+      const processRowsFile = path.join(path.resolve(options.outDir), 'qa-input-processes.jsonl');
       writeJsonLinesArtifact(processRowsFile, processRows);
       processReport = await (options.processQaImpl ?? runProcessQa)({
         rowsFile: processRowsFile,

--- a/src/lib/flow-fetch-rows.ts
+++ b/src/lib/flow-fetch-rows.ts
@@ -61,14 +61,14 @@ export type FlowFetchRowsReport = {
   allow_latest_fallback: boolean;
   requested_ref_count: number;
   resolved_ref_count: number;
-  review_input_row_count: number;
-  duplicate_review_input_rows_collapsed: number;
+  qa_input_row_count: number;
+  duplicate_qa_input_rows_collapsed: number;
   missing_ref_count: number;
   ambiguous_ref_count: number;
   resolution_counts: Record<SupabaseFlowLookup['resolution'], number>;
   files: {
     resolved_flow_rows: string;
-    review_input_rows: string;
+    qa_input_rows: string;
     fetch_summary: string;
     missing_flow_refs: string;
     ambiguous_flow_refs: string;
@@ -162,7 +162,7 @@ function buildMaterializedRow(
   };
 }
 
-function buildReviewInputRow(
+function buildQaInputRow(
   row: JsonRecord,
   flowKey: string,
   contexts: FlowFetchMaterializationContext[],
@@ -217,7 +217,7 @@ export async function runFlowFetchRows(
   const resolvedRowArtifacts: JsonRecord[] = [];
   const missingRefs: JsonRecord[] = [];
   const ambiguousRefs: JsonRecord[] = [];
-  const reviewInputByKey = new Map<
+  const qaInputByKey = new Map<
     string,
     { row: JsonRecord; contexts: FlowFetchMaterializationContext[] }
   >();
@@ -284,22 +284,22 @@ export async function runFlowFetchRows(
     resolvedRowArtifacts.push(materializedRow);
 
     const flowKey = `${resolvedFlowId}@${resolvedVersion}`;
-    const existing = reviewInputByKey.get(flowKey);
+    const existing = qaInputByKey.get(flowKey);
     if (existing) {
       existing.contexts.push(context);
     } else {
-      reviewInputByKey.set(flowKey, {
+      qaInputByKey.set(flowKey, {
         row: materializedRow,
         contexts: [context],
       });
     }
   }
 
-  const reviewInputRows = [...reviewInputByKey.entries()]
+  const qaInputRows = [...qaInputByKey.entries()]
     .sort(([left], [right]) => left.localeCompare(right))
-    .map(([flowKey, entry]) => buildReviewInputRow(entry.row, flowKey, entry.contexts));
+    .map(([flowKey, entry]) => buildQaInputRow(entry.row, flowKey, entry.contexts));
 
-  const duplicateReviewInputRowsCollapsed = resolvedRowArtifacts.length - reviewInputRows.length;
+  const duplicateQaInputRowsCollapsed = resolvedRowArtifacts.length - qaInputRows.length;
   const unresolvedRefCount = missingRefs.length + ambiguousRefs.length;
   const status: FlowFetchSummaryStatus =
     unresolvedRefCount > 0
@@ -307,13 +307,13 @@ export async function runFlowFetchRows(
       : 'completed_flow_row_materialization';
 
   const resolvedRowsPath = path.join(resolvedOutDir, 'resolved-flow-rows.jsonl');
-  const reviewInputRowsPath = path.join(resolvedOutDir, 'review-input-rows.jsonl');
+  const qaInputRowsPath = path.join(resolvedOutDir, 'qa-input-rows.jsonl');
   const missingRefsPath = path.join(resolvedOutDir, 'missing-flow-refs.jsonl');
   const ambiguousRefsPath = path.join(resolvedOutDir, 'ambiguous-flow-refs.jsonl');
   const summaryPath = path.join(resolvedOutDir, 'fetch-summary.json');
 
   writeJsonLinesArtifact(resolvedRowsPath, resolvedRowArtifacts);
-  writeJsonLinesArtifact(reviewInputRowsPath, reviewInputRows);
+  writeJsonLinesArtifact(qaInputRowsPath, qaInputRows);
   writeJsonLinesArtifact(missingRefsPath, missingRefs);
   writeJsonLinesArtifact(ambiguousRefsPath, ambiguousRefs);
 
@@ -326,14 +326,14 @@ export async function runFlowFetchRows(
     allow_latest_fallback: allowLatestFallback,
     requested_ref_count: rows.length,
     resolved_ref_count: resolvedRowArtifacts.length,
-    review_input_row_count: reviewInputRows.length,
-    duplicate_review_input_rows_collapsed: duplicateReviewInputRowsCollapsed,
+    qa_input_row_count: qaInputRows.length,
+    duplicate_qa_input_rows_collapsed: duplicateQaInputRowsCollapsed,
     missing_ref_count: missingRefs.length,
     ambiguous_ref_count: ambiguousRefs.length,
     resolution_counts: resolutionCounts,
     files: {
       resolved_flow_rows: resolvedRowsPath,
-      review_input_rows: reviewInputRowsPath,
+      qa_input_rows: qaInputRowsPath,
       fetch_summary: summaryPath,
       missing_flow_refs: missingRefsPath,
       ambiguous_flow_refs: ambiguousRefsPath,

--- a/src/lib/flow-qa.ts
+++ b/src/lib/flow-qa.ts
@@ -103,7 +103,7 @@ type FlowSimilarityPair = {
   right_name_en: string;
 };
 
-type FlowReviewLlmBatchResult = {
+type FlowQaLlmBatchResult = {
   batch_index: number;
   batch_size: number;
   enabled: boolean;
@@ -112,17 +112,17 @@ type FlowReviewLlmBatchResult = {
   raw_preview?: string;
 };
 
-export type FlowReviewLlmResult = {
+export type FlowQaLlmResult = {
   enabled: boolean;
   ok?: boolean;
   reason?: string;
   batch_count: number;
   reviewed_flow_count: number;
   truncated: boolean;
-  batch_results: FlowReviewLlmBatchResult[];
+  batch_results: FlowQaLlmBatchResult[];
 };
 
-type FlowReviewLlmRunResult = FlowReviewLlmResult & {
+type FlowQaLlmRunResult = FlowQaLlmResult & {
   llmFindings: FlowRuleFinding[];
 };
 
@@ -140,10 +140,10 @@ type FlowRulesetGate = {
   next_action: 'continue' | 'review_findings' | 'fix_blockers';
 };
 
-export type FlowReviewReport = {
+export type FlowQaReport = {
   schema_version: 1;
   generated_at_utc: string;
-  status: 'completed_local_flow_review';
+  status: 'completed_local_flow_qa';
   run_id: string;
   out_dir: string;
   input_mode: 'rows_file' | 'flows_dir' | 'run_root';
@@ -166,9 +166,9 @@ export type FlowReviewReport = {
   rule_counts: Record<string, number>;
   methodology_rule_counts?: Record<string, number>;
   ruleset_gate?: FlowRulesetGate;
-  llm: FlowReviewLlmResult;
+  llm: FlowQaLlmResult;
   files: {
-    review_input_summary: string;
+    qa_input_summary: string;
     materialization_summary: string | null;
     rule_findings: string;
     llm_findings: string;
@@ -177,14 +177,14 @@ export type FlowReviewReport = {
     flow_summaries: string;
     similarity_pairs: string;
     summary: string;
-    review_zh: string;
-    review_en: string;
+    qa_zh: string;
+    qa_en: string;
     timing: string;
     report: string;
   };
 };
 
-export type RunFlowReviewOptions = {
+export type RunFlowQaOptions = {
   rowsFile?: string;
   flowsDir?: string;
   runRoot?: string;
@@ -746,7 +746,7 @@ function buildFlowSummaryAndRuleFindings(
         flowUuidValue,
         baseVersion,
         'warning',
-        'elementary_flow_in_flow_review',
+        'elementary_flow_in_flow_qa',
         'Flow type is Elementary flow; check whether this batch should exclude it.',
         {
           fixability: 'review-needed',
@@ -1059,7 +1059,7 @@ async function runOptionalLlmReview(
     outDir: string;
     runId: string;
   },
-): Promise<FlowReviewLlmRunResult> {
+): Promise<FlowQaLlmRunResult> {
   if (!options.enableLlm) {
     return {
       enabled: false,
@@ -1090,7 +1090,7 @@ async function runOptionalLlmReview(
   const summaryByUuid = Object.fromEntries(
     summaries.map((summary) => [summary.flow_uuid, summary]),
   );
-  const batchResults: FlowReviewLlmBatchResult[] = [];
+  const batchResults: FlowQaLlmBatchResult[] = [];
   const llmFindings: FlowRuleFinding[] = [];
 
   for (let index = 0; index < batches.length; index += 1) {
@@ -1114,7 +1114,7 @@ async function runOptionalLlmReview(
         timeoutMs: 45_000,
         cacheDir: path.join(options.outDir, '.llm-cache'),
         tracePath: path.join(options.outDir, 'llm-trace.jsonl'),
-        module: 'review-flow',
+        module: 'flow-qa',
         stage: `semantic-review-${index + 1}`,
         runId: options.runId,
       });
@@ -1230,7 +1230,7 @@ function readJsonObject(filePath: string): JsonRecord {
     const parsed = JSON.parse(readFileSync(filePath, 'utf8')) as unknown;
     if (!isRecord(parsed)) {
       throw new CliError(`Expected JSON object in flow file: ${filePath}`, {
-        code: 'FLOW_REVIEW_INVALID_FLOW_FILE',
+        code: 'FLOW_QA_INVALID_FLOW_FILE',
         exitCode: 2,
       });
     }
@@ -1240,7 +1240,7 @@ function readJsonObject(filePath: string): JsonRecord {
       throw error;
     }
     throw new CliError(`Invalid flow JSON file: ${filePath}`, {
-      code: 'FLOW_REVIEW_INVALID_FLOW_FILE',
+      code: 'FLOW_QA_INVALID_FLOW_FILE',
       exitCode: 2,
       details: String(error),
     });
@@ -1252,7 +1252,7 @@ function materializeRowsFile(
   outDir: string,
 ): { flowsDir: string; summaryPath: string } {
   const rows = loadRowsFromFile(rowsFile);
-  const targetDir = path.join(outDir, 'review-input', 'flows');
+  const targetDir = path.join(outDir, 'qa-input', 'flows');
   mkdirSync(targetDir, { recursive: true });
 
   const byKey: Record<string, JsonRecord> = {};
@@ -1285,7 +1285,7 @@ function materializeRowsFile(
       });
     });
 
-  const summaryPath = path.join(outDir, 'review-input', 'materialization-summary.json');
+  const summaryPath = path.join(outDir, 'qa-input', 'materialization-summary.json');
   writeJsonArtifact(summaryPath, {
     source_rows_file: path.resolve(rowsFile),
     input_row_count: rows.length,
@@ -1301,7 +1301,7 @@ function materializeRowsFile(
   };
 }
 
-function resolveReviewInput(options: RunFlowReviewOptions): {
+function resolveReviewInput(options: RunFlowQaOptions): {
   inputMode: 'rows_file' | 'flows_dir' | 'run_root';
   effectiveFlowsDir: string;
   materializationSummaryPath: string | null;
@@ -1315,9 +1315,9 @@ function resolveReviewInput(options: RunFlowReviewOptions): {
   ].filter(Boolean);
   if (declaredModes.length !== 1) {
     throw new CliError(
-      'Flow review requires exactly one of --rows-file, --flows-dir, or --run-root.',
+      'Flow QA requires exactly one of --rows-file, --flows-dir, or --run-root.',
       {
-        code: 'FLOW_REVIEW_INPUT_MODE_REQUIRED',
+        code: 'FLOW_QA_INPUT_MODE_REQUIRED',
         exitCode: 2,
       },
     );
@@ -1380,8 +1380,8 @@ function resolveReviewInput(options: RunFlowReviewOptions): {
 
 function listFlowFiles(flowsDir: string): string[] {
   if (!existsSync(flowsDir) || !statSync(flowsDir).isDirectory()) {
-    throw new CliError(`Flow review directory not found: ${flowsDir}`, {
-      code: 'FLOW_REVIEW_DIR_NOT_FOUND',
+    throw new CliError(`Flow QA directory not found: ${flowsDir}`, {
+      code: 'FLOW_QA_DIR_NOT_FOUND',
       exitCode: 2,
     });
   }
@@ -1408,12 +1408,12 @@ function renderZhReview(options: {
   flowSummaries: JsonRecord[];
   ruleFindings: FlowRuleFinding[];
   llmFindings: FlowRuleFinding[];
-  llmResult: FlowReviewLlmResult;
+  llmResult: FlowQaLlmResult;
   mergedFindings: FlowRuleFinding[];
-  summary: FlowReviewReport;
+  summary: FlowQaReport;
 }): string {
   const lines = [
-    '# flow_review_zh\n',
+    '# flow_qa_zh\n',
     `- run_id: \`${options.runId}\`\n`,
     `- logic_version: \`${options.logicVersion}\`\n`,
     `- flows_dir: \`${options.flowsDir}\`\n`,
@@ -1469,7 +1469,7 @@ function renderZhReview(options: {
 
   lines.push(
     '\n## 说明\n',
-    '- 当前 CLI 版本保持 local-first / artifact-first，不在 review flow 阶段接入 MCP。\n',
+    '- 当前 CLI 版本保持 local-first / artifact-first，不在 qa flow 阶段接入 MCP。\n',
     '- flow property / unitgroup 的额外本地 registry 丰富暂未接入 CLI，本轮 summary 中统一标记为 disabled。\n',
   );
 
@@ -1483,11 +1483,11 @@ function renderEnReview(options: {
   flowCount: number;
   ruleFindingCount: number;
   llmFindingCount: number;
-  llmResult: FlowReviewLlmResult;
+  llmResult: FlowQaLlmResult;
   methodologyRuleSource: string;
 }): string {
   const lines = [
-    '# flow_review_en\n',
+    '# flow_qa_en\n',
     `- run_id: \`${options.runId}\`\n`,
     `- logic_version: \`${options.logicVersion}\`\n`,
     `- flows_dir: \`${options.flowsDir}\`\n`,
@@ -1518,7 +1518,7 @@ function renderTimingReview(options: {
   endTs?: string;
   flowCount: number;
 }): string {
-  const lines = ['# flow_review_timing\n', `- run_id: \`${options.runId}\`\n`];
+  const lines = ['# flow_qa_timing\n', `- run_id: \`${options.runId}\`\n`];
   if (options.startTs) {
     lines.push(`- start: \`${options.startTs}\`\n`);
   }
@@ -1539,10 +1539,10 @@ function renderTimingReview(options: {
   return lines.join('');
 }
 
-export async function runFlowReview(options: RunFlowReviewOptions): Promise<FlowReviewReport> {
+export async function runFlowQa(options: RunFlowQaOptions): Promise<FlowQaReport> {
   if (!options.outDir.trim()) {
     throw new CliError('Missing required --out-dir value.', {
-      code: 'FLOW_REVIEW_OUT_DIR_REQUIRED',
+      code: 'FLOW_QA_OUT_DIR_REQUIRED',
       exitCode: 2,
     });
   }
@@ -1557,7 +1557,7 @@ export async function runFlowReview(options: RunFlowReviewOptions): Promise<Flow
   const flowFiles = listFlowFiles(resolvedInput.effectiveFlowsDir);
   if (!flowFiles.length) {
     throw new CliError(`No flow JSON files found in ${resolvedInput.effectiveFlowsDir}`, {
-      code: 'FLOW_REVIEW_NO_FLOW_FILES',
+      code: 'FLOW_QA_NO_FLOW_FILES',
       exitCode: 2,
     });
   }
@@ -1609,7 +1609,7 @@ export async function runFlowReview(options: RunFlowReviewOptions): Promise<Flow
     runId: resolvedInput.runId,
   });
 
-  const llmResult: FlowReviewLlmResult = {
+  const llmResult: FlowQaLlmResult = {
     enabled: llmRun.enabled,
     ...(llmRun.ok === undefined ? {} : { ok: llmRun.ok }),
     ...(llmRun.reason ? { reason: llmRun.reason } : {}),
@@ -1623,18 +1623,18 @@ export async function runFlowReview(options: RunFlowReviewOptions): Promise<Flow
   const savedSummaries = flowSummaries.map((summary) => stripInternalSummaryFields(summary));
   const now = options.now ?? (() => new Date());
 
-  const reviewInputSummaryPath = path.join(outDir, 'review-input-summary.json');
+  const reviewInputSummaryPath = path.join(outDir, 'qa-input-summary.json');
   const ruleFindingsPath = path.join(outDir, 'rule_findings.jsonl');
   const llmFindingsPath = path.join(outDir, 'llm_findings.jsonl');
   const findingsPath = path.join(outDir, 'findings.jsonl');
-  const rulesetGatePath = path.join(outDir, 'flow-review-ruleset-gate.json');
+  const rulesetGatePath = path.join(outDir, 'flow-qa-ruleset-gate.json');
   const flowSummariesPath = path.join(outDir, 'flow_summaries.jsonl');
   const similarityPairsPath = path.join(outDir, 'similarity_pairs.jsonl');
-  const summaryPath = path.join(outDir, 'flow_review_summary.json');
-  const reviewZhPath = path.join(outDir, 'flow_review_zh.md');
-  const reviewEnPath = path.join(outDir, 'flow_review_en.md');
-  const timingPath = path.join(outDir, 'flow_review_timing.md');
-  const reportPath = path.join(outDir, 'flow_review_report.json');
+  const summaryPath = path.join(outDir, 'flow_qa_summary.json');
+  const reviewZhPath = path.join(outDir, 'flow_qa_zh.md');
+  const reviewEnPath = path.join(outDir, 'flow_qa_en.md');
+  const timingPath = path.join(outDir, 'flow_qa_timing.md');
+  const reportPath = path.join(outDir, 'flow_qa_report.json');
 
   writeJsonArtifact(reviewInputSummaryPath, resolvedInput.reviewInputSummary);
   writeJsonLinesArtifact(ruleFindingsPath, ruleFindings);
@@ -1644,10 +1644,10 @@ export async function runFlowReview(options: RunFlowReviewOptions): Promise<Flow
   writeJsonLinesArtifact(flowSummariesPath, savedSummaries);
   writeJsonLinesArtifact(similarityPairsPath, similarity.pairs);
 
-  const report: FlowReviewReport = {
+  const report: FlowQaReport = {
     schema_version: 1,
     generated_at_utc: now().toISOString(),
-    status: 'completed_local_flow_review',
+    status: 'completed_local_flow_qa',
     run_id: resolvedInput.runId,
     out_dir: outDir,
     input_mode: resolvedInput.inputMode,
@@ -1672,7 +1672,7 @@ export async function runFlowReview(options: RunFlowReviewOptions): Promise<Flow
     ruleset_gate: rulesetGate,
     llm: llmResult,
     files: {
-      review_input_summary: reviewInputSummaryPath,
+      qa_input_summary: reviewInputSummaryPath,
       materialization_summary: resolvedInput.materializationSummaryPath,
       rule_findings: ruleFindingsPath,
       llm_findings: llmFindingsPath,
@@ -1681,8 +1681,8 @@ export async function runFlowReview(options: RunFlowReviewOptions): Promise<Flow
       flow_summaries: flowSummariesPath,
       similarity_pairs: similarityPairsPath,
       summary: summaryPath,
-      review_zh: reviewZhPath,
-      review_en: reviewEnPath,
+      qa_zh: reviewZhPath,
+      qa_en: reviewEnPath,
       timing: timingPath,
       report: reportPath,
     },

--- a/src/lib/flow-qa.ts
+++ b/src/lib/flow-qa.ts
@@ -1314,13 +1314,10 @@ function resolveReviewInput(options: RunFlowQaOptions): {
     Boolean(options.runRoot),
   ].filter(Boolean);
   if (declaredModes.length !== 1) {
-    throw new CliError(
-      'Flow QA requires exactly one of --rows-file, --flows-dir, or --run-root.',
-      {
-        code: 'FLOW_QA_INPUT_MODE_REQUIRED',
-        exitCode: 2,
-      },
-    );
+    throw new CliError('Flow QA requires exactly one of --rows-file, --flows-dir, or --run-root.', {
+      code: 'FLOW_QA_INPUT_MODE_REQUIRED',
+      exitCode: 2,
+    });
   }
 
   if (options.rowsFile) {

--- a/src/lib/lifecyclemodel-qa.ts
+++ b/src/lib/lifecyclemodel-qa.ts
@@ -48,17 +48,17 @@ type SeverityCounts = {
   info: number;
 };
 
-export type LifecyclemodelReviewFinding = {
+export type LifecyclemodelQaFinding = {
   run_name: string;
   model_file: string | null;
   severity: 'error' | 'warning' | 'info';
   rule_id: string;
-  source: 'validation' | 'review';
+  source: 'validation' | 'qa';
   message: string;
   evidence: JsonObject;
 };
 
-export type LifecyclemodelReviewModelSummary = {
+export type LifecyclemodelQaModelSummary = {
   run_name: string;
   model_files: string[];
   model_uuids: string[];
@@ -89,10 +89,10 @@ export type LifecyclemodelReviewModelSummary = {
   severity_counts: SeverityCounts;
 };
 
-export type LifecyclemodelReviewReport = {
+export type LifecyclemodelQaReport = {
   schema_version: 1;
   generated_at_utc: string;
-  status: 'completed_local_lifecyclemodel_review';
+  status: 'completed_local_lifecyclemodel_qa';
   run_id: string;
   run_root: string;
   out_dir: string;
@@ -112,16 +112,16 @@ export type LifecyclemodelReviewReport = {
     model_summaries: string;
     findings: string;
     summary: string;
-    review_zh: string;
-    review_en: string;
+    qa_zh: string;
+    qa_en: string;
     timing: string;
     report: string;
   };
-  model_summaries: LifecyclemodelReviewModelSummary[];
+  model_summaries: LifecyclemodelQaModelSummary[];
   next_actions: string[];
 };
 
-export type RunLifecyclemodelReviewOptions = {
+export type RunLifecyclemodelQaOptions = {
   runDir: string;
   outDir: string;
   startTs?: string;
@@ -131,7 +131,7 @@ export type RunLifecyclemodelReviewOptions = {
   cwd?: string;
 };
 
-export type LifecyclemodelReviewLayout = {
+export type LifecyclemodelQaLayout = {
   runId: string;
   runRoot: string;
   outDir: string;
@@ -227,7 +227,7 @@ function emptySeverityCounts(): SeverityCounts {
   };
 }
 
-function severityCounts(findings: LifecyclemodelReviewFinding[]): SeverityCounts {
+function severityCounts(findings: LifecyclemodelQaFinding[]): SeverityCounts {
   return findings.reduce<SeverityCounts>((counts, finding) => {
     counts[finding.severity] += 1;
     return counts;
@@ -302,7 +302,7 @@ function readOptionalJsonArray(
   return value;
 }
 
-function buildLayout(runRoot: string, outDir: string): LifecyclemodelReviewLayout {
+function buildLayout(runRoot: string, outDir: string): LifecyclemodelQaLayout {
   const runId = path.basename(runRoot);
   return {
     runId,
@@ -320,27 +320,27 @@ function buildLayout(runRoot: string, outDir: string): LifecyclemodelReviewLayou
     ),
     modelSummariesPath: path.join(outDir, 'model_summaries.jsonl'),
     findingsPath: path.join(outDir, 'findings.jsonl'),
-    summaryPath: path.join(outDir, 'lifecyclemodel_review_summary.json'),
-    reviewZhPath: path.join(outDir, 'lifecyclemodel_review_zh.md'),
-    reviewEnPath: path.join(outDir, 'lifecyclemodel_review_en.md'),
-    timingPath: path.join(outDir, 'lifecyclemodel_review_timing.md'),
-    reportPath: path.join(outDir, 'lifecyclemodel_review_report.json'),
+    summaryPath: path.join(outDir, 'lifecyclemodel_qa_summary.json'),
+    reviewZhPath: path.join(outDir, 'lifecyclemodel_qa_zh.md'),
+    reviewEnPath: path.join(outDir, 'lifecyclemodel_qa_en.md'),
+    timingPath: path.join(outDir, 'lifecyclemodel_qa_timing.md'),
+    reportPath: path.join(outDir, 'lifecyclemodel_qa_report.json'),
   };
 }
 
-function resolveLayout(options: RunLifecyclemodelReviewOptions): LifecyclemodelReviewLayout {
+function resolveLayout(options: RunLifecyclemodelQaOptions): LifecyclemodelQaLayout {
   const runDir = nonEmptyString(options.runDir);
   if (!runDir) {
-    throw new CliError('Missing required --run-dir for review lifecyclemodel.', {
-      code: 'LIFECYCLEMODEL_REVIEW_RUN_DIR_REQUIRED',
+    throw new CliError('Missing required --run-dir for qa lifecyclemodel.', {
+      code: 'LIFECYCLEMODEL_QA_RUN_DIR_REQUIRED',
       exitCode: 2,
     });
   }
 
   const outDir = nonEmptyString(options.outDir);
   if (!outDir) {
-    throw new CliError('Missing required --out-dir for review lifecyclemodel.', {
-      code: 'LIFECYCLEMODEL_REVIEW_OUT_DIR_REQUIRED',
+    throw new CliError('Missing required --out-dir for qa lifecyclemodel.', {
+      code: 'LIFECYCLEMODEL_QA_OUT_DIR_REQUIRED',
       exitCode: 2,
     });
   }
@@ -348,29 +348,29 @@ function resolveLayout(options: RunLifecyclemodelReviewOptions): LifecyclemodelR
   return buildLayout(path.resolve(runDir), path.resolve(outDir));
 }
 
-function ensureRunRootExists(layout: LifecyclemodelReviewLayout): void {
+function ensureRunRootExists(layout: LifecyclemodelQaLayout): void {
   if (!existsSync(layout.runRoot)) {
-    throw new CliError(`lifecyclemodel review run root not found: ${layout.runRoot}`, {
-      code: 'LIFECYCLEMODEL_REVIEW_RUN_NOT_FOUND',
+    throw new CliError(`lifecyclemodel QA run root not found: ${layout.runRoot}`, {
+      code: 'LIFECYCLEMODEL_QA_RUN_NOT_FOUND',
       exitCode: 2,
     });
   }
 }
 
-function readRequiredRunManifest(layout: LifecyclemodelReviewLayout): JsonObject {
+function readRequiredRunManifest(layout: LifecyclemodelQaLayout): JsonObject {
   const manifest = readRequiredJsonObject(
     layout.runManifestPath,
-    'LIFECYCLEMODEL_REVIEW_RUN_MANIFEST_MISSING',
-    'LIFECYCLEMODEL_REVIEW_RUN_MANIFEST_INVALID',
+    'LIFECYCLEMODEL_QA_RUN_MANIFEST_MISSING',
+    'LIFECYCLEMODEL_QA_RUN_MANIFEST_INVALID',
     'run-manifest',
   );
 
   const manifestRunId = nonEmptyString(manifest.runId);
   if (manifestRunId && manifestRunId !== layout.runId) {
     throw new CliError(
-      `lifecyclemodel review run manifest runId mismatch: ${layout.runManifestPath}`,
+      `lifecyclemodel QA run manifest runId mismatch: ${layout.runManifestPath}`,
       {
-        code: 'LIFECYCLEMODEL_REVIEW_RUN_MANIFEST_MISMATCH',
+        code: 'LIFECYCLEMODEL_QA_RUN_MANIFEST_MISMATCH',
         exitCode: 2,
         details: {
           expected: layout.runId,
@@ -383,7 +383,7 @@ function readRequiredRunManifest(layout: LifecyclemodelReviewLayout): JsonObject
   return manifest;
 }
 
-function readInvocationIndex(layout: LifecyclemodelReviewLayout): JsonObject {
+function readInvocationIndex(layout: LifecyclemodelQaLayout): JsonObject {
   if (!existsSync(layout.invocationIndexPath)) {
     return {
       schema_version: 1,
@@ -394,9 +394,9 @@ function readInvocationIndex(layout: LifecyclemodelReviewLayout): JsonObject {
   const value = readJsonArtifact(layout.invocationIndexPath);
   if (!isRecord(value)) {
     throw new CliError(
-      `Expected lifecyclemodel review invocation index JSON object: ${layout.invocationIndexPath}`,
+      `Expected lifecyclemodel QA invocation index JSON object: ${layout.invocationIndexPath}`,
       {
-        code: 'LIFECYCLEMODEL_REVIEW_INVOCATION_INDEX_INVALID',
+        code: 'LIFECYCLEMODEL_QA_INVOCATION_INDEX_INVALID',
         exitCode: 2,
       },
     );
@@ -411,9 +411,9 @@ function readInvocationIndex(layout: LifecyclemodelReviewLayout): JsonObject {
 
   if (!Array.isArray(value.invocations)) {
     throw new CliError(
-      `Expected lifecyclemodel review invocation index to contain an invocations array: ${layout.invocationIndexPath}`,
+      `Expected lifecyclemodel QA invocation index to contain an invocations array: ${layout.invocationIndexPath}`,
       {
-        code: 'LIFECYCLEMODEL_REVIEW_INVOCATION_INDEX_INVALID',
+        code: 'LIFECYCLEMODEL_QA_INVOCATION_INDEX_INVALID',
         exitCode: 2,
       },
     );
@@ -422,7 +422,7 @@ function readInvocationIndex(layout: LifecyclemodelReviewLayout): JsonObject {
   return value;
 }
 
-function discoverModelEntries(layout: LifecyclemodelReviewLayout): ModelEntry[] {
+function discoverModelEntries(layout: LifecyclemodelQaLayout): ModelEntry[] {
   const runNames = existsSync(layout.modelsDir) ? readdirSync(layout.modelsDir).sort() : [];
   const entries = runNames.flatMap((runName) => {
     const lifecyclemodelsDir = path.join(
@@ -442,9 +442,9 @@ function discoverModelEntries(layout: LifecyclemodelReviewLayout): ModelEntry[] 
 
     if (modelFiles.length === 0) {
       throw new CliError(
-        `lifecyclemodel review found a bundle without lifecyclemodel JSON files: ${lifecyclemodelsDir}`,
+        `lifecyclemodel QA found a bundle without lifecyclemodel JSON files: ${lifecyclemodelsDir}`,
         {
-          code: 'LIFECYCLEMODEL_REVIEW_MODELS_EMPTY',
+          code: 'LIFECYCLEMODEL_QA_MODELS_EMPTY',
           exitCode: 2,
         },
       );
@@ -463,9 +463,9 @@ function discoverModelEntries(layout: LifecyclemodelReviewLayout): ModelEntry[] 
 
   if (entries.length === 0) {
     throw new CliError(
-      `lifecyclemodel review run does not contain any model bundles: ${layout.modelsDir}`,
+      `lifecyclemodel QA run does not contain any model bundles: ${layout.modelsDir}`,
       {
-        code: 'LIFECYCLEMODEL_REVIEW_MODELS_NOT_FOUND',
+        code: 'LIFECYCLEMODEL_QA_MODELS_NOT_FOUND',
         exitCode: 2,
       },
     );
@@ -536,11 +536,11 @@ function collectValidationIssues(validation: JsonObject): ValidationIssue[] {
 }
 
 function readValidationAggregate(
-  layout: LifecyclemodelReviewLayout,
+  layout: LifecyclemodelQaLayout,
 ): LifecyclemodelValidationAggregate {
   const aggregate = readOptionalJsonObject(
     layout.validationReportPath,
-    'LIFECYCLEMODEL_REVIEW_VALIDATION_REPORT_INVALID',
+    'LIFECYCLEMODEL_QA_VALIDATION_REPORT_INVALID',
     'validate-build report',
   );
 
@@ -556,7 +556,7 @@ function readValidationAggregate(
     throw new CliError(
       `Expected lifecyclemodel validate-build report to contain a model_reports array: ${layout.validationReportPath}`,
       {
-        code: 'LIFECYCLEMODEL_REVIEW_VALIDATION_REPORT_INVALID',
+        code: 'LIFECYCLEMODEL_QA_VALIDATION_REPORT_INVALID',
         exitCode: 2,
       },
     );
@@ -568,7 +568,7 @@ function readValidationAggregate(
       throw new CliError(
         `Expected lifecyclemodel validate-build model report entry JSON object: ${layout.validationReportPath}`,
         {
-          code: 'LIFECYCLEMODEL_REVIEW_VALIDATION_REPORT_INVALID',
+          code: 'LIFECYCLEMODEL_QA_VALIDATION_REPORT_INVALID',
           exitCode: 2,
         },
       );
@@ -579,7 +579,7 @@ function readValidationAggregate(
       throw new CliError(
         `Expected lifecyclemodel validate-build model report entry to contain run_name and validation: ${layout.validationReportPath}`,
         {
-          code: 'LIFECYCLEMODEL_REVIEW_VALIDATION_REPORT_INVALID',
+          code: 'LIFECYCLEMODEL_QA_VALIDATION_REPORT_INVALID',
           exitCode: 2,
         },
       );
@@ -611,8 +611,8 @@ function modelRoot(value: JsonObject): JsonObject {
 function readModelFileReviewInfo(filePath: string): ModelFileReviewInfo {
   const payload = readJsonArtifact(filePath);
   if (!isRecord(payload)) {
-    throw new CliError(`Expected lifecyclemodel review payload JSON object: ${filePath}`, {
-      code: 'LIFECYCLEMODEL_REVIEW_MODEL_INVALID',
+    throw new CliError(`Expected lifecyclemodel QA payload JSON object: ${filePath}`, {
+      code: 'LIFECYCLEMODEL_QA_MODEL_INVALID',
       exitCode: 2,
     });
   }
@@ -662,12 +662,12 @@ function readModelFileReviewInfo(filePath: string): ModelFileReviewInfo {
 function makeFinding(
   runName: string,
   modelFile: string | null,
-  severity: LifecyclemodelReviewFinding['severity'],
+  severity: LifecyclemodelQaFinding['severity'],
   ruleId: string,
-  source: LifecyclemodelReviewFinding['source'],
+  source: LifecyclemodelQaFinding['source'],
   message: string,
   evidence: JsonObject,
-): LifecyclemodelReviewFinding {
+): LifecyclemodelQaFinding {
   return {
     run_name: runName,
     model_file: modelFile,
@@ -683,22 +683,22 @@ function buildModelReview(
   entry: ModelEntry,
   validationAggregate: LifecyclemodelValidationAggregate,
 ): {
-  summary: LifecyclemodelReviewModelSummary;
-  findings: LifecyclemodelReviewFinding[];
+  summary: LifecyclemodelQaModelSummary;
+  findings: LifecyclemodelQaFinding[];
 } {
   const summaryArtifact = readOptionalJsonObject(
     entry.summaryPath,
-    'LIFECYCLEMODEL_REVIEW_SUMMARY_INVALID',
+    'LIFECYCLEMODEL_QA_SUMMARY_INVALID',
     'summary',
   );
   const connections = readOptionalJsonArray(
     entry.connectionsPath,
-    'LIFECYCLEMODEL_REVIEW_CONNECTIONS_INVALID',
+    'LIFECYCLEMODEL_QA_CONNECTIONS_INVALID',
     'connections',
   );
   const processCatalog = readOptionalJsonArray(
     entry.processCatalogPath,
-    'LIFECYCLEMODEL_REVIEW_PROCESS_CATALOG_INVALID',
+    'LIFECYCLEMODEL_QA_PROCESS_CATALOG_INVALID',
     'process-catalog',
   );
   const modelFileInfos = entry.modelFiles.map((modelFile) => readModelFileReviewInfo(modelFile));
@@ -709,7 +709,7 @@ function buildModelReview(
     issues: [],
   };
 
-  const findings: LifecyclemodelReviewFinding[] = [];
+  const findings: LifecyclemodelQaFinding[] = [];
   validation.issues.forEach((issue) => {
     findings.push(
       makeFinding(
@@ -763,7 +763,7 @@ function buildModelReview(
         entry.modelFiles[0] ?? null,
         'warning',
         'missing_model_summary',
-        'review',
+        'qa',
         'Model bundle is missing summary.json generated by lifecyclemodel auto-build.',
         {
           summary_path: entry.summaryPath,
@@ -779,7 +779,7 @@ function buildModelReview(
         entry.modelFiles[0] ?? null,
         'warning',
         'missing_connections_artifact',
-        'review',
+        'qa',
         'Model bundle is missing connections.json generated by lifecyclemodel auto-build.',
         {
           connections_path: entry.connectionsPath,
@@ -795,7 +795,7 @@ function buildModelReview(
         entry.modelFiles[0] ?? null,
         'warning',
         'missing_process_catalog',
-        'review',
+        'qa',
         'Model bundle is missing process-catalog.json generated by lifecyclemodel auto-build.',
         {
           process_catalog_path: entry.processCatalogPath,
@@ -811,8 +811,8 @@ function buildModelReview(
         entry.modelFiles[0] ?? null,
         'warning',
         'missing_reference_process_uuid',
-        'review',
-        'Review could not resolve reference_process_uuid from summary.json.',
+        'qa',
+        'QA could not resolve reference_process_uuid from summary.json.',
         {
           summary_path: summaryArtifact ? entry.summaryPath : null,
         },
@@ -827,8 +827,8 @@ function buildModelReview(
         entry.modelFiles[0] ?? null,
         'warning',
         'missing_resulting_process_ref',
-        'review',
-        'Review could not resolve referenceToResultingProcess from the lifecyclemodel payload.',
+        'qa',
+        'QA could not resolve referenceToResultingProcess from the lifecyclemodel payload.',
         {
           model_files: entry.modelFiles,
         },
@@ -843,7 +843,7 @@ function buildModelReview(
         entry.modelFiles[0] ?? null,
         'error',
         'empty_process_instances',
-        'review',
+        'qa',
         'Lifecyclemodel payload does not contain any processInstance entries.',
         {
           model_files: entry.modelFiles,
@@ -859,7 +859,7 @@ function buildModelReview(
         entry.modelFiles[0] ?? null,
         'warning',
         'process_count_mismatch',
-        'review',
+        'qa',
         'summary.json process_count does not match the number of processInstance entries in the payload.',
         {
           summary_process_count: summaryProcessCount,
@@ -876,7 +876,7 @@ function buildModelReview(
         entry.modelFiles[0] ?? null,
         'warning',
         'edge_count_mismatch',
-        'review',
+        'qa',
         'summary.json edge_count does not match the connections.json row count.',
         {
           summary_edge_count: summaryEdgeCount,
@@ -893,7 +893,7 @@ function buildModelReview(
         entry.modelFiles[0] ?? null,
         'warning',
         'process_catalog_count_mismatch',
-        'review',
+        'qa',
         'process-catalog.json row count does not match the number of processInstance entries in the payload.',
         {
           process_catalog_count: processCatalog.length,
@@ -914,7 +914,7 @@ function buildModelReview(
         entry.modelFiles[0] ?? null,
         'warning',
         'multiplication_factor_count_mismatch',
-        'review',
+        'qa',
         'summary.json multiplication_factors count does not match the number of processInstance entries in the payload.',
         {
           multiplication_factor_count: multiplicationFactorCount,
@@ -961,16 +961,16 @@ function buildModelReview(
 }
 
 function buildInvocationIndex(
-  layout: LifecyclemodelReviewLayout,
+  layout: LifecyclemodelQaLayout,
   invocationIndex: JsonObject,
-  options: RunLifecyclemodelReviewOptions,
+  options: RunLifecyclemodelQaOptions,
   now: Date,
 ): JsonObject {
   const priorInvocations = Array.isArray(invocationIndex.invocations)
     ? [...invocationIndex.invocations]
     : [];
   const command = [
-    'review',
+    'qa',
     'lifecyclemodel',
     '--run-dir',
     options.runDir,
@@ -1007,7 +1007,7 @@ function buildInvocationIndex(
 }
 
 function buildNextActions(
-  layout: LifecyclemodelReviewLayout,
+  layout: LifecyclemodelQaLayout,
   validationAggregate: LifecyclemodelValidationAggregate,
 ): string[] {
   return [
@@ -1023,12 +1023,12 @@ function renderZhReview(options: {
   runId: string;
   logicVersion: string;
   runRoot: string;
-  modelSummaries: LifecyclemodelReviewModelSummary[];
-  findings: LifecyclemodelReviewFinding[];
-  validation: LifecyclemodelReviewReport['validation'];
+  modelSummaries: LifecyclemodelQaModelSummary[];
+  findings: LifecyclemodelQaFinding[];
+  validation: LifecyclemodelQaReport['validation'];
 }): string {
   const lines = [
-    '# lifecyclemodel_review_zh\n',
+    '# lifecyclemodel_qa_zh\n',
     `- run_id: \`${options.runId}\`\n`,
     `- logic_version: \`${options.logicVersion}\`\n`,
     `- run_root: \`${options.runRoot}\`\n`,
@@ -1049,7 +1049,7 @@ function renderZhReview(options: {
 
   lines.push('\n## Findings\n');
   if (options.findings.length === 0) {
-    lines.push('- 未发现新的 lifecyclemodel review findings。\n');
+    lines.push('- 未发现新的 lifecyclemodel QA findings。\n');
   } else {
     lines.push('\n|run name|severity|source|rule id|message|\n|---|---|---|---|---|\n');
     options.findings.slice(0, 200).forEach((finding) => {
@@ -1061,8 +1061,8 @@ function renderZhReview(options: {
 
   lines.push(
     '\n## 说明\n',
-    '- 当前 review lifecyclemodel 保持 local-first / artifact-first，只读取现有 build run 与 validate-build 产物。\n',
-    '- 当前命令不引入 Python、LangGraph 或 skill 私有 review runtime。\n',
+    '- 当前 qa lifecyclemodel 保持 local-first / artifact-first，只读取现有 build run 与 validate-build 产物。\n',
+    '- 当前命令不引入 Python、LangGraph 或 skill 私有 QA runtime。\n',
   );
 
   return lines.join('');
@@ -1072,12 +1072,12 @@ function renderEnReview(options: {
   runId: string;
   logicVersion: string;
   runRoot: string;
-  modelSummaries: LifecyclemodelReviewModelSummary[];
-  findings: LifecyclemodelReviewFinding[];
-  validation: LifecyclemodelReviewReport['validation'];
+  modelSummaries: LifecyclemodelQaModelSummary[];
+  findings: LifecyclemodelQaFinding[];
+  validation: LifecyclemodelQaReport['validation'];
 }): string {
   const lines = [
-    '# lifecyclemodel_review_en\n',
+    '# lifecyclemodel_qa_en\n',
     `- run_id: \`${options.runId}\`\n`,
     `- logic_version: \`${options.logicVersion}\`\n`,
     `- run_root: \`${options.runRoot}\`\n`,
@@ -1112,13 +1112,13 @@ function renderTiming(options: {
   endTs?: string;
   modelCount: number;
 }): string {
-  const lines = ['# lifecyclemodel_review_timing\n', `- run_id: \`${options.runId}\`\n`];
+  const lines = ['# lifecyclemodel_qa_timing\n', `- run_id: \`${options.runId}\`\n`];
   if (options.startTs && options.endTs) {
     const started = Date.parse(options.startTs);
     const ended = Date.parse(options.endTs);
     if (!Number.isFinite(started) || !Number.isFinite(ended)) {
       throw new CliError('Expected --start-ts and --end-ts to be valid ISO timestamps.', {
-        code: 'LIFECYCLEMODEL_REVIEW_INVALID_TIMESTAMP',
+        code: 'LIFECYCLEMODEL_QA_INVALID_TIMESTAMP',
         exitCode: 2,
       });
     }
@@ -1135,26 +1135,26 @@ function renderTiming(options: {
   return lines.join('');
 }
 
-export async function runLifecyclemodelReview(
-  options: RunLifecyclemodelReviewOptions,
-): Promise<LifecyclemodelReviewReport> {
+export async function runLifecyclemodelQa(
+  options: RunLifecyclemodelQaOptions,
+): Promise<LifecyclemodelQaReport> {
   const layout = resolveLayout(options);
   ensureRunRootExists(layout);
   readRequiredRunManifest(layout);
   const invocationIndex = readInvocationIndex(layout);
   const validationAggregate = readValidationAggregate(layout);
   const modelEntries = discoverModelEntries(layout);
-  const logicVersion = options.logicVersion?.trim() || 'lifecyclemodel-review-v1.0';
+  const logicVersion = options.logicVersion?.trim() || 'lifecyclemodel-qa-v1.0';
   const now = options.now ?? (() => new Date());
   const generatedAt = now();
 
   const reviewedModels = modelEntries.map((entry) => buildModelReview(entry, validationAggregate));
   const modelSummaries = reviewedModels.map((model) => model.summary);
   const findings = reviewedModels.flatMap((model) => model.findings);
-  const report: LifecyclemodelReviewReport = {
+  const report: LifecyclemodelQaReport = {
     schema_version: 1,
     generated_at_utc: generatedAt.toISOString(),
-    status: 'completed_local_lifecyclemodel_review',
+    status: 'completed_local_lifecyclemodel_qa',
     run_id: layout.runId,
     run_root: layout.runRoot,
     out_dir: layout.outDir,
@@ -1174,8 +1174,8 @@ export async function runLifecyclemodelReview(
       model_summaries: layout.modelSummariesPath,
       findings: layout.findingsPath,
       summary: layout.summaryPath,
-      review_zh: layout.reviewZhPath,
-      review_en: layout.reviewEnPath,
+      qa_zh: layout.reviewZhPath,
+      qa_en: layout.reviewEnPath,
       timing: layout.timingPath,
       report: layout.reportPath,
     },

--- a/src/lib/lifecyclemodel-qa.ts
+++ b/src/lib/lifecyclemodel-qa.ts
@@ -367,17 +367,14 @@ function readRequiredRunManifest(layout: LifecyclemodelQaLayout): JsonObject {
 
   const manifestRunId = nonEmptyString(manifest.runId);
   if (manifestRunId && manifestRunId !== layout.runId) {
-    throw new CliError(
-      `lifecyclemodel QA run manifest runId mismatch: ${layout.runManifestPath}`,
-      {
-        code: 'LIFECYCLEMODEL_QA_RUN_MANIFEST_MISMATCH',
-        exitCode: 2,
-        details: {
-          expected: layout.runId,
-          actual: manifestRunId,
-        },
+    throw new CliError(`lifecyclemodel QA run manifest runId mismatch: ${layout.runManifestPath}`, {
+      code: 'LIFECYCLEMODEL_QA_RUN_MANIFEST_MISMATCH',
+      exitCode: 2,
+      details: {
+        expected: layout.runId,
+        actual: manifestRunId,
       },
-    );
+    });
   }
 
   return manifest;

--- a/src/lib/process-qa.ts
+++ b/src/lib/process-qa.ts
@@ -354,7 +354,10 @@ function sourceGroup(exchange: JsonRecord, groupName: 'inputGroup' | 'outputGrou
   return text || null;
 }
 
-function classifyExchange(exchange: JsonRecord, referenceFlowId: string | null = null): ClassifiedExchange {
+function classifyExchange(
+  exchange: JsonRecord,
+  referenceFlowId: string | null = null,
+): ClassifiedExchange {
   const comments =
     `${textFromValue(exchange.commonComment)} ${textFromValue(exchange.generalComment)}`.toLowerCase();
   const flowDescription = textFromValue(
@@ -524,7 +527,8 @@ function reviewFindingsForBase(processFile: string, base: BaseInfoCheck): Proces
         processFile,
         severity: 'warning',
         code: 'process_missing_source_base_name',
-        message: 'Process baseName should include a usable source-language entry before Foundry authoring is complete.',
+        message:
+          'Process baseName should include a usable source-language entry before Foundry authoring is complete.',
         evidence: { base_names: base.base_names },
       }),
     );
@@ -535,7 +539,8 @@ function reviewFindingsForBase(processFile: string, base: BaseInfoCheck): Proces
         processFile,
         severity: 'warning',
         code: 'process_missing_functional_unit',
-        message: 'Process quantitative reference functionalUnitOrOther is missing and should be curated by Foundry.',
+        message:
+          'Process quantitative reference functionalUnitOrOther is missing and should be curated by Foundry.',
       }),
     );
   }
@@ -721,14 +726,11 @@ function loadReviewRows(rowsFile: string): JsonRecord[] {
           if (error instanceof CliError) {
             throw error;
           }
-          throw new CliError(
-            `Process QA rows file contains invalid JSONL at line ${index + 1}.`,
-            {
-              code: 'PROCESS_QA_ROWS_INVALID_JSONL',
-              exitCode: 2,
-              details: String(error),
-            },
-          );
+          throw new CliError(`Process QA rows file contains invalid JSONL at line ${index + 1}.`, {
+            code: 'PROCESS_QA_ROWS_INVALID_JSONL',
+            exitCode: 2,
+            details: String(error),
+          });
         }
       });
   }
@@ -1121,9 +1123,7 @@ function renderUnitIssues(runId: string, unitIssues: UnitIssue[]): string {
   return lines.join('');
 }
 
-export async function runProcessQa(
-  options: RunProcessQaOptions,
-): Promise<ProcessQaReport> {
+export async function runProcessQa(options: RunProcessQaOptions): Promise<ProcessQaReport> {
   const outDir = path.resolve(
     requiredNonEmpty(options.outDir, '--out-dir', 'PROCESS_QA_OUT_DIR_REQUIRED'),
   );

--- a/src/lib/process-qa.ts
+++ b/src/lib/process-qa.ts
@@ -4,12 +4,7 @@ import { writeJsonArtifact, writeJsonLinesArtifact, writeTextArtifact } from './
 import { CliError } from './errors.js';
 import type { FetchLike } from './http.js';
 import { readJsonInput } from './io.js';
-import { invokeLlm, readLlmRuntimeEnv, type LlmRuntimeEnv } from './llm.js';
-import {
-  getRuntimeRuleset,
-  isRuntimeRuleBlocker,
-  resolveRuntimeRuleId,
-} from './runtime-rulesets.js';
+import { getRuntimeRuleset, resolveRuntimeRuleId } from './runtime-rulesets.js';
 
 type JsonRecord = Record<string, unknown>;
 
@@ -50,7 +45,7 @@ const BYP_WORDS = ['by-product', 'co-product', '副产品', '联产'] as const;
 const WASTE_WORDS = ['waste', '废', 'residue', 'sludge'] as const;
 
 type BaseInfoCheck = {
-  name_zh_en_ok: boolean;
+  source_name_ok: boolean;
   functional_unit_ok: boolean;
   system_boundary_ok: boolean;
   time_ok: boolean;
@@ -74,6 +69,9 @@ type ClassifiedExchange = {
   kinds: string[];
   uoms: string[];
   blob: string;
+  source_input_group: string | null;
+  source_output_group: string | null;
+  reference_flow: boolean;
 };
 
 type UnitIssue = {
@@ -84,7 +82,7 @@ type UnitIssue = {
   confidence: string;
 };
 
-type ProcessReviewRow = {
+type ProcessQaRow = {
   process_file: string;
   raw_input: number;
   product: number;
@@ -95,7 +93,7 @@ type ProcessReviewRow = {
   relative_deviation: number | null;
 };
 
-type ProcessReviewTotals = {
+type ProcessQaTotals = {
   raw_input: number;
   product_plus_byproduct_plus_waste: number;
   delta: number;
@@ -103,7 +101,7 @@ type ProcessReviewTotals = {
   energy_excluded: number;
 };
 
-type ProcessReviewFinding = {
+type ProcessQaFinding = {
   process_file: string;
   severity: 'info' | 'warning' | 'blocker';
   code: string;
@@ -123,15 +121,15 @@ type ProcessRulesetGate = {
     findings: number;
     blockers: number;
   };
-  blockers: ProcessReviewFinding[];
-  next_action: 'continue' | 'review_findings' | 'fix_blockers';
+  blockers: ProcessQaFinding[];
+  next_action: 'continue' | 'review_findings_in_foundry' | 'fix_blockers';
 };
 
 type ProcessSummaryForLlm = {
   process_file: string;
   base_names: string[];
   base_checks: {
-    name_zh_en_ok: boolean;
+    source_name_ok: boolean;
     functional_unit_ok: boolean;
     system_boundary_ok: boolean;
     time_ok: boolean;
@@ -149,7 +147,7 @@ type ProcessSummaryForLlm = {
   };
 };
 
-export type ProcessReviewLlmResult =
+export type ProcessQaLlmResult =
   | {
       enabled: false;
       reason: string;
@@ -166,19 +164,21 @@ export type ProcessReviewLlmResult =
       raw?: string;
     };
 
-export type ProcessReviewSummary = {
+export type ProcessQaSummary = {
   run_id: string;
   logic_version: string;
   process_count: number;
-  totals: ProcessReviewTotals;
+  totals: ProcessQaTotals;
   ruleset_gate?: ProcessRulesetGate;
-  llm: ProcessReviewLlmResult;
+  llm: ProcessQaLlmResult;
+  policy_decision_owner: 'foundry';
+  qa_mode: 'deterministic_qa_report';
 };
 
-export type ProcessReviewReport = {
+export type ProcessQaReport = {
   schema_version: 1;
   generated_at_utc: string;
-  status: 'completed_local_process_review';
+  status: 'completed_local_process_qa';
   run_id: string;
   run_root: string;
   rows_file: string;
@@ -191,26 +191,28 @@ export type ProcessReviewReport = {
   ruleset_source_version?: string;
   ruleset_rule_ids?: string[];
   process_count: number;
-  totals: ProcessReviewTotals;
+  totals: ProcessQaTotals;
   rule_finding_count?: number;
   blocker_count?: number;
   ruleset_gate?: ProcessRulesetGate;
+  policy_decision_owner: 'foundry';
+  qa_mode: 'deterministic_qa_report';
   files: {
-    review_input_summary: string;
+    qa_input_summary: string;
     materialization_summary: string | null;
     rule_findings?: string;
     ruleset_gate?: string;
-    review_zh: string;
-    review_en: string;
+    qa_zh: string;
+    qa_en: string;
     timing: string;
     unit_issue_log: string;
     summary: string;
     report: string;
   };
-  llm: ProcessReviewLlmResult;
+  llm: ProcessQaLlmResult;
 };
 
-export type RunProcessReviewOptions = {
+export type RunProcessQaOptions = {
   rowsFile?: string;
   runRoot?: string;
   runId?: string;
@@ -308,7 +310,7 @@ function hasNonEmpty(value: unknown): boolean {
   return true;
 }
 
-function extractBaseNames(processPayload: JsonRecord): [boolean, boolean, string[]] {
+function extractBaseNames(processPayload: JsonRecord): [boolean, string[]] {
   const base = deepGet(processPayload, [
     'processDataSet',
     'processInformation',
@@ -317,37 +319,42 @@ function extractBaseNames(processPayload: JsonRecord): [boolean, boolean, string
     'baseName',
   ]);
   const items = Array.isArray(base) ? base : base ? [base] : [];
-  let zh = false;
-  let en = false;
   const values: string[] = [];
 
   items.forEach((item) => {
     if (!isRecord(item)) {
       return;
     }
-    const lang = String(item['@xml:lang'] ?? '').toLowerCase();
     const text = String(item['#text'] ?? '').trim();
     if (!text) {
       return;
     }
     values.push(text);
-    if (lang.startsWith('zh')) {
-      zh = true;
-    }
-    if (lang.startsWith('en')) {
-      en = true;
-    }
   });
 
-  if (!(zh && en) && values.length >= 2) {
-    zh = zh || true;
-    en = en || true;
-  }
-
-  return [zh, en, values];
+  return [values.length > 0, values];
 }
 
-function classifyExchange(exchange: JsonRecord): ClassifiedExchange {
+function sourceTracePayload(exchange: JsonRecord): JsonRecord | null {
+  const payload = deepGet(exchange, ['common:other', 'tidasimport:sourceTrace', 'payload']);
+  if (!isRecord(payload)) {
+    return null;
+  }
+  return isRecord(payload.sourceTrace) ? payload.sourceTrace : payload;
+}
+
+function sourceClassification(exchange: JsonRecord): JsonRecord {
+  const payload = sourceTracePayload(exchange);
+  return payload && isRecord(payload.sourceClassification) ? payload.sourceClassification : {};
+}
+
+function sourceGroup(exchange: JsonRecord, groupName: 'inputGroup' | 'outputGroup'): string | null {
+  const value = sourceClassification(exchange)[groupName];
+  const text = String(value ?? '').trim();
+  return text || null;
+}
+
+function classifyExchange(exchange: JsonRecord, referenceFlowId: string | null = null): ClassifiedExchange {
   const comments =
     `${textFromValue(exchange.commonComment)} ${textFromValue(exchange.generalComment)}`.toLowerCase();
   const flowDescription = textFromValue(
@@ -360,40 +367,60 @@ function classifyExchange(exchange: JsonRecord): ClassifiedExchange {
   const kindSet = new Set(kinds);
   const uoms = Array.from(blob.matchAll(UOM_RE), (match) => match[1].toLowerCase());
   const direction = String(exchange.exchangeDirection ?? '').toLowerCase();
+  const inputGroup = sourceGroup(exchange, 'inputGroup');
+  const outputGroup = sourceGroup(exchange, 'outputGroup');
+  const internalId = String(exchange['@dataSetInternalID'] ?? '').trim();
+  const isReferenceFlow = Boolean(referenceFlowId && internalId === referenceFlowId);
+  const meta = {
+    kinds,
+    uoms,
+    blob,
+    source_input_group: inputGroup,
+    source_output_group: outputGroup,
+    reference_flow: isReferenceFlow,
+  };
   const isEnergy =
     ENERGY_WORDS.some((word) => blob.includes(word)) ||
     uoms.some((uom) => uom === 'kwh' || uom === 'mj' || uom === 'gj');
 
   if (direction === 'input') {
     if (kindSet.has('energy') || isEnergy) {
-      return { classification: 'energy_input', kinds, uoms, blob };
+      return { classification: 'energy_input', ...meta };
     }
     if (kindSet.has('waste')) {
-      return { classification: 'other_input', kinds, uoms, blob };
+      return { classification: 'other_input', ...meta };
     }
-    if (kindSet.has('raw_material') || kindSet.has('resource')) {
-      return { classification: 'raw_material_input', kinds, uoms, blob };
+    if (inputGroup === '4' || kindSet.has('raw_material') || kindSet.has('resource')) {
+      return { classification: 'raw_material_input', ...meta };
     }
     if (kindSet.has('product') || RAW_WORDS.some((word) => blob.includes(word))) {
-      return { classification: 'raw_material_input', kinds, uoms, blob };
+      return { classification: 'raw_material_input', ...meta };
     }
-    return { classification: 'other_input', kinds, uoms, blob };
+    return { classification: 'other_input', ...meta };
   }
 
   if (direction === 'output') {
-    if (kindSet.has('waste') || WASTE_WORDS.some((word) => blob.includes(word))) {
-      return { classification: 'waste_output', kinds, uoms, blob };
+    if (isReferenceFlow || outputGroup === '0') {
+      return { classification: 'product_output', ...meta };
+    }
+    if (
+      kindSet.has('waste') ||
+      outputGroup === '4' ||
+      outputGroup === '5' ||
+      WASTE_WORDS.some((word) => blob.includes(word))
+    ) {
+      return { classification: 'waste_output', ...meta };
     }
     if (BYP_WORDS.some((word) => blob.includes(word))) {
-      return { classification: 'byproduct_output', kinds, uoms, blob };
+      return { classification: 'byproduct_output', ...meta };
     }
     if (kindSet.has('product')) {
-      return { classification: 'product_output', kinds, uoms, blob };
+      return { classification: 'product_output', ...meta };
     }
-    return { classification: 'other_output', kinds, uoms, blob };
+    return { classification: 'other_output', ...meta };
   }
 
-  return { classification: 'other', kinds, uoms, blob };
+  return { classification: 'other', ...meta };
 }
 
 function unitIssueCheck(exchange: JsonRecord, uoms: string[], blob: string): UnitIssue[] {
@@ -470,13 +497,13 @@ function hasNumericAmount(exchange: JsonRecord): boolean {
   return false;
 }
 
-function createProcessReviewFinding(options: {
+function createProcessQaFinding(options: {
   processFile: string;
-  severity: ProcessReviewFinding['severity'];
+  severity: ProcessQaFinding['severity'];
   code: string;
   message: string;
   evidence?: JsonRecord;
-}): ProcessReviewFinding {
+}): ProcessQaFinding {
   const methodologyRuleId = resolveRuntimeRuleId('process-authoring/strict', options.code);
   return {
     process_file: options.processFile,
@@ -489,26 +516,26 @@ function createProcessReviewFinding(options: {
   };
 }
 
-function reviewFindingsForBase(processFile: string, base: BaseInfoCheck): ProcessReviewFinding[] {
-  const findings: ProcessReviewFinding[] = [];
-  if (!base.name_zh_en_ok) {
+function reviewFindingsForBase(processFile: string, base: BaseInfoCheck): ProcessQaFinding[] {
+  const findings: ProcessQaFinding[] = [];
+  if (!base.source_name_ok) {
     findings.push(
-      createProcessReviewFinding({
+      createProcessQaFinding({
         processFile,
-        severity: 'blocker',
-        code: 'process_missing_bilingual_base_name',
-        message: 'Process baseName must include usable Chinese and English entries.',
+        severity: 'warning',
+        code: 'process_missing_source_base_name',
+        message: 'Process baseName should include a usable source-language entry before Foundry authoring is complete.',
         evidence: { base_names: base.base_names },
       }),
     );
   }
   if (!base.functional_unit_ok) {
     findings.push(
-      createProcessReviewFinding({
+      createProcessQaFinding({
         processFile,
-        severity: 'blocker',
+        severity: 'warning',
         code: 'process_missing_functional_unit',
-        message: 'Process quantitative reference functionalUnitOrOther is missing.',
+        message: 'Process quantitative reference functionalUnitOrOther is missing and should be curated by Foundry.',
       }),
     );
   }
@@ -529,7 +556,7 @@ function reviewFindingsForBase(processFile: string, base: BaseInfoCheck): Proces
   ] as const) {
     if (!ok) {
       findings.push(
-        createProcessReviewFinding({
+        createProcessQaFinding({
           processFile,
           severity: 'warning',
           code,
@@ -541,12 +568,9 @@ function reviewFindingsForBase(processFile: string, base: BaseInfoCheck): Proces
   return findings;
 }
 
-function processRulesetGate(findings: ProcessReviewFinding[]): ProcessRulesetGate {
+function processRulesetGate(findings: ProcessQaFinding[]): ProcessRulesetGate {
   const ruleset = getRuntimeRuleset('process-authoring/strict');
-  const blockers = findings.filter(
-    (finding) =>
-      finding.severity === 'blocker' || isRuntimeRuleBlocker(finding.methodology_rule_id),
-  );
+  const blockers = findings.filter((finding) => finding.severity === 'blocker');
   const status = blockers.length > 0 ? 'blocked' : findings.length > 0 ? 'needs_review' : 'passed';
   return {
     status,
@@ -563,13 +587,13 @@ function processRulesetGate(findings: ProcessReviewFinding[]): ProcessRulesetGat
       status === 'blocked'
         ? 'fix_blockers'
         : status === 'needs_review'
-          ? 'review_findings'
+          ? 'review_findings_in_foundry'
           : 'continue',
   };
 }
 
 function baseInfoCheck(processPayload: JsonRecord): BaseInfoCheck {
-  const [zhOk, enOk, values] = extractBaseNames(processPayload);
+  const [sourceNameOk, values] = extractBaseNames(processPayload);
   const functionalUnit = deepGet(processPayload, [
     'processDataSet',
     'processInformation',
@@ -596,7 +620,6 @@ function baseInfoCheck(processPayload: JsonRecord): BaseInfoCheck {
     'administrativeInformation',
   ]);
 
-  const nameOk = zhOk && enOk;
   const functionalUnitOk = hasNonEmpty(functionalUnit);
   const systemBoundaryOk = hasNonEmpty(mixAndLocation) || hasNonEmpty(route);
   const timeOk = hasNonEmpty(time);
@@ -604,7 +627,7 @@ function baseInfoCheck(processPayload: JsonRecord): BaseInfoCheck {
   const technologyOk = hasNonEmpty(technology);
   const administrativeOk = hasNonEmpty(administrativeInformation);
   const completenessScore = [
-    nameOk,
+    sourceNameOk,
     functionalUnitOk,
     systemBoundaryOk,
     timeOk,
@@ -614,7 +637,7 @@ function baseInfoCheck(processPayload: JsonRecord): BaseInfoCheck {
   ].filter(Boolean).length;
 
   return {
-    name_zh_en_ok: nameOk,
+    source_name_ok: sourceNameOk,
     functional_unit_ok: functionalUnitOk,
     system_boundary_ok: systemBoundaryOk,
     time_ok: timeOk,
@@ -628,8 +651,8 @@ function baseInfoCheck(processPayload: JsonRecord): BaseInfoCheck {
 
 function unwrapProcessPayload(value: unknown, filePath: string): JsonRecord {
   if (!isRecord(value)) {
-    throw new CliError(`Expected process review file to contain a JSON object: ${filePath}`, {
-      code: 'PROCESS_REVIEW_INPUT_INVALID',
+    throw new CliError(`Expected process QA file to contain a JSON object: ${filePath}`, {
+      code: 'PROCESS_QA_INPUT_INVALID',
       exitCode: 2,
     });
   }
@@ -642,8 +665,8 @@ function unwrapProcessPayload(value: unknown, filePath: string): JsonRecord {
     value;
 
   if (!isRecord(candidate.processDataSet)) {
-    throw new CliError(`Process review file is missing processDataSet: ${filePath}`, {
-      code: 'PROCESS_REVIEW_INPUT_INVALID',
+    throw new CliError(`Process QA file is missing processDataSet: ${filePath}`, {
+      code: 'PROCESS_QA_INPUT_INVALID',
       exitCode: 2,
     });
   }
@@ -689,7 +712,7 @@ function loadReviewRows(rowsFile: string): JsonRecord[] {
           const parsed = JSON.parse(line) as unknown;
           if (!isRecord(parsed)) {
             throw new CliError(`Expected JSON object rows in JSONL file: ${resolved}`, {
-              code: 'PROCESS_REVIEW_ROWS_INVALID_JSONL_ROW',
+              code: 'PROCESS_QA_ROWS_INVALID_JSONL_ROW',
               exitCode: 2,
             });
           }
@@ -699,9 +722,9 @@ function loadReviewRows(rowsFile: string): JsonRecord[] {
             throw error;
           }
           throw new CliError(
-            `Process review rows file contains invalid JSONL at line ${index + 1}.`,
+            `Process QA rows file contains invalid JSONL at line ${index + 1}.`,
             {
-              code: 'PROCESS_REVIEW_ROWS_INVALID_JSONL',
+              code: 'PROCESS_QA_ROWS_INVALID_JSONL',
               exitCode: 2,
               details: String(error),
             },
@@ -714,8 +737,8 @@ function loadReviewRows(rowsFile: string): JsonRecord[] {
   try {
     parsed = JSON.parse(text) as unknown;
   } catch (error) {
-    throw new CliError(`Process review rows file is not valid JSON: ${resolved}`, {
-      code: 'PROCESS_REVIEW_ROWS_INVALID_JSON',
+    throw new CliError(`Process QA rows file is not valid JSON: ${resolved}`, {
+      code: 'PROCESS_QA_ROWS_INVALID_JSON',
       exitCode: 2,
       details: String(error),
     });
@@ -729,7 +752,7 @@ function loadReviewRows(rowsFile: string): JsonRecord[] {
   }
 
   throw new CliError(`Expected JSON array of objects or a report object with rows[]: ${resolved}`, {
-    code: 'PROCESS_REVIEW_ROWS_INVALID_JSON',
+    code: 'PROCESS_QA_ROWS_INVALID_JSON',
     exitCode: 2,
   });
 }
@@ -739,7 +762,7 @@ function materializeRowsFile(
   outDir: string,
 ): { processesDir: string; summaryPath: string } {
   const rows = loadReviewRows(rowsFile);
-  const targetDir = path.join(outDir, 'review-input', 'processes');
+  const targetDir = path.join(outDir, 'qa-input', 'processes');
   mkdirSync(targetDir, { recursive: true });
 
   const byKey: Record<string, JsonRecord> = {};
@@ -768,7 +791,7 @@ function materializeRowsFile(
       });
     });
 
-  const summaryPath = path.join(outDir, 'review-input', 'materialization-summary.json');
+  const summaryPath = path.join(outDir, 'qa-input', 'materialization-summary.json');
   writeJsonArtifact(summaryPath, {
     source_rows_file: path.resolve(rowsFile),
     input_row_count: rows.length,
@@ -800,8 +823,8 @@ function resolveReviewInput(options: {
 } {
   const declaredModes = [Boolean(options.rowsFile), Boolean(options.runRoot)].filter(Boolean);
   if (declaredModes.length !== 1) {
-    throw new CliError('Process review requires exactly one of --rows-file or --run-root.', {
-      code: 'PROCESS_REVIEW_INPUT_MODE_REQUIRED',
+    throw new CliError('Process QA requires exactly one of --rows-file or --run-root.', {
+      code: 'PROCESS_QA_INPUT_MODE_REQUIRED',
       exitCode: 2,
     });
   }
@@ -846,8 +869,8 @@ function resolveReviewInput(options: {
 
 function readProcessFiles(processDir: string): string[] {
   if (!existsSync(processDir) || !statSync(processDir).isDirectory()) {
-    throw new CliError(`Process review directory not found: ${processDir}`, {
-      code: 'PROCESS_REVIEW_EXPORTS_NOT_FOUND',
+    throw new CliError(`Process QA directory not found: ${processDir}`, {
+      code: 'PROCESS_QA_EXPORTS_NOT_FOUND',
       exitCode: 2,
     });
   }
@@ -860,7 +883,7 @@ function readProcessFiles(processDir: string): string[] {
 
 function buildPrompt(processSummaries: ProcessSummaryForLlm[]): string {
   return [
-    '请基于以下 process 摘要做语义一致性审核（中英名称一致性、边界表达、修订建议）。',
+    '请基于以下 process 摘要做语义一致性审核（源语言名称、边界表达、修订建议）。',
     '要求：',
     '1) 只根据给定摘要；',
     '2) 证据不足必须明确标注；',
@@ -892,7 +915,12 @@ async function runOptionalLlmReview(
     fetchImpl: FetchLike;
     outDir: string;
   },
-): Promise<ProcessReviewLlmResult> {
+): Promise<ProcessQaLlmResult> {
+  void processSummaries;
+  void options.env;
+  void options.fetchImpl;
+  void options.outDir;
+
   if (!options.enableLlm) {
     return {
       enabled: false,
@@ -900,52 +928,10 @@ async function runOptionalLlmReview(
     };
   }
 
-  let env = readLlmRuntimeEnv(options.env);
-  if (options.llmModel) {
-    env = {
-      ...env,
-      model: options.llmModel,
-    } satisfies LlmRuntimeEnv;
-  }
-
-  try {
-    const response = await invokeLlm({
-      env,
-      input: {
-        prompt: '你是严谨的LCA审核助手。只给基于输入证据的判断，不得臆造。输出必须是JSON对象。',
-        context: buildPrompt(processSummaries),
-      },
-      fetchImpl: options.fetchImpl,
-      timeoutMs: 45_000,
-      cacheDir: path.join(options.outDir, '.llm-cache'),
-      tracePath: path.join(options.outDir, 'llm-trace.jsonl'),
-      module: 'review-process',
-      stage: 'semantic-review',
-      runId: 'review-process',
-    });
-
-    const parsed = parseLlmJsonOutput(response.output);
-    if (!parsed) {
-      return {
-        enabled: true,
-        ok: false,
-        reason: 'llm_non_json_output',
-        raw: response.output.slice(0, 8_000),
-      };
-    }
-
-    return {
-      enabled: true,
-      ok: true,
-      result: parsed,
-    };
-  } catch (error) {
-    return {
-      enabled: true,
-      ok: false,
-      reason: error instanceof Error ? error.message : String(error),
-    };
-  }
+  return {
+    enabled: false,
+    reason: 'moved_to_foundry_process_curation',
+  };
 }
 
 function formatPercent(value: number | null): string {
@@ -956,24 +942,24 @@ function renderZhReview(options: {
   runId: string;
   logicVersion: string;
   baseRows: Array<[string, BaseInfoCheck]>;
-  rows: ProcessReviewRow[];
-  totals: ProcessReviewTotals;
-  llmResult: ProcessReviewLlmResult;
+  rows: ProcessQaRow[];
+  totals: ProcessQaTotals;
+  llmResult: ProcessQaLlmResult;
   evidenceStrong: string[];
   evidenceWeak: string[];
 }): string {
   const lines = [
-    '# one_flow_rerun_review_v2_1_zh\n',
+    '# one_flow_rerun_qa_v2_1_zh\n',
     `- run_id: \`${options.runId}\`\n`,
     `- logic_version: \`${options.logicVersion}\`\n`,
     '\n## 2.1 基础信息核查\n',
-    '|process file|中英名称|功能单位|系统边界|时间|地理|技术|管理元数据|完整性得分(0-7)|\n',
+    '|process file|源语言名称|功能单位|系统边界|时间|地理|技术|管理元数据|完整性得分(0-7)|\n',
     '|---|---|---|---|---|---|---|---|---:|\n',
   ];
 
   options.baseRows.forEach(([fileName, base]) => {
     lines.push(
-      `|${fileName}|${base.name_zh_en_ok ? '✅' : '❌'}|${base.functional_unit_ok ? '✅' : '❌'}|${base.system_boundary_ok ? '✅' : '❌'}|${base.time_ok ? '✅' : '❌'}|${base.geo_ok ? '✅' : '❌'}|${base.tech_ok ? '✅' : '❌'}|${base.admin_ok ? '✅' : '❌'}|${base.completeness_score}|\n`,
+      `|${fileName}|${base.source_name_ok ? '✅' : '❌'}|${base.functional_unit_ok ? '✅' : '❌'}|${base.system_boundary_ok ? '✅' : '❌'}|${base.time_ok ? '✅' : '❌'}|${base.geo_ok ? '✅' : '❌'}|${base.tech_ok ? '✅' : '❌'}|${base.admin_ok ? '✅' : '❌'}|${base.completeness_score}|\n`,
     );
   });
 
@@ -1031,23 +1017,23 @@ function renderEnReview(options: {
   runId: string;
   logicVersion: string;
   baseRows: Array<[string, BaseInfoCheck]>;
-  rows: ProcessReviewRow[];
-  totals: ProcessReviewTotals;
+  rows: ProcessQaRow[];
+  totals: ProcessQaTotals;
   evidenceStrong: string[];
   evidenceWeak: string[];
 }): string {
   const lines = [
-    '# one_flow_rerun_review_v2_1_en\n',
+    '# one_flow_rerun_qa_v2_1_en\n',
     `- run_id: \`${options.runId}\`\n`,
     `- logic_version: \`${options.logicVersion}\`\n`,
     '\n## 2.1 Basic info checks\n',
-    '|process file|zh+en names|functional unit|system boundary|time|geo|tech|admin metadata|completeness(0-7)|\n',
+    '|process file|source-language name|functional unit|system boundary|time|geo|tech|admin metadata|completeness(0-7)|\n',
     '|---|---|---|---|---|---|---|---|---:|\n',
   ];
 
   options.baseRows.forEach(([fileName, base]) => {
     lines.push(
-      `|${fileName}|${base.name_zh_en_ok ? '✅' : '❌'}|${base.functional_unit_ok ? '✅' : '❌'}|${base.system_boundary_ok ? '✅' : '❌'}|${base.time_ok ? '✅' : '❌'}|${base.geo_ok ? '✅' : '❌'}|${base.tech_ok ? '✅' : '❌'}|${base.admin_ok ? '✅' : '❌'}|${base.completeness_score}|\n`,
+      `|${fileName}|${base.source_name_ok ? '✅' : '❌'}|${base.functional_unit_ok ? '✅' : '❌'}|${base.system_boundary_ok ? '✅' : '❌'}|${base.time_ok ? '✅' : '❌'}|${base.geo_ok ? '✅' : '❌'}|${base.tech_ok ? '✅' : '❌'}|${base.admin_ok ? '✅' : '❌'}|${base.completeness_score}|\n`,
     );
   });
 
@@ -1090,7 +1076,7 @@ function renderTiming(options: {
     const end = new Date(options.endTs);
     if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
       throw new CliError('Expected --start-ts and --end-ts to be valid ISO timestamps.', {
-        code: 'PROCESS_REVIEW_INVALID_TIMESTAMP',
+        code: 'PROCESS_QA_INVALID_TIMESTAMP',
         exitCode: 2,
       });
     }
@@ -1135,11 +1121,11 @@ function renderUnitIssues(runId: string, unitIssues: UnitIssue[]): string {
   return lines.join('');
 }
 
-export async function runProcessReview(
-  options: RunProcessReviewOptions,
-): Promise<ProcessReviewReport> {
+export async function runProcessQa(
+  options: RunProcessQaOptions,
+): Promise<ProcessQaReport> {
   const outDir = path.resolve(
-    requiredNonEmpty(options.outDir, '--out-dir', 'PROCESS_REVIEW_OUT_DIR_REQUIRED'),
+    requiredNonEmpty(options.outDir, '--out-dir', 'PROCESS_QA_OUT_DIR_REQUIRED'),
   );
   const resolvedInput = resolveReviewInput({
     rowsFile: options.rowsFile,
@@ -1147,7 +1133,7 @@ export async function runProcessReview(
     runId: options.runId,
     outDir,
   });
-  const runId = requiredNonEmpty(resolvedInput.runId, '--run-id', 'PROCESS_REVIEW_RUN_ID_REQUIRED');
+  const runId = requiredNonEmpty(resolvedInput.runId, '--run-id', 'PROCESS_QA_RUN_ID_REQUIRED');
   const logicVersion = options.logicVersion?.trim() || 'v2.1';
   const fetchImpl = options.fetchImpl ?? (fetch as FetchLike);
   const env = options.env ?? process.env;
@@ -1159,9 +1145,9 @@ export async function runProcessReview(
       : 8;
   const processFiles = readProcessFiles(resolvedInput.effectiveProcessesDir);
   const baseRows: Array<[string, BaseInfoCheck]> = [];
-  const rows: ProcessReviewRow[] = [];
+  const rows: ProcessQaRow[] = [];
   const unitIssues: UnitIssue[] = [];
-  const ruleFindings: ProcessReviewFinding[] = [];
+  const ruleFindings: ProcessQaFinding[] = [];
   const processSummariesForLlm: ProcessSummaryForLlm[] = [];
 
   let totalRaw = 0;
@@ -1178,6 +1164,15 @@ export async function runProcessReview(
       : isRecord(exchangesValue)
         ? [exchangesValue]
         : [];
+    const referenceFlowId =
+      String(
+        deepGet(processPayload, [
+          'processDataSet',
+          'processInformation',
+          'quantitativeReference',
+          'referenceToReferenceFlow',
+        ]) ?? '',
+      ).trim() || null;
     const base = baseInfoCheck(processPayload);
     const fileName = path.basename(filePath);
     baseRows.push([fileName, base]);
@@ -1190,14 +1185,15 @@ export async function runProcessReview(
     let energyExcluded = 0;
 
     exchanges.forEach((exchange) => {
-      const classified = classifyExchange(exchange);
+      const classified = classifyExchange(exchange, referenceFlowId);
       if (!hasNumericAmount(exchange)) {
         ruleFindings.push(
-          createProcessReviewFinding({
+          createProcessQaFinding({
             processFile: fileName,
-            severity: 'blocker',
+            severity: 'warning',
             code: 'process_missing_exchange_amount',
-            message: 'Process exchange is missing both numeric meanAmount and resultingAmount.',
+            message:
+              'Process exchange is missing both numeric meanAmount and resultingAmount and should be curated by Foundry.',
             evidence: {
               exchange_internal_id: String(exchange['@dataSetInternalID'] ?? ''),
               direction: String(exchange.exchangeDirection ?? ''),
@@ -1221,7 +1217,7 @@ export async function runProcessReview(
       unitIssues.push(...currentUnitIssues);
       currentUnitIssues.forEach((issue) => {
         ruleFindings.push(
-          createProcessReviewFinding({
+          createProcessQaFinding({
             processFile: fileName,
             severity: 'warning',
             code: 'process_exchange_unit_semantic_mismatch',
@@ -1249,18 +1245,19 @@ export async function runProcessReview(
 
     if (relativeDeviation !== null && relativeDeviation > 0.05) {
       ruleFindings.push(
-        createProcessReviewFinding({
+        createProcessQaFinding({
           processFile: fileName,
-          severity: relativeDeviation > 0.1 ? 'blocker' : 'warning',
+          severity: 'warning',
           code: 'process_material_balance_deviation',
           message:
-            'Material balance deviation exceeds the review threshold for raw inputs versus product/by-product/waste outputs.',
+            'Material balance deviation exceeds the QA threshold for raw inputs versus product/by-product/waste outputs.',
           evidence: {
             raw_input: rawInput,
             product,
             byproduct,
             waste,
             relative_deviation: relativeDeviation,
+            policy_decision_owner: 'foundry',
           },
         }),
       );
@@ -1277,7 +1274,7 @@ export async function runProcessReview(
         process_file: fileName,
         base_names: base.base_names.slice(0, 4),
         base_checks: {
-          name_zh_en_ok: base.name_zh_en_ok,
+          source_name_ok: base.source_name_ok,
           functional_unit_ok: base.functional_unit_ok,
           system_boundary_ok: base.system_boundary_ok,
           time_ok: base.time_ok,
@@ -1297,7 +1294,7 @@ export async function runProcessReview(
     }
   });
 
-  const totals: ProcessReviewTotals = {
+  const totals: ProcessQaTotals = {
     raw_input: totalRaw,
     product_plus_byproduct_plus_waste: totalProduct + totalByproduct + totalWaste,
     delta: totalProduct + totalByproduct + totalWaste - totalRaw,
@@ -1309,7 +1306,7 @@ export async function runProcessReview(
   };
 
   const evidenceStrong = [
-    '已基于 exchange 的 comment 标签/描述做口径过滤，仅核算 原材料投入 vs 产品+副产品+废物，能量单列不计入平衡。',
+    '已优先使用 quantitativeReference.referenceToReferenceFlow、EcoSpold inputGroup/outputGroup 和 exchange 标签/描述做口径过滤，仅核算 原材料投入 vs 产品+副产品+废物，能量单列不计入平衡。',
     ...(unitIssues.length > 0
       ? ['发现单位疑似错误时均附带 flow 描述与单位标签的直接矛盾证据。']
       : []),
@@ -1329,29 +1326,31 @@ export async function runProcessReview(
   });
   const rulesetGate = processRulesetGate(ruleFindings);
 
-  const summary: ProcessReviewSummary = {
+  const summary: ProcessQaSummary = {
     run_id: runId,
     logic_version: logicVersion,
     process_count: processFiles.length,
     totals,
     ruleset_gate: rulesetGate,
     llm: llmResult,
+    policy_decision_owner: 'foundry',
+    qa_mode: 'deterministic_qa_report',
   };
   const reviewInputSummaryPath = writeJsonArtifact(
-    path.join(outDir, 'review-input-summary.json'),
+    path.join(outDir, 'qa-input-summary.json'),
     resolvedInput.reviewInputSummary,
   );
   const ruleFindingsPath = writeJsonLinesArtifact(
-    path.join(outDir, 'process-review-rule-findings.jsonl'),
+    path.join(outDir, 'process-qa-rule-findings.jsonl'),
     ruleFindings,
   );
   const rulesetGatePath = writeJsonArtifact(
-    path.join(outDir, 'process-review-ruleset-gate.json'),
+    path.join(outDir, 'process-qa-ruleset-gate.json'),
     rulesetGate,
   );
 
   const reviewZhPath = writeTextArtifact(
-    path.join(outDir, 'one_flow_rerun_review_v2_1_zh.md'),
+    path.join(outDir, 'one_flow_rerun_qa_v2_1_zh.md'),
     renderZhReview({
       runId,
       logicVersion,
@@ -1364,7 +1363,7 @@ export async function runProcessReview(
     }),
   );
   const reviewEnPath = writeTextArtifact(
-    path.join(outDir, 'one_flow_rerun_review_v2_1_en.md'),
+    path.join(outDir, 'one_flow_rerun_qa_v2_1_en.md'),
     renderEnReview({
       runId,
       logicVersion,
@@ -1388,12 +1387,12 @@ export async function runProcessReview(
     path.join(outDir, 'flow_unit_issue_log.md'),
     renderUnitIssues(runId, unitIssues),
   );
-  const summaryPath = writeJsonArtifact(path.join(outDir, 'review_summary_v2_1.json'), summary);
+  const summaryPath = writeJsonArtifact(path.join(outDir, 'qa_summary_v2_1.json'), summary);
 
-  const report: ProcessReviewReport = {
+  const report: ProcessQaReport = {
     schema_version: 1,
     generated_at_utc: (options.now ?? (() => new Date()))().toISOString(),
-    status: 'completed_local_process_review',
+    status: 'completed_local_process_qa',
     run_id: runId,
     run_root: resolvedInput.runRoot,
     rows_file: resolvedInput.rowsFile,
@@ -1410,13 +1409,15 @@ export async function runProcessReview(
     rule_finding_count: ruleFindings.length,
     blocker_count: rulesetGate.counts.blockers,
     ruleset_gate: rulesetGate,
+    policy_decision_owner: 'foundry',
+    qa_mode: 'deterministic_qa_report',
     files: {
-      review_input_summary: reviewInputSummaryPath,
+      qa_input_summary: reviewInputSummaryPath,
       materialization_summary: resolvedInput.materializationSummaryPath,
       rule_findings: ruleFindingsPath,
       ruleset_gate: rulesetGatePath,
-      review_zh: reviewZhPath,
-      review_en: reviewEnPath,
+      qa_zh: reviewZhPath,
+      qa_en: reviewEnPath,
       timing: timingPath,
       unit_issue_log: unitIssuePath,
       summary: summaryPath,
@@ -1425,7 +1426,7 @@ export async function runProcessReview(
     llm: llmResult,
   };
 
-  const reportPath = writeJsonArtifact(path.join(outDir, 'process-review-report.json'), report);
+  const reportPath = writeJsonArtifact(path.join(outDir, 'process-qa-report.json'), report);
   report.files.report = reportPath;
   writeJsonArtifact(reportPath, report);
   return report;
@@ -1441,7 +1442,7 @@ export const __testInternals = {
   classifyExchange,
   unitIssueCheck,
   hasNumericAmount,
-  createProcessReviewFinding,
+  createProcessQaFinding,
   reviewFindingsForBase,
   processRulesetGate,
   baseInfoCheck,

--- a/src/lib/runtime-rulesets.ts
+++ b/src/lib/runtime-rulesets.ts
@@ -244,7 +244,7 @@ const RULES_BY_ID = Object.fromEntries(RUNTIME_RULES.map((item) => [item.id, ite
 
 const LOCAL_RULE_ID_MAP: Partial<Record<RuntimeRulesetId, Record<string, string>>> = {
   'process-authoring/strict': {
-    process_missing_bilingual_base_name: 'tidas.process.name.base-name.align-reference-flow',
+    process_missing_source_base_name: 'tidas.process.name.base-name.align-reference-flow',
     process_missing_functional_unit: 'tidas.process.quantitative-reference.required',
     process_missing_quantitative_reference: 'tidas.process.quantitative-reference.required',
     process_missing_exchange_amount: 'tidas.process.exchange.amount.required',
@@ -264,7 +264,7 @@ const LOCAL_RULE_ID_MAP: Partial<Record<RuntimeRulesetId, Record<string, string>
   },
   'flow-authoring/strict': {
     missing_type_of_dataset: 'tidas.flow.type.required',
-    elementary_flow_in_flow_review: 'tidas.flow.type.required',
+    elementary_flow_in_flow_qa: 'tidas.flow.type.required',
     methodology_invalid_type_of_dataset: 'tidas.flow.type.required',
     missing_name_text: 'tidas.flow.name.base-name.technical',
     name_contains_emergy: 'tidas.flow.name.base-name.technical',

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -4434,6 +4434,8 @@ test('executeCli executes qa process with injected implementation', async () => 
             effective_processes_dir: path.join(dir, 'run-root', 'exports', 'processes'),
             logic_version: options.logicVersion ?? 'v2.1',
             process_count: 1,
+            policy_decision_owner: 'foundry',
+            qa_mode: 'deterministic_qa_report',
             totals: {
               raw_input: 1,
               product_plus_byproduct_plus_waste: 1,
@@ -4497,6 +4499,8 @@ test('executeCli passes rows-file qa process input through to the implementation
             effective_processes_dir: path.join(dir, 'review', 'qa-input', 'processes'),
             logic_version: 'v2.1',
             process_count: 1,
+            policy_decision_owner: 'foundry',
+            qa_mode: 'deterministic_qa_report',
             totals: {
               raw_input: 1,
               product_plus_byproduct_plus_waste: 1,
@@ -4574,6 +4578,8 @@ test('executeCli executes qa process with only required flags', async () => {
             effective_processes_dir: path.join(dir, 'run-root', 'exports', 'processes'),
             logic_version: 'v2.1',
             process_count: 0,
+            policy_decision_owner: 'foundry',
+            qa_mode: 'deterministic_qa_report',
             totals: {
               raw_input: 0,
               product_plus_byproduct_plus_waste: 0,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -15,8 +15,8 @@ import type {
   RunFlowValidateProcessesOptions,
 } from '../src/lib/flow-regen-product.js';
 import type { RunFlowRemediateOptions } from '../src/lib/flow-remediate.js';
-import type { RunFlowReviewOptions } from '../src/lib/review-flow.js';
-import type { RunLifecyclemodelReviewOptions } from '../src/lib/review-lifecyclemodel.js';
+import type { RunFlowQaOptions } from '../src/lib/flow-qa.js';
+import type { RunLifecyclemodelQaOptions } from '../src/lib/lifecyclemodel-qa.js';
 import {
   buildSupabaseTestEnv,
   isSupabaseAuthTokenUrl,
@@ -67,7 +67,7 @@ test('executeCli prints main help when no command is given', async () => {
   assert.match(result.stdout, /lifecyclemodel auto-build/u);
   assert.match(result.stdout, /lifecyclemodel auto-build \| validate-build \| publish-build/u);
   assert.match(result.stdout, /publish-resulting-process/u);
-  assert.match(result.stdout, /review\s+process/u);
+  assert.match(result.stdout, /qa\s+process \| flow \| lifecyclemodel/u);
   assert.match(result.stdout, /exit with code 2/u);
   assert.equal(result.stderr, '');
 });
@@ -163,9 +163,9 @@ test('executeCli returns help for publish and validation namespaces', async () =
   assert.equal(validationHelp.exitCode, 0);
   assert.match(validationHelp.stdout, /tiangong-lca validation run/u);
 
-  const reviewHelp = await executeCli(['review', '--help'], makeDeps());
-  assert.equal(reviewHelp.exitCode, 0);
-  assert.match(reviewHelp.stdout, /tiangong-lca review <subcommand>/u);
+  const qaHelp = await executeCli(['qa', '--help'], makeDeps());
+  assert.equal(qaHelp.exitCode, 0);
+  assert.match(qaHelp.stdout, /tiangong-lca qa <subcommand>/u);
 
   const flowHelp = await executeCli(['flow', '--help'], makeDeps());
   assert.equal(flowHelp.exitCode, 0);
@@ -197,33 +197,33 @@ test('executeCli returns help for publish and validation subcommands', async () 
   assert.equal(validationHelp.exitCode, 0);
   assert.match(validationHelp.stdout, /--report-file/u);
 
-  const reviewHelp = await executeCli(['review', 'process', '--help'], makeDeps());
+  const reviewHelp = await executeCli(['qa', 'process', '--help'], makeDeps());
   assert.equal(reviewHelp.exitCode, 0);
   assert.ok(
     reviewHelp.stdout.includes(
-      'tiangong-lca review process (--rows-file <file> | --run-root <dir>) --out-dir <dir>',
+      'tiangong-lca qa process (--rows-file <file> | --run-root <dir>) --out-dir <dir>',
     ),
   );
   assert.match(reviewHelp.stdout, /full process list reports with rows\[\] are also accepted/u);
   assert.match(reviewHelp.stdout, /--enable-llm/u);
 
-  const reviewFlowHelp = await executeCli(['review', 'flow', '--help'], makeDeps());
+  const reviewFlowHelp = await executeCli(['qa', 'flow', '--help'], makeDeps());
   assert.equal(reviewFlowHelp.exitCode, 0);
   assert.ok(
     reviewFlowHelp.stdout.includes(
-      'tiangong-lca review flow (--rows-file <file> | --flows-dir <dir> | --run-root <dir>) --out-dir <dir>',
+      'tiangong-lca qa flow (--rows-file <file> | --flows-dir <dir> | --run-root <dir>) --out-dir <dir>',
     ),
   );
   assert.match(reviewFlowHelp.stdout, /--similarity-threshold/u);
 
   const reviewLifecyclemodelHelp = await executeCli(
-    ['review', 'lifecyclemodel', '--help'],
+    ['qa', 'lifecyclemodel', '--help'],
     makeDeps(),
   );
   assert.equal(reviewLifecyclemodelHelp.exitCode, 0);
   assert.match(
     reviewLifecyclemodelHelp.stdout,
-    /tiangong-lca review lifecyclemodel --run-dir <dir> --out-dir <dir>/u,
+    /tiangong-lca qa lifecyclemodel --run-dir <dir> --out-dir <dir>/u,
   );
   assert.match(
     reviewLifecyclemodelHelp.stdout,
@@ -303,7 +303,7 @@ test('executeCli returns help for publish and validation subcommands', async () 
   assert.equal(flowFetchRowsHelp.exitCode, 0);
   assert.match(flowFetchRowsHelp.stdout, /tiangong-lca flow fetch-rows --refs-file <file>/u);
   assert.match(flowFetchRowsHelp.stdout, /--no-latest-fallback/u);
-  assert.match(flowFetchRowsHelp.stdout, /review-input-rows\.jsonl/u);
+  assert.match(flowFetchRowsHelp.stdout, /qa-input-rows\.jsonl/u);
   assert.doesNotMatch(flowFetchRowsHelp.stdout, /Planned command/u);
 
   const flowMaterializeDecisionsHelp = await executeCli(
@@ -1106,8 +1106,8 @@ test('executeCli executes flow fetch-rows with injected implementation', async (
           allow_latest_fallback: false,
           requested_ref_count: 2,
           resolved_ref_count: 1,
-          review_input_row_count: 1,
-          duplicate_review_input_rows_collapsed: 0,
+          qa_input_row_count: 1,
+          duplicate_qa_input_rows_collapsed: 0,
           missing_ref_count: 1,
           ambiguous_ref_count: 0,
           resolution_counts: {
@@ -1117,7 +1117,7 @@ test('executeCli executes flow fetch-rows with injected implementation', async (
           },
           files: {
             resolved_flow_rows: '/tmp/out/resolved-flow-rows.jsonl',
-            review_input_rows: '/tmp/out/review-input-rows.jsonl',
+            qa_input_rows: '/tmp/out/qa-input-rows.jsonl',
             fetch_summary: '/tmp/out/fetch-summary.json',
             missing_flow_refs: '/tmp/out/missing-flow-refs.jsonl',
             ambiguous_flow_refs: '/tmp/out/ambiguous-flow-refs.jsonl',
@@ -1129,7 +1129,7 @@ test('executeCli executes flow fetch-rows with injected implementation', async (
 
   assert.equal(result.exitCode, 1);
   assert.match(result.stdout, /"status":"completed_flow_row_materialization_with_gaps"/u);
-  assert.match(result.stdout, /"review_input_row_count":1/u);
+  assert.match(result.stdout, /"qa_input_row_count":1/u);
 });
 
 test('executeCli keeps exit code 0 for flow fetch-rows gaps unless --fail-on-missing is enabled', async () => {
@@ -1146,8 +1146,8 @@ test('executeCli keeps exit code 0 for flow fetch-rows gaps unless --fail-on-mis
         allow_latest_fallback: true,
         requested_ref_count: 1,
         resolved_ref_count: 0,
-        review_input_row_count: 0,
-        duplicate_review_input_rows_collapsed: 0,
+        qa_input_row_count: 0,
+        duplicate_qa_input_rows_collapsed: 0,
         missing_ref_count: 1,
         ambiguous_ref_count: 0,
         resolution_counts: {
@@ -1157,7 +1157,7 @@ test('executeCli keeps exit code 0 for flow fetch-rows gaps unless --fail-on-mis
         },
         files: {
           resolved_flow_rows: '/tmp/out/resolved-flow-rows.jsonl',
-          review_input_rows: '/tmp/out/review-input-rows.jsonl',
+          qa_input_rows: '/tmp/out/qa-input-rows.jsonl',
           fetch_summary: '/tmp/out/fetch-summary.json',
           missing_flow_refs: '/tmp/out/missing-flow-refs.jsonl',
           ambiguous_flow_refs: '/tmp/out/ambiguous-flow-refs.jsonl',
@@ -4104,13 +4104,13 @@ test('executeCli returns parsing errors for invalid publish and validation flags
   assert.equal(validationResult.exitCode, 2);
   assert.match(validationResult.stderr, /INVALID_ARGS/u);
 
-  const reviewFlagResult = await executeCli(['review', 'process', '--bad-flag'], makeDeps());
+  const reviewFlagResult = await executeCli(['qa', 'process', '--bad-flag'], makeDeps());
   assert.equal(reviewFlagResult.exitCode, 2);
   assert.match(reviewFlagResult.stderr, /INVALID_ARGS/u);
 
   const reviewResult = await executeCli(
     [
-      'review',
+      'qa',
       'process',
       '--run-root',
       '/tmp/run',
@@ -4169,7 +4169,7 @@ test('executeCli returns parsing errors for invalid lifecyclemodel, process, and
   assert.match(orchestrateResult.stderr, /INVALID_ARGS/u);
 
   const reviewLifecyclemodelResult = await executeCli(
-    ['review', 'lifecyclemodel', '--bad-flag'],
+    ['qa', 'lifecyclemodel', '--bad-flag'],
     makeDeps(),
   );
   assert.equal(reviewLifecyclemodelResult.exitCode, 2);
@@ -4388,13 +4388,13 @@ test('executeCli executes validation run with injected implementation and report
   }
 });
 
-test('executeCli executes review process with injected implementation', async () => {
+test('executeCli executes qa process with injected implementation', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-cli-'));
 
   try {
     const result = await executeCli(
       [
-        'review',
+        'qa',
         'process',
         '--run-root',
         path.join(dir, 'run-root'),
@@ -4416,7 +4416,7 @@ test('executeCli executes review process with injected implementation', async ()
       ],
       {
         ...makeDeps(),
-        runProcessReviewImpl: async (options) => {
+        runProcessQaImpl: async (options) => {
           assert.equal(options.rowsFile, undefined);
           assert.equal(options.runRoot, path.join(dir, 'run-root'));
           assert.equal(options.runId, 'run-001');
@@ -4428,7 +4428,7 @@ test('executeCli executes review process with injected implementation', async ()
           return {
             schema_version: 1,
             generated_at_utc: '2026-03-30T00:00:00.000Z',
-            status: 'completed_local_process_review',
+            status: 'completed_local_process_qa',
             run_id: options.runId ?? 'run-001',
             run_root: options.runRoot ?? '',
             rows_file: options.rowsFile ?? '',
@@ -4445,10 +4445,10 @@ test('executeCli executes review process with injected implementation', async ()
               energy_excluded: 0,
             },
             files: {
-              review_input_summary: path.join(dir, 'review', 'review-input-summary.json'),
+              qa_input_summary: path.join(dir, 'review', 'qa-input-summary.json'),
               materialization_summary: null,
-              review_zh: path.join(dir, 'review', 'zh.md'),
-              review_en: path.join(dir, 'review', 'en.md'),
+              qa_zh: path.join(dir, 'review', 'zh.md'),
+              qa_en: path.join(dir, 'review', 'en.md'),
               timing: path.join(dir, 'review', 'timing.md'),
               unit_issue_log: path.join(dir, 'review', 'unit.md'),
               summary: path.join(dir, 'review', 'summary.json'),
@@ -4467,7 +4467,7 @@ test('executeCli executes review process with injected implementation', async ()
     );
 
     assert.equal(result.exitCode, 0);
-    assert.match(result.stdout, /"status": "completed_local_process_review"/u);
+    assert.match(result.stdout, /"status": "completed_local_process_qa"/u);
     assert.match(result.stdout, /"run_id": "run-001"/u);
     assert.match(result.stdout, /"logic_version": "v2\.2"/u);
   } finally {
@@ -4475,29 +4475,29 @@ test('executeCli executes review process with injected implementation', async ()
   }
 });
 
-test('executeCli passes rows-file review process input through to the implementation', async () => {
+test('executeCli passes rows-file qa process input through to the implementation', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-cli-rows-'));
   const rowsFile = path.join(dir, 'process-list-report.json');
 
   try {
     const result = await executeCli(
-      ['review', 'process', '--rows-file', rowsFile, '--out-dir', path.join(dir, 'review')],
+      ['qa', 'process', '--rows-file', rowsFile, '--out-dir', path.join(dir, 'review')],
       {
         ...makeDeps(),
-        runProcessReviewImpl: async (options) => {
+        runProcessQaImpl: async (options) => {
           assert.equal(options.rowsFile, rowsFile);
           assert.equal(options.runRoot, undefined);
           assert.equal(options.runId, undefined);
           return {
             schema_version: 1,
             generated_at_utc: '2026-03-30T00:00:00.000Z',
-            status: 'completed_local_process_review',
+            status: 'completed_local_process_qa',
             run_id: 'process-list-report',
             run_root: '',
             rows_file: rowsFile,
             out_dir: options.outDir,
             input_mode: 'rows_file',
-            effective_processes_dir: path.join(dir, 'review', 'review-input', 'processes'),
+            effective_processes_dir: path.join(dir, 'review', 'qa-input', 'processes'),
             logic_version: 'v2.1',
             process_count: 1,
             totals: {
@@ -4508,15 +4508,15 @@ test('executeCli passes rows-file review process input through to the implementa
               energy_excluded: 0,
             },
             files: {
-              review_input_summary: path.join(dir, 'review', 'review-input-summary.json'),
+              qa_input_summary: path.join(dir, 'review', 'qa-input-summary.json'),
               materialization_summary: path.join(
                 dir,
                 'review',
-                'review-input',
+                'qa-input',
                 'materialization-summary.json',
               ),
-              review_zh: path.join(dir, 'review', 'zh.md'),
-              review_en: path.join(dir, 'review', 'en.md'),
+              qa_zh: path.join(dir, 'review', 'zh.md'),
+              qa_en: path.join(dir, 'review', 'en.md'),
               timing: path.join(dir, 'review', 'timing.md'),
               unit_issue_log: path.join(dir, 'review', 'unit.md'),
               summary: path.join(dir, 'review', 'summary.json'),
@@ -4538,13 +4538,13 @@ test('executeCli passes rows-file review process input through to the implementa
   }
 });
 
-test('executeCli executes review process with only required flags', async () => {
+test('executeCli executes qa process with only required flags', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-cli-required-'));
 
   try {
     const result = await executeCli(
       [
-        'review',
+        'qa',
         'process',
         '--run-root',
         path.join(dir, 'run-root'),
@@ -4555,7 +4555,7 @@ test('executeCli executes review process with only required flags', async () => 
       ],
       {
         ...makeDeps(),
-        runProcessReviewImpl: async (options) => {
+        runProcessQaImpl: async (options) => {
           assert.equal(options.rowsFile, undefined);
           assert.equal(options.runRoot, path.join(dir, 'run-root'));
           assert.equal(options.runId, 'run-required');
@@ -4568,7 +4568,7 @@ test('executeCli executes review process with only required flags', async () => 
           return {
             schema_version: 1,
             generated_at_utc: '2026-03-30T00:00:00.000Z',
-            status: 'completed_local_process_review',
+            status: 'completed_local_process_qa',
             run_id: options.runId ?? 'run-required',
             run_root: options.runRoot ?? '',
             rows_file: options.rowsFile ?? '',
@@ -4585,10 +4585,10 @@ test('executeCli executes review process with only required flags', async () => 
               energy_excluded: 0,
             },
             files: {
-              review_input_summary: path.join(dir, 'review', 'review-input-summary.json'),
+              qa_input_summary: path.join(dir, 'review', 'qa-input-summary.json'),
               materialization_summary: null,
-              review_zh: path.join(dir, 'review', 'zh.md'),
-              review_en: path.join(dir, 'review', 'en.md'),
+              qa_zh: path.join(dir, 'review', 'zh.md'),
+              qa_en: path.join(dir, 'review', 'en.md'),
               timing: path.join(dir, 'review', 'timing.md'),
               unit_issue_log: path.join(dir, 'review', 'unit.md'),
               summary: path.join(dir, 'review', 'summary.json'),
@@ -4647,6 +4647,26 @@ test('executeCli rejects unknown root options', async () => {
   assert.match(result.stderr, /UNKNOWN_ROOT_OPTION/u);
 });
 
+test('executeCli rejects removed review command group without aliasing to qa', async () => {
+  const result = await executeCli(['review', 'process', '--help'], makeDeps());
+  assert.equal(result.exitCode, 2);
+  assert.equal(result.stdout, '');
+  assert.match(result.stderr, /Command 'review process' was removed/u);
+  assert.match(result.stderr, /tiangong-lca qa process/u);
+
+  const flowResult = await executeCli(['review', 'flow', '--help'], makeDeps());
+  assert.equal(flowResult.exitCode, 2);
+  assert.equal(flowResult.stdout, '');
+  assert.match(flowResult.stderr, /Command 'review flow' was removed/u);
+  assert.match(flowResult.stderr, /tiangong-lca qa flow/u);
+
+  const lifecyclemodelResult = await executeCli(['review', 'lifecyclemodel', '--help'], makeDeps());
+  assert.equal(lifecyclemodelResult.exitCode, 2);
+  assert.equal(lifecyclemodelResult.stdout, '');
+  assert.match(lifecyclemodelResult.stderr, /Command 'review lifecyclemodel' was removed/u);
+  assert.match(lifecyclemodelResult.stderr, /tiangong-lca qa lifecyclemodel/u);
+});
+
 test('executeCli prints main help when root help appears before the command', async () => {
   const result = await executeCli(['--help', 'search', 'flow'], makeDeps());
   assert.equal(result.exitCode, 0);
@@ -4672,14 +4692,14 @@ test('executeCli validates missing required flow regen-product inputs once the c
   assert.match(result.stderr, /FLOW_REGEN_PROCESSES_FILE_REQUIRED/u);
 });
 
-test('executeCli dispatches review lifecyclemodel to the implemented CLI module', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-lifecyclemodel-dispatch-'));
+test('executeCli dispatches qa lifecyclemodel to the implemented CLI module', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-qa-dispatch-'));
 
   try {
-    let observedOptions: RunLifecyclemodelReviewOptions | undefined;
+    let observedOptions: RunLifecyclemodelQaOptions | undefined;
     const result = await executeCli(
       [
-        'review',
+        'qa',
         'lifecyclemodel',
         '--run-dir',
         path.join(dir, 'run'),
@@ -4695,12 +4715,12 @@ test('executeCli dispatches review lifecyclemodel to the implemented CLI module'
       ],
       {
         ...makeDeps(),
-        runLifecyclemodelReviewImpl: async (options) => {
+        runLifecyclemodelQaImpl: async (options) => {
           observedOptions = options;
           return {
             schema_version: 1,
             generated_at_utc: '2026-03-30T00:06:00.000Z',
-            status: 'completed_local_lifecyclemodel_review',
+            status: 'completed_local_lifecyclemodel_qa',
             run_id: 'lm-run-001',
             run_root: path.join(dir, 'run'),
             out_dir: path.join(dir, 'review'),
@@ -4728,11 +4748,11 @@ test('executeCli dispatches review lifecyclemodel to the implemented CLI module'
               ),
               model_summaries: path.join(dir, 'review', 'model_summaries.jsonl'),
               findings: path.join(dir, 'review', 'findings.jsonl'),
-              summary: path.join(dir, 'review', 'lifecyclemodel_review_summary.json'),
-              review_zh: path.join(dir, 'review', 'lifecyclemodel_review_zh.md'),
-              review_en: path.join(dir, 'review', 'lifecyclemodel_review_en.md'),
-              timing: path.join(dir, 'review', 'lifecyclemodel_review_timing.md'),
-              report: path.join(dir, 'review', 'lifecyclemodel_review_report.json'),
+              summary: path.join(dir, 'review', 'lifecyclemodel_qa_summary.json'),
+              qa_zh: path.join(dir, 'review', 'lifecyclemodel_qa_zh.md'),
+              qa_en: path.join(dir, 'review', 'lifecyclemodel_qa_en.md'),
+              timing: path.join(dir, 'review', 'lifecyclemodel_qa_timing.md'),
+              report: path.join(dir, 'review', 'lifecyclemodel_qa_report.json'),
             },
             model_summaries: [],
             next_actions: ['inspect: findings'],
@@ -4751,7 +4771,7 @@ test('executeCli dispatches review lifecyclemodel to the implemented CLI module'
     });
 
     const payload = JSON.parse(result.stdout) as { status: string; logic_version: string };
-    assert.equal(payload.status, 'completed_local_lifecyclemodel_review');
+    assert.equal(payload.status, 'completed_local_lifecyclemodel_qa');
     assert.equal(payload.logic_version, 'review-v1');
     assert.equal(result.stderr, '');
   } finally {
@@ -4759,16 +4779,16 @@ test('executeCli dispatches review lifecyclemodel to the implemented CLI module'
   }
 });
 
-test('executeCli dispatches review flow to the implemented CLI module', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-flow-dispatch-'));
+test('executeCli dispatches qa flow to the implemented CLI module', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-qa-dispatch-'));
   const rowsFile = path.join(dir, 'flows.json');
   writeFileSync(rowsFile, '[]\n', 'utf8');
 
   try {
-    let observedOptions: RunFlowReviewOptions | undefined;
+    let observedOptions: RunFlowQaOptions | undefined;
     const result = await executeCli(
       [
-        'review',
+        'qa',
         'flow',
         '--rows-file',
         rowsFile,
@@ -4789,16 +4809,16 @@ test('executeCli dispatches review flow to the implemented CLI module', async ()
       ],
       {
         ...makeDeps(),
-        runFlowReviewImpl: async (options) => {
+        runFlowQaImpl: async (options) => {
           observedOptions = options;
           return {
             schema_version: 1,
             generated_at_utc: '2026-03-30T00:00:00.000Z',
-            status: 'completed_local_flow_review',
+            status: 'completed_local_flow_qa',
             run_id: 'flow-run',
             out_dir: path.join(dir, 'review'),
             input_mode: 'rows_file',
-            effective_flows_dir: path.join(dir, 'review-input', 'flows'),
+            effective_flows_dir: path.join(dir, 'qa-input', 'flows'),
             logic_version: 'flow-v1.0-cli',
             flow_count: 1,
             similarity_threshold: 0.9,
@@ -4819,11 +4839,11 @@ test('executeCli dispatches review flow to the implemented CLI module', async ()
               batch_results: [],
             },
             files: {
-              review_input_summary: path.join(dir, 'review', 'review-input-summary.json'),
+              qa_input_summary: path.join(dir, 'review', 'qa-input-summary.json'),
               materialization_summary: path.join(
                 dir,
                 'review',
-                'review-input',
+                'qa-input',
                 'materialization-summary.json',
               ),
               rule_findings: path.join(dir, 'review', 'rule_findings.jsonl'),
@@ -4831,11 +4851,11 @@ test('executeCli dispatches review flow to the implemented CLI module', async ()
               findings: path.join(dir, 'review', 'findings.jsonl'),
               flow_summaries: path.join(dir, 'review', 'flow_summaries.jsonl'),
               similarity_pairs: path.join(dir, 'review', 'similarity_pairs.jsonl'),
-              summary: path.join(dir, 'review', 'flow_review_summary.json'),
-              review_zh: path.join(dir, 'review', 'flow_review_zh.md'),
-              review_en: path.join(dir, 'review', 'flow_review_en.md'),
-              timing: path.join(dir, 'review', 'flow_review_timing.md'),
-              report: path.join(dir, 'review', 'flow_review_report.json'),
+              summary: path.join(dir, 'review', 'flow_qa_summary.json'),
+              qa_zh: path.join(dir, 'review', 'flow_qa_zh.md'),
+              qa_en: path.join(dir, 'review', 'flow_qa_en.md'),
+              timing: path.join(dir, 'review', 'flow_qa_timing.md'),
+              report: path.join(dir, 'review', 'flow_qa_report.json'),
             },
           };
         },
@@ -4844,7 +4864,7 @@ test('executeCli dispatches review flow to the implemented CLI module', async ()
 
     assert.equal(result.exitCode, 0);
     assert.equal(result.stderr, '');
-    assert.equal(JSON.parse(result.stdout).status, 'completed_local_flow_review');
+    assert.equal(JSON.parse(result.stdout).status, 'completed_local_flow_qa');
     assert.equal(observedOptions?.rowsFile, rowsFile);
     assert.equal(observedOptions?.runId, 'flow-run');
     assert.equal(observedOptions?.enableLlm, true);
@@ -5911,15 +5931,15 @@ test('executeCli returns parsing errors for invalid flow get, list, remediate, p
   assert.match(invalidRegenPoolResult.stderr, /FLOW_REGEN_PROCESS_POOL_REQUIRES_APPLY/u);
 });
 
-test('executeCli supports alternate review flow input modes and validates numeric review-flow flags', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-flow-alt-dispatch-'));
+test('executeCli supports alternate qa flow input modes and validates numeric flow-qa flags', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-qa-alt-dispatch-'));
   const rowsFile = path.join(dir, 'flows.json');
-  const observedOptions: RunFlowReviewOptions[] = [];
+  const observedOptions: RunFlowQaOptions[] = [];
 
   writeFileSync(rowsFile, '[]\n', 'utf8');
 
   try {
-    const runFlowReviewImpl = async (options: RunFlowReviewOptions) => {
+    const runFlowQaImpl = async (options: RunFlowQaOptions) => {
       observedOptions.push(options);
       const inputMode: 'flows_dir' | 'run_root' | 'rows_file' = options.flowsDir
         ? 'flows_dir'
@@ -5929,11 +5949,11 @@ test('executeCli supports alternate review flow input modes and validates numeri
       const effectiveFlowsDir =
         options.flowsDir ??
         options.runRoot ??
-        path.join(path.dirname(options.outDir), 'review-input', 'flows');
+        path.join(path.dirname(options.outDir), 'qa-input', 'flows');
       return {
         schema_version: 1 as const,
         generated_at_utc: '2026-03-30T00:00:00.000Z',
-        status: 'completed_local_flow_review' as const,
+        status: 'completed_local_flow_qa' as const,
         run_id: options.runId ?? 'flow-run',
         out_dir: options.outDir,
         input_mode: inputMode,
@@ -5957,28 +5977,28 @@ test('executeCli supports alternate review flow input modes and validates numeri
           batch_results: [],
         },
         files: {
-          review_input_summary: path.join(options.outDir, 'review-input-summary.json'),
+          qa_input_summary: path.join(options.outDir, 'qa-input-summary.json'),
           materialization_summary: null,
           rule_findings: path.join(options.outDir, 'rule_findings.jsonl'),
           llm_findings: path.join(options.outDir, 'llm_findings.jsonl'),
           findings: path.join(options.outDir, 'findings.jsonl'),
           flow_summaries: path.join(options.outDir, 'flow_summaries.jsonl'),
           similarity_pairs: path.join(options.outDir, 'similarity_pairs.jsonl'),
-          summary: path.join(options.outDir, 'flow_review_summary.json'),
-          review_zh: path.join(options.outDir, 'flow_review_zh.md'),
-          review_en: path.join(options.outDir, 'flow_review_en.md'),
-          timing: path.join(options.outDir, 'flow_review_timing.md'),
-          report: path.join(options.outDir, 'flow_review_report.json'),
+          summary: path.join(options.outDir, 'flow_qa_summary.json'),
+          qa_zh: path.join(options.outDir, 'flow_qa_zh.md'),
+          qa_en: path.join(options.outDir, 'flow_qa_en.md'),
+          timing: path.join(options.outDir, 'flow_qa_timing.md'),
+          report: path.join(options.outDir, 'flow_qa_report.json'),
         },
       };
     };
 
     const flowsDir = path.join(dir, 'flows');
     const flowsDirResult = await executeCli(
-      ['review', 'flow', '--flows-dir', flowsDir, '--out-dir', path.join(dir, 'review-flows')],
+      ['qa', 'flow', '--flows-dir', flowsDir, '--out-dir', path.join(dir, 'flow-qas')],
       {
         ...makeDeps(),
-        runFlowReviewImpl,
+        runFlowQaImpl,
       },
     );
     assert.equal(flowsDirResult.exitCode, 0);
@@ -5990,7 +6010,7 @@ test('executeCli supports alternate review flow input modes and validates numeri
     const runRoot = path.join(dir, 'run-root');
     const runRootResult = await executeCli(
       [
-        'review',
+        'qa',
         'flow',
         '--run-root',
         runRoot,
@@ -6009,7 +6029,7 @@ test('executeCli supports alternate review flow input modes and validates numeri
       ],
       {
         ...makeDeps(),
-        runFlowReviewImpl,
+        runFlowQaImpl,
       },
     );
     assert.equal(runRootResult.exitCode, 0);
@@ -6021,13 +6041,13 @@ test('executeCli supports alternate review flow input modes and validates numeri
     assert.equal(observedOptions[1].logicVersion, 'flow-v2');
     assert.equal(observedOptions[1].llmModel, 'gpt-5.4-mini');
 
-    const badFlagResult = await executeCli(['review', 'flow', '--bad-flag'], makeDeps());
+    const badFlagResult = await executeCli(['qa', 'flow', '--bad-flag'], makeDeps());
     assert.equal(badFlagResult.exitCode, 2);
     assert.match(badFlagResult.stderr, /INVALID_ARGS/u);
 
     const invalidMaxFlowsResult = await executeCli(
       [
-        'review',
+        'qa',
         'flow',
         '--rows-file',
         rowsFile,
@@ -6043,7 +6063,7 @@ test('executeCli supports alternate review flow input modes and validates numeri
 
     const invalidBatchSizeResult = await executeCli(
       [
-        'review',
+        'qa',
         'flow',
         '--rows-file',
         rowsFile,
@@ -6059,7 +6079,7 @@ test('executeCli supports alternate review flow input modes and validates numeri
 
     const invalidThresholdResult = await executeCli(
       [
-        'review',
+        'qa',
         'flow',
         '--rows-file',
         rowsFile,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -4651,6 +4651,12 @@ test('executeCli rejects unknown root options', async () => {
 });
 
 test('executeCli rejects removed review command group without aliasing to qa', async () => {
+  const rootResult = await executeCli(['review'], makeDeps());
+  assert.equal(rootResult.exitCode, 2);
+  assert.equal(rootResult.stdout, '');
+  assert.match(rootResult.stderr, /Command 'review' was removed/u);
+  assert.match(rootResult.stderr, /tiangong-lca qa/u);
+
   const result = await executeCli(['review', 'process', '--help'], makeDeps());
   assert.equal(result.exitCode, 2);
   assert.equal(result.stdout, '');

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -216,10 +216,7 @@ test('executeCli returns help for publish and validation subcommands', async () 
   );
   assert.match(reviewFlowHelp.stdout, /--similarity-threshold/u);
 
-  const reviewLifecyclemodelHelp = await executeCli(
-    ['qa', 'lifecyclemodel', '--help'],
-    makeDeps(),
-  );
+  const reviewLifecyclemodelHelp = await executeCli(['qa', 'lifecyclemodel', '--help'], makeDeps());
   assert.equal(reviewLifecyclemodelHelp.exitCode, 0);
   assert.match(
     reviewLifecyclemodelHelp.stdout,

--- a/test/dataset-bilingual.test.ts
+++ b/test/dataset-bilingual.test.ts
@@ -13,8 +13,8 @@ import {
 } from '../src/lib/dataset-bilingual.js';
 import type { DatasetValidateReport } from '../src/lib/dataset-validate.js';
 import type { DotEnvLoadResult } from '../src/lib/dotenv.js';
-import type { FlowReviewReport } from '../src/lib/review-flow.js';
-import type { ProcessReviewReport } from '../src/lib/review-process.js';
+import type { FlowQaReport } from '../src/lib/flow-qa.js';
+import type { ProcessQaReport } from '../src/lib/process-qa.js';
 
 const dotEnvStatus: DotEnvLoadResult = {
   loaded: false,
@@ -133,11 +133,11 @@ function validDatasetReport(
   };
 }
 
-function processReviewReport(reportFile: string): ProcessReviewReport {
+function processQaReport(reportFile: string): ProcessQaReport {
   return {
     schema_version: 1,
     generated_at_utc: '2026-05-23T00:00:00.000Z',
-    status: 'completed_local_process_review',
+    status: 'completed_local_process_qa',
     run_id: 'test',
     run_root: path.dirname(reportFile),
     rows_file: reportFile,
@@ -158,10 +158,10 @@ function processReviewReport(reportFile: string): ProcessReviewReport {
       reason: 'disabled',
     },
     files: {
-      review_input_summary: reportFile,
+      qa_input_summary: reportFile,
       materialization_summary: null,
-      review_zh: reportFile,
-      review_en: reportFile,
+      qa_zh: reportFile,
+      qa_en: reportFile,
       timing: reportFile,
       unit_issue_log: reportFile,
       summary: reportFile,
@@ -170,11 +170,11 @@ function processReviewReport(reportFile: string): ProcessReviewReport {
   };
 }
 
-function flowReviewReport(reportFile: string): FlowReviewReport {
+function flowQaReport(reportFile: string): FlowQaReport {
   return {
     schema_version: 1,
     generated_at_utc: '2026-05-23T00:00:00.000Z',
-    status: 'completed_local_flow_review',
+    status: 'completed_local_flow_qa',
     run_id: 'test',
     out_dir: path.dirname(reportFile),
     input_mode: 'rows_file',
@@ -198,7 +198,7 @@ function flowReviewReport(reportFile: string): FlowReviewReport {
       batch_results: [],
     },
     files: {
-      review_input_summary: reportFile,
+      qa_input_summary: reportFile,
       materialization_summary: null,
       rule_findings: reportFile,
       llm_findings: reportFile,
@@ -206,8 +206,8 @@ function flowReviewReport(reportFile: string): FlowReviewReport {
       flow_summaries: reportFile,
       similarity_pairs: reportFile,
       summary: reportFile,
-      review_zh: reportFile,
-      review_en: reportFile,
+      qa_zh: reportFile,
+      qa_en: reportFile,
       timing: reportFile,
       report: reportFile,
     },
@@ -301,7 +301,7 @@ test('dataset bilingual apply writes translated rows and evidence', async () => 
   }
 });
 
-test('dataset bilingual validate combines scans with schema and review gates', async () => {
+test('dataset bilingual validate combines scans with schema and QA gates', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-bilingual-validate-'));
   const inputPath = path.join(dir, 'processes.jsonl');
   const outDir = path.join(dir, 'out');
@@ -317,16 +317,16 @@ test('dataset bilingual validate combines scans with schema and review gates', a
       type: 'process',
       now: new Date('2026-05-23T00:00:00.000Z'),
       datasetValidateImpl: async (options) => validDatasetReport(options.inputPath, null),
-      processReviewImpl: async (options) =>
-        processReviewReport(path.join(options.outDir, 'review-report.json')),
-      flowReviewImpl: async (options) => flowReviewReport(path.join(options.outDir, 'report.json')),
+      processQaImpl: async (options) =>
+        processQaReport(path.join(options.outDir, 'qa-report.json')),
+      flowQaImpl: async (options) => flowQaReport(path.join(options.outDir, 'report.json')),
     });
 
     assert.equal(report.status, 'blocked');
     assert.equal(report.scan.blocker_count, 2);
     assert.equal(report.scan.warning_count, 1);
     assert.equal(report.schema_gate.invalid, 0);
-    assert.equal(report.review_gate.status, 'completed');
+    assert.equal(report.qa_gate.status, 'completed');
     assert.equal(existsSync(report.files.report ?? ''), true);
     assert.equal(readJsonl(report.files.findings ?? '').length, 3);
   } finally {
@@ -459,14 +459,14 @@ test('dataset bilingual covers local-only extraction, apply blockers, and flow r
       outDir: path.join(dir, 'validate-flow'),
       type: 'flow',
       datasetValidateImpl: async (options) => validDatasetReport(options.inputPath, null, 'flow'),
-      processReviewImpl: async (options) =>
-        processReviewReport(path.join(options.outDir, 'report.json')),
-      flowReviewImpl: async (options) => flowReviewReport(path.join(options.outDir, 'report.json')),
+      processQaImpl: async (options) =>
+        processQaReport(path.join(options.outDir, 'report.json')),
+      flowQaImpl: async (options) => flowQaReport(path.join(options.outDir, 'report.json')),
       now: new Date('2026-05-23T00:00:00.000Z'),
     });
     assert.equal(flowValidateReport.status, 'completed');
-    assert.equal(flowValidateReport.review_gate.status, 'completed');
-    assert.match(flowValidateReport.review_gate.flow_report_file ?? '', /review[\\/]flow/u);
+    assert.equal(flowValidateReport.qa_gate.status, 'completed');
+    assert.match(flowValidateReport.qa_gate.flow_report_file ?? '', /qa[\\/]flow/u);
 
     const localValidateReport = await runDatasetBilingualValidate({
       inputPath,
@@ -475,7 +475,7 @@ test('dataset bilingual covers local-only extraction, apply blockers, and flow r
       datasetValidateImpl: async (options) => validDatasetReport(options.inputPath, null),
     });
     assert.equal(localValidateReport.files.report, null);
-    assert.equal(localValidateReport.review_gate.status, 'not_run');
+    assert.equal(localValidateReport.qa_gate.status, 'not_run');
 
     const schemaBlockedReport = await runDatasetBilingualValidate({
       inputPath,
@@ -494,23 +494,23 @@ test('dataset bilingual covers local-only extraction, apply blockers, and flow r
     });
     assert.equal(schemaBlockedReport.status, 'blocked');
 
-    const defaultReviewReport = await runDatasetBilingualValidate({
+    const defaultQaReport = await runDatasetBilingualValidate({
       inputPath,
       rawInput: { rows: [sampleFlowRow()] },
-      outDir: path.join(dir, 'default-flow-review'),
+      outDir: path.join(dir, 'default-flow-qa'),
       type: 'flow',
       datasetValidateImpl: async (options) => validDatasetReport(options.inputPath, null, 'flow'),
     });
-    assert.equal(defaultReviewReport.review_gate.status, 'completed');
+    assert.equal(defaultQaReport.qa_gate.status, 'completed');
 
-    const defaultProcessReviewReport = await runDatasetBilingualValidate({
+    const defaultProcessQaReport = await runDatasetBilingualValidate({
       inputPath,
       rawInput: { rows: [sampleProcessRow()] },
-      outDir: path.join(dir, 'default-process-review'),
+      outDir: path.join(dir, 'default-process-qa'),
       type: 'process',
       datasetValidateImpl: async (options) => validDatasetReport(options.inputPath, null),
     });
-    assert.equal(defaultProcessReviewReport.review_gate.status, 'completed');
+    assert.equal(defaultProcessQaReport.qa_gate.status, 'completed');
 
     const defaultSchemaGateReport = await runDatasetBilingualValidate({
       inputPath: 'memory',
@@ -887,7 +887,7 @@ test('executeCli dispatches dataset bilingual subcommands', async () => {
             invalid: 0,
             report_file: null,
           },
-          review_gate: {
+          qa_gate: {
             status: 'not_run',
             process_report_file: null,
             flow_report_file: null,
@@ -930,7 +930,7 @@ test('executeCli dispatches dataset bilingual subcommands', async () => {
           invalid: 0,
           report_file: null,
         },
-        review_gate: {
+        qa_gate: {
           status: 'not_run',
           process_report_file: null,
           flow_report_file: null,

--- a/test/dataset-bilingual.test.ts
+++ b/test/dataset-bilingual.test.ts
@@ -146,6 +146,8 @@ function processQaReport(reportFile: string): ProcessQaReport {
     effective_processes_dir: path.dirname(reportFile),
     logic_version: 'test',
     process_count: 1,
+    policy_decision_owner: 'foundry',
+    qa_mode: 'deterministic_qa_report',
     totals: {
       raw_input: 0,
       product_plus_byproduct_plus_waste: 0,

--- a/test/dataset-bilingual.test.ts
+++ b/test/dataset-bilingual.test.ts
@@ -459,8 +459,7 @@ test('dataset bilingual covers local-only extraction, apply blockers, and flow r
       outDir: path.join(dir, 'validate-flow'),
       type: 'flow',
       datasetValidateImpl: async (options) => validDatasetReport(options.inputPath, null, 'flow'),
-      processQaImpl: async (options) =>
-        processQaReport(path.join(options.outDir, 'report.json')),
+      processQaImpl: async (options) => processQaReport(path.join(options.outDir, 'report.json')),
       flowQaImpl: async (options) => flowQaReport(path.join(options.outDir, 'report.json')),
       now: new Date('2026-05-23T00:00:00.000Z'),
     });

--- a/test/flow-fetch-rows.test.ts
+++ b/test/flow-fetch-rows.test.ts
@@ -54,7 +54,7 @@ function jsonFetch(responses: unknown[], observedUrls: string[] = []): FetchLike
   }) as FetchLike;
 }
 
-test('runFlowFetchRows materializes real DB refs into review-input rows and gap artifacts', async () => {
+test('runFlowFetchRows materializes real DB refs into qa-input rows and gap artifacts', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-fetch-rows-'));
   const refsFile = path.join(dir, 'refs.json');
   const outDir = path.join(dir, 'out');
@@ -173,8 +173,8 @@ test('runFlowFetchRows materializes real DB refs into review-input rows and gap 
       allow_latest_fallback: true,
       requested_ref_count: 5,
       resolved_ref_count: 3,
-      review_input_row_count: 2,
-      duplicate_review_input_rows_collapsed: 1,
+      qa_input_row_count: 2,
+      duplicate_qa_input_rows_collapsed: 1,
       missing_ref_count: 1,
       ambiguous_ref_count: 1,
       resolution_counts: {
@@ -184,7 +184,7 @@ test('runFlowFetchRows materializes real DB refs into review-input rows and gap 
       },
       files: {
         resolved_flow_rows: path.join(outDir, 'resolved-flow-rows.jsonl'),
-        review_input_rows: path.join(outDir, 'review-input-rows.jsonl'),
+        qa_input_rows: path.join(outDir, 'qa-input-rows.jsonl'),
         fetch_summary: path.join(outDir, 'fetch-summary.json'),
         missing_flow_refs: path.join(outDir, 'missing-flow-refs.jsonl'),
         ambiguous_flow_refs: path.join(outDir, 'ambiguous-flow-refs.jsonl'),
@@ -200,7 +200,7 @@ test('runFlowFetchRows materializes real DB refs into review-input rows and gap 
       'remote_supabase_latest_fallback',
     );
 
-    const reviewInputRows = readJsonLines(report.files.review_input_rows);
+    const reviewInputRows = readJsonLines(report.files.qa_input_rows);
     assert.equal(reviewInputRows.length, 2);
     const flowAReviewRow = reviewInputRows.find((row) => row.id === 'flow-a') as JsonRecord;
     const flowAMaterialization = flowAReviewRow._materialization as JsonRecord;
@@ -225,7 +225,7 @@ test('runFlowFetchRows materializes real DB refs into review-input rows and gap 
     assert.equal(ambiguousRefs[0]?.code, 'FLOW_GET_AMBIGUOUS');
 
     const summary = readJson(report.files.fetch_summary);
-    assert.equal(summary.review_input_row_count, 2);
+    assert.equal(summary.qa_input_row_count, 2);
     assert.equal(summary.ambiguous_ref_count, 1);
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -411,7 +411,7 @@ test(
       });
       assert.equal(observedUrls.length, 1);
 
-      const reviewInputRows = readJsonLines(report.files.review_input_rows);
+      const reviewInputRows = readJsonLines(report.files.qa_input_rows);
       assert.equal(reviewInputRows.length, 1);
       assert.equal(reviewInputRows[0]?.id, 'flow-global');
       assert.equal(reviewInputRows[0]?.version, '01.00.001');
@@ -543,7 +543,7 @@ test('runFlowFetchRows can materialize a ref with an empty resolved version when
     assert.equal(resolvedRows[0]?.id, 'flow-no-version');
     assert.equal(resolvedRows[0]?.version, '');
 
-    const reviewRows = readJsonLines(report.files.review_input_rows);
+    const reviewRows = readJsonLines(report.files.qa_input_rows);
     assert.equal(reviewRows[0]?.version, '');
     assert.equal(
       ((reviewRows[0]?._materialization as JsonRecord).flow_key as string) ?? '',

--- a/test/flow-qa.test.ts
+++ b/test/flow-qa.test.ts
@@ -5,7 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { CliError } from '../src/lib/errors.js';
 import type { FetchLike } from '../src/lib/http.js';
-import { __testInternals, runFlowReview } from '../src/lib/review-flow.js';
+import { __testInternals, runFlowQa } from '../src/lib/flow-qa.js';
 
 type JsonRecord = Record<string, unknown>;
 
@@ -115,8 +115,8 @@ function createLlmFetch(outputText: string, observedBodies: unknown[] = []): Fet
   }) as FetchLike;
 }
 
-test('runFlowReview materializes rows-file input and writes artifact-first review outputs', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-flow-'));
+test('runFlowQa materializes rows-file input and writes artifact-first QA outputs', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-qa-'));
   const rowsFile = path.join(dir, 'rows.json');
   const outDir = path.join(dir, 'review');
 
@@ -168,7 +168,7 @@ test('runFlowReview materializes rows-file input and writes artifact-first revie
   ]);
 
   try {
-    const report = await runFlowReview({
+    const report = await runFlowQa({
       rowsFile,
       outDir,
       runId: 'flow-run-001',
@@ -177,7 +177,7 @@ test('runFlowReview materializes rows-file input and writes artifact-first revie
       now: () => new Date('2026-03-30T00:11:00.000Z'),
     });
 
-    assert.equal(report.status, 'completed_local_flow_review');
+    assert.equal(report.status, 'completed_local_flow_qa');
     assert.equal(report.run_id, 'flow-run-001');
     assert.equal(report.input_mode, 'rows_file');
     assert.equal(report.flow_count, 2);
@@ -193,7 +193,7 @@ test('runFlowReview materializes rows-file input and writes artifact-first revie
     assert.ok(report.rule_finding_count > 0);
     assert.ok(report.finding_count >= report.rule_finding_count);
     assert.equal(report.generated_at_utc, '2026-03-30T00:11:00.000Z');
-    assert.ok(existsSync(report.files.review_input_summary));
+    assert.ok(existsSync(report.files.qa_input_summary));
     assert.ok(existsSync(report.files.materialization_summary ?? ''));
     assert.ok(existsSync(report.files.rule_findings));
     assert.ok(existsSync(report.files.ruleset_gate ?? ''));
@@ -201,8 +201,8 @@ test('runFlowReview materializes rows-file input and writes artifact-first revie
     assert.ok(existsSync(report.files.flow_summaries));
     assert.ok(existsSync(report.files.similarity_pairs));
     assert.ok(existsSync(report.files.summary));
-    assert.ok(existsSync(report.files.review_zh));
-    assert.ok(existsSync(report.files.review_en));
+    assert.ok(existsSync(report.files.qa_zh));
+    assert.ok(existsSync(report.files.qa_en));
     assert.ok(existsSync(report.files.timing));
     assert.ok(existsSync(report.files.report));
 
@@ -229,7 +229,7 @@ test('runFlowReview materializes rows-file input and writes artifact-first revie
       .map((line) => JSON.parse(line) as JsonRecord);
     assert.equal(pairs.length, 0);
 
-    const zhReview = readFileSync(report.files.review_zh, 'utf8');
+    const zhReview = readFileSync(report.files.qa_zh, 'utf8');
     assert.match(zhReview, /基础统计/u);
     assert.match(zhReview, /LLM 语义复审层/u);
 
@@ -240,8 +240,8 @@ test('runFlowReview materializes rows-file input and writes artifact-first revie
   }
 });
 
-test('runFlowReview supports flows-dir input and CLI-owned LLM semantic review', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-flow-llm-'));
+test('runFlowQa supports flows-dir input and CLI-owned LLM semantic review', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-qa-llm-'));
   const flowsDir = path.join(dir, 'flows');
   const outDir = path.join(dir, 'review');
   const observedBodies: unknown[] = [];
@@ -264,7 +264,7 @@ test('runFlowReview supports flows-dir input and CLI-owned LLM semantic review',
   );
 
   try {
-    const report = await runFlowReview({
+    const report = await runFlowQa({
       flowsDir,
       outDir,
       runId: 'flow-run-llm',
@@ -325,17 +325,17 @@ test('runFlowReview supports flows-dir input and CLI-owned LLM semantic review',
     assert.equal((llmFindings[0].evidence as JsonRecord).text, 'name too generic');
     assert.equal(llmFindings[1].action, 'dedupe me');
 
-    const reviewZh = readFileSync(report.files.review_zh, 'utf8');
+    const reviewZh = readFileSync(report.files.qa_zh, 'utf8');
     assert.match(reviewZh, /仅复审前/u);
-    const reviewEn = readFileSync(report.files.review_en, 'utf8');
+    const reviewEn = readFileSync(report.files.qa_en, 'utf8');
     assert.match(reviewEn, /reviewed only the first/u);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test('review-flow internals handle invalid input modes, fallback run-root resolution, and malformed flow files', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-flow-internals-'));
+test('flow-qa internals handle invalid input modes, fallback run-root resolution, and malformed flow files', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-qa-internals-'));
   const outDir = path.join(dir, 'review');
   const runRoot = path.join(dir, 'run-root');
   const exportsFlowsDir = path.join(runRoot, 'exports', 'flows');
@@ -344,14 +344,14 @@ test('review-flow internals handle invalid input modes, fallback run-root resolu
 
   try {
     await assert.rejects(
-      runFlowReview({
+      runFlowQa({
         rowsFile: path.join(dir, 'rows.json'),
         flowsDir: path.join(dir, 'flows'),
         outDir,
       }),
       (error: unknown) => {
         assert.ok(error instanceof CliError);
-        assert.equal(error.code, 'FLOW_REVIEW_INPUT_MODE_REQUIRED');
+        assert.equal(error.code, 'FLOW_QA_INPUT_MODE_REQUIRED');
         return true;
       },
     );
@@ -444,7 +444,7 @@ test('review-flow internals handle invalid input modes, fallback run-root resolu
       'built_in',
     );
     const rareRuleIds = rareSummary.findings.map((finding) => finding.rule_id);
-    assert.ok(rareRuleIds.includes('elementary_flow_in_flow_review'));
+    assert.ok(rareRuleIds.includes('elementary_flow_in_flow_qa'));
     assert.ok(rareRuleIds.includes('name_contains_emergy'));
     assert.ok(rareRuleIds.includes('invalid_flow_property_reference'));
     assert.ok(rareRuleIds.includes('missing_quantitative_reference'));
@@ -513,19 +513,19 @@ test('review-flow internals handle invalid input modes, fallback run-root resolu
       () => __testInternals.listFlowFiles(missingDir),
       (error: unknown) => {
         assert.ok(error instanceof CliError);
-        assert.equal(error.code, 'FLOW_REVIEW_DIR_NOT_FOUND');
+        assert.equal(error.code, 'FLOW_QA_DIR_NOT_FOUND');
         return true;
       },
     );
 
     await assert.rejects(
-      runFlowReview({
+      runFlowQa({
         flowsDir: exportsFlowsDir,
         outDir,
       }),
       (error: unknown) => {
         assert.ok(error instanceof CliError);
-        assert.equal(error.code, 'FLOW_REVIEW_INVALID_FLOW_FILE');
+        assert.equal(error.code, 'FLOW_QA_INVALID_FLOW_FILE');
         return true;
       },
     );
@@ -535,7 +535,7 @@ test('review-flow internals handle invalid input modes, fallback run-root resolu
       () => __testInternals.readJsonObject(path.join(exportsFlowsDir, 'malformed.json')),
       (error: unknown) => {
         assert.ok(error instanceof CliError);
-        assert.equal(error.code, 'FLOW_REVIEW_INVALID_FLOW_FILE');
+        assert.equal(error.code, 'FLOW_QA_INVALID_FLOW_FILE');
         return true;
       },
     );
@@ -544,7 +544,7 @@ test('review-flow internals handle invalid input modes, fallback run-root resolu
   }
 });
 
-test('review-flow helpers cover methodology fallbacks, similarity sorting, and truncated rendering', () => {
+test('flow-qa helpers cover methodology fallbacks, similarity sorting, and truncated rendering', () => {
   const detailed = __testInternals.buildFlowSummaryAndRuleFindings(
     {
       flowDataSet: {
@@ -668,7 +668,7 @@ test('review-flow helpers cover methodology fallbacks, similarity sorting, and t
   const truncatedSummary = {
     schema_version: 1 as const,
     generated_at_utc: '2026-03-30T00:00:00.000Z',
-    status: 'completed_local_flow_review' as const,
+    status: 'completed_local_flow_qa' as const,
     run_id: 'truncated',
     out_dir: '/tmp/review',
     input_mode: 'flows_dir' as const,
@@ -693,7 +693,7 @@ test('review-flow helpers cover methodology fallbacks, similarity sorting, and t
       batch_results: [],
     },
     files: {
-      review_input_summary: '',
+      qa_input_summary: '',
       materialization_summary: null,
       rule_findings: '',
       llm_findings: '',
@@ -701,8 +701,8 @@ test('review-flow helpers cover methodology fallbacks, similarity sorting, and t
       flow_summaries: '',
       similarity_pairs: '',
       summary: '',
-      review_zh: '',
-      review_en: '',
+      qa_zh: '',
+      qa_en: '',
       timing: '',
       report: '',
     },
@@ -747,7 +747,7 @@ test('review-flow helpers cover methodology fallbacks, similarity sorting, and t
   assert.match(enTruncated, /only the first/u);
 });
 
-test('review-flow direct helpers cover rare fallback branches', () => {
+test('flow-qa direct helpers cover rare fallback branches', () => {
   assert.deepEqual(__testInternals.walkStrings('   '), []);
   assert.deepEqual(__testInternals.walkStrings({ '#text': 'Root|Text', nested: [' Child '] }), [
     'Root|Text',
@@ -940,8 +940,8 @@ test('review-flow direct helpers cover rare fallback branches', () => {
   assert.equal(normalizedWithSuggestion?.action, 'use suggestion field');
 });
 
-test('review-flow internal llm helpers cover disabled, fallback, invalid-json, and failure branches', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-flow-llm-internals-'));
+test('flow-qa internal llm helpers cover disabled, fallback, invalid-json, and failure branches', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-qa-llm-internals-'));
   const summaries = [
     {
       flow_uuid: '88888888-8888-8888-8888-888888888888',
@@ -1081,7 +1081,7 @@ test('review-flow internal llm helpers cover disabled, fallback, invalid-json, a
     summary: {
       schema_version: 1,
       generated_at_utc: '2026-03-30T00:00:00.000Z',
-      status: 'completed_local_flow_review',
+      status: 'completed_local_flow_qa',
       run_id: 'zh-failure',
       out_dir: dir,
       input_mode: 'flows_dir',
@@ -1107,7 +1107,7 @@ test('review-flow internal llm helpers cover disabled, fallback, invalid-json, a
         batch_results: [],
       },
       files: {
-        review_input_summary: '',
+        qa_input_summary: '',
         materialization_summary: null,
         rule_findings: '',
         llm_findings: '',
@@ -1115,8 +1115,8 @@ test('review-flow internal llm helpers cover disabled, fallback, invalid-json, a
         flow_summaries: '',
         similarity_pairs: '',
         summary: '',
-        review_zh: '',
-        review_en: '',
+        qa_zh: '',
+        qa_en: '',
         timing: '',
         report: '',
       },
@@ -1143,7 +1143,7 @@ test('review-flow internal llm helpers cover disabled, fallback, invalid-json, a
     summary: {
       schema_version: 1,
       generated_at_utc: '2026-03-30T00:00:00.000Z',
-      status: 'completed_local_flow_review',
+      status: 'completed_local_flow_qa',
       run_id: 'zh-ok',
       out_dir: dir,
       input_mode: 'flows_dir',
@@ -1168,7 +1168,7 @@ test('review-flow internal llm helpers cover disabled, fallback, invalid-json, a
         batch_results: [],
       },
       files: {
-        review_input_summary: '',
+        qa_input_summary: '',
         materialization_summary: null,
         rule_findings: '',
         llm_findings: '',
@@ -1176,8 +1176,8 @@ test('review-flow internal llm helpers cover disabled, fallback, invalid-json, a
         flow_summaries: '',
         similarity_pairs: '',
         summary: '',
-        review_zh: '',
-        review_en: '',
+        qa_zh: '',
+        qa_en: '',
         timing: '',
         report: '',
       },
@@ -1214,13 +1214,13 @@ test('review-flow internal llm helpers cover disabled, fallback, invalid-json, a
   assert.match(timing, /bad-start/u);
 
   await assert.rejects(
-    runFlowReview({
+    runFlowQa({
       rowsFile: path.join(dir, 'rows.json'),
       outDir: '',
     }),
     (error: unknown) => {
       assert.ok(error instanceof CliError);
-      assert.equal(error.code, 'FLOW_REVIEW_OUT_DIR_REQUIRED');
+      assert.equal(error.code, 'FLOW_QA_OUT_DIR_REQUIRED');
       return true;
     },
   );
@@ -1228,26 +1228,26 @@ test('review-flow internal llm helpers cover disabled, fallback, invalid-json, a
   const emptyFlowDir = path.join(dir, 'empty-flows');
   mkdirSync(emptyFlowDir, { recursive: true });
   await assert.rejects(
-    runFlowReview({
+    runFlowQa({
       flowsDir: emptyFlowDir,
       outDir: path.join(dir, 'empty-review'),
     }),
     (error: unknown) => {
       assert.ok(error instanceof CliError);
-      assert.equal(error.code, 'FLOW_REVIEW_NO_FLOW_FILES');
+      assert.equal(error.code, 'FLOW_QA_NO_FLOW_FILES');
       return true;
     },
   );
 
   const missingDir = path.join(dir, 'not-there');
   await assert.rejects(
-    runFlowReview({
+    runFlowQa({
       flowsDir: missingDir,
       outDir: path.join(dir, 'missing-dir-review'),
     }),
     (error: unknown) => {
       assert.ok(error instanceof CliError);
-      assert.equal(error.code, 'FLOW_REVIEW_DIR_NOT_FOUND');
+      assert.equal(error.code, 'FLOW_QA_DIR_NOT_FOUND');
       return true;
     },
   );
@@ -1255,8 +1255,8 @@ test('review-flow internal llm helpers cover disabled, fallback, invalid-json, a
   rmSync(dir, { recursive: true, force: true });
 });
 
-test('review-flow LLM review deduplicates fallback findings from single-item batches', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-flow-llm-dedupe-'));
+test('flow-qa LLM review deduplicates fallback findings from single-item batches', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-qa-llm-dedupe-'));
   const summaries = [
     {
       flow_uuid: '12121212-3434-5656-7878-909090909090',
@@ -1323,8 +1323,8 @@ test('review-flow LLM review deduplicates fallback findings from single-item bat
   }
 });
 
-test('review-flow direct runtime helpers cover materialization, non-array findings, and rendering defaults', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-flow-direct-runtime-'));
+test('flow-qa direct runtime helpers cover materialization, non-array findings, and rendering defaults', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-flow-qa-direct-runtime-'));
   const rowsFile = path.join(dir, 'rows.json');
   const outDir = path.join(dir, 'review');
   const cacheFlowsDir = path.join(dir, 'run-root', 'cache', 'flows');
@@ -1526,7 +1526,7 @@ test('review-flow direct runtime helpers cover materialization, non-array findin
       summary: {
         schema_version: 1,
         generated_at_utc: '2026-03-30T00:00:00.000Z',
-        status: 'completed_local_flow_review',
+        status: 'completed_local_flow_qa',
         run_id: 'zh-disabled',
         out_dir: dir,
         input_mode: 'flows_dir',
@@ -1550,7 +1550,7 @@ test('review-flow direct runtime helpers cover materialization, non-array findin
           batch_results: [],
         },
         files: {
-          review_input_summary: '',
+          qa_input_summary: '',
           materialization_summary: null,
           rule_findings: '',
           llm_findings: '',
@@ -1558,8 +1558,8 @@ test('review-flow direct runtime helpers cover materialization, non-array findin
           flow_summaries: '',
           similarity_pairs: '',
           summary: '',
-          review_zh: '',
-          review_en: '',
+          qa_zh: '',
+          qa_en: '',
           timing: '',
           report: '',
         },
@@ -1605,7 +1605,7 @@ test('review-flow direct runtime helpers cover materialization, non-array findin
       summary: {
         schema_version: 1,
         generated_at_utc: '2026-03-30T00:00:00.000Z',
-        status: 'completed_local_flow_review',
+        status: 'completed_local_flow_qa',
         run_id: 'zh-uuid-fallback',
         out_dir: dir,
         input_mode: 'flows_dir',
@@ -1629,7 +1629,7 @@ test('review-flow direct runtime helpers cover materialization, non-array findin
           batch_results: [],
         },
         files: {
-          review_input_summary: '',
+          qa_input_summary: '',
           materialization_summary: null,
           rule_findings: '',
           llm_findings: '',
@@ -1637,8 +1637,8 @@ test('review-flow direct runtime helpers cover materialization, non-array findin
           flow_summaries: '',
           similarity_pairs: '',
           summary: '',
-          review_zh: '',
-          review_en: '',
+          qa_zh: '',
+          qa_en: '',
           timing: '',
           report: '',
         },
@@ -1685,7 +1685,7 @@ test('review-flow direct runtime helpers cover materialization, non-array findin
       summary: {
         schema_version: 1,
         generated_at_utc: '2026-03-30T00:00:00.000Z',
-        status: 'completed_local_flow_review',
+        status: 'completed_local_flow_qa',
         run_id: 'zh-pipes',
         out_dir: dir,
         input_mode: 'flows_dir',
@@ -1710,7 +1710,7 @@ test('review-flow direct runtime helpers cover materialization, non-array findin
           batch_results: [],
         },
         files: {
-          review_input_summary: '',
+          qa_input_summary: '',
           materialization_summary: null,
           rule_findings: '',
           llm_findings: '',
@@ -1718,8 +1718,8 @@ test('review-flow direct runtime helpers cover materialization, non-array findin
           flow_summaries: '',
           similarity_pairs: '',
           summary: '',
-          review_zh: '',
-          review_en: '',
+          qa_zh: '',
+          qa_en: '',
           timing: '',
           report: '',
         },
@@ -1747,7 +1747,7 @@ test('review-flow direct runtime helpers cover materialization, non-array findin
       summary: {
         schema_version: 1,
         generated_at_utc: '2026-03-30T00:00:00.000Z',
-        status: 'completed_local_flow_review',
+        status: 'completed_local_flow_qa',
         run_id: 'zh-failure-unknown',
         out_dir: dir,
         input_mode: 'flows_dir',
@@ -1772,7 +1772,7 @@ test('review-flow direct runtime helpers cover materialization, non-array findin
           batch_results: [],
         },
         files: {
-          review_input_summary: '',
+          qa_input_summary: '',
           materialization_summary: null,
           rule_findings: '',
           llm_findings: '',
@@ -1780,8 +1780,8 @@ test('review-flow direct runtime helpers cover materialization, non-array findin
           flow_summaries: '',
           similarity_pairs: '',
           summary: '',
-          review_zh: '',
-          review_en: '',
+          qa_zh: '',
+          qa_en: '',
           timing: '',
           report: '',
         },
@@ -1835,7 +1835,7 @@ test('review-flow direct runtime helpers cover materialization, non-array findin
         nameZh: '显式逻辑流',
       }),
     );
-    const explicitLogicReport = await runFlowReview({
+    const explicitLogicReport = await runFlowQa({
       flowsDir,
       outDir: path.join(dir, 'explicit-logic-review'),
       logicVersion: 'custom-flow-logic',

--- a/test/lifecyclemodel-qa.test.ts
+++ b/test/lifecyclemodel-qa.test.ts
@@ -361,7 +361,7 @@ test('runLifecyclemodelQa writes artifact-first outputs and dedupes validation f
     assert.equal(invocationIndex.invocations.length, 1);
     assert.deepEqual(invocationIndex.invocations[0]?.command, [
       'qa',
-        'lifecyclemodel',
+      'lifecyclemodel',
       '--run-dir',
       runRoot,
       '--out-dir',

--- a/test/lifecyclemodel-qa.test.ts
+++ b/test/lifecyclemodel-qa.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import { __testInternals, runLifecyclemodelReview } from '../src/lib/review-lifecyclemodel.js';
+import { __testInternals, runLifecyclemodelQa } from '../src/lib/lifecyclemodel-qa.js';
 
 type JsonRecord = Record<string, unknown>;
 
@@ -180,8 +180,8 @@ function writeLifecyclemodelBundle(
   return modelFile;
 }
 
-test('runLifecyclemodelReview writes artifact-first outputs and dedupes validation findings', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-lifecyclemodel-'));
+test('runLifecyclemodelQa writes artifact-first outputs and dedupes validation findings', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-qa-'));
   const runRoot = path.join(dir, 'lm-run-1');
   const outDir = path.join(dir, 'review');
 
@@ -278,17 +278,17 @@ test('runLifecyclemodelReview writes artifact-first outputs and dedupes validati
   );
 
   try {
-    const report = await runLifecyclemodelReview({
+    const report = await runLifecyclemodelQa({
       runDir: runRoot,
       outDir,
       logicVersion: 'review-v1',
       startTs: '2026-03-30T00:00:00.000Z',
       endTs: '2026-03-30T00:10:00.000Z',
       now: () => new Date('2026-03-30T00:11:00.000Z'),
-      cwd: '/tmp/lifecyclemodel-review',
+      cwd: '/tmp/lifecyclemodel-qa',
     });
 
-    assert.equal(report.status, 'completed_local_lifecyclemodel_review');
+    assert.equal(report.status, 'completed_local_lifecyclemodel_qa');
     assert.equal(report.logic_version, 'review-v1');
     assert.equal(report.model_count, 2);
     assert.equal(report.finding_count, 11);
@@ -306,8 +306,8 @@ test('runLifecyclemodelReview writes artifact-first outputs and dedupes validati
     assert.ok(existsSync(report.files.model_summaries));
     assert.ok(existsSync(report.files.findings));
     assert.ok(existsSync(report.files.summary));
-    assert.ok(existsSync(report.files.review_zh));
-    assert.ok(existsSync(report.files.review_en));
+    assert.ok(existsSync(report.files.qa_zh));
+    assert.ok(existsSync(report.files.qa_en));
     assert.ok(existsSync(report.files.timing));
     assert.ok(existsSync(report.files.report));
 
@@ -348,7 +348,7 @@ test('runLifecyclemodelReview writes artifact-first outputs and dedupes validati
       report: path.join(runRoot, 'reports', 'lifecyclemodel-validate-build-report.json'),
     });
 
-    const zhReview = readFileSync(report.files.review_zh, 'utf8');
+    const zhReview = readFileSync(report.files.qa_zh, 'utf8');
     assert.match(zhReview, /模型摘要/u);
     assert.match(zhReview, /当前命令不引入 Python、LangGraph/u);
 
@@ -360,8 +360,8 @@ test('runLifecyclemodelReview writes artifact-first outputs and dedupes validati
     );
     assert.equal(invocationIndex.invocations.length, 1);
     assert.deepEqual(invocationIndex.invocations[0]?.command, [
-      'review',
-      'lifecyclemodel',
+      'qa',
+        'lifecyclemodel',
       '--run-dir',
       runRoot,
       '--out-dir',
@@ -373,14 +373,14 @@ test('runLifecyclemodelReview writes artifact-first outputs and dedupes validati
       '--end-ts',
       '2026-03-30T00:10:00.000Z',
     ]);
-    assert.equal(invocationIndex.invocations[0]?.cwd, '/tmp/lifecyclemodel-review');
+    assert.equal(invocationIndex.invocations[0]?.cwd, '/tmp/lifecyclemodel-qa');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test('runLifecyclemodelReview supports missing validation reports and consistent single-model bundles', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-lifecyclemodel-ok-'));
+test('runLifecyclemodelQa supports missing validation reports and consistent single-model bundles', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-qa-ok-'));
   const runRoot = path.join(dir, 'lm-run-2');
   const outDir = path.join(dir, 'review');
 
@@ -426,7 +426,7 @@ test('runLifecyclemodelReview supports missing validation reports and consistent
   ]);
 
   try {
-    const report = await runLifecyclemodelReview({
+    const report = await runLifecyclemodelQa({
       runDir: runRoot,
       outDir,
       now: () => new Date('2026-03-30T00:00:00.000Z'),
@@ -452,8 +452,8 @@ test('runLifecyclemodelReview supports missing validation reports and consistent
   }
 });
 
-test('runLifecyclemodelReview rejects invalid inputs, missing runs, and malformed timestamps', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-lifecyclemodel-errors-'));
+test('runLifecyclemodelQa rejects invalid inputs, missing runs, and malformed timestamps', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-qa-errors-'));
   const invalidRunRoot = path.join(dir, 'lm-run-invalid');
   const noModelsRunRoot = path.join(dir, 'lm-run-no-models');
   const badTimestampRunRoot = path.join(dir, 'lm-run-bad-ts');
@@ -504,7 +504,7 @@ test('runLifecyclemodelReview rejects invalid inputs, missing runs, and malforme
   try {
     await assert.rejects(
       async () =>
-        runLifecyclemodelReview({
+        runLifecyclemodelQa({
           runDir: '',
           outDir,
         }),
@@ -513,7 +513,7 @@ test('runLifecyclemodelReview rejects invalid inputs, missing runs, and malforme
 
     await assert.rejects(
       async () =>
-        runLifecyclemodelReview({
+        runLifecyclemodelQa({
           runDir: path.join(dir, 'missing'),
           outDir,
         }),
@@ -522,7 +522,7 @@ test('runLifecyclemodelReview rejects invalid inputs, missing runs, and malforme
 
     await assert.rejects(
       async () =>
-        runLifecyclemodelReview({
+        runLifecyclemodelQa({
           runDir: invalidRunRoot,
           outDir,
         }),
@@ -531,7 +531,7 @@ test('runLifecyclemodelReview rejects invalid inputs, missing runs, and malforme
 
     await assert.rejects(
       async () =>
-        runLifecyclemodelReview({
+        runLifecyclemodelQa({
           runDir: noModelsRunRoot,
           outDir,
         }),
@@ -540,7 +540,7 @@ test('runLifecyclemodelReview rejects invalid inputs, missing runs, and malforme
 
     await assert.rejects(
       async () =>
-        runLifecyclemodelReview({
+        runLifecyclemodelQa({
           runDir: badTimestampRunRoot,
           outDir,
           startTs: 'bad-start',
@@ -553,8 +553,8 @@ test('runLifecyclemodelReview rejects invalid inputs, missing runs, and malforme
   }
 });
 
-test('review lifecyclemodel internals cover invocation index and model discovery edge cases', () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-lifecyclemodel-internals-'));
+test('qa lifecyclemodel internals cover invocation index and model discovery edge cases', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-qa-internals-'));
   const runRoot = path.join(dir, 'lm-run-internals');
   const outDir = path.join(dir, 'review');
   const layout = __testInternals.buildLayout(runRoot, outDir);
@@ -620,8 +620,8 @@ test('review lifecyclemodel internals cover invocation index and model discovery
   }
 });
 
-test('review lifecyclemodel validation helpers cover invalid report shapes and normalization fallbacks', () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-lifecyclemodel-validation-'));
+test('qa lifecyclemodel validation helpers cover invalid report shapes and normalization fallbacks', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-qa-validation-'));
   const runRoot = path.join(dir, 'lm-run-validation');
   const outDir = path.join(dir, 'review');
   const layout = __testInternals.buildLayout(runRoot, outDir);
@@ -751,7 +751,7 @@ test('review lifecyclemodel validation helpers cover invalid report shapes and n
     assert.equal(invocationIndex.schema_version, 1);
     assert.deepEqual(invocationIndex.invocations, [
       {
-        command: ['review', 'lifecyclemodel', '--run-dir', runRoot, '--out-dir', outDir],
+        command: ['qa', 'lifecyclemodel', '--run-dir', runRoot, '--out-dir', outDir],
         cwd: process.cwd(),
         created_at: '2026-03-30T00:00:00.000Z',
         run_id: 'lm-run-validation',
@@ -764,8 +764,8 @@ test('review lifecyclemodel validation helpers cover invalid report shapes and n
   }
 });
 
-test('review lifecyclemodel model helpers cover direct payload roots, fallbacks, and invalid artifacts', () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-lifecyclemodel-model-'));
+test('qa lifecyclemodel model helpers cover direct payload roots, fallbacks, and invalid artifacts', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-qa-model-'));
 
   try {
     const directModelPath = path.join(dir, 'direct-model.json');
@@ -955,8 +955,8 @@ test('review lifecyclemodel model helpers cover direct payload roots, fallbacks,
   }
 });
 
-test('runLifecyclemodelReview rejects missing run manifests and mismatched run ids', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-lifecyclemodel-manifest-'));
+test('runLifecyclemodelQa rejects missing run manifests and mismatched run ids', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-lifecyclemodel-qa-manifest-'));
   const missingManifestRunRoot = path.join(dir, 'lm-run-missing-manifest');
   const mismatchRunRoot = path.join(dir, 'lm-run-mismatch');
   const outDir = path.join(dir, 'review');
@@ -967,7 +967,7 @@ test('runLifecyclemodelReview rejects missing run manifests and mismatched run i
   try {
     await assert.rejects(
       async () =>
-        runLifecyclemodelReview({
+        runLifecyclemodelQa({
           runDir: missingManifestRunRoot,
           outDir,
         }),
@@ -976,7 +976,7 @@ test('runLifecyclemodelReview rejects missing run manifests and mismatched run i
 
     await assert.rejects(
       async () =>
-        runLifecyclemodelReview({
+        runLifecyclemodelQa({
           runDir: mismatchRunRoot,
           outDir,
         }),

--- a/test/process-qa.test.ts
+++ b/test/process-qa.test.ts
@@ -5,7 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { CliError } from '../src/lib/errors.js';
 import type { FetchLike } from '../src/lib/http.js';
-import { __testInternals, runProcessReview } from '../src/lib/review-process.js';
+import { __testInternals, runProcessQa } from '../src/lib/process-qa.js';
 
 type JsonRecord = Record<string, unknown>;
 
@@ -130,8 +130,8 @@ function createLlmFetch(outputText: string, observedBodies: unknown[] = []): Fet
   }) as FetchLike;
 }
 
-test('runProcessReview writes artifact-first local review outputs without LLM', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-process-'));
+test('runProcessQa writes artifact-first local QA outputs without LLM', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-qa-'));
   const runRoot = path.join(dir, 'run-root');
   const processDir = path.join(runRoot, 'exports', 'processes');
   const outDir = path.join(dir, 'review');
@@ -169,14 +169,14 @@ test('runProcessReview writes artifact-first local review outputs without LLM', 
   );
 
   try {
-    const report = await runProcessReview({
+    const report = await runProcessQa({
       runRoot,
       outDir,
       logicVersion: 'v2.1',
       now: () => new Date('2026-03-30T00:00:00.000Z'),
     });
 
-    assert.equal(report.status, 'completed_local_process_review');
+    assert.equal(report.status, 'completed_local_process_qa');
     assert.equal(report.run_id, 'run-root');
     assert.equal(report.run_root, runRoot);
     assert.equal(report.rows_file, '');
@@ -192,17 +192,19 @@ test('runProcessReview writes artifact-first local review outputs without LLM', 
     assert.equal(report.totals.relative_deviation, 0);
     assert.equal(report.ruleset_id, 'process-authoring/strict');
     assert.equal(report.ruleset_version, '1');
-    assert.equal(report.ruleset_gate?.status, 'blocked');
+    assert.equal(report.ruleset_gate?.status, 'needs_review');
     assert.equal(report.rule_finding_count, 1);
-    assert.equal(report.blocker_count, 1);
+    assert.equal(report.blocker_count, 0);
+    assert.equal(report.policy_decision_owner, 'foundry');
+    assert.equal(report.qa_mode, 'deterministic_qa_report');
     assert.equal(report.generated_at_utc, '2026-03-30T00:00:00.000Z');
-    assert.ok(existsSync(report.files.review_zh));
-    assert.ok(existsSync(report.files.review_en));
+    assert.ok(existsSync(report.files.qa_zh));
+    assert.ok(existsSync(report.files.qa_en));
     assert.ok(existsSync(report.files.timing));
     assert.ok(existsSync(report.files.unit_issue_log));
     assert.ok(existsSync(report.files.rule_findings ?? ''));
     assert.ok(existsSync(report.files.ruleset_gate ?? ''));
-    assert.ok(existsSync(report.files.review_input_summary));
+    assert.ok(existsSync(report.files.qa_input_summary));
     assert.ok(existsSync(report.files.summary));
     assert.ok(existsSync(report.files.report));
     assert.equal(report.files.materialization_summary, null);
@@ -211,7 +213,7 @@ test('runProcessReview writes artifact-first local review outputs without LLM', 
     assert.equal(summary.process_count, 1);
     assert.equal((summary.llm as JsonRecord).enabled, false);
 
-    const zhReview = readFileSync(report.files.review_zh, 'utf8');
+    const zhReview = readFileSync(report.files.qa_zh, 'utf8');
     assert.match(zhReview, /基础信息核查/u);
     assert.match(zhReview, /LLM 语义审核层/u);
 
@@ -229,8 +231,8 @@ test('runProcessReview writes artifact-first local review outputs without LLM', 
   }
 });
 
-test('runProcessReview materializes rows-file and full process-list reports before reviewing', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-process-rows-'));
+test('runProcessQa materializes rows-file and full process-list reports before reviewing', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-qa-rows-'));
   const rowsFile = path.join(dir, 'process-list-report.json');
   const outDir = path.join(dir, 'review');
 
@@ -250,7 +252,7 @@ test('runProcessReview materializes rows-file and full process-list reports befo
   });
 
   try {
-    const report = await runProcessReview({
+    const report = await runProcessQa({
       rowsFile,
       outDir,
       now: () => new Date('2026-03-30T00:00:00.000Z'),
@@ -262,7 +264,7 @@ test('runProcessReview materializes rows-file and full process-list reports befo
     assert.equal(report.run_id, 'process-list-report');
     assert.equal(report.process_count, 1);
     assert.ok(report.files.materialization_summary);
-    assert.ok(existsSync(report.files.review_input_summary));
+    assert.ok(existsSync(report.files.qa_input_summary));
     assert.ok(existsSync(report.files.materialization_summary as string));
 
     const materialization = JSON.parse(
@@ -276,8 +278,8 @@ test('runProcessReview materializes rows-file and full process-list reports befo
   }
 });
 
-test('runProcessReview accepts direct rows arrays and falls back to row identity defaults', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-process-array-'));
+test('runProcessQa accepts direct rows arrays and falls back to row identity defaults', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-qa-array-'));
   const rowsFile = path.join(dir, 'rows.json');
   const outDir = path.join(dir, 'review');
 
@@ -295,7 +297,7 @@ test('runProcessReview accepts direct rows arrays and falls back to row identity
   ]);
 
   try {
-    const report = await runProcessReview({
+    const report = await runProcessQa({
       rowsFile,
       outDir,
       now: () => new Date('2026-03-30T00:05:00.000Z'),
@@ -317,8 +319,8 @@ test('runProcessReview accepts direct rows arrays and falls back to row identity
   }
 });
 
-test('runProcessReview accepts JSONL rows-file inputs and trims explicit run ids', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-process-jsonl-'));
+test('runProcessQa accepts JSONL rows-file inputs and trims explicit run ids', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-qa-jsonl-'));
   const rowsFile = path.join(dir, 'rows.jsonl');
   const outDir = path.join(dir, 'review');
 
@@ -333,7 +335,7 @@ test('runProcessReview accepts JSONL rows-file inputs and trims explicit run ids
   );
 
   try {
-    const report = await runProcessReview({
+    const report = await runProcessQa({
       rowsFile,
       runId: '  explicit-run-id  ',
       outDir,
@@ -348,8 +350,8 @@ test('runProcessReview accepts JSONL rows-file inputs and trims explicit run ids
   }
 });
 
-test('runProcessReview can invoke the CLI LLM client and persist semantic review traces', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-process-llm-'));
+test('runProcessQa treats process LLM review as a Foundry curation concern', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-qa-llm-'));
   const runRoot = path.join(dir, 'run-root');
   const processDir = path.join(runRoot, 'exports', 'processes');
   const outDir = path.join(dir, 'review');
@@ -358,7 +360,7 @@ test('runProcessReview can invoke the CLI LLM client and persist semantic review
   writeJson(path.join(processDir, 'proc-a.json'), createProcessPayload());
 
   try {
-    const report = await runProcessReview({
+    const report = await runProcessQa({
       runRoot,
       runId: 'run-llm',
       outDir,
@@ -376,7 +378,7 @@ test('runProcessReview can invoke the CLI LLM client and persist semantic review
               process_file: 'proc-a.json',
               severity: 'medium',
               fixability: 'review-needed',
-              evidence: 'missing bilingual route qualifiers',
+              evidence: 'missing source-language route qualifiers',
               action: 'add route qualifier',
             },
           ],
@@ -385,29 +387,19 @@ test('runProcessReview can invoke the CLI LLM client and persist semantic review
       ),
     });
 
-    assert.equal(report.llm.enabled, true);
-    assert.equal(report.llm.ok, true);
-    assert.deepEqual((report.llm.result.findings as JsonRecord[])[0], {
-      process_file: 'proc-a.json',
-      severity: 'medium',
-      fixability: 'review-needed',
-      evidence: 'missing bilingual route qualifiers',
-      action: 'add route qualifier',
-    });
-    assert.equal(observedBodies.length, 1);
-    assert.equal((observedBodies[0] as JsonRecord).model, 'gpt-5.4');
-    assert.ok(existsSync(path.join(outDir, 'llm-trace.jsonl')));
-    assert.ok(existsSync(path.join(outDir, '.llm-cache')));
+    assert.equal(report.llm.enabled, false);
+    assert.equal(report.llm.reason, 'moved_to_foundry_process_curation');
+    assert.equal(observedBodies.length, 0);
 
-    const zhReview = readFileSync(report.files.review_zh, 'utf8');
-    assert.match(zhReview, /missing bilingual route qualifiers/u);
+    const zhReview = readFileSync(report.files.qa_zh, 'utf8');
+    assert.match(zhReview, /moved_to_foundry_process_curation/u);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test('runProcessReview records non-fatal LLM runtime failures and validates timestamps', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-process-errors-'));
+test('runProcessQa records non-fatal LLM runtime failures and validates timestamps', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-qa-errors-'));
   const runRoot = path.join(dir, 'run-root');
   const processDir = path.join(runRoot, 'exports', 'processes');
   const outDir = path.join(dir, 'review');
@@ -415,7 +407,7 @@ test('runProcessReview records non-fatal LLM runtime failures and validates time
   writeJson(path.join(processDir, 'proc-a.json'), createProcessPayload());
 
   try {
-    const missingEnvReport = await runProcessReview({
+    const missingEnvReport = await runProcessQa({
       runRoot,
       runId: 'run-missing-env',
       outDir,
@@ -423,12 +415,11 @@ test('runProcessReview records non-fatal LLM runtime failures and validates time
       env: {} as NodeJS.ProcessEnv,
     });
 
-    assert.equal(missingEnvReport.llm.enabled, true);
-    assert.equal(missingEnvReport.llm.ok, false);
-    assert.match(missingEnvReport.llm.reason, /Missing LLM base URL/u);
+    assert.equal(missingEnvReport.llm.enabled, false);
+    assert.equal(missingEnvReport.llm.reason, 'moved_to_foundry_process_curation');
 
     await assert.rejects(
-      runProcessReview({
+      runProcessQa({
         runRoot,
         runId: 'run-invalid-ts',
         outDir: path.join(dir, 'review-invalid'),
@@ -437,31 +428,31 @@ test('runProcessReview records non-fatal LLM runtime failures and validates time
       }),
       (error) => {
         assert.ok(error instanceof CliError);
-        assert.equal(error.code, 'PROCESS_REVIEW_INVALID_TIMESTAMP');
+        assert.equal(error.code, 'PROCESS_QA_INVALID_TIMESTAMP');
         return true;
       },
     );
 
     await assert.rejects(
-      runProcessReview({
+      runProcessQa({
         runRoot: path.join(dir, 'missing-run-root'),
         runId: 'run-missing-root',
         outDir,
       }),
       (error) => {
         assert.ok(error instanceof CliError);
-        assert.equal(error.code, 'PROCESS_REVIEW_EXPORTS_NOT_FOUND');
+        assert.equal(error.code, 'PROCESS_QA_EXPORTS_NOT_FOUND');
         return true;
       },
     );
 
     await assert.rejects(
-      runProcessReview({
+      runProcessQa({
         outDir: path.join(dir, 'review-missing-input'),
       }),
       (error) => {
         assert.ok(error instanceof CliError);
-        assert.equal(error.code, 'PROCESS_REVIEW_INPUT_MODE_REQUIRED');
+        assert.equal(error.code, 'PROCESS_QA_INPUT_MODE_REQUIRED');
         return true;
       },
     );
@@ -470,8 +461,8 @@ test('runProcessReview records non-fatal LLM runtime failures and validates time
   }
 });
 
-test('runProcessReview validates malformed rows-file inputs', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-process-invalid-rows-'));
+test('runProcessQa validates malformed rows-file inputs', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-qa-invalid-rows-'));
   const invalidJsonlPath = path.join(dir, 'rows.jsonl');
   const invalidJsonlRowPath = path.join(dir, 'rows-scalar.jsonl');
   const invalidJsonPath = path.join(dir, 'rows.json');
@@ -484,50 +475,50 @@ test('runProcessReview validates malformed rows-file inputs', async () => {
 
   try {
     await assert.rejects(
-      runProcessReview({
+      runProcessQa({
         rowsFile: invalidJsonlPath,
         outDir: path.join(dir, 'review-jsonl'),
       }),
       (error) => {
         assert.ok(error instanceof CliError);
-        assert.equal(error.code, 'PROCESS_REVIEW_ROWS_INVALID_JSONL');
+        assert.equal(error.code, 'PROCESS_QA_ROWS_INVALID_JSONL');
         return true;
       },
     );
 
     await assert.rejects(
-      runProcessReview({
+      runProcessQa({
         rowsFile: invalidJsonlRowPath,
         outDir: path.join(dir, 'review-jsonl-row'),
       }),
       (error) => {
         assert.ok(error instanceof CliError);
-        assert.equal(error.code, 'PROCESS_REVIEW_ROWS_INVALID_JSONL_ROW');
+        assert.equal(error.code, 'PROCESS_QA_ROWS_INVALID_JSONL_ROW');
         return true;
       },
     );
 
     await assert.rejects(
-      runProcessReview({
+      runProcessQa({
         rowsFile: invalidJsonPath,
         outDir: path.join(dir, 'review-json'),
       }),
       (error) => {
         assert.ok(error instanceof CliError);
-        assert.equal(error.code, 'PROCESS_REVIEW_ROWS_INVALID_JSON');
+        assert.equal(error.code, 'PROCESS_QA_ROWS_INVALID_JSON');
         assert.match(error.message, /not valid JSON/u);
         return true;
       },
     );
 
     await assert.rejects(
-      runProcessReview({
+      runProcessQa({
         rowsFile: invalidShapePath,
         outDir: path.join(dir, 'review-shape'),
       }),
       (error) => {
         assert.ok(error instanceof CliError);
-        assert.equal(error.code, 'PROCESS_REVIEW_ROWS_INVALID_JSON');
+        assert.equal(error.code, 'PROCESS_QA_ROWS_INVALID_JSON');
         assert.match(error.message, /rows\[\]/u);
         return true;
       },
@@ -537,8 +528,8 @@ test('runProcessReview validates malformed rows-file inputs', async () => {
   }
 });
 
-test('runProcessReview covers exchange-object fallback, empty exchanges, and zero-input totals', async () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-review-process-zero-'));
+test('runProcessQa covers exchange-object fallback, empty exchanges, and zero-input totals', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-qa-zero-'));
   const runRoot = path.join(dir, 'run-root');
   const processDir = path.join(runRoot, 'exports', 'processes');
   const outDir = path.join(dir, 'review');
@@ -630,7 +621,7 @@ test('runProcessReview covers exchange-object fallback, empty exchanges, and zer
   );
 
   try {
-    const report = await runProcessReview({
+    const report = await runProcessQa({
       runRoot,
       runId: 'run-zero',
       outDir,
@@ -640,13 +631,13 @@ test('runProcessReview covers exchange-object fallback, empty exchanges, and zer
     assert.equal(report.totals.raw_input, 20);
     assert.equal(Number(report.totals.relative_deviation?.toFixed(2)), 0.33);
     assert.equal(report.totals.product_plus_byproduct_plus_waste, 13.4);
-    assert.equal(report.ruleset_gate?.status, 'blocked');
+    assert.equal(report.ruleset_gate?.status, 'needs_review');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test('review-process internals cover helper branches and rendering fallbacks', async () => {
+test('process-qa internals cover helper branches and rendering fallbacks', async () => {
   assert.equal(__testInternals.requiredNonEmpty(' value ', '--x', 'ERR'), 'value');
   assert.throws(() => __testInternals.requiredNonEmpty('', '--x', 'ERR'), /Missing required/u);
 
@@ -678,7 +669,7 @@ test('review-process internals cover helper branches and rendering fallbacks', a
         names: [{ '#text': 'name zh-ish' }, { '#text': 'name en-ish' }],
       }),
     ),
-    [true, true, ['name zh-ish', 'name en-ish']],
+    [true, ['name zh-ish', 'name en-ish']],
   );
   assert.deepEqual(
     __testInternals.extractBaseNames(
@@ -688,7 +679,7 @@ test('review-process internals cover helper branches and rendering fallbacks', a
         },
       }),
     ),
-    [false, false, ['single name entry']],
+    [true, ['single name entry']],
   );
   assert.deepEqual(
     __testInternals.extractBaseNames({
@@ -698,7 +689,7 @@ test('review-process internals cover helper branches and rendering fallbacks', a
         },
       },
     }),
-    [false, false, []],
+    [false, []],
   );
   assert.deepEqual(
     __testInternals.extractBaseNames(
@@ -706,7 +697,7 @@ test('review-process internals cover helper branches and rendering fallbacks', a
         names: [{ '@xml:lang': 'en' }],
       }),
     ),
-    [false, false, []],
+    [false, []],
   );
   assert.deepEqual(
     __testInternals.extractBaseNames({
@@ -718,7 +709,7 @@ test('review-process internals cover helper branches and rendering fallbacks', a
         },
       },
     }),
-    [false, false, []],
+    [false, []],
   );
   assert.deepEqual(
     __testInternals.extractBaseNames(
@@ -726,7 +717,7 @@ test('review-process internals cover helper branches and rendering fallbacks', a
         names: [1, { '@xml:lang': 'en', '#text': '' }],
       }),
     ),
-    [false, false, []],
+    [false, []],
   );
 
   assert.equal(
@@ -913,19 +904,32 @@ test('review-process internals cover helper branches and rendering fallbacks', a
       administrativeInformation: {},
     }),
   );
-  assert.equal(minimalBase.name_zh_en_ok, false);
-  assert.equal(minimalBase.completeness_score, 0);
+  assert.equal(minimalBase.source_name_ok, true);
+  assert.equal(minimalBase.completeness_score, 1);
 
   const baseFindings = __testInternals.reviewFindingsForBase('proc.json', minimalBase);
-  assert.ok(baseFindings.some((finding) => finding.code === 'process_missing_bilingual_base_name'));
+  assert.ok(!baseFindings.some((finding) => finding.code === 'process_missing_source_base_name'));
   assert.ok(baseFindings.some((finding) => finding.code === 'process_missing_functional_unit'));
+
+  const missingSourceNameBase = __testInternals.baseInfoCheck(
+    createProcessPayload({
+      names: [],
+      functionalUnit: '1 kg',
+    }),
+  );
+  assert.equal(missingSourceNameBase.source_name_ok, false);
+  assert.ok(
+    __testInternals
+      .reviewFindingsForBase('proc-no-name.json', missingSourceNameBase)
+      .some((finding) => finding.code === 'process_missing_source_base_name'),
+  );
   assert.equal(__testInternals.hasNumericAmount({ meanAmount: '0' }), true);
   assert.equal(__testInternals.hasNumericAmount({ resultingAmount: 0 }), true);
   assert.equal(__testInternals.hasNumericAmount({ meanAmount: 'bad' }), false);
   assert.equal(__testInternals.processRulesetGate([]).status, 'passed');
   assert.equal(
     __testInternals.processRulesetGate([
-      __testInternals.createProcessReviewFinding({
+      __testInternals.createProcessQaFinding({
         processFile: 'proc.json',
         severity: 'warning',
         code: 'unknown_warning',
@@ -973,7 +977,7 @@ test('review-process internals cover helper branches and rendering fallbacks', a
   );
   assert.throws(
     () => __testInternals.unwrapProcessPayload([], '/tmp/proc.json'),
-    /Expected process review file/u,
+    /Expected process QA file/u,
   );
   assert.throws(
     () => __testInternals.unwrapProcessPayload({}, '/tmp/proc.json'),
@@ -989,7 +993,7 @@ test('review-process internals cover helper branches and rendering fallbacks', a
     llmModel: undefined,
     env: {} as NodeJS.ProcessEnv,
     fetchImpl: createLlmFetch('{}'),
-    outDir: path.join(os.tmpdir(), 'tg-cli-review-process-internals'),
+    outDir: path.join(os.tmpdir(), 'tg-cli-process-qa-internals'),
   });
   assert.deepEqual(llmDisabled, {
     enabled: false,
@@ -1005,12 +1009,10 @@ test('review-process internals cover helper branches and rendering fallbacks', a
       TIANGONG_LCA_REVIEW_LLM_MODEL: 'gpt-5.4',
     } as NodeJS.ProcessEnv,
     fetchImpl: createLlmFetch('not json'),
-    outDir: path.join(os.tmpdir(), 'tg-cli-review-process-internals-2'),
+    outDir: path.join(os.tmpdir(), 'tg-cli-process-qa-internals-2'),
   });
-  assert.equal(llmNonJson.enabled, true);
-  assert.equal(llmNonJson.ok, false);
-  assert.equal(llmNonJson.reason, 'llm_non_json_output');
-  assert.equal(llmNonJson.raw, 'not json');
+  assert.equal(llmNonJson.enabled, false);
+  assert.equal(llmNonJson.reason, 'moved_to_foundry_process_curation');
 
   const llmThrownString = await __testInternals.runOptionalLlmReview([], {
     enableLlm: true,
@@ -1023,11 +1025,10 @@ test('review-process internals cover helper branches and rendering fallbacks', a
     fetchImpl: (async () => {
       throw 'boom';
     }) as FetchLike,
-    outDir: path.join(os.tmpdir(), 'tg-cli-review-process-internals-3'),
+    outDir: path.join(os.tmpdir(), 'tg-cli-process-qa-internals-3'),
   });
-  assert.equal(llmThrownString.enabled, true);
-  assert.equal(llmThrownString.ok, false);
-  assert.equal(llmThrownString.reason, 'boom');
+  assert.equal(llmThrownString.enabled, false);
+  assert.equal(llmThrownString.reason, 'moved_to_foundry_process_curation');
 
   const timing = __testInternals.renderTiming({
     runId: 'run-1',
@@ -1087,7 +1088,7 @@ test('review-process internals cover helper branches and rendering fallbacks', a
       [
         'proc-a.json',
         {
-          name_zh_en_ok: false,
+          source_name_ok: false,
           functional_unit_ok: false,
           system_boundary_ok: false,
           time_ok: false,
@@ -1185,7 +1186,7 @@ test('review-process internals cover helper branches and rendering fallbacks', a
       [
         'proc-a.json',
         {
-          name_zh_en_ok: false,
+          source_name_ok: false,
           functional_unit_ok: false,
           system_boundary_ok: false,
           time_ok: false,

--- a/test/process-qa.test.ts
+++ b/test/process-qa.test.ts
@@ -750,6 +750,22 @@ test('process-qa internals cover helper branches and rendering fallbacks', async
   assert.equal(
     __testInternals.classifyExchange({
       exchangeDirection: 'Input',
+      commonComment: 'source classification input group',
+      'common:other': {
+        'tidasimport:sourceTrace': {
+          payload: {
+            sourceClassification: {
+              inputGroup: '4',
+            },
+          },
+        },
+      },
+    }).classification,
+    'raw_material_input',
+  );
+  assert.equal(
+    __testInternals.classifyExchange({
+      exchangeDirection: 'Input',
       commonComment: 'misc auxiliary input',
       referenceToFlowDataSet: 'not-an-object',
     }).classification,
@@ -778,6 +794,49 @@ test('process-qa internals cover helper branches and rendering fallbacks', async
       }),
     ).classification,
     'product_output',
+  );
+  assert.equal(
+    __testInternals.classifyExchange(
+      {
+        '@dataSetInternalID': 'reference-output-1',
+        exchangeDirection: 'Output',
+        commonComment: 'declared quantitative reference output',
+      },
+      'reference-output-1',
+    ).classification,
+    'product_output',
+  );
+  assert.equal(
+    __testInternals.classifyExchange({
+      exchangeDirection: 'Output',
+      commonComment: 'source trace output group reference',
+      'common:other': {
+        'tidasimport:sourceTrace': {
+          payload: {
+            sourceTrace: {
+              sourceClassification: {
+                outputGroup: '0',
+              },
+            },
+          },
+        },
+      },
+    }).classification,
+    'product_output',
+  );
+  assert.equal(
+    __testInternals.classifyExchange({
+      exchangeDirection: 'Input',
+      commonComment: 'source trace without classification',
+      'common:other': {
+        'tidasimport:sourceTrace': {
+          payload: {
+            sourceTrace: {},
+          },
+        },
+      },
+    }).classification,
+    'other_input',
   );
   assert.equal(
     __testInternals.classifyExchange(
@@ -938,6 +997,23 @@ test('process-qa internals cover helper branches and rendering fallbacks', async
     ]).status,
     'needs_review',
   );
+  const warningFinding = __testInternals.createProcessQaFinding({
+    processFile: 'proc-null-rule.json',
+    severity: 'warning',
+    code: 'unknown_warning',
+    message: 'review only',
+  });
+  assert.equal(warningFinding.methodology_rule_id, null);
+  const blockerGate = __testInternals.processRulesetGate([
+    __testInternals.createProcessQaFinding({
+      processFile: 'proc-blocker.json',
+      severity: 'blocker',
+      code: 'process_missing_functional_unit',
+      message: 'blocker',
+    }),
+  ]);
+  assert.equal(blockerGate.status, 'blocked');
+  assert.equal(blockerGate.next_action, 'fix_blockers');
 
   assert.equal(
     __testInternals.unwrapProcessPayload(
@@ -985,6 +1061,32 @@ test('process-qa internals cover helper branches and rendering fallbacks', async
   );
 
   assert.deepEqual(__testInternals.parseLlmJsonOutput('{"findings":[]}'), { findings: [] });
+  assert.match(
+    __testInternals.buildPrompt([
+      {
+        process_file: 'proc.json',
+        base_names: ['Process'],
+        base_checks: {
+          source_name_ok: true,
+          functional_unit_ok: true,
+          system_boundary_ok: true,
+          time_ok: true,
+          geo_ok: true,
+          tech_ok: true,
+          admin_ok: true,
+        },
+        balance: {
+          raw_in: 1,
+          product: 1,
+          byproduct: 0,
+          waste: 0,
+          energy_excluded: 0,
+          relative_deviation: 0,
+        },
+      },
+    ]),
+    /输入摘要/u,
+  );
   assert.equal(__testInternals.parseLlmJsonOutput('[]'), null);
   assert.equal(__testInternals.parseLlmJsonOutput('not json'), null);
 


### PR DESCRIPTION
Closes tiangong-lca/tiangong-cli#131

## Summary
- Move deterministic process, flow, and lifecyclemodel checks from the removed review namespace to the qa namespace.
- Keep review as a hard removed-command error with no compatibility alias.

## Key Decisions
- Foundry owns AI semantic curation; CLI owns deterministic QA and schema/ruleset gates.
- All three deterministic entity checks now follow the same qa command surface.

## Validation
- npm run build
- node --import tsx --test test/cli.test.ts test/process-qa.test.ts test/flow-qa.test.ts test/lifecyclemodel-qa.test.ts test/flow-fetch-rows.test.ts test/dataset-bilingual.test.ts
- npm run test:coverage && npm run test:coverage:assert-full
- git push pre-push gate: docpact lint, lint, tsc, coverage 100%

## Risks / Rollback
- Medium command-surface risk mitigated by intentionally removing review aliases and updating tests/docs.

## Follow-ups
- After merge, release the CLI package and update the lca-workspace submodule pointer.

## Workspace Integration
- Requires workspace integration pointer bump after merge and release.