### PR TITLE
Release CLI 0.0.13

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-# Review note, 2026-06-05: release 0.0.12 is a package metadata bump only; no docpact routing or ownership rules changed.
-lastReviewedAt: '2026-06-05'
-lastReviewedCommit: 'a090d611199c2c5a34a9f8c266957845bb6404c3'
+# Review note, 2026-06-06: release 0.0.13 keeps the existing release ownership and routes; publication is documented as PR merge to upstream main followed by GitHub Actions Trusted Publishing, not local npm publish.
+lastReviewedAt: '2026-06-06'
+lastReviewedCommit: '2ea2094cd0f120eab40f76182fcd7ae4af902baf'
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ Route those tasks to:
 - Node baseline: `>=24 <25`
 - Runtime style: TypeScript source, Node-native CLI, direct REST and Edge Function access only
 - Newly added process-maintenance commands such as `process identity-preflight`, `process build-plan`, `process scope-statistics`, `process dedup-review`, `process refresh-references`, and `process verify-rows` still belong to the native CLI command surface in `src/cli.ts` and `src/lib/process-*.ts` / shared CLI-native helpers.
-- `process save-draft` now has a local `ProcessSchema` validation gate before any commit path writes remote state.
+- `process save-draft` now has a local `ProcessSchema` validation gate before any commit path writes remote state, and `--target-user-id` is a hard current-session/visible-draft owner guard for account-scoped batch imports.
 - Dataset-level local governance commands such as `dataset validate`, `dataset curation-queue build/next/verify`, and `dataset references rewrite` belong to the same native CLI command surface in `src/cli.ts` and `src/lib/dataset-*.ts`.
 - `lifecyclemodel save-draft` validates canonical lifecyclemodel payloads with `LifeCycleModelSchema` before any commit path writes remote state; `lifecyclemodel graph` remains a local artifact command.
 - `flow publish-version` validates canonical flow payloads with `FlowSchema` before remote visibility planning or writes, and emits `flow-publish-version-gate-report.json` as the blocking ruleset artifact.
@@ -116,11 +116,13 @@ Route those tasks to:
 - The canonical minimum validation command is `npm run lint`
 - The authoritative full gate is `npm run prepush:gate`; the local pre-push hook runs it after docpact.
 - Release tagging is guarded in `.github/workflows/tag-release-from-merge.yml` so only the upstream repository can execute the merge-tag flow, and it runs the release gate only when a package version change will create a `cli-v<version>` tag. `.github/workflows/publish.yml` publishes from that tag and also supports `workflow_dispatch` for existing-tag recovery/backfill.
+- CLI npm releases must go through a version-bump PR merged to upstream `main`; do not use local `npm publish` as the release path. The release-prep PR updates `package.json` and `package-lock.json`, merge creates `cli-v<version>`, and GitHub Actions publishes through npm Trusted Publishing.
 - Coverage for `src/**/*.ts` is expected to stay at `100%` statements, branches, functions, and lines
 
 ## Hard Boundaries
 
 - Do not add orchestration frameworks or new npm dependencies without explicit approval
+- Do not publish `@tiangong-lca/cli` from a local workstation for routine releases; local npm auth state is not part of the release contract.
 - Do not move business logic into skill wrappers when the native `tiangong-lca` CLI should own it
 - Do not weaken the coverage gate with ignore pragmas; cover the branch or remove dead code
 - Do not treat governed docs as optional when command-surface, validation, or release-gate behavior changes; `docpact` should either require a matching source-doc update or record explicit review evidence.

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -118,9 +118,11 @@ npm run build
 日常 release 采用 tag 驱动的 GitHub Actions 流程：
 
 - 从 `main` 开一个 release-prep PR
-- 只修改 CLI 包自己的 `package.json` 版本号
+- release-prep PR 修改 CLI 包自己的 `package.json` 和 `package-lock.json` 版本号
 - PR 合并后，`.github/workflows/tag-release-from-merge.yml` 自动创建 `cli-vX.Y.Z`
 - `.github/workflows/publish.yml` 再从这个不可变 tag 通过 npm Trusted Publishing 发布
+
+正式发布不要在本机执行 `npm publish`。本机只负责版本 bump、验证和 PR；合并到 upstream `main` 之后，由 GitHub Actions 创建 tag 并完成 npm 发布。本机 npm 登录状态或个人 npm 权限不属于 release 契约。
 
 值班发布步骤见 [docs/release-runbook.md](./docs/release-runbook.md)。
 
@@ -313,10 +315,11 @@ npm exec tiangong-lca -- admin embedding-run --input ./jobs.json --dry-run
 - 读取 process rows JSON/JSONL 或 publish request 中的 canonical process payload
 - 在本地先执行 `ProcessSchema` 校验，阻断 schema-invalid payload
 - 对精确版本做可见性预检，区分 current-user `state_code=0` draft 与其它可见行
+- 当传入 `--target-user-id` 时，写入前校验当前 CLI auth user 与目标用户一致，并要求已有 visible draft 也属于该目标用户
 - 对 current-user draft 走 `cmd_dataset_save_draft`
 - 把 schema-invalid 或执行失败的行写入 `outputs/save-draft-rpc/failures.jsonl`
 
-这个命令当前只负责 current-user draft 的 save-draft/update 语义；它不会替代 public `state_code=100` 的版本修订 publish 路径。
+这个命令当前只负责 current-user draft 的 save-draft/update 语义；`--target-user-id` 是批量导入时的账号/写入 guard，不能替代写后 readback verify，也不会替代 public `state_code=100` 的版本修订 publish 路径。
 
 `tiangong-lca process auto-build` 现在已经承担 `process_from_flow` 主链的第一个 CLI 切片，负责：
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ tiangong-lca lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrat
 tiangong-lca qa process --rows-file ./process-list-report.json --out-dir ./process-qa
 tiangong-lca qa process --run-root /abs/path/to/process-run --run-id <run_id> --out-dir ./process-qa
 tiangong-lca process save-draft --input ./patched-processes.jsonl --out-dir /abs/path/to/process-save-draft --dry-run --json
