### PR TITLE
Gate unavailable annual process volumes

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "4606c45dfa129abbb707f305f4182bd39a584a9e"
+lastReviewedCommit: "f9968a4f59ade568ddc97413501ceadade8bfb42"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 4606c45dfa129abbb707f305f4182bd39a584a9e
+lastReviewedCommit: f9968a4f59ade568ddc97413501ceadade8bfb42
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -19,7 +19,7 @@ checkPaths:
   - scripts/**
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 56757053fca9dc5f4c8120225ee35e2b4cc995ef
+lastReviewedCommit: 9bdc6e905d93b4bab9bb33972f7eedb5e9a447a6
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - README.md
   - src/**
   - test/**
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 24f96578290267865df3ee1244a96723129bc376
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: f9968a4f59ade568ddc97413501ceadade8bfb42
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -18,7 +18,7 @@ checkPaths:
   - src/**
   - test/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 56757053fca9dc5f4c8120225ee35e2b4cc995ef
+lastReviewedCommit: 9bdc6e905d93b4bab9bb33972f7eedb5e9a447a6
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
+++ b/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
@@ -16,7 +16,7 @@ checkPaths:
   - src/lib/supabase-session.ts
   - src/lib/supabase-client.ts
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 56757053fca9dc5f4c8120225ee35e2b4cc995ef
+lastReviewedCommit: 9bdc6e905d93b4bab9bb33972f7eedb5e9a447a6
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
+++ b/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
@@ -17,7 +17,7 @@ checkPaths:
   - src/lib/tidas-sdk-package-validator.ts
   - test/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 56757053fca9dc5f4c8120225ee35e2b4cc995ef
+lastReviewedCommit: 9bdc6e905d93b4bab9bb33972f7eedb5e9a447a6
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: a397e19fd97dfc114a8a749298c1a9bc3e8357ce
+lastReviewedCommit: f9968a4f59ade568ddc97413501ceadade8bfb42
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 4606c45dfa129abbb707f305f4182bd39a584a9e
+lastReviewedCommit: f9968a4f59ade568ddc97413501ceadade8bfb42
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 4606c45dfa129abbb707f305f4182bd39a584a9e
+lastReviewedCommit: f9968a4f59ade568ddc97413501ceadade8bfb42
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 4606c45dfa129abbb707f305f4182bd39a584a9e
+lastReviewedCommit: f9968a4f59ade568ddc97413501ceadade8bfb42
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/src/lib/process-required-fields.ts
+++ b/src/lib/process-required-fields.ts
@@ -18,6 +18,8 @@ const ANNUAL_SUPPLY_ROOT_FIELD =
 const NUMERIC_TEXT_WITH_SUFFIX_PATTERN = /^[+-]?(\d+(\.\d*)?|\.\d+)([Ee][+-]?\d+)?\s+\S.*$/u;
 const ANNUAL_PERIOD_PATTERN =
   /(?:\/\s*(?:year|yr|a)\b|\bper\s+(?:year|annum)\b|\/\s*年|每年|年度|年供应|年产)/iu;
+const ANNUAL_UNAVAILABLE_PATTERN =
+  /\b(?:source\s+)?(?:production\s+)?volume\s+(?:unavailable|unknown|not\s+available)\b/iu;
 const CJK_TEXT_PATTERN = /[\p{Script=Han}]/u;
 const NET_CALORIFIC_VALUE_ID = '93a60a56-a3c8-11da-a746-0800200c9a66';
 const DEFAULT_COMPLIANCE_SYSTEM = {
@@ -174,7 +176,11 @@ function isValidAnnualSupplyVolume(value: unknown): boolean {
     items.length > 0 &&
     items.every((item) => {
       const text = item['#text'].trim();
-      return NUMERIC_TEXT_WITH_SUFFIX_PATTERN.test(text) && ANNUAL_PERIOD_PATTERN.test(text);
+      return (
+        !ANNUAL_UNAVAILABLE_PATTERN.test(text) &&
+        NUMERIC_TEXT_WITH_SUFFIX_PATTERN.test(text) &&
+        ANNUAL_PERIOD_PATTERN.test(text)
+      );
     })
   );
 }
@@ -245,6 +251,18 @@ export function collectProcessRequiredFieldIssues(
 
   const items = annualSupplyItems(annualSupply);
   if (items.length === 0) {
+    return [
+      ...issues,
+      {
+        code: 'annual_supply_or_production_volume_missing',
+        message:
+          'Process payload must include annualSupplyOrProductionVolume as numeric text with a unit or context suffix.',
+        path: ANNUAL_SUPPLY_FIELD,
+      },
+    ];
+  }
+
+  if (items.some((item) => ANNUAL_UNAVAILABLE_PATTERN.test(item['#text'].trim()))) {
     return [
       ...issues,
       {

--- a/test/process-required-fields.test.ts
+++ b/test/process-required-fields.test.ts
@@ -413,6 +413,24 @@ test('process required field issue collector detects missing and invalid annual 
         modellingAndValidation: {
           ...validRequiredStructures,
           dataSourcesTreatmentAndRepresentativeness: {
+            annualSupplyOrProductionVolume: [
+              {
+                '@xml:lang': 'en',
+                '#text': '0 kg/year; source production volume unavailable',
+              },
+            ],
+          },
+        },
+      },
+    }).map((issue) => issue.code),
+    ['annual_supply_or_production_volume_missing'],
+  );
+  assert.deepEqual(
+    collectProcessRequiredFieldIssues({
+      processDataSet: {
+        modellingAndValidation: {
+          ...validRequiredStructures,
+          dataSourcesTreatmentAndRepresentativeness: {
             annualSupplyOrProductionVolume: [{ '@xml:lang': 'en', '#text': 'not quantified' }],
           },
         },


### PR DESCRIPTION
Closes #137

## Summary
- Treat annualSupplyOrProductionVolume values that only contain an unavailable source marker as missing required process content.
- Keep deterministic schema-valid conversion output from tidas-tools while ensuring Foundry/CLI validation blocks these rows before publish or database writes.

## Key Decisions
- Classify source production volume unavailable as a process required-field issue, not a schema-shape problem.

## Validation
- npm run build && node --import tsx --test test/process-required-fields.test.ts
- npm test
- npm run prepush:gate
- Foundry cleaned BAFU two-process validation now reports only annual_supply_or_production_volume_missing for each target process; qa process reports blocker_count 0 and curation-gate blocks both for Foundry AI authoring.

## Risks / Rollback
- This intentionally increases blocking behavior for converted processes with no real source production volume evidence.

## Workspace Integration
- After merge, update the lca-workspace tiangong-lca-cli submodule pointer.