### PR TITLE
Add dataset curation queue build

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "1a615b8f7b8e7c9c321f350edd15baa94d227646"
+lastReviewedCommit: "3a5af4677994de587b31bc80ebac2f16f9d65442"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 1a615b8f7b8e7c9c321f350edd15baa94d227646
+lastReviewedCommit: 3a5af4677994de587b31bc80ebac2f16f9d65442
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -63,6 +63,7 @@ related:
 - `tiangong-lca process publish-build`
 - `tiangong-lca process batch-build`
 - `tiangong-lca dataset validate`
+- `tiangong-lca dataset curation-queue build`
 - `tiangong-lca dataset references rewrite`
 - `tiangong-lca lifecyclemodel auto-build`
 - `tiangong-lca lifecyclemodel validate-build`
@@ -194,6 +195,7 @@ TIANGONG_LCA_UNSTRUCTURED_RETURN_TXT=true
 | `process identity-preflight` | 默认无；若启用 `--remote-candidates` 或输入 `remote_candidate_search.enabled=true`，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY`（`TIANGONG_LCA_REGION` 可选） |
 | `process auto-build \| resume-build \| publish-build \| batch-build` | 无 |
 | `dataset validate` | 无 |
+| `dataset curation-queue build` | 无 |
 | `dataset references rewrite` | 本地 rewrite 默认无；若 `--commit` 写入 patched rows，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` |
 | `lifecyclemodel auto-build \| validate-build \| publish-build \| graph \| orchestrate` | 无 |
 | `lifecyclemodel save-draft` | 本地 dry-run 默认无；若 `--commit` 写入 lifecyclemodel draft，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` |
@@ -240,6 +242,7 @@ npm exec tiangong-lca -- process resume-build --run-dir /abs/path/to/process-run
 npm exec tiangong-lca -- process publish-build --run-dir /abs/path/to/process-run --json
 npm exec tiangong-lca -- process batch-build --input ./examples/process-batch-build.request.json --out-dir /abs/path/to/process-batch --json
 npm exec tiangong-lca -- dataset validate --input ./rows.jsonl --type auto --out-dir ./dataset-validate --json
+npm exec tiangong-lca -- dataset curation-queue build --processes ./rows/processes.jsonl --flows ./rows/flows.jsonl --support ./rows/sources.jsonl --out-dir ./curation-queue --json
 npm exec tiangong-lca -- dataset references rewrite --input ./rows.jsonl --from flow:<old-id>@<old-version> --to flow:<new-id>@<new-version> --out-dir ./dataset-rewrite --json
 npm exec tiangong-lca -- lifecyclemodel auto-build --input ./examples/lifecyclemodel-auto-build.request.json --out-dir /abs/path/to/lifecyclemodel-run --json
 npm exec tiangong-lca -- lifecyclemodel validate-build --run-dir /abs/path/to/lifecyclemodel-run --json

--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ tiangong-lca process resume-build --run-dir /abs/path/to/process-run --json
 tiangong-lca process publish-build --run-dir /abs/path/to/process-run --json
 tiangong-lca process batch-build --input ./examples/process-batch-build.request.json --out-dir /abs/path/to/process-batch --json
 tiangong-lca dataset validate --input ./rows.jsonl --type auto --out-dir /abs/path/to/dataset-validate --json
+tiangong-lca dataset curation-queue build --processes ./rows/processes.jsonl --flows ./rows/flows.jsonl --support ./rows/sources.jsonl --out-dir /abs/path/to/curation-queue --json
 tiangong-lca dataset evidence-search plan --query "中国2026年电力结构数据" --out-dir /abs/path/to/evidence-search --json
 tiangong-lca dataset evidence-search run --input ./evidence-search.request.json --results ./search-results.json --out-dir /abs/path/to/evidence-search --json
 tiangong-lca dataset references rewrite --input ./rows.jsonl --from flow:<old-id>@<old-version> --to flow:<new-id>@<new-version> --out-dir /abs/path/to/dataset-rewrite --json
@@ -301,6 +302,8 @@ For `publish run`, `verification-report.json` is written next to `publish-report
 For `lifecyclemodel save-draft`, canonical lifecyclemodel payloads are validated locally with `LifeCycleModelSchema` before any `--commit` write. Schema-invalid rows remain in `outputs/save-draft-bundle/failures.jsonl` instead of being persisted.
 
 For `dataset evidence-search`, `plan` creates the field-level query matrix and search budget. `run` accepts normalized external search results from browser/web-search tools or a generic JSON provider endpoint, then writes `outputs/evidence-search-plan.json`, `outputs/evidence-search-results.jsonl`, `outputs/evidence-search-report.json`, and `outputs/evidence-search-declaration.json` when evidence is absent or only partial. The CLI records scope and normalization; Codex/skills still own semantic judgement and source selection.
+
+For `dataset curation-queue build`, the CLI writes entity-level Foundry import queue artifacts: `outputs/curation-queue-manifest.json`, `outputs/curation-queue-tasks.jsonl`, `outputs/curation-queue-locks.json`, `outputs/curation-queue-blockers.jsonl`, and per-entity `input.jsonl`, `closure.json`, and `entity-run-plan.json`. The command only builds deterministic queue state. AI authoring must return structured patches or build plans, and remote writes remain gated by deterministic apply, schema/QA, prewrite verify, and readback.
 
 For `dataset references rewrite`, `--commit` executes the state-aware save-draft path for patched process and lifecyclemodel rows; without `--commit`, the command only writes local rewrite artifacts.
 

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -138,6 +138,7 @@ tiangong-lca
 | `tiangong-lca process publish-build` | 本地 `process_from_flow` publish handoff；先用 `ProcessSchema` 写出 `reports/process-publish-schema-gate.json`，通过后再产出 publish bundle/request/intent 并更新 state/invocation/handoff |
 | `tiangong-lca process batch-build` | 本地 `process_from_flow` batch manifest 编排、批量调用 auto-build、batch report 输出 |
 | `tiangong-lca dataset validate` | 本地 flow / process / lifecyclemodel rows 的统一 TIDAS SDK validation 与稳定报告输出 |
+| `tiangong-lca dataset curation-queue build` | 本地 Foundry external dataset import 的 entity-level curation queue 构建入口；输出 manifest、tasks、locks、blockers、per-entity input/closure/run-plan artifacts，不执行 AI、不写远端 |
 | `tiangong-lca dataset references rewrite` | 本地 process / lifecyclemodel rows 的 flow reference rewrite、patch evidence 输出，并可选走 state-aware save-draft commit |
 | `tiangong-lca lifecyclemodel auto-build` | 本地 lifecyclemodel local-run intake、graph 推断、reference process 选择、`json_ordered` artifact 输出 |
 | `tiangong-lca lifecyclemodel validate-build` | 本地 lifecyclemodel build run 校验重跑、per-model 校验报告与 aggregate report 输出 |
@@ -197,6 +198,7 @@ tiangong-lca
 `tiangong-lca dataset ...` 现在已经开始承接跨 dataset 的本地治理切片，其中：
 
 - `tiangong-lca dataset validate` 已可执行
+- `tiangong-lca dataset curation-queue build` 已可执行
 - `tiangong-lca dataset references rewrite` 已可执行
 
 注意：
@@ -213,6 +215,7 @@ tiangong-lca
 - 已实现的 `process batch-build` 继续走本地优先、artifact-first 路径，并把批量 item 编排、聚合 report、显式 batch root 下的 item run_dir 分配统一收口到 CLI
 - `process batch-build` 当前只负责本地 batch orchestration，不直接串接 resume / publish 或远端执行器
 - 已实现的 `dataset validate` 把 flow / process / lifecyclemodel 本地 rows 的 TIDAS SDK 校验收口到一个 dataset 级入口，并输出 type summary、validation report 与 failures jsonl
+- 已实现的 `dataset curation-queue build` 把 Foundry external dataset import 的 support / flow / process rows 收口成 entity-level queue artifact contract：`curation-queue-manifest.json`、`curation-queue-tasks.jsonl`、`curation-queue-locks.json`、`curation-queue-blockers.jsonl`，以及每个 entity 的 `input.jsonl`、`closure.json`、`entity-run-plan.json`。CLI 只负责稳定状态机、依赖闭包、锁和 blocker；AI authoring 仍必须通过 skill/Codex 输出 structured patch 或 build plan，并在 deterministic apply、schema/QA、prewrite verify、readback 后才允许进入远端写入。
 - 已实现的 `dataset references rewrite` 把 process / lifecyclemodel rows 中的 flow reference rewrite 收口到一个 deterministic 本地入口，默认只写 patch artifacts，只有显式 `--commit` 时才调用 state-aware save-draft 写入路径
 - 已实现的 `lifecyclemodel auto-build` 走本地只读、artifact-first 路径，输入固定为 local run manifest，不依赖 Python、MCP、KB、LLM 或远端 CRUD
 - `lifecyclemodel auto-build` 当前负责 graph 推断、reference process 选择、`@multiplicationFactor` 计算与 `json_ordered` lifecyclemodel 产物输出，并保留 `run-plan.json`、`resolved-manifest.json`、`selection/selection-brief.md`、`discovery/reference-model-summary.json`、`connections.json`、`process-catalog.json` 等 CLI 契约

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -18,7 +18,7 @@ checkPaths:
   - src/**
   - test/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 9bdc6e905d93b4bab9bb33972f7eedb5e9a447a6
+lastReviewedCommit: 3a5af4677994de587b31bc80ebac2f16f9d65442
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
+++ b/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
@@ -16,7 +16,7 @@ checkPaths:
   - src/lib/supabase-session.ts
   - src/lib/supabase-client.ts
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 9bdc6e905d93b4bab9bb33972f7eedb5e9a447a6
+lastReviewedCommit: 3a5af4677994de587b31bc80ebac2f16f9d65442
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
+++ b/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
@@ -17,7 +17,7 @@ checkPaths:
   - src/lib/tidas-sdk-package-validator.ts
   - test/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 9bdc6e905d93b4bab9bb33972f7eedb5e9a447a6
+lastReviewedCommit: 3a5af4677994de587b31bc80ebac2f16f9d65442
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -124,12 +124,13 @@ These modules share one contract:
 Dataset-local governance now uses the same CLI-native command layer:
 
 - `src/lib/dataset-validate.ts`
+- `src/lib/dataset-curation-queue.ts`
 - `src/lib/dataset-references-rewrite.ts`
 - `src/lib/dataset-local.ts`
 - `src/lib/lifecyclemodel-save-draft-run.ts`
 - `src/lib/lifecyclemodel-graph.ts`
 
-These modules keep validation, reference rewrites, save-draft preparation, graph extraction, and local artifact reports inside the CLI instead of routing through skills or MCP transports.
+These modules keep validation, entity-level curation queue state, reference rewrites, save-draft preparation, graph extraction, and local artifact reports inside the CLI instead of routing through skills or MCP transports.
 
 ### Artifact and filesystem behavior
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -83,7 +83,7 @@ Facts that matter:
 - `npm run prepush:gate` is the exact local test gate
 - the local `pre-push` hook runs docpact first and then `npm run prepush:gate`
 - `.github/workflows/quality-gate.yml` is manual-dispatch only for remote reproduction, not an ordinary push-triggered test runner
-- `process save-draft`, `lifecyclemodel save-draft`, dataset governance commands, BuildPlan gates, publish schema/verification gates, and the newer process maintenance commands are expected to preserve `100%` coverage even when they add schema-validation, rewrite, or fallback branches
+- `process save-draft`, `lifecyclemodel save-draft`, dataset governance commands such as curation queue build, BuildPlan gates, publish schema/verification gates, and the newer process maintenance commands are expected to preserve `100%` coverage even when they add schema-validation, rewrite, or fallback branches
 - release-tag and docpact lint workflow changes should be described in the PR note when they alter the local or protected-branch proof
 - `tag-release-from-merge.yml` is idempotent when the expected `cli-v*` tag already points at the merge commit, and `publish.yml` can be re-run with `workflow_dispatch` only for an existing `cli-v*` tag on `origin/main`
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -53,6 +53,8 @@ Before starting a release:
 - confirm npm has not already published the target version
 - confirm any command-surface feature PRs that will be included in the release have passed the local pre-push gate, including `npm run prepush:gate` and docpact, before preparing the version bump
 
+Review note, 2026-06-02: dataset curation queue command additions follow the existing feature-then-release flow; release prep still remains a separate package metadata bump.
+
 Useful commands:
 
 ```bash

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -64,6 +64,8 @@ The current workflows expect a token that can:
 
 GitHub Actions must be enabled for the repository.
 
+Review note, 2026-06-02: adding the dataset curation queue command does not change Trusted Publishing, release token, tag, or workflow setup.
+
 The publish workflow file is fixed at:
 
 - `.github/workflows/publish.yml`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -194,6 +194,11 @@ import {
   type RunDatasetValidateOptions,
 } from './lib/dataset-validate.js';
 import {
+  runDatasetCurationQueueBuild,
+  type DatasetCurationQueueBuildReport,
+  type RunDatasetCurationQueueBuildOptions,
+} from './lib/dataset-curation-queue.js';
+import {
   runDatasetReferencesRewrite,
   type DatasetReferencesRewriteReport,
   type RunDatasetReferencesRewriteOptions,
@@ -357,6 +362,9 @@ export type CliDeps = {
     options: RunFlowBuildPlanMaterializeOptions,
   ) => Promise<FlowBuildPlanGateReport>;
   runDatasetValidateImpl?: (options: RunDatasetValidateOptions) => Promise<DatasetValidateReport>;
+  runDatasetCurationQueueBuildImpl?: (
+    options: RunDatasetCurationQueueBuildOptions,
+  ) => Promise<DatasetCurationQueueBuildReport>;
   runDatasetReferencesRewriteImpl?: (
     options: RunDatasetReferencesRewriteOptions,
   ) => Promise<DatasetReferencesRewriteReport>;
@@ -415,7 +423,7 @@ Implemented Commands:
   doctor     show environment diagnostics
   search     flow | process | lifecyclemodel
   process    get | list | identity-preflight | build-plan | scope-statistics | dedup-review | auto-build | resume-build | publish-build | complete-required-fields | save-draft | batch-build | refresh-references | verify-rows
-  dataset    contract get | context-pack | import-lca convert | author | validate | verify-remote | bilingual extract/apply/validate | evidence-search plan/run | references rewrite/refresh-remote
+  dataset    contract get | context-pack | curation-queue build | import-lca convert | author | validate | verify-remote | bilingual extract/apply/validate | evidence-search plan/run | references rewrite/refresh-remote
   flow       get | list | identity-preflight | build-plan | fetch-rows | materialize-decisions | remediate | publish-version | publish-reviewed-data | build-alias-map | scan-process-flow-refs | plan-process-flow-repairs | apply-process-flow-repairs | regen-product | validate-processes
   lifecyclemodel auto-build | validate-build | publish-build | save-draft | graph | build-resulting-process | publish-resulting-process | orchestrate
   qa         process | flow | lifecyclemodel
@@ -450,6 +458,7 @@ Examples:
   tiangong-lca dataset validate --input ./rows.jsonl --type auto --out-dir /abs/path/to/dataset-validate
   tiangong-lca dataset contract get --type process --include schema,methodology,ruleset --out-dir ./contract
   tiangong-lca dataset context-pack --type process --profile ai-import --out-dir ./context-pack
+  tiangong-lca dataset curation-queue build --processes ./processes.jsonl --flows ./flows.jsonl --out-dir ./curation-queue
   tiangong-lca dataset import-lca convert --input ./external-package --output-dir ./converted --from-format auto --target tidas
   tiangong-lca dataset author --input ./source.pdf --target-types process,flow --out-dir ./authoring
   tiangong-lca dataset verify-remote --input ./rows.jsonl --out-dir /abs/path/to/dataset-remote-verify
@@ -597,6 +606,7 @@ function renderDatasetHelp(): string {
 Implemented Subcommands:
   contract get        Write TIDAS schema / methodology / ruleset contract artifacts
   context-pack        Write an AI-ready TIDAS contract context pack
+  curation-queue build Build entity-level AI curation queue artifacts for Foundry imports
   import-lca convert  Convert supported external LCA packages through tidas-tools
   author              Extract source evidence and prepare TIDAS context packs for AI authoring
   validate             Validate local flow / process / lifecyclemodel rows with the TIDAS SDK
@@ -611,6 +621,7 @@ Implemented Subcommands:
 Examples:
   tiangong-lca dataset contract get --type process --include schema,methodology,ruleset --out-dir ./contract --help
   tiangong-lca dataset context-pack --type process --profile ai-import --out-dir ./context-pack --help
+  tiangong-lca dataset curation-queue build --processes ./rows/processes.jsonl --flows ./rows/flows.jsonl --support ./rows/sources.jsonl --out-dir ./curation-queue --help
   tiangong-lca dataset import-lca convert --input ./external-package --output-dir ./converted --from-format auto --target tidas --help
   tiangong-lca dataset author --input ./source.pdf --target-types process,flow --out-dir ./authoring --help
   tiangong-lca dataset validate --input ./rows.jsonl --type auto --out-dir ./dataset-validate --help
@@ -666,6 +677,36 @@ Outputs written under --out-dir:
   - outputs/ai-context.json
   - outputs/ai-context.md
   - outputs/contract-report.json
+`.trim();
+}
+
+function renderDatasetCurationQueueHelp(): string {
+  return `Usage:
+  tiangong-lca dataset curation-queue build --processes <file> --out-dir <dir> [options]
+
+Options:
+  --processes <file>         Process rows JSON/JSONL
+  --flows <file>             Local flow rows JSON/JSONL used by process references
+  --support <file>           Repeatable support rows JSON/JSONL, for source/contact/unitgroup/flowproperty rows
+  --external-flow-ref <file> Repeatable external flow ref rows JSON/JSONL treated as already resolvable
+  --exclude-process-id <id>  Repeatable process id to skip
+  --process-limit <n>        Limit process tasks for focused validation or retries
+  --out-dir <dir>            Queue artifact directory
+  --json                     Print compact JSON
+  -h, --help
+
+Outputs written under --out-dir:
+  - outputs/curation-queue-manifest.json
+  - outputs/curation-queue-tasks.jsonl
+  - outputs/curation-queue-locks.json
+  - outputs/curation-queue-blockers.jsonl
+  - entities/<supports|flows|processes>/<id>__<version>/input.jsonl
+  - entities/<supports|flows|processes>/<id>__<version>/closure.json
+  - entities/<supports|flows|processes>/<id>__<version>/entity-run-plan.json
+
+Contract:
+  This command builds the queue only. AI authoring must write structured patches or build plans,
+  and remote writes remain blocked until deterministic apply, schema/QA, prewrite verify, and readback gates pass.
 `.trim();
 }
 
@@ -2289,6 +2330,66 @@ function parseDatasetContractFlags(args: string[]): {
       : [],
     profile: typeof values.profile === 'string' ? values.profile : undefined,
     outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : null,
+  };
+}
+
+function parseDatasetCurationQueueBuildFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  processesPath: string;
+  flowsPath: string | undefined;
+  supportPaths: string[];
+  externalFlowRefPaths: string[];
+  outDir: string;
+  excludeProcessIds: string[];
+  processLimit: number | undefined;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        processes: { type: 'string' },
+        flows: { type: 'string' },
+        support: { type: 'string', multiple: true },
+        'external-flow-ref': { type: 'string', multiple: true },
+        'exclude-process-id': { type: 'string', multiple: true },
+        'process-limit': { type: 'string' },
+        'out-dir': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  const processLimit =
+    typeof values['process-limit'] === 'string'
+      ? Number.parseInt(values['process-limit'], 10)
+      : undefined;
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    processesPath: typeof values.processes === 'string' ? values.processes : '',
+    flowsPath: typeof values.flows === 'string' ? values.flows : undefined,
+    supportPaths: Array.isArray(values.support)
+      ? values.support.filter((value): value is string => typeof value === 'string')
+      : [],
+    externalFlowRefPaths: Array.isArray(values['external-flow-ref'])
+      ? values['external-flow-ref'].filter((value): value is string => typeof value === 'string')
+      : [],
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : '',
+    excludeProcessIds: Array.isArray(values['exclude-process-id'])
+      ? values['exclude-process-id'].filter((value): value is string => typeof value === 'string')
+      : [],
+    processLimit,
   };
 }
 
@@ -5008,6 +5109,8 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
     const flowBuildPlanMaterializeImpl =
       deps.runFlowBuildPlanMaterializeImpl ?? runFlowBuildPlanMaterialize;
     const datasetValidateImpl = deps.runDatasetValidateImpl ?? runDatasetValidate;
+    const datasetCurationQueueBuildImpl =
+      deps.runDatasetCurationQueueBuildImpl ?? runDatasetCurationQueueBuild;
     const datasetReferencesRewriteImpl =
       deps.runDatasetReferencesRewriteImpl ?? runDatasetReferencesRewrite;
     const datasetRemoteRefreshImpl = deps.runDatasetRemoteRefreshImpl ?? runDatasetRemoteRefresh;
@@ -5118,6 +5221,37 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
       });
       return {
         exitCode: 0,
+        stdout: stringifyJson(report, datasetFlags.json),
+        stderr: '',
+      };
+    }
+
+    if (command === 'dataset' && subcommand === 'curation-queue') {
+      const action = commandArgs[0] ?? '';
+      if (!action || action === '--help' || action === '-h') {
+        return { exitCode: 0, stdout: `${renderDatasetCurationQueueHelp()}\n`, stderr: '' };
+      }
+      if (action !== 'build') {
+        throw new CliError("dataset curation-queue action must be 'build'.", {
+          code: 'DATASET_CURATION_QUEUE_ACTION_INVALID',
+          exitCode: 2,
+        });
+      }
+      const datasetFlags = parseDatasetCurationQueueBuildFlags(commandArgs.slice(1));
+      if (datasetFlags.help) {
+        return { exitCode: 0, stdout: `${renderDatasetCurationQueueHelp()}\n`, stderr: '' };
+      }
+      const report = await datasetCurationQueueBuildImpl({
+        processesPath: datasetFlags.processesPath,
+        flowsPath: datasetFlags.flowsPath,
+        supportPaths: datasetFlags.supportPaths,
+        externalFlowRefPaths: datasetFlags.externalFlowRefPaths,
+        outDir: datasetFlags.outDir,
+        excludeProcessIds: datasetFlags.excludeProcessIds,
+        processLimit: datasetFlags.processLimit,
+      });
+      return {
+        exitCode: report.status === 'blocked' ? 1 : 0,
         stdout: stringifyJson(report, datasetFlags.json),
         stderr: '',
       };

--- a/src/lib/dataset-curation-queue.ts
+++ b/src/lib/dataset-curation-queue.ts
@@ -1,0 +1,596 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { CliError } from './errors.js';
+import {
+  firstNonEmpty,
+  isRecord,
+  materializeDatasetRows,
+  type DatasetRowInput,
+  type JsonObject,
+} from './dataset-local.js';
+
+export type DatasetCurationQueueEntityType = 'support' | 'flow' | 'process';
+
+export type RunDatasetCurationQueueBuildOptions = {
+  processesPath: string;
+  flowsPath?: string;
+  supportPaths?: string[];
+  externalFlowRefPaths?: string[];
+  outDir: string;
+  excludeProcessIds?: string[];
+  processLimit?: number;
+};
+
+export type DatasetCurationQueueTask = {
+  schema_version: 1;
+  entity_type: DatasetCurationQueueEntityType;
+  task_id: string;
+  entity_id: string;
+  version: string;
+  lock_key: string;
+  depends_on: string[];
+  input_rows_file: string;
+  work_dir: string;
+  checkpoint_file: string;
+  run_plan_file: string;
+  closure_file: string;
+};
+
+type DatasetCurationQueueBlocker = {
+  schema_version: 1;
+  code: string;
+  severity: 'blocker';
+  entity_type: DatasetCurationQueueEntityType;
+  entity_id: string | null;
+  version: string | null;
+  message: string;
+  details?: unknown;
+};
+
+export type DatasetCurationQueueBuildReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: 'ready' | 'blocked';
+  out_dir: string;
+  inputs: {
+    processes: string;
+    flows: string | null;
+    support: string[];
+    external_flow_refs: string[];
+  };
+  counts: {
+    support_rows: number;
+    flow_rows: number;
+    process_rows: number;
+    external_flow_refs: number;
+    tasks: number;
+    blockers: number;
+  };
+  hashes: {
+    inputs: Record<string, string>;
+    task_order: string;
+  };
+  files: {
+    manifest: string;
+    tasks: string;
+    locks: string;
+    blockers: string;
+  };
+  tasks: DatasetCurationQueueTask[];
+  blockers: DatasetCurationQueueBlocker[];
+};
+
+type QueueRow = {
+  entityType: DatasetCurationQueueEntityType;
+  sourcePath: string;
+  sourceIndex: number;
+  row: JsonObject;
+  payload: JsonObject;
+  id: string;
+  version: string;
+};
+
+type FlowRef = {
+  id: string;
+  version: string | null;
+  path: string;
+};
+
+const DEFAULT_VERSION = 'unversioned';
+
+export async function runDatasetCurationQueueBuild(
+  options: RunDatasetCurationQueueBuildOptions,
+): Promise<DatasetCurationQueueBuildReport> {
+  const outDir = requirePath(options.outDir, '--out-dir');
+  const processesPath = requireExistingPath(options.processesPath, '--processes');
+  const flowsPath = options.flowsPath ? requireExistingPath(options.flowsPath, '--flows') : null;
+  const supportPaths = (options.supportPaths ?? []).map((inputPath) =>
+    requireExistingPath(inputPath, '--support'),
+  );
+  const externalFlowRefPaths = (options.externalFlowRefPaths ?? []).map((inputPath) =>
+    requireExistingPath(inputPath, '--external-flow-ref'),
+  );
+  const processLimit = normalizeProcessLimit(options.processLimit);
+  const excludedProcessIds = new Set((options.excludeProcessIds ?? []).map((id) => id.trim()));
+
+  const supportRows = supportPaths.flatMap((inputPath) => readQueueRows(inputPath, 'support'));
+  const flowRows = flowsPath ? readQueueRows(flowsPath, 'flow') : [];
+  const processRows = readQueueRows(processesPath, 'process')
+    .filter((row) => !excludedProcessIds.has(row.id))
+    .slice(0, processLimit ?? undefined);
+  const externalFlowRefs = externalFlowRefPaths.flatMap((inputPath) =>
+    readExternalFlowRefs(inputPath),
+  );
+
+  mkdirSync(outDir, { recursive: true });
+
+  const localFlowTasks = new Map<string, string>();
+  const flowRowsById = new Map<string, QueueRow>();
+  for (const row of flowRows) {
+    const taskId = taskIdFor(row.entityType, row.id, row.version);
+    localFlowTasks.set(row.id, taskId);
+    flowRowsById.set(row.id, row);
+  }
+
+  const externalFlowIds = new Set(externalFlowRefs.map((ref) => ref.id));
+  const blockers: DatasetCurationQueueBlocker[] = [];
+  const supportTasks = supportRows.map((row) => buildTask(outDir, row, []));
+  const flowTasks = flowRows.map((row) => buildTask(outDir, row, []));
+  const processTasks = processRows.map((row) => {
+    const refs = extractProcessFlowRefs(row.payload);
+    const dependsOn = new Set<string>();
+    const missingRefs: FlowRef[] = [];
+    for (const ref of refs) {
+      const taskId = localFlowTasks.get(ref.id);
+      if (taskId) {
+        dependsOn.add(taskId);
+      } else if (!externalFlowIds.has(ref.id)) {
+        missingRefs.push(ref);
+      }
+    }
+    if (missingRefs.length > 0) {
+      blockers.push({
+        schema_version: 1,
+        code: 'process_flow_reference_unresolved',
+        severity: 'blocker',
+        entity_type: 'process',
+        entity_id: row.id,
+        version: row.version,
+        message:
+          'Process references flows that are neither present in local flow rows nor declared as external flow refs.',
+        details: { missing_flow_refs: missingRefs },
+      });
+    }
+    return buildTask(outDir, row, [...dependsOn].sort());
+  });
+  const tasks = [...supportTasks, ...flowTasks, ...processTasks];
+  const taskRows = [
+    ...supportRows.map((row, index) => ({ row, task: supportTasks[index] })),
+    ...flowRows.map((row, index) => ({ row, task: flowTasks[index] })),
+    ...processRows.map((row, index) => ({ row, task: processTasks[index] })),
+  ];
+
+  for (const { row, task } of taskRows) {
+    writeEntityArtifacts({
+      row,
+      task,
+      flowRefs: row.entityType === 'process' ? extractProcessFlowRefs(row.payload) : [],
+      externalFlowIds,
+      flowRowsById,
+    });
+  }
+
+  const outputsDir = path.join(outDir, 'outputs');
+  mkdirSync(outputsDir, { recursive: true });
+  const manifestPath = path.join(outputsDir, 'curation-queue-manifest.json');
+  const tasksPath = path.join(outputsDir, 'curation-queue-tasks.jsonl');
+  const locksPath = path.join(outputsDir, 'curation-queue-locks.json');
+  const blockersPath = path.join(outputsDir, 'curation-queue-blockers.jsonl');
+  const inputHashes = buildInputHashes([
+    processesPath,
+    ...(flowsPath ? [flowsPath] : []),
+    ...supportPaths,
+    ...externalFlowRefPaths,
+  ]);
+  const locks = {
+    schema_version: 1,
+    generated_at_utc: new Date().toISOString(),
+    locks: tasks.map((task) => ({
+      lock_key: task.lock_key,
+      task_id: task.task_id,
+      entity_type: task.entity_type,
+      entity_id: task.entity_id,
+      version: task.version,
+      status: 'available',
+    })),
+  };
+  const report: DatasetCurationQueueBuildReport = {
+    schema_version: 1,
+    generated_at_utc: new Date().toISOString(),
+    status: blockers.length > 0 ? 'blocked' : 'ready',
+    out_dir: path.resolve(outDir),
+    inputs: {
+      processes: path.resolve(processesPath),
+      flows: flowsPath ? path.resolve(flowsPath) : null,
+      support: supportPaths.map((inputPath) => path.resolve(inputPath)),
+      external_flow_refs: externalFlowRefPaths.map((inputPath) => path.resolve(inputPath)),
+    },
+    counts: {
+      support_rows: supportRows.length,
+      flow_rows: flowRows.length,
+      process_rows: processRows.length,
+      external_flow_refs: externalFlowRefs.length,
+      tasks: tasks.length,
+      blockers: blockers.length,
+    },
+    hashes: {
+      inputs: inputHashes,
+      task_order: sha256(tasks.map((task) => task.task_id).join('\n')),
+    },
+    files: {
+      manifest: manifestPath,
+      tasks: tasksPath,
+      locks: locksPath,
+      blockers: blockersPath,
+    },
+    tasks,
+    blockers,
+  };
+
+  writeJson(manifestPath, report);
+  writeText(tasksPath, jsonLines(tasks));
+  writeJson(locksPath, locks);
+  writeText(blockersPath, jsonLines(blockers));
+  return report;
+}
+
+function readQueueRows(inputPath: string, entityType: DatasetCurationQueueEntityType): QueueRow[] {
+  const rows = materializeDatasetRows(inputPath);
+  return rows.map((row) => queueRowFromDatasetRow(inputPath, entityType, row));
+}
+
+function queueRowFromDatasetRow(
+  inputPath: string,
+  entityType: DatasetCurationQueueEntityType,
+  row: DatasetRowInput,
+): QueueRow {
+  const tidasIdentity = genericTidasDatasetIdentity(row.payload);
+  const id = firstNonEmpty(row.id, row.row.id, row.row.dataset_id, row.row.uuid, tidasIdentity.id);
+  if (!id) {
+    throw new CliError(
+      `${entityType} row is missing a stable id in ${inputPath} at index ${row.index}.`,
+      {
+        code: 'CURATION_QUEUE_ROW_ID_MISSING',
+        exitCode: 2,
+      },
+    );
+  }
+  return {
+    entityType,
+    sourcePath: inputPath,
+    sourceIndex: row.index,
+    row: row.row,
+    payload: row.payload,
+    id,
+    version: firstNonEmpty(row.version, row.row.version, tidasIdentity.version) ?? DEFAULT_VERSION,
+  };
+}
+
+function genericTidasDatasetIdentity(payload: JsonObject): {
+  id: string | null;
+  version: string | null;
+} {
+  const root = genericTidasDatasetRoot(payload);
+  const information = Object.values(root).find(
+    (value) => isRecord(value) && isRecord(value.dataSetInformation),
+  );
+  const dataSetInformation =
+    isRecord(information) && isRecord(information.dataSetInformation)
+      ? information.dataSetInformation
+      : {};
+  const administrativeInformation = isRecord(root.administrativeInformation)
+    ? root.administrativeInformation
+    : {};
+  const publicationAndOwnership = isRecord(administrativeInformation.publicationAndOwnership)
+    ? administrativeInformation.publicationAndOwnership
+    : {};
+
+  return {
+    id: firstNonEmpty(dataSetInformation['common:UUID']),
+    version: firstNonEmpty(publicationAndOwnership['common:dataSetVersion']),
+  };
+}
+
+function genericTidasDatasetRoot(payload: JsonObject): JsonObject {
+  const datasetRoots: JsonObject[] = [];
+  for (const [key, value] of Object.entries(payload)) {
+    if (key.endsWith('DataSet') && isRecord(value)) {
+      datasetRoots.push(value);
+    }
+  }
+  return datasetRoots.length === 1 ? datasetRoots[0] : payload;
+}
+
+function buildTask(outDir: string, row: QueueRow, dependsOn: string[]): DatasetCurationQueueTask {
+  const taskId = taskIdFor(row.entityType, row.id, row.version);
+  const workDir = path.join(
+    outDir,
+    'entities',
+    entityDirPlural(row.entityType),
+    entityDirName(row.id, row.version),
+  );
+  return {
+    schema_version: 1,
+    entity_type: row.entityType,
+    task_id: taskId,
+    entity_id: row.id,
+    version: row.version,
+    lock_key: taskId,
+    depends_on: dependsOn,
+    input_rows_file: path.join(workDir, 'input.jsonl'),
+    work_dir: workDir,
+    checkpoint_file: path.join(workDir, 'checkpoint.json'),
+    run_plan_file: path.join(workDir, 'entity-run-plan.json'),
+    closure_file: path.join(workDir, 'closure.json'),
+  };
+}
+
+function writeEntityArtifacts(options: {
+  row: QueueRow;
+  task: DatasetCurationQueueTask;
+  flowRefs: FlowRef[];
+  externalFlowIds: Set<string>;
+  flowRowsById: Map<string, QueueRow>;
+}): void {
+  mkdirSync(path.join(options.task.work_dir, 'checkpoints'), { recursive: true });
+  writeText(options.task.input_rows_file, jsonLines([options.row.row]));
+  writeJson(options.task.closure_file, {
+    schema_version: 1,
+    entity_type: options.row.entityType,
+    entity_id: options.row.id,
+    version: options.row.version,
+    source: {
+      file: path.resolve(options.row.sourcePath),
+      index: options.row.sourceIndex,
+    },
+    dependencies: buildDependencyClosure(options),
+  });
+  writeJson(options.task.run_plan_file, buildRunPlan(options.task));
+}
+
+function buildDependencyClosure(options: {
+  row: QueueRow;
+  task: DatasetCurationQueueTask;
+  flowRefs: FlowRef[];
+  externalFlowIds: Set<string>;
+  flowRowsById: Map<string, QueueRow>;
+}): unknown {
+  if (options.row.entityType !== 'process') {
+    return {
+      local_tasks: [],
+      external_refs: [],
+      unresolved_refs: [],
+    };
+  }
+  return {
+    local_tasks: options.flowRefs
+      .map((ref) => ({ ref, row: options.flowRowsById.get(ref.id) }))
+      .filter((item): item is { ref: FlowRef; row: QueueRow } => Boolean(item.row))
+      .map(({ ref, row }) => ({
+        entity_type: 'flow',
+        entity_id: ref.id,
+        version: row.version,
+        task_id: taskIdFor('flow', ref.id, row.version),
+        ref_path: ref.path,
+      })),
+    external_refs: options.flowRefs
+      .filter((ref) => !options.flowRowsById.has(ref.id) && options.externalFlowIds.has(ref.id))
+      .map((ref) => ({
+        entity_type: 'flow',
+        entity_id: ref.id,
+        version: ref.version,
+        ref_path: ref.path,
+      })),
+    unresolved_refs: options.flowRefs
+      .filter((ref) => !options.flowRowsById.has(ref.id) && !options.externalFlowIds.has(ref.id))
+      .map((ref) => ({
+        entity_type: 'flow',
+        entity_id: ref.id,
+        version: ref.version,
+        ref_path: ref.path,
+      })),
+  };
+}
+
+function buildRunPlan(task: DatasetCurationQueueTask): unknown {
+  const stagesByType: Record<DatasetCurationQueueEntityType, string[]> = {
+    support: ['identity', 'schema', 'qa_or_profile', 'checkpoint'],
+    flow: ['identity', 'name_plan', 'schema', 'qa', 'checkpoint'],
+    process: [
+      'dependency_closure',
+      'reference_refresh',
+      'required_fields',
+      'schema',
+      'qa',
+      'curation',
+      'remote_dry_run',
+      'readback',
+    ],
+  };
+  return {
+    schema_version: 1,
+    task_id: task.task_id,
+    entity_type: task.entity_type,
+    entity_id: task.entity_id,
+    version: task.version,
+    input_rows_file: task.input_rows_file,
+    checkpoint_file: task.checkpoint_file,
+    stages: stagesByType[task.entity_type].map((stage) => ({
+      id: stage,
+      status: 'pending',
+      checkpoint_file: path.join(task.work_dir, 'checkpoints', `${stage}.json`),
+    })),
+    ai_authoring_policy: {
+      output_only: 'structured_patch_or_build_plan',
+      deterministic_apply_required: true,
+      remote_write_allowed: false,
+    },
+  };
+}
+
+function extractProcessFlowRefs(payload: unknown): FlowRef[] {
+  const refs = new Map<string, FlowRef>();
+  scanForFlowRefs(payload, [], refs);
+  return [...refs.values()].sort((a, b) =>
+    `${a.id}@${a.version ?? ''}`.localeCompare(`${b.id}@${b.version ?? ''}`),
+  );
+}
+
+function scanForFlowRefs(value: unknown, pathParts: string[], refs: Map<string, FlowRef>): void {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => scanForFlowRefs(item, [...pathParts, String(index)], refs));
+    return;
+  }
+  if (!isRecord(value)) {
+    return;
+  }
+
+  const keyPath = pathParts.join('.');
+  const keyHint = keyPath.toLowerCase();
+  const looksLikeFlowRef =
+    keyHint.includes('referencetoflowdataset') ||
+    keyHint.includes('reference_to_flow_dataset') ||
+    keyHint.includes('flowdataset') ||
+    keyHint.includes('flow_dataset');
+  if (looksLikeFlowRef) {
+    const id = firstNonEmpty(
+      value['@refObjectId'],
+      value.refObjectId,
+      value.ref_object_id,
+      value.id,
+      value.uuid,
+      value['common:UUID'],
+    );
+    if (id) {
+      const version = firstNonEmpty(
+        value['@version'],
+        value.version,
+        value.dataSetVersion,
+        value['common:dataSetVersion'],
+      );
+      refs.set(`${id}@${version ?? ''}@${keyPath}`, {
+        id,
+        version,
+        path: keyPath,
+      });
+    }
+  }
+
+  for (const [key, nested] of Object.entries(value)) {
+    scanForFlowRefs(nested, [...pathParts, key], refs);
+  }
+}
+
+function readExternalFlowRefs(inputPath: string): FlowRef[] {
+  const rows = materializeDatasetRows(inputPath);
+  return rows.map((row) => {
+    const id = firstNonEmpty(row.id, row.row.id, row.row.dataset_id, row.row.uuid);
+    if (!id) {
+      throw new CliError(`External flow ref is missing id in ${inputPath} at index ${row.index}.`, {
+        code: 'CURATION_QUEUE_EXTERNAL_FLOW_REF_ID_MISSING',
+        exitCode: 2,
+      });
+    }
+    return {
+      id,
+      version: firstNonEmpty(row.version, row.row.version) ?? null,
+      path: `${inputPath}#${row.index}`,
+    };
+  });
+}
+
+function normalizeProcessLimit(value: number | undefined): number | null {
+  if (value === undefined) {
+    return null;
+  }
+  if (!Number.isInteger(value) || value < 1) {
+    throw new CliError('--process-limit must be a positive integer.', {
+      code: 'CURATION_QUEUE_PROCESS_LIMIT_INVALID',
+      exitCode: 2,
+    });
+  }
+  return value;
+}
+
+function requirePath(value: string | undefined, flag: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    throw new CliError(`${flag} is required.`, {
+      code: 'CURATION_QUEUE_REQUIRED_FLAG_MISSING',
+      exitCode: 2,
+    });
+  }
+  return trimmed;
+}
+
+function requireExistingPath(value: string | undefined, flag: string): string {
+  const inputPath = requirePath(value, flag);
+  if (!existsSync(inputPath)) {
+    throw new CliError(`${flag} file does not exist: ${inputPath}`, {
+      code: 'CURATION_QUEUE_INPUT_NOT_FOUND',
+      exitCode: 2,
+    });
+  }
+  return inputPath;
+}
+
+function entityDirPlural(entityType: DatasetCurationQueueEntityType): string {
+  return entityType === 'process' ? 'processes' : entityType === 'flow' ? 'flows' : 'supports';
+}
+
+function entityDirName(id: string, version: string): string {
+  return `${sanitizePathToken(id)}__${sanitizePathToken(version)}`;
+}
+
+function taskIdFor(
+  entityType: DatasetCurationQueueEntityType,
+  id: string,
+  version: string,
+): string {
+  return `${entityType}:${id}@${version}`;
+}
+
+function sanitizePathToken(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]+/gu, '_').replace(/^_+|_+$/gu, '') || 'unknown';
+}
+
+function buildInputHashes(inputPaths: string[]): Record<string, string> {
+  const hashes: Record<string, string> = {};
+  for (const inputPath of inputPaths) {
+    hashes[path.resolve(inputPath)] = sha256(readFileSync(inputPath));
+  }
+  return hashes;
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function writeText(filePath: string, value: string): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, value, 'utf8');
+}
+
+function jsonLines(rows: unknown[]): string {
+  return rows.map((row) => JSON.stringify(row)).join('\n') + (rows.length > 0 ? '\n' : '');
+}
+
+export const __testInternals = {
+  extractProcessFlowRefs,
+};

--- a/test/dataset-curation-queue.test.ts
+++ b/test/dataset-curation-queue.test.ts
@@ -1,0 +1,494 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { executeCli } from '../src/cli.js';
+import {
+  runDatasetCurationQueueBuild,
+  __testInternals,
+  type DatasetCurationQueueBuildReport,
+} from '../src/lib/dataset-curation-queue.js';
+import type { DotEnvLoadResult } from '../src/lib/dotenv.js';
+import type { FetchLike } from '../src/lib/http.js';
+
+const dotEnvStatus: DotEnvLoadResult = {
+  loaded: false,
+  path: '/tmp/.env',
+  count: 0,
+};
+
+const deps = {
+  env: {},
+  dotEnvStatus,
+  fetchImpl: (async () => ({
+    ok: true,
+    status: 200,
+    headers: { get: () => 'application/json' },
+    text: async () => JSON.stringify({ ok: true }),
+  })) as FetchLike,
+};
+
+function writeJsonl(filePath: string, rows: unknown[]): void {
+  writeFileSync(filePath, rows.map((row) => JSON.stringify(row)).join('\n') + '\n', 'utf8');
+}
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+function makeFlow(id = 'flow-1') {
+  return {
+    id,
+    version: '01.00.000',
+    json_ordered: {
+      flowDataSet: {
+        flowInformation: {
+          dataSetInformation: {
+            'common:UUID': id,
+          },
+        },
+        administrativeInformation: {
+          publicationAndOwnership: {
+            'common:dataSetVersion': '01.00.000',
+          },
+        },
+      },
+    },
+  };
+}
+
+function makeProcess(flowId = 'flow-1') {
+  return {
+    id: 'process-1',
+    version: '01.00.000',
+    json_ordered: {
+      processDataSet: {
+        processInformation: {
+          dataSetInformation: {
+            'common:UUID': 'process-1',
+          },
+        },
+        exchanges: {
+          exchange: [
+            {
+              referenceToFlowDataSet: {
+                '@refObjectId': flowId,
+                '@version': '01.00.000',
+              },
+            },
+          ],
+        },
+        administrativeInformation: {
+          publicationAndOwnership: {
+            'common:dataSetVersion': '01.00.000',
+          },
+        },
+      },
+    },
+  };
+}
+
+function makeSource() {
+  return {
+    sourceDataSet: {
+      sourceInformation: {
+        dataSetInformation: {
+          'common:UUID': 'source-1',
+        },
+      },
+      administrativeInformation: {
+        publicationAndOwnership: {
+          'common:dataSetVersion': '01.00.000',
+        },
+      },
+    },
+  };
+}
+
+test('runDatasetCurationQueueBuild writes entity-level queue artifacts', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-curation-queue-'));
+  const processes = path.join(dir, 'processes.jsonl');
+  const flows = path.join(dir, 'flows.jsonl');
+  const support = path.join(dir, 'sources.jsonl');
+  const outDir = path.join(dir, 'queue');
+  writeJsonl(processes, [makeProcess()]);
+  writeJsonl(flows, [makeFlow()]);
+  writeJsonl(support, [makeSource()]);
+
+  try {
+    const report = await runDatasetCurationQueueBuild({
+      processesPath: processes,
+      flowsPath: flows,
+      supportPaths: [support],
+      outDir,
+    });
+
+    assert.equal(report.status, 'ready');
+    assert.equal(report.counts.tasks, 3);
+    assert.equal(report.counts.blockers, 0);
+    assert.equal(existsSync(report.files.manifest), true);
+    assert.equal(existsSync(report.files.tasks), true);
+    assert.equal(existsSync(report.files.locks), true);
+    assert.equal(existsSync(report.files.blockers), true);
+
+    const supportTask = report.tasks.find((task) => task.entity_type === 'support');
+    assert.ok(supportTask);
+    assert.equal(supportTask.entity_id, 'source-1');
+    assert.equal(supportTask.version, '01.00.000');
+
+    const processTask = report.tasks.find((task) => task.entity_type === 'process');
+    assert.ok(processTask);
+    assert.deepEqual(processTask.depends_on, ['flow:flow-1@01.00.000']);
+    assert.equal(existsSync(processTask.input_rows_file), true);
+    assert.equal(existsSync(processTask.closure_file), true);
+    assert.equal(existsSync(processTask.run_plan_file), true);
+    assert.match(readFileSync(processTask.run_plan_file, 'utf8'), /dependency_closure/u);
+
+    const manifest = readJson(report.files.manifest) as DatasetCurationQueueBuildReport;
+    assert.equal(manifest.hashes.task_order, report.hashes.task_order);
+    assert.deepEqual(manifest.counts, report.counts);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runDatasetCurationQueueBuild blocks unresolved process flow references', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-curation-queue-blocker-'));
+  const processes = path.join(dir, 'processes.jsonl');
+  const flows = path.join(dir, 'flows.jsonl');
+  const outDir = path.join(dir, 'queue');
+  writeJsonl(processes, [makeProcess('missing-flow')]);
+  writeJsonl(flows, [makeFlow()]);
+
+  try {
+    const report = await runDatasetCurationQueueBuild({
+      processesPath: processes,
+      flowsPath: flows,
+      outDir,
+    });
+
+    assert.equal(report.status, 'blocked');
+    assert.equal(report.counts.blockers, 1);
+    assert.equal(report.blockers[0]?.code, 'process_flow_reference_unresolved');
+    assert.match(readFileSync(report.files.blockers, 'utf8'), /missing-flow/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runDatasetCurationQueueBuild accepts external flow refs and focused process subsets', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-curation-queue-external-'));
+  const processes = path.join(dir, 'processes.jsonl');
+  const externalRefs = path.join(dir, 'external-flows.jsonl');
+  const outDir = path.join(dir, 'queue');
+  writeJsonl(processes, [makeProcess('external-flow'), makeProcess('skipped-flow')]);
+  writeJsonl(externalRefs, [
+    { id: 'external-flow', version: '02.00.000' },
+    { id: 'external-unused' },
+  ]);
+
+  try {
+    const report = await runDatasetCurationQueueBuild({
+      processesPath: processes,
+      externalFlowRefPaths: [externalRefs],
+      excludeProcessIds: ['skipped-process', 'process-skip', 'process-2'],
+      processLimit: 1,
+      outDir,
+    });
+
+    assert.equal(report.status, 'ready');
+    assert.equal(report.inputs.flows, null);
+    assert.equal(report.counts.flow_rows, 0);
+    assert.equal(report.counts.process_rows, 1);
+    assert.equal(report.counts.external_flow_refs, 2);
+
+    const processTask = report.tasks.find((task) => task.entity_type === 'process');
+    assert.ok(processTask);
+    const closure = readJson(processTask.closure_file) as {
+      dependencies?: { external_refs?: Array<{ entity_id: string }> };
+    };
+    assert.equal(closure.dependencies?.external_refs?.[0]?.entity_id, 'external-flow');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runDatasetCurationQueueBuild supports unversioned rows and sanitized entity directories', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-curation-queue-unversioned-'));
+  const processes = path.join(dir, 'processes.jsonl');
+  const outDir = path.join(dir, 'queue');
+  writeJsonl(processes, [
+    {
+      id: '$$$',
+      json_ordered: {
+        processDataSet: {
+          processInformation: {
+            dataSetInformation: {
+              'common:UUID': '$$$',
+            },
+          },
+        },
+      },
+    },
+  ]);
+
+  try {
+    const report = await runDatasetCurationQueueBuild({
+      processesPath: processes,
+      outDir,
+    });
+
+    assert.equal(report.status, 'ready');
+    assert.equal(report.tasks[0]?.version, 'unversioned');
+    assert.match(report.tasks[0]?.work_dir ?? '', /unknown__unversioned/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runDatasetCurationQueueBuild validates required flags and row identities', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-curation-queue-errors-'));
+  const processes = path.join(dir, 'processes.jsonl');
+  const externalRefs = path.join(dir, 'external-flows.jsonl');
+  writeJsonl(processes, [makeProcess()]);
+  writeJsonl(externalRefs, [{ payload: {} }]);
+
+  try {
+    await assert.rejects(
+      () => runDatasetCurationQueueBuild({ processesPath: '', outDir: path.join(dir, 'queue') }),
+      /--processes is required/u,
+    );
+    await assert.rejects(
+      () =>
+        runDatasetCurationQueueBuild({
+          processesPath: path.join(dir, 'missing.jsonl'),
+          outDir: path.join(dir, 'queue'),
+        }),
+      /file does not exist/u,
+    );
+    await assert.rejects(
+      () =>
+        runDatasetCurationQueueBuild({
+          processesPath: processes,
+          processLimit: 0,
+          outDir: path.join(dir, 'queue'),
+        }),
+      /--process-limit must be a positive integer/u,
+    );
+    await assert.rejects(
+      () =>
+        runDatasetCurationQueueBuild({
+          processesPath: externalRefs,
+          outDir: path.join(dir, 'queue'),
+        }),
+      /process row is missing a stable id/u,
+    );
+    await assert.rejects(
+      () =>
+        runDatasetCurationQueueBuild({
+          processesPath: processes,
+          externalFlowRefPaths: [externalRefs],
+          outDir: path.join(dir, 'queue'),
+        }),
+      /External flow ref is missing id/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('dataset curation queue flow ref extraction covers supported reference shapes', () => {
+  const refs = __testInternals.extractProcessFlowRefs({
+    noRef: 'ignored',
+    flow_dataset: {
+      refObjectId: 'flow-a',
+      version: '01',
+    },
+    nested: [
+      null,
+      {
+        reference_to_flow_dataset: {
+          ref_object_id: 'flow-b',
+          dataSetVersion: '02',
+        },
+      },
+      {
+        flowDataSet: {
+          uuid: 'flow-c',
+          'common:dataSetVersion': '03',
+        },
+      },
+      {
+        referenceToFlowDataSet: {
+          'common:UUID': 'flow-d',
+        },
+      },
+      {
+        referenceToFlowDataSet: {
+          id: 'flow-e',
+        },
+      },
+    ],
+  });
+
+  assert.deepEqual(
+    refs.map((ref) => `${ref.id}@${ref.version ?? ''}`),
+    ['flow-a@01', 'flow-b@02', 'flow-c@03', 'flow-d@', 'flow-e@'],
+  );
+});
+
+test('executeCli executes dataset curation-queue build with injected implementation', async () => {
+  const result = await executeCli(
+    [
+      'dataset',
+      'curation-queue',
+      'build',
+      '--json',
+      '--processes',
+      './processes.jsonl',
+      '--flows',
+      './flows.jsonl',
+      '--support',
+      './sources.jsonl',
+      '--external-flow-ref',
+      './external-flows.jsonl',
+      '--exclude-process-id',
+      'process-skip',
+      '--process-limit',
+      '2',
+      '--out-dir',
+      './queue',
+    ],
+    {
+      ...deps,
+      runDatasetCurationQueueBuildImpl: async (options) => {
+        assert.equal(options.processesPath, './processes.jsonl');
+        assert.equal(options.flowsPath, './flows.jsonl');
+        assert.deepEqual(options.supportPaths, ['./sources.jsonl']);
+        assert.deepEqual(options.externalFlowRefPaths, ['./external-flows.jsonl']);
+        assert.deepEqual(options.excludeProcessIds, ['process-skip']);
+        assert.equal(options.processLimit, 2);
+        assert.equal(options.outDir, './queue');
+        return {
+          schema_version: 1,
+          generated_at_utc: '2026-06-02T00:00:00.000Z',
+          status: 'ready',
+          out_dir: '/tmp/queue',
+          inputs: {
+            processes: '/tmp/processes.jsonl',
+            flows: '/tmp/flows.jsonl',
+            support: ['/tmp/sources.jsonl'],
+            external_flow_refs: ['/tmp/external-flows.jsonl'],
+          },
+          counts: {
+            support_rows: 1,
+            flow_rows: 1,
+            process_rows: 1,
+            external_flow_refs: 1,
+            tasks: 3,
+            blockers: 0,
+          },
+          hashes: {
+            inputs: {},
+            task_order: 'abc',
+          },
+          files: {
+            manifest: '/tmp/queue/outputs/curation-queue-manifest.json',
+            tasks: '/tmp/queue/outputs/curation-queue-tasks.jsonl',
+            locks: '/tmp/queue/outputs/curation-queue-locks.json',
+            blockers: '/tmp/queue/outputs/curation-queue-blockers.jsonl',
+          },
+          tasks: [],
+          blockers: [],
+        };
+      },
+    },
+  );
+
+  assert.equal(result.exitCode, 0);
+  assert.match(result.stdout, /"status":"ready"/u);
+});
+
+test('executeCli exposes dataset curation-queue help and errors', async () => {
+  const namespaceHelp = await executeCli(['dataset', 'curation-queue'], deps);
+  assert.equal(namespaceHelp.exitCode, 0);
+  assert.match(namespaceHelp.stdout, /dataset curation-queue build/u);
+
+  const actionHelp = await executeCli(['dataset', 'curation-queue', 'build', '--help'], deps);
+  assert.equal(actionHelp.exitCode, 0);
+  assert.match(actionHelp.stdout, /curation-queue-blockers\.jsonl/u);
+
+  const invalidAction = await executeCli(['dataset', 'curation-queue', 'next'], deps);
+  assert.equal(invalidAction.exitCode, 2);
+  assert.match(invalidAction.stderr, /action must be 'build'/u);
+
+  const invalidFlag = await executeCli(
+    ['dataset', 'curation-queue', 'build', '--processes', './rows.jsonl', '--bad-flag'],
+    deps,
+  );
+  assert.equal(invalidFlag.exitCode, 2);
+  assert.match(invalidFlag.stderr, /Unknown option/u);
+});
+
+test('executeCli maps dataset curation-queue blockers to exit code 1', async () => {
+  const result = await executeCli(
+    [
+      'dataset',
+      'curation-queue',
+      'build',
+      '--processes',
+      './processes.jsonl',
+      '--out-dir',
+      './queue',
+    ],
+    {
+      ...deps,
+      runDatasetCurationQueueBuildImpl: async () => ({
+        schema_version: 1,
+        generated_at_utc: '2026-06-02T00:00:00.000Z',
+        status: 'blocked',
+        out_dir: '/tmp/queue',
+        inputs: {
+          processes: '/tmp/processes.jsonl',
+          flows: null,
+          support: [],
+          external_flow_refs: [],
+        },
+        counts: {
+          support_rows: 0,
+          flow_rows: 0,
+          process_rows: 1,
+          external_flow_refs: 0,
+          tasks: 1,
+          blockers: 1,
+        },
+        hashes: {
+          inputs: {},
+          task_order: 'abc',
+        },
+        files: {
+          manifest: '/tmp/queue/outputs/curation-queue-manifest.json',
+          tasks: '/tmp/queue/outputs/curation-queue-tasks.jsonl',
+          locks: '/tmp/queue/outputs/curation-queue-locks.json',
+          blockers: '/tmp/queue/outputs/curation-queue-blockers.jsonl',
+        },
+        tasks: [],
+        blockers: [
+          {
+            schema_version: 1,
+            code: 'process_flow_reference_unresolved',
+            severity: 'blocker',
+            entity_type: 'process',
+            entity_id: 'process-1',
+            version: '01.00.000',
+            message: 'missing flow',
+          },
+        ],
+      }),
+    },
+  );
+
+  assert.equal(result.exitCode, 1);
+  assert.match(result.stdout, /process_flow_reference_unresolved/u);
+});


### PR DESCRIPTION
Closes #141

## Summary
- Add `tiangong-lca dataset curation-queue build` for entity-level Foundry import queues.
- Write manifest, tasks, locks, blockers, per-entity input, closure, and run-plan artifacts.
- Resolve process flow dependencies against local flow rows or explicit external flow refs, and extract canonical TIDAS support-row identity from `*DataSet` payloads.

## Validation
- `npm run prepush:gate`
- Real BAFU two-process validation through Foundry wrapper: 42 tasks, 0 blockers; target processes had 13 and 12 local flow dependencies with 0 unresolved refs.
- Foundry curation gate package check confirmed schema/YAML/ruleset plus queue closure, referenced flow rows, and support rows are available for AI authoring.