-tiangong-lca process save-draft --input ./patched-processes.jsonl --out-dir /abs/path/to/process-save-draft --commit --json
+tiangong-lca process save-draft --input ./patched-processes.jsonl --out-dir /abs/path/to/process-save-draft --commit --target-user-id <user-id> --json
 tiangong-lca flow publish-version --input-file ./ready-flows.jsonl --out-dir /abs/path/to/flow-publish --dry-run --json
 tiangong-lca flow publish-reviewed-data --flow-rows-file ./reviewed-flows.jsonl --out-dir /abs/path/to/reviewed-publish --dry-run --json
 tiangong-lca publish run --input ./publish-request.json --dry-run
@@ -298,7 +298,7 @@ For `process identity-preflight` and `flow identity-preflight`, canonical TIDAS 
 
 For `process build-plan` and `flow build-plan`, canonical payloads embedded in the plan are schema-checked during `materialize`. Plan-only materialization now creates deterministic canonical `processDataSet` / `flowDataSet` wrappers from the build plan and validates them with the TIDAS SDK before reporting `passed`.
 
-For `process save-draft`, canonical process payloads are validated locally with `ProcessSchema` before any `--commit` write. Schema-invalid rows remain in `outputs/save-draft-rpc/failures.jsonl` instead of being persisted.
+For `process save-draft`, canonical process payloads are validated locally with `ProcessSchema` before any `--commit` write. Schema-invalid rows remain in `outputs/save-draft-rpc/failures.jsonl` instead of being persisted. Batch import callers should pass `--target-user-id`; the CLI then verifies the current auth session and any visible draft owner before writing, while downstream readback verification still proves the final owner and payload.
 
 For `flow publish-version`, canonical flow payloads are validated locally with `FlowSchema` before remote visibility planning or writes. The command always writes `flow-publish-version-gate-report.json`; blocked rows are written to the remote-failure JSONL without calling the remote service.
 

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - README.md
   - src/**
   - test/**
-lastReviewedAt: 2026-06-04
-lastReviewedCommit: 44d7a7450d1050ec2c4a76ebf97394698a89800c
+lastReviewedAt: 2026-06-06
+lastReviewedCommit: 2ea2094cd0f120eab40f76182fcd7ae4af902baf
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -977,9 +977,10 @@ npm run prepush:gate
 
 CLI 现在额外有一条独立于质量门的 npm 发布链路：
 
-- release-prep PR 修改 `package.json` 版本号
+- release-prep PR 修改 `package.json` 和 `package-lock.json` 版本元数据
 - 合并到 `main` 后，`tag-release-from-merge.yml` 自动创建 `cli-vX.Y.Z`
 - `publish.yml` 从该 tag 触发 npm Trusted Publishing
+- 例行发布不在本机执行 `npm publish`；本机只做版本修改、质量门、未发布校验和 `npm pack --dry-run`
 
 每次发版的 operator runbook 见 [release-runbook.md](./release-runbook.md)。
 

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -17,8 +17,8 @@ checkPaths:
   - package.json
   - src/**
   - test/**
-lastReviewedAt: 2026-06-04
-lastReviewedCommit: 44d7a7450d1050ec2c4a76ebf97394698a89800c
+lastReviewedAt: 2026-06-06
+lastReviewedCommit: 2ea2094cd0f120eab40f76182fcd7ae4af902baf
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -45,6 +45,7 @@ related:
 - 2026-05-13 复核：新增 `dataset validate`、`dataset references rewrite`、`lifecyclemodel save-draft` 和 `lifecyclemodel graph` 仍属于既有 CLI-native 迁移方向，不重新引入 Python、POSIX shell 或 MCP runtime 前提
 - 2026-05-23 复核：review / dedup / publish ruleset metadata 继续落在 TypeScript CLI 内部，不新增 Python、POSIX shell 或 MCP runtime 前提
 - 2026-06-04 复核：`dataset curation-queue next/verify` 继续沿用 TypeScript CLI-native 路径，不重新引入 Python、POSIX shell 或 MCP runtime 前提
+- 2026-06-06 复核：release 0.0.13 发布路径澄清为 PR merge 到 upstream `main` 后由 GitHub Actions / npm Trusted Publishing 执行，不重新引入 Python、POSIX shell、MCP runtime 或本地发布脚本前提
 
 这份文档记录的是：
 

--- a/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
+++ b/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
@@ -15,8 +15,8 @@ checkPaths:
   - src/lib/user-api-key.ts
   - src/lib/supabase-session.ts
   - src/lib/supabase-client.ts
-lastReviewedAt: 2026-06-04
-lastReviewedCommit: 44d7a7450d1050ec2c4a76ebf97394698a89800c
+lastReviewedAt: 2026-06-06
+lastReviewedCommit: 2ea2094cd0f120eab40f76182fcd7ae4af902baf
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -35,6 +35,7 @@ related:
 - 在方案正式落地前，不把这里的内容视为对外稳定 contract。
 - 2026-05-13 复核：`dataset references rewrite --commit` 与 `lifecyclemodel save-draft --commit` 继续复用现有用户 session 链，不新增认证 env 或 alternate bearer 模式。
 - 2026-06-04 复核：`dataset curation-queue next/verify` 只读取本地队列 artifact 和 checkpoint，不改变认证/session 设计。
+- 2026-06-06 复核：release 0.0.13 的发布路径改为明确依赖 PR merge 后的 GitHub Actions / npm Trusted Publishing，不改变 CLI 用户 API key、session 或 `--target-user-id` 账号守卫语义；本地 npm 登录状态不是 CLI 运行时认证模型的一部分。
 
 ## 1. 已确认事实
 

--- a/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
+++ b/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - src/lib/supabase-client.ts
   - src/lib/tidas-sdk-package-validator.ts
   - test/**
-lastReviewedAt: 2026-06-04
-lastReviewedCommit: 44d7a7450d1050ec2c4a76ebf97394698a89800c
+lastReviewedAt: 2026-06-06
+lastReviewedCommit: 2ea2094cd0f120eab40f76182fcd7ae4af902baf
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -44,6 +44,8 @@ related:
 - 直到 repo 级验证、PR、workspace integration 全部完成，才算结束。
 
 当前状态：
+
+2026-06-06 复核：release 0.0.13 发布路径澄清只影响包版本元数据和 GitHub Actions / npm Trusted Publishing 操作说明，不改变 Supabase JS 或 TIDAS SDK direct dependency 结论；本文件保持历史 TODO 记录用途。
 
 2026-06-04 复核：`dataset curation-queue next/verify` 不改变 Supabase JS 或 TIDAS SDK direct dependency 结论；本文件保持历史 TODO 记录用途。
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-05
-lastReviewedCommit: a090d611199c2c5a34a9f8c266957845bb6404c3
+lastReviewedAt: 2026-06-06
+lastReviewedCommit: 2ea2094cd0f120eab40f76182fcd7ae4af902baf
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -43,6 +43,8 @@ This repo is organized around one stable launcher plus a library-style `src/lib/
 Review note, 2026-06-04: Foundry entity queue state now stays in the native CLI command family as `dataset curation-queue build/next/verify`; no secondary orchestration runtime was introduced.
 
 Review note, 2026-06-05: release 0.0.12 is a package metadata bump only; no command-family ownership, launcher, session, artifact, or release architecture paths changed.
+
+Review note, 2026-06-06: release 0.0.13 keeps the release architecture unchanged: maintainers open a version-bump PR, update `package.json` and `package-lock.json`, merge to upstream `main`, and let GitHub Actions create the tag and publish through npm Trusted Publishing. Local `npm publish` is not part of the release architecture.
 
 ## Stable Path Map
 
@@ -117,7 +119,7 @@ These modules share one contract:
 - `src/cli.ts` owns subcommand registration, help, and exit semantics
 - `process/flow identity-preflight` owns embedded/local candidate scan inputs, explicit hybrid-search remote candidate inputs, identity/fingerprint comparison, duplicate/manual-review decisions, and `identity-candidate-sources.json` provenance artifacts before any build-plan or generation step
 - `process/flow build-plan` validates minimum authoring contracts and writes standard gate artifacts before downstream materialization or publish handoff; materialize now creates canonical `processDataSet` / `flowDataSet` wrappers from plan fields when no canonical payload is supplied
-- `process save-draft` validates canonical payloads with `ProcessSchema` before remote writes
+- `process save-draft` validates canonical payloads with `ProcessSchema` before remote writes and accepts `--target-user-id` as an account/write guard that must match the current CLI auth user and any visible draft owner
 - `flow publish-version` and `process publish-build` validate canonical payloads with `FlowSchema` / `ProcessSchema` before publish planning or handoff artifacts proceed
 - `publish run` writes a deterministic `verification-report.json` next to the final publish report so downstream automation can read blockers without parsing execution details
 - `runtime-rulesets` maps CLI-local QA, dedup, and publish findings to stable methodology rule ids so Foundry and UI handoffs can consume one ruleset profile contract
@@ -163,6 +165,7 @@ Important constraints:
 - `docpact` enforces that command-surface and release-gate changes also refresh or review the governed source docs
 - the merge-tag workflow is guarded so only the upstream repository can execute release tagging
 - the publish workflow releases from `cli-v<package.json version>` and supports manual dispatch for existing-tag recovery/backfill
+- routine npm releases must flow through an upstream `main` PR merge and GitHub Actions Trusted Publishing; local workstations may validate with `npm pack --dry-run` but must not publish
 
 ## Cross-Repo Boundaries
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-05
-lastReviewedCommit: a090d611199c2c5a34a9f8c266957845bb6404c3
+lastReviewedAt: 2026-06-06
+lastReviewedCommit: 2ea2094cd0f120eab40f76182fcd7ae4af902baf
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -66,6 +66,8 @@ Review note, 2026-06-04: dataset curation queue state changes are covered by foc
 
 Review note, 2026-06-05: release 0.0.12 uses the existing release proof contract: unpublished-version check, `npm run prepush:gate`, and `npm pack --dry-run`.
 
+Review note, 2026-06-06: release 0.0.13 keeps local validation separate from publication. Local proof is unpublished-version check, `npm run prepush:gate`, `npm pack --dry-run`, and docpact; npm publication must happen only after the version-bump PR merges to upstream `main` and GitHub Actions runs the tag and publish workflows.
+
 ## Validation Matrix
 
 | Change type | Minimum local proof | Additional proof when risk is higher | Notes |
@@ -90,6 +92,7 @@ Facts that matter:
 - `process save-draft`, `lifecyclemodel save-draft`, dataset governance commands such as curation queue build/next/verify, BuildPlan gates, publish schema/verification gates, and the newer process maintenance commands are expected to preserve `100%` coverage even when they add schema-validation, rewrite, or fallback branches
 - release-tag and docpact lint workflow changes should be described in the PR note when they alter the local or protected-branch proof
 - `tag-release-from-merge.yml` is idempotent when the expected `cli-v*` tag already points at the merge commit, and `publish.yml` can be re-run with `workflow_dispatch` only for an existing `cli-v*` tag on `origin/main`
+- local npm authentication is not release validation evidence; routine publication is verified by the upstream tag workflow and npm Trusted Publishing workflow after merge
 
 If the task changes control flow, add or update tests instead of using coverage-ignore pragmas.
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -52,6 +52,7 @@ Before starting a release:
 - keep the release-prep change scoped to CLI package version metadata
 - confirm npm has not already published the target version
 - confirm any command-surface feature PRs that will be included in the release have passed the local pre-push gate, including `npm run prepush:gate` and docpact, before preparing the version bump
+- do not run local `npm publish` for routine releases; the canonical release path is a version-bump PR merged to upstream `main`, followed by tag creation and npm Trusted Publishing in GitHub Actions
 
 Review note, 2026-06-02: dataset curation queue command additions follow the existing feature-then-release flow; release prep still remains a separate package metadata bump.
 
@@ -60,6 +61,8 @@ Review note, 2026-06-04: `dataset curation-queue next/verify` follows the same f
 Release 0.0.11 note, 2026-06-02: prechecks are `node ./scripts/ci/release-version.cjs assert-unpublished --version 0.0.11`, `npm run prepush:gate`, and `npm pack --dry-run`.
 
 Release 0.0.12 note, 2026-06-05: prechecks are `node ./scripts/ci/release-version.cjs assert-unpublished --version 0.0.12`, `npm run prepush:gate`, and `npm pack --dry-run`; no tag or publish workflow semantics changed.
+
+Release 0.0.13 note, 2026-06-06: prechecks are `node ./scripts/ci/release-version.cjs assert-unpublished --version 0.0.13`, `npm run prepush:gate`, and `npm pack --dry-run`; this release adds `process save-draft --target-user-id` account/write guard support for batch import handoff.
 
 Useful commands:
 
@@ -87,7 +90,7 @@ npm pack --dry-run >/dev/null
 4. Open a normal PR with local pre-push gate evidence. Use the manual `quality-gate` workflow only when remote reproduction is needed.
 5. Merge the PR into `main`.
 
-Release automation starts only after the version bump PR is merged into `main`.
+Release automation starts only after the version bump PR is merged into upstream `main`. A local workstation may run `npm pack --dry-run` for package validation, but it must not publish the package; local npm authentication and personal registry permissions are intentionally outside the release contract.
 
 ## Post-Merge Checks
 

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -19,8 +19,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-05
-lastReviewedCommit: a090d611199c2c5a34a9f8c266957845bb6404c3
+lastReviewedAt: 2026-06-06
+lastReviewedCommit: 2ea2094cd0f120eab40f76182fcd7ae4af902baf
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -37,9 +37,10 @@ For the repeatable per-release operator steps, see [release-runbook.md](./releas
 Recommended model:
 
 - maintainers open a normal release-prep PR from `main`
-- the PR updates `package.json` version for the next CLI release
+- the PR updates `package.json` and `package-lock.json` version metadata for the next CLI release
 - after that PR merges, `tag-release-from-merge.yml` creates the immutable package tag
 - `publish.yml` publishes the package from that tag through npm Trusted Publishing
+- maintainers do not run local `npm publish` for routine releases
 
 Current workflow files:
 
@@ -72,6 +73,8 @@ Release 0.0.11 note, 2026-06-02: package version bump only; no repository secret
 
 Release 0.0.12 note, 2026-06-05: package version bump only; no repository secret, Trusted Publisher, tag, workflow filename, or GitHub environment setup change is required.
 
+Release 0.0.13 note, 2026-06-06: package version and lockfile bump only; no repository secret, Trusted Publisher, tag, workflow filename, or GitHub environment setup change is required. The operator path is PR merge to upstream `main`, then GitHub Actions tag and publish.
+
 The publish workflow file is fixed at:
 
 - `.github/workflows/publish.yml`
@@ -102,7 +105,8 @@ Leave the environment name unset unless the workflow is explicitly updated to us
 
 - `publish.yml` validates that the Git tag matches the package version before upload and supports `workflow_dispatch` for existing-tag recovery/backfill.
 - `tag-release-from-merge.yml` only creates a tag when `package.json` version changes on `main`, and it runs `npm run prepush:gate` before creating that tag. If the expected tag already points at the current merge commit, the tag step is idempotent; if it points elsewhere, the workflow fails.
-- The release-prep PR should update only the intended versioned release metadata for the CLI package.
+- The release-prep PR should update only the intended versioned release metadata for the CLI package, normally `package.json` and `package-lock.json`.
+- Local workstations may run `npm pack --dry-run` for package validation, but routine npm publication belongs to GitHub Actions Trusted Publishing after the upstream `main` merge.
 - Adding CLI command families such as dataset or lifecyclemodel maintenance commands does not require release setup changes by itself; those feature PRs are covered by the normal quality and docpact gates before a later version bump.
 
 ## Local Docpact Push Gate

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/cli",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.101.1",
         "@tiangong-lca/tidas-sdk": "^0.1.41"
       },
       "bin": {
-        "tiangong-lca": "bin/tiangong-lca.js"
+        "tiangong-lca": "./bin/tiangong-lca.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Unified TianGong LCA CLI with direct REST adapters and low-entropy command surface.",
   "repository": {
     "type": "git",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2132,6 +2132,8 @@ Options:
   --out-dir <dir>    Run root written relative to cwd when a relative path is passed
   --commit           Execute remote save-draft writes
   --dry-run          Keep the command local-only (default)
+  --target-user-id <id>
+                    Require --commit to run as this user and update an owned draft
   --json             Print compact JSON
   -h, --help
 
@@ -5538,6 +5540,7 @@ function parseProcessSaveDraftFlags(args: string[]): {
   inputPath: string;
   outDir: string | null;
   commit: boolean;
+  targetUserId: string | null;
 } {
   let values: ReturnType<typeof parseArgs>['values'];
   try {
@@ -5552,6 +5555,7 @@ function parseProcessSaveDraftFlags(args: string[]): {
         'out-dir': { type: 'string' },
         commit: { type: 'boolean' },
         'dry-run': { type: 'boolean' },
+        'target-user-id': { type: 'string' },
       },
     }));
   } catch (error) {
@@ -5574,6 +5578,7 @@ function parseProcessSaveDraftFlags(args: string[]): {
     inputPath: typeof values.input === 'string' ? values.input : '',
     outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : null,
     commit: Boolean(values.commit),
+    targetUserId: typeof values['target-user-id'] === 'string' ? values['target-user-id'] : null,
   };
 }
 
@@ -7016,6 +7021,7 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
         inputPath: processFlags.inputPath,
         outDir: processFlags.outDir,
         commit: processFlags.commit,
+        targetUserId: processFlags.targetUserId,
         env: deps.env,
         fetchImpl: deps.fetchImpl,
       });

--- a/src/lib/process-save-draft-run.ts
+++ b/src/lib/process-save-draft-run.ts
@@ -217,6 +217,13 @@ export type ProcessSaveDraftReport = {
   out_dir: string;
   commit: boolean;
   mode: 'dry_run' | 'commit';
+  target_user_id: string | null;
+  account_guard: {
+    target_user_id_required: boolean;
+    target_user_id: string | null;
+    commit_account_binding: 'current_cli_auth_session';
+    post_write_verify_required: boolean;
+  };
   status: 'completed' | 'completed_with_failures';
   counts: {
     selected: number;
@@ -243,6 +250,7 @@ export type RunProcessSaveDraftOptions = {
   fetchImpl?: FetchLike;
   timeoutMs?: number;
   now?: Date;
+  targetUserId?: string | null;
   validateProcessPayloadImpl?: (payload: JsonObject) => ProcessPayloadValidationResult;
 };
 
@@ -439,6 +447,7 @@ export async function runProcessSaveDraft(
   const now = options.now ?? new Date();
   const inputPath = path.resolve(options.inputPath);
   const commit = options.commit === true;
+  const targetUserId = first_non_empty(options.targetUserId);
   const rawInput = options.rawInput ?? readStructuredInput(inputPath);
   const validateProcessPayloadImpl = options.validateProcessPayloadImpl ?? validateProcessPayload;
   const prepared = prepareProcessSaveDraftInput(
@@ -492,10 +501,12 @@ export async function runProcessSaveDraft(
         env: options.env!,
         fetchImpl: options.fetchImpl!,
         timeoutMs: options.timeoutMs,
+        targetUserId,
         audit: {
           command: 'tiangong-lca process save-draft',
           source: candidate.source,
           bundle_path: candidate.bundle_path,
+          target_user_id: targetUserId,
         },
       });
       report.status = 'executed';
@@ -518,6 +529,13 @@ export async function runProcessSaveDraft(
     out_dir: outDir,
     commit,
     mode: commit ? 'commit' : 'dry_run',
+    target_user_id: targetUserId,
+    account_guard: {
+      target_user_id_required: Boolean(targetUserId),
+      target_user_id: targetUserId,
+      commit_account_binding: 'current_cli_auth_session',
+      post_write_verify_required: Boolean(targetUserId),
+    },
     status: failedReports.length > 0 ? 'completed_with_failures' : 'completed',
     counts: {
       selected: prepared.processes.length,

--- a/src/lib/process-save-draft.ts
+++ b/src/lib/process-save-draft.ts
@@ -1,9 +1,10 @@
 import { CliError } from './errors.js';
 import type { FetchLike } from './http.js';
-import { postJson, requireRemoteOkPayload } from './http.js';
+import { getJson, postJson, requireRemoteOkPayload } from './http.js';
 import {
   buildSupabaseAuthHeaders,
   createSupabaseDataClient,
+  deriveSupabaseProjectBaseUrl,
   requireSupabaseRestRuntime,
   runSupabaseArrayQuery,
 } from './supabase-client.js';
@@ -61,6 +62,7 @@ export type SyncStateAwareProcessRecordOptions = {
   timeoutMs?: number;
   audit?: JsonObject;
   modelId?: string | null;
+  targetUserId?: string | null;
 };
 
 function buildVisibleRowsUrl(restBaseUrl: string, id: string, version: string): string {
@@ -142,6 +144,67 @@ function visibleDraftRow(rows: VisibleProcessRow[]): VisibleProcessRow | null {
   return rows.find((row) => row.state_code === 0) ?? null;
 }
 
+function visibleDraftRowForTarget(
+  rows: VisibleProcessRow[],
+  targetUserId: string | null,
+): VisibleProcessRow | null {
+  if (!targetUserId) {
+    return visibleDraftRow(rows);
+  }
+  return rows.find((row) => row.state_code === 0 && row.user_id === targetUserId) ?? null;
+}
+
+function buildCurrentUserUrl(restBaseUrl: string): string {
+  return `${deriveSupabaseProjectBaseUrl(restBaseUrl)}/auth/v1/user`;
+}
+
+async function currentUserId(options: {
+  restBaseUrl: string;
+  publishableKey: string;
+  accessToken: string;
+  timeoutMs: number;
+  fetchImpl: FetchLike;
+}): Promise<string> {
+  const url = buildCurrentUserUrl(options.restBaseUrl);
+  const payload = await getJson({
+    url,
+    headers: buildSupabaseAuthHeaders(options.publishableKey, options.accessToken),
+    timeoutMs: options.timeoutMs,
+    fetchImpl: options.fetchImpl,
+  });
+  const userId = isRecord(payload) ? trimToken(payload.id) : null;
+  if (!userId) {
+    throw new CliError('Supabase current-user lookup succeeded without a user id.', {
+      code: 'PROCESS_SAVE_DRAFT_CURRENT_USER_ID_MISSING',
+      exitCode: 1,
+      details: payload,
+    });
+  }
+  return userId;
+}
+
+function assertTargetUserMatchesCurrent(options: {
+  targetUserId: string | null;
+  currentUserId: string;
+}): void {
+  if (!options.targetUserId) {
+    return;
+  }
+  if (options.currentUserId !== options.targetUserId) {
+    throw new CliError(
+      `Process save-draft target user ${options.targetUserId} does not match current CLI auth user ${options.currentUserId}.`,
+      {
+        code: 'PROCESS_SAVE_DRAFT_TARGET_USER_MISMATCH',
+        exitCode: 1,
+        details: {
+          target_user_id: options.targetUserId,
+          current_user_id: options.currentUserId,
+        },
+      },
+    );
+  }
+}
+
 function buildUnsupportedVisibleRowError(
   id: string,
   version: string,
@@ -217,6 +280,7 @@ export async function syncStateAwareProcessRecord(
   options: SyncStateAwareProcessRecordOptions,
 ): Promise<ProcessStateAwareWriteResult> {
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const targetUserId = trimToken(options.targetUserId);
   const visible = await exactVisibleRows({
     id: options.id,
     version: options.version,
@@ -224,7 +288,18 @@ export async function syncStateAwareProcessRecord(
     fetchImpl: options.fetchImpl,
     timeoutMs,
   });
-  const draftRow = visibleDraftRow(visible.rows);
+  if (targetUserId) {
+    const userId = await currentUserId({
+      restBaseUrl: visible.restBaseUrl,
+      publishableKey: visible.publishableKey,
+      accessToken: visible.accessToken,
+      timeoutMs,
+      fetchImpl: options.fetchImpl,
+    });
+    assertTargetUserMatchesCurrent({ targetUserId, currentUserId: userId });
+  }
+
+  const draftRow = visibleDraftRowForTarget(visible.rows, targetUserId);
 
   if (!draftRow) {
     if (visible.rows.length > 0) {
@@ -265,7 +340,10 @@ export async function syncStateAwareProcessRecord(
 
 export const __testInternals = {
   buildVisibleRowsUrl,
+  buildCurrentUserUrl,
   parseVisibleRows,
   visibleDraftRow,
+  visibleDraftRowForTarget,
+  assertTargetUserMatchesCurrent,
   buildUnsupportedVisibleRowError,
 };

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1828,6 +1828,7 @@ test('executeCli returns help for the process namespace and implemented subcomma
   assert.equal(saveDraftHelp.exitCode, 0);
   assert.match(saveDraftHelp.stdout, /tiangong-lca process save-draft --input <file>/u);
   assert.match(saveDraftHelp.stdout, /--commit/u);
+  assert.match(saveDraftHelp.stdout, /--target-user-id <id>/u);
   assert.match(saveDraftHelp.stdout, /outputs\/save-draft-rpc\/summary\.json/u);
   assert.doesNotMatch(saveDraftHelp.stdout, /Planned command/u);
 
@@ -3348,6 +3349,8 @@ test('executeCli executes process save-draft with injected implementation', asyn
         '--out-dir',
         './save-root',
         '--commit',
+        '--target-user-id',
+        'user-1',
       ],
       {
         ...makeDeps(),
@@ -3355,6 +3358,7 @@ test('executeCli executes process save-draft with injected implementation', asyn
           assert.equal(options.inputPath, inputPath);
           assert.equal(options.outDir, './save-root');
           assert.equal(options.commit, true);
+          assert.equal(options.targetUserId, 'user-1');
           return {
             generated_at_utc: '2026-04-14T12:00:00.000Z',
             input_path: inputPath,
@@ -3362,6 +3366,13 @@ test('executeCli executes process save-draft with injected implementation', asyn
             out_dir: path.join(dir, 'save-root'),
             commit: true,
             mode: 'commit',
+            target_user_id: 'user-1',
+            account_guard: {
+              target_user_id_required: true,
+              target_user_id: 'user-1',
+              commit_account_binding: 'current_cli_auth_session',
+              post_write_verify_required: true,
+            },
             status: 'completed',
             counts: {
               selected: 1,
@@ -3554,6 +3565,13 @@ test('executeCli maps process save-draft failures to exit code 1', async () => {
         out_dir: path.join(dir, 'save-root'),
         commit: false,
         mode: 'dry_run',
+        target_user_id: null,
+        account_guard: {
+          target_user_id_required: false,
+          target_user_id: null,
+          commit_account_binding: 'current_cli_auth_session',
+          post_write_verify_required: false,
+        },
         status: 'completed_with_failures',
         counts: {
           selected: 1,

--- a/test/dataset-references-rewrite.test.ts
+++ b/test/dataset-references-rewrite.test.ts
@@ -213,6 +213,13 @@ test('runDatasetReferencesRewrite validates flags and supports commit delegates'
           out_dir: options.outDir ?? '',
           commit: true,
           mode: 'commit',
+          target_user_id: null,
+          account_guard: {
+            target_user_id_required: false,
+            target_user_id: null,
+            commit_account_binding: 'current_cli_auth_session',
+            post_write_verify_required: false,
+          },
           status: 'completed',
           counts: { selected: 1, prepared: 0, executed: 1, failed: 0 },
           files: {

--- a/test/process-save-draft-run.test.ts
+++ b/test/process-save-draft-run.test.ts
@@ -285,6 +285,75 @@ test('runProcessSaveDraft executes state-aware save-draft writes on commit', asy
   }
 });
 
+test('runProcessSaveDraft records target user guard on commit', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-save-draft-target-user-'));
+  const inputPath = path.join(dir, 'patched-processes.jsonl');
+  const observed: Array<{ method: string; url: string; body?: string }> = [];
+
+  writeJsonl(inputPath, [makeCanonicalProcess('proc-target-guard')]);
+
+  try {
+    const report = await runProcessSaveDraft({
+      inputPath,
+      commit: true,
+      targetUserId: 'user-1',
+      env: buildSupabaseTestEnv({
+        TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+        TIANGONG_LCA_API_KEY: 'key',
+      }),
+      fetchImpl: withSupabaseAuthBootstrap(async (url, init) => {
+        observed.push({
+          method: String(init?.method ?? 'GET'),
+          url: String(url),
+          body: typeof init?.body === 'string' ? init.body : undefined,
+        });
+
+        if (String(url).includes('/rest/v1/processes')) {
+          return makeResponse({
+            ok: true,
+            status: 200,
+            body: '[{"id":"proc-target-guard","version":"01.01.000","user_id":"user-1","state_code":0}]',
+          });
+        }
+
+        if (String(url).includes('/auth/v1/user')) {
+          return makeResponse({
+            ok: true,
+            status: 200,
+            body: '{"id":"user-1"}',
+          });
+        }
+
+        return makeResponse({
+          ok: true,
+          status: 200,
+          body: '{"ok":true,"data":{"id":"proc-target-guard"}}',
+        });
+      }),
+      now: new Date('2026-04-14T00:25:00.000Z'),
+      validateProcessPayloadImpl: VALIDATION_OK,
+    });
+
+    assert.deepEqual(
+      observed.map((entry) => entry.method),
+      ['GET', 'GET', 'POST'],
+    );
+    assert.match(observed[2]?.body ?? '', /"target_user_id":"user-1"/u);
+    assert.equal(report.status, 'completed');
+    assert.equal(report.target_user_id, 'user-1');
+    assert.deepEqual(report.account_guard, {
+      target_user_id_required: true,
+      target_user_id: 'user-1',
+      commit_account_binding: 'current_cli_auth_session',
+      post_write_verify_required: true,
+    });
+    const summary = readJson(report.files.summary_json) as { target_user_id?: unknown };
+    assert.equal(summary.target_user_id, 'user-1');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('runProcessSaveDraft records non-canonical payloads as failed entries', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-process-save-draft-invalid-'));
   const inputPath = path.join(dir, 'patched-processes.jsonl');

--- a/test/process-save-draft.test.ts
+++ b/test/process-save-draft.test.ts
@@ -94,6 +94,172 @@ test('state-aware process write routes visible drafts through cmd_dataset_save_d
   });
 });
 
+test('state-aware process write enforces target user guard before remote writes', async () => {
+  const observed: Array<{ method: string; url: string; body?: string }> = [];
+  const result = await syncStateAwareProcessRecord({
+    id: 'proc-target',
+    version: '01.00.001',
+    payload: { processDataSet: {} },
+    targetUserId: 'user-1',
+    env: buildSupabaseTestEnv({
+      TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+      TIANGONG_LCA_API_KEY: 'key',
+    }),
+    fetchImpl: withSupabaseAuthBootstrap(async (url, init) => {
+      observed.push({
+        method: String(init?.method ?? 'GET'),
+        url: String(url),
+        body: typeof init?.body === 'string' ? init.body : undefined,
+      });
+
+      if (String(url).includes('/rest/v1/processes')) {
+        return makeResponse({
+          ok: true,
+          status: 200,
+          body: '[{"id":"proc-target","version":"01.00.001","user_id":"user-1","state_code":0}]',
+        });
+      }
+
+      if (String(url).includes('/auth/v1/user')) {
+        return makeResponse({
+          ok: true,
+          status: 200,
+          body: '{"id":"user-1"}',
+        });
+      }
+
+      return makeResponse({
+        ok: true,
+        status: 200,
+        body: '{"ok":true,"data":{"id":"proc-target"}}',
+      });
+    }),
+  });
+
+  assert.deepEqual(
+    observed.map((entry) => entry.method),
+    ['GET', 'GET', 'POST'],
+  );
+  assert.match(observed[1]?.url ?? '', /\/auth\/v1\/user$/u);
+  assert.deepEqual(result, {
+    status: 'success',
+    operation: 'save_draft',
+    write_path: 'cmd_dataset_save_draft',
+    rpc_result: { ok: true, data: { id: 'proc-target' } },
+    visible_row: {
+      id: 'proc-target',
+      version: '01.00.001',
+      user_id: 'user-1',
+      state_code: 0,
+    },
+  });
+});
+
+test('state-aware process write rejects target user mismatches', async () => {
+  await assert.rejects(
+    () =>
+      syncStateAwareProcessRecord({
+        id: 'proc-target-mismatch',
+        version: '01.00.001',
+        payload: { processDataSet: {} },
+        targetUserId: 'target-user',
+        env: buildSupabaseTestEnv({
+          TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+          TIANGONG_LCA_API_KEY: 'key',
+        }),
+        fetchImpl: withSupabaseAuthBootstrap(async (url) => {
+          if (String(url).includes('/rest/v1/processes')) {
+            return makeResponse({
+              ok: true,
+              status: 200,
+              body: '[]',
+            });
+          }
+          return makeResponse({
+            ok: true,
+            status: 200,
+            body: '{"id":"current-user"}',
+          });
+        }),
+      }),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'PROCESS_SAVE_DRAFT_TARGET_USER_MISMATCH');
+      assert.match(error.message, /target-user/u);
+      return true;
+    },
+  );
+});
+
+test('state-aware process write rejects target user guards without current auth ids', async () => {
+  await assert.rejects(
+    () =>
+      syncStateAwareProcessRecord({
+        id: 'proc-target-missing-user',
+        version: '01.00.001',
+        payload: { processDataSet: {} },
+        targetUserId: 'target-user',
+        env: buildSupabaseTestEnv({
+          TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+          TIANGONG_LCA_API_KEY: 'key',
+        }),
+        fetchImpl: withSupabaseAuthBootstrap(async (url) => {
+          if (String(url).includes('/rest/v1/processes')) {
+            return makeResponse({
+              ok: true,
+              status: 200,
+              body: '[]',
+            });
+          }
+          return makeResponse({
+            ok: true,
+            status: 200,
+            body: '{}',
+          });
+        }),
+      }),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'PROCESS_SAVE_DRAFT_CURRENT_USER_ID_MISSING');
+      assert.match(error.message, /without a user id/u);
+      return true;
+    },
+  );
+
+  await assert.rejects(
+    () =>
+      syncStateAwareProcessRecord({
+        id: 'proc-target-malformed-user',
+        version: '01.00.001',
+        payload: { processDataSet: {} },
+        targetUserId: 'target-user',
+        env: buildSupabaseTestEnv({
+          TIANGONG_LCA_API_BASE_URL: 'https://example.supabase.co',
+          TIANGONG_LCA_API_KEY: 'key',
+        }),
+        fetchImpl: withSupabaseAuthBootstrap(async (url) => {
+          if (String(url).includes('/rest/v1/processes')) {
+            return makeResponse({
+              ok: true,
+              status: 200,
+              body: '[]',
+            });
+          }
+          return makeResponse({
+            ok: true,
+            status: 200,
+            body: '[]',
+          });
+        }),
+      }),
+    (error) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, 'PROCESS_SAVE_DRAFT_CURRENT_USER_ID_MISSING');
+      return true;
+    },
+  );
+});
+
 test('state-aware process write rejects visible non-draft rows before raw table updates', async () => {
   await assert.rejects(
     () =>
@@ -217,6 +383,10 @@ test('state-aware process write helpers normalize edge-case visible rows', () =>
     ),
     'https://example.supabase.co/rest/v1/processes?select=id%2Cversion%2Cuser_id%2Cstate_code&id=eq.proc-1&version=eq.01.00.001',
   );
+  assert.equal(
+    __testInternals.buildCurrentUserUrl('https://example.supabase.co/rest/v1'),
+    'https://example.supabase.co/auth/v1/user',
+  );
   assert.deepEqual(
     __testInternals.parseVisibleRows(
       [{ id: 'proc-1', version: '01.00.001', user_id: 'user-1', state_code: 0 }],
@@ -244,6 +414,29 @@ test('state-aware process write helpers normalize edge-case visible rows', () =>
       { id: 'proc-1', version: '01.00.001', user_id: 'user-2', state_code: 0 },
     ]),
     { id: 'proc-1', version: '01.00.001', user_id: 'user-2', state_code: 0 },
+  );
+  assert.deepEqual(
+    __testInternals.visibleDraftRowForTarget(
+      [
+        { id: 'proc-1', version: '01.00.001', user_id: 'user-2', state_code: 0 },
+        { id: 'proc-1', version: '01.00.001', user_id: 'user-1', state_code: 0 },
+      ],
+      'user-1',
+    ),
+    { id: 'proc-1', version: '01.00.001', user_id: 'user-1', state_code: 0 },
+  );
+  assert.equal(
+    __testInternals.visibleDraftRowForTarget(
+      [{ id: 'proc-1', version: '01.00.001', user_id: 'user-2', state_code: 0 }],
+      'user-1',
+    ),
+    null,
+  );
+  assert.doesNotThrow(() =>
+    __testInternals.assertTargetUserMatchesCurrent({
+      targetUserId: null,
+      currentUserId: 'user-1',
+    }),
   );
   assert.throws(
     () => __testInternals.parseVisibleRows([0], 'https://example.com'),


### PR DESCRIPTION
Summary
- Add process save-draft --target-user-id account/write guard support for batch import handoff.
- Bump @tiangong-lca/cli package metadata to 0.0.13.
- Document the release path: version-bump PR merged to upstream main, then GitHub Actions tag creation and npm Trusted Publishing; local npm publish is not the release path.

Validation
- npm run prepush:gate (771 tests, 767 pass, 4 skipped; src coverage 100% statements/branches/functions/lines)
- ../scripts/docpact validate-config --root . --strict
- ../scripts/docpact lint --root . --staged --mode enforce
- npm pack --dry-run
- npm view @tiangong-lca/cli version => 0.0.12 before this PR, so 0.0.13 is unpublished

Release handoff
- After merge to upstream main, tag-release-from-merge.yml should create cli-v0.0.13.
- publish.yml should publish @tiangong-lca/cli@0.0.13 from that tag through npm Trusted Publishing.

No linked issue: operator-requested release PR.