### PR TITLE
Release CLI 0.0.10

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "f9968a4f59ade568ddc97413501ceadade8bfb42"
+lastReviewedCommit: "1a615b8f7b8e7c9c321f350edd15baa94d227646"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: f9968a4f59ade568ddc97413501ceadade8bfb42
+lastReviewedCommit: 1a615b8f7b8e7c9c321f350edd15baa94d227646
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: f9968a4f59ade568ddc97413501ceadade8bfb42
+lastReviewedCommit: ca614e1cfaa0f071b7d008138c3f96a66e9c89ab
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: f9968a4f59ade568ddc97413501ceadade8bfb42
+lastReviewedCommit: 1a615b8f7b8e7c9c321f350edd15baa94d227646
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: f9968a4f59ade568ddc97413501ceadade8bfb42
+lastReviewedCommit: 1a615b8f7b8e7c9c321f350edd15baa94d227646
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: f9968a4f59ade568ddc97413501ceadade8bfb42
+lastReviewedCommit: 1a615b8f7b8e7c9c321f350edd15baa94d227646
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/cli",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.101.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Unified TianGong LCA CLI with direct REST adapters and low-entropy command surface.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #139

## Summary
- Bump @tiangong-lca/cli package metadata from 0.0.9 to 0.0.10.
- Include docpact review evidence for release and validation governance docs touched by the version bump.

## Key Decisions
- Use the merge-triggered tag workflow to create cli-v0.0.10, then publish from that tag.

## Validation
- npm run build && node ./scripts/ci/check-release-tag.cjs cli cli-v0.0.10
- npm run prepush:gate
- docpact lint passed locally and in pre-push.

## Risks / Rollback
- Release automation will still check npm availability and run the release gate before publishing.

## Workspace Integration
- After merge, verify cli-v0.0.10 tag/publish workflow and update lca-workspace tiangong-lca-cli pointer if main advances.