### PR TITLE
chore: release cli 0.0.9

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "56757053fca9dc5f4c8120225ee35e2b4cc995ef"
+lastReviewedCommit: "0915b000a687328b07b80ec5636e3f09a086f2b8"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 56757053fca9dc5f4c8120225ee35e2b4cc995ef
+lastReviewedCommit: 0915b000a687328b07b80ec5636e3f09a086f2b8
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: f281bb99a364bfcaca30702c72fbaa5402361b5f
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: 1f0142883a58edbc40f40ae177405629f8b062ee
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 56757053fca9dc5f4c8120225ee35e2b4cc995ef
+lastReviewedCommit: 0915b000a687328b07b80ec5636e3f09a086f2b8
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 56757053fca9dc5f4c8120225ee35e2b4cc995ef
+lastReviewedCommit: 0915b000a687328b07b80ec5636e3f09a086f2b8
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 56757053fca9dc5f4c8120225ee35e2b4cc995ef
+lastReviewedCommit: 0915b000a687328b07b80ec5636e3f09a086f2b8
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/cli",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.101.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Unified TianGong LCA CLI with direct REST adapters and low-entropy command surface.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes tiangong-lca/tiangong-cli#133

## Summary
- Bump @tiangong-lca/cli package metadata from 0.0.8 to 0.0.9.
- Prepare the merged QA command-surface migration for npm release.

## Key Decisions
- Keep the release-prep PR scoped to package.json, package-lock.json, and docpact review evidence required by release contracts.

## Validation
- node ./scripts/ci/release-version.cjs assert-unpublished --version 0.0.9
- npm pack --dry-run
- npm run prepush:gate
- push pre-push gate: docpact lint plus npm run prepush:gate

## Risks / Rollback
- Low release metadata risk; publish automation validates the tag and package version before npm publish.

## Follow-ups
- Verify Tag Release From Merge, cli-v0.0.9, Publish Package, and npm latest after merge.

## Workspace Integration
- Only update lca-workspace CLI submodule pointer after npm shows @tiangong-lca/cli@0.0.9 as latest.