### PR TITLE
fix(schema): allow shallow classification paths (remove over-strict cardinality)

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 # Review note, 2026-06-11: release 0.0.15 keeps existing command-family, validation, and release routing. The dataset import-lca wrapper now targets the tidas-tools 0.0.28 process-bundle CLI surface; routing and ownership are unchanged.
-lastReviewedAt: "2026-06-11"
-lastReviewedCommit: "878388e91ffa15e1ba3e26782edbffd262b55f8b"
+lastReviewedAt: "2026-06-15"
+lastReviewedCommit: "9d52329b947a8b13f675247bd61b16f0a1982cf9"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-11
-lastReviewedCommit: 878388e91ffa15e1ba3e26782edbffd262b55f8b
+lastReviewedAt: 2026-06-15
+lastReviewedCommit: 9d52329b947a8b13f675247bd61b16f0a1982cf9
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/assets/tidas-schemas/tidas_contacts.json
+++ b/assets/tidas-schemas/tidas_contacts.json
@@ -109,30 +109,8 @@
                                 }
                               ],
                               "uniqueItems": true,
-                              "allOf": [
-                                {
-                                  "maxContains": 1,
-                                  "minContains": 0,
-                                  "contains": {
-                                    "properties": {
-                                      "@level": {
-                                        "const": "0"
-                                      }
-                                    }
-                                  }
-                                },
-                                {
-                                  "maxContains": 1,
-                                  "minContains": 0,
-                                  "contains": {
-                                    "properties": {
-                                      "@level": {
-                                        "const": "1"
-                                      }
-                                    }
-                                  }
-                                }
-                              ]
+                              "maxItems": 2,
+                              "additionalItems": false
                             },
                             {
                               "type": "object",

--- a/assets/tidas-schemas/tidas_flows.json
+++ b/assets/tidas-schemas/tidas_flows.json
@@ -159,41 +159,8 @@
                             }
                           ],
                           "uniqueItems": true,
-                          "allOf": [
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "0"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "1"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "2"
-                                  }
-                                }
-                              }
-                            }
-                          ]
+                          "maxItems": 3,
+                          "additionalItems": false
                         },
                         "common:other": {
                           "$ref": "tidas_data_types.json#/$defs/CommonOther"
@@ -336,63 +303,8 @@
                             }
                           ],
                           "uniqueItems": true,
-                          "allOf": [
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "0"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "1"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "2"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "3"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "4"
-                                  }
-                                }
-                              }
-                            }
-                          ]
+                          "maxItems": 5,
+                          "additionalItems": false
                         },
                         "common:other": {
                           "$ref": "tidas_data_types.json#/$defs/CommonOther"

--- a/assets/tidas-schemas/tidas_lciamethods.json
+++ b/assets/tidas-schemas/tidas_lciamethods.json
@@ -132,41 +132,8 @@
                                 }
                               ],
                               "uniqueItems": true,
-                              "allOf": [
-                                {
-                                  "maxContains": 1,
-                                  "minContains": 0,
-                                  "contains": {
-                                    "properties": {
-                                      "@level": {
-                                        "const": "0"
-                                      }
-                                    }
-                                  }
-                                },
-                                {
-                                  "maxContains": 1,
-                                  "minContains": 0,
-                                  "contains": {
-                                    "properties": {
-                                      "@level": {
-                                        "const": "1"
-                                      }
-                                    }
-                                  }
-                                },
-                                {
-                                  "maxContains": 1,
-                                  "minContains": 0,
-                                  "contains": {
-                                    "properties": {
-                                      "@level": {
-                                        "const": "2"
-                                      }
-                                    }
-                                  }
-                                }
-                              ]
+                              "maxItems": 3,
+                              "additionalItems": false
                             }
                           ]
                         },

--- a/assets/tidas-schemas/tidas_lifecyclemodels.json
+++ b/assets/tidas-schemas/tidas_lifecyclemodels.json
@@ -188,52 +188,8 @@
                             }
                           ],
                           "uniqueItems": true,
-                          "allOf": [
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "0"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "1"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "2"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "3"
-                                  }
-                                }
-                              }
-                            }
-                          ]
+                          "maxItems": 4,
+                          "additionalItems": false
                         },
                         "common:other": {
                           "$ref": "tidas_data_types.json#/$defs/CommonOther"

--- a/assets/tidas-schemas/tidas_processes.json
+++ b/assets/tidas-schemas/tidas_processes.json
@@ -196,52 +196,8 @@
                             }
                           ],
                           "uniqueItems": true,
-                          "allOf": [
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "0"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "1"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "2"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "3"
-                                  }
-                                }
-                              }
-                            }
-                          ]
+                          "maxItems": 4,
+                          "additionalItems": false
                         },
                         "common:other": {
                           "$ref": "tidas_data_types.json#/$defs/CommonOther"

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-11
-lastReviewedCommit: 878388e91ffa15e1ba3e26782edbffd262b55f8b
+lastReviewedAt: 2026-06-15
+lastReviewedCommit: ccdf27d6fcd75b95b05998f889053d748871151a
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-11
-lastReviewedCommit: 878388e91ffa15e1ba3e26782edbffd262b55f8b
+lastReviewedAt: 2026-06-15
+lastReviewedCommit: 9d52329b947a8b13f675247bd61b16f0a1982cf9
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-11
-lastReviewedCommit: bb203a607873b01331dead75396de3dd9799fbda
+lastReviewedAt: 2026-06-15
+lastReviewedCommit: 9d52329b947a8b13f675247bd61b16f0a1982cf9
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -19,8 +19,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-11
-lastReviewedCommit: bb203a607873b01331dead75396de3dd9799fbda
+lastReviewedAt: 2026-06-15
+lastReviewedCommit: 9d52329b947a8b13f675247bd61b16f0a1982cf9
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/cli",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.101.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Unified TianGong LCA CLI with direct REST adapters and low-entropy command surface.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem

TIDAS classification arrays force a **full-depth** path, wrongly rejecting legitimately-shallow classifications — e.g. ILCD **"Land use"** (level 0–1) and **"Other elementary flows" / Noise** (level 0) elementary flows, which have no deeper levels in the category scheme.

Root cause: the arrays expressed *"0..N levels, at most one per level"* via JSON-Schema `allOf`/`contains` + `minContains:0` / `maxContains:1`. But every validator in the stack is **draft-07** — `jsonschema@1.5.0` (TS SDK `validatePackageDir`), `Draft7Validator` (tidas-tools `validate.py`), `fastjsonschema`/`jsonschema` (Python SDK) — and **silently ignores `minContains`/`maxContains`**. Bare draft-07 `contains` means "≥1 match required", so the per-level `contains` blocks force the array to contain one item of **every** level.

## Fix

Replace each broken `allOf`/`contains` block with draft-07-native **`maxItems: N` + `additionalItems: false`**. The positional `items` tuple + `uniqueItems` already pin level-by-position. **Strictly loosening** on the count dimension (0..N levels now valid; >N still rejected). Value-level catId/text validation (`dependencies` → category scheme) and the code-level classification-hierarchy ordering check are unchanged.

6 blocks across 5 schemas: `tidas_flows` (×2: elementary `common:category` + product `common:classification`), `tidas_contacts`, `tidas_lciamethods`, `tidas_lifecyclemodels`, `tidas_processes`.

> The generated **Zod** (TS) and **Pydantic** (Python) models never encoded this cardinality (`ts-to-zod` / `datamodel-codegen` can't express `contains`), so **only the JSON schemas change** — regenerating types/Zod/Pydantic produces no diff. This is also why the fix lives entirely in the JSON schemas.

## Verification (all green)

- **tidas-tools**: `uv run pytest` → **89 passed**
- **tidas-sdk**: jest **41 passed**; pytest **37 passed**
- **cli**: `npm test` → **775 passed**
- **305/305** sample BAFU flows valid under the patched schemas (the 13 previously-blocked Land-use/Noise elementary flows now validate); negative tests (over-deep array, invalid catId/text, wrong order) still rejected.

## Repo note

The CLI validates via `@tiangong-lca/tidas-sdk` (FlowSchema/ProcessSchema + `validatePackageDir`) **and** its own vendored `assets/tidas-schemas/` (used by `dataset-classification`). This PR updates the vendored copy (5 schemas). The `@tiangong-lca/tidas-sdk` dependency (`^0.1.41`) auto-resolves to the fixed SDK once it republishes — see tiangong-lca/tidas-tools#101 (root) and the tidas-sdk PR.
