### PR TITLE
Release CLI 0.0.11

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,5 +1,6 @@
 version: 1
 layout: repo
+# Review note, 2026-06-02: release 0.0.11 prep keeps docpact ownership and coverage rules unchanged.
 lastReviewedAt: "2026-06-02"
 lastReviewedCommit: "3a5af4677994de587b31bc80ebac2f16f9d65442"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,8 @@ related:
 
 `tiangong-lca-cli` owns the checked-in public `tiangong-lca` CLI contract: command nouns and verbs, launcher behavior, local artifact workflow, remote session/auth handling, and the repo-level release gate. Start here when the task may change what the CLI does or how it is validated.
 
+Review note, 2026-06-02: release 0.0.11 is a package metadata release for the merged dataset curation queue command; repo ownership boundaries remain unchanged.
+
 ## Bootstrap Order
 
 Load docs in this order:

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -40,6 +40,8 @@ related:
 
 This repo is organized around one stable launcher plus a library-style `src/lib/**` tree that implements command families and shared helpers.
 
+Review note, 2026-06-02: release 0.0.11 does not change CLI architecture; it publishes the existing dataset curation queue command family through the normal package release path.
+
 ## Stable Path Map
 
 | Path group | Role |

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -62,6 +62,8 @@ scripts/docpact validate-config --root . --strict
 scripts/docpact lint --root . --base <base> --head <head> --mode enforce
 ```
 
+Review note, 2026-06-02: release 0.0.11 validation uses the unchanged `npm run prepush:gate`, docpact, and npm pack dry-run flow.
+
 ## Validation Matrix
 
 | Change type | Minimum local proof | Additional proof when risk is higher | Notes |

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -55,6 +55,8 @@ Before starting a release:
 
 Review note, 2026-06-02: dataset curation queue command additions follow the existing feature-then-release flow; release prep still remains a separate package metadata bump.
 
+Release 0.0.11 note, 2026-06-02: prechecks are `node ./scripts/ci/release-version.cjs assert-unpublished --version 0.0.11`, `npm run prepush:gate`, and `npm pack --dry-run`.
+
 Useful commands:
 
 ```bash

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -66,6 +66,8 @@ GitHub Actions must be enabled for the repository.
 
 Review note, 2026-06-02: adding the dataset curation queue command does not change Trusted Publishing, release token, tag, or workflow setup.
 
+Release 0.0.11 note, 2026-06-02: package version bump only; no repository secret, Trusted Publisher, tag, or workflow setup change is required.
+
 The publish workflow file is fixed at:
 
 - `.github/workflows/publish.yml`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/cli",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.101.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Unified TianGong LCA CLI with direct REST adapters and low-entropy command surface.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump `@tiangong-lca/cli` from 0.0.10 to 0.0.11.
- Release includes the merged dataset curation queue build command from #142.

## Validation
- `node ./scripts/ci/release-version.cjs assert-unpublished --version 0.0.11`
- `npm run prepush:gate`
- `npm pack --dry-run`
- Push-time docpact and pre-push gate passed.
