### PR TITLE
fix: handle missing CLI release tag refs

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "0915b000a687328b07b80ec5636e3f09a086f2b8"
+lastReviewedCommit: "4606c45dfa129abbb707f305f4182bd39a584a9e"
 
 catalog:
   repos:

--- a/.github/workflows/tag-release-from-merge.yml
+++ b/.github/workflows/tag-release-from-merge.yml
@@ -87,10 +87,15 @@ jobs:
           TARGET_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          existing_sha="$(
+          existing_sha=""
+          if existing_sha="$(
             gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG_NAME}" \
-              --jq '.object.sha' 2>/dev/null || true
-          )"
+              --jq '.object.sha' 2>/dev/null
+          )"; then
+            :
+          else
+            existing_sha=""
+          fi
 
           if [ -n "$existing_sha" ]; then
             if [ "$existing_sha" = "$TARGET_SHA" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 0915b000a687328b07b80ec5636e3f09a086f2b8
+lastReviewedCommit: 4606c45dfa129abbb707f305f4182bd39a584a9e
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 1f0142883a58edbc40f40ae177405629f8b062ee
+lastReviewedCommit: a397e19fd97dfc114a8a749298c1a9bc3e8357ce
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 0915b000a687328b07b80ec5636e3f09a086f2b8
+lastReviewedCommit: 4606c45dfa129abbb707f305f4182bd39a584a9e
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 0915b000a687328b07b80ec5636e3f09a086f2b8
+lastReviewedCommit: 4606c45dfa129abbb707f305f4182bd39a584a9e
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 0915b000a687328b07b80ec5636e3f09a086f2b8
+lastReviewedCommit: 4606c45dfa129abbb707f305f4182bd39a584a9e
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml


### PR DESCRIPTION
Closes tiangong-lca/tiangong-cli#135

## Summary
- Fix Tag Release From Merge so a missing tag ref clears existing_sha instead of treating gh's 404 JSON as an existing tag SHA.
- Unblocks cli-v0.0.9 tag creation after the release-prep PR merged.

## Key Decisions
- Keep the change local to release automation; no CLI runtime code changes.

## Validation
- npx prettier --check .github/workflows/tag-release-from-merge.yml
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/tag-release-from-merge.yml')"
- push pre-push gate: docpact lint plus npm run prepush:gate

## Risks / Rollback
- Low workflow-only risk; existing-tag conflict behavior is preserved when lookup succeeds.

## Follow-ups
- After merge, rerun Tag Release From Merge for the 0.0.9 release commit and verify npm publish.

## Workspace Integration
- Workspace pointer update remains blocked until @tiangong-lca/cli@0.0.9 is published.