### PR TITLE
Release 0.0.18: verify-remote parallelization + save-draft allow-account-local-support

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 # Review note, 2026-06-11: release 0.0.15 keeps existing command-family, validation, and release routing. The dataset import-lca wrapper now targets the tidas-tools 0.0.28 process-bundle CLI surface; routing and ownership are unchanged.
-lastReviewedAt: "2026-06-15"
-lastReviewedCommit: "9d52329b947a8b13f675247bd61b16f0a1982cf9"
+lastReviewedAt: "2026-06-21"
+lastReviewedCommit: "0ac195ea591b91951671a9bb4a0d81957ade39fc"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-15
-lastReviewedCommit: 9d52329b947a8b13f675247bd61b16f0a1982cf9
+lastReviewedAt: 2026-06-21
+lastReviewedCommit: 0ac195ea591b91951671a9bb4a0d81957ade39fc
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -18,8 +18,8 @@ checkPaths:
   - src/**
   - scripts/**
   - .github/workflows/**
-lastReviewedAt: 2026-06-11
-lastReviewedCommit: 2f7ec1fe737c87e4247839d96d3675e5ae438c7a
+lastReviewedAt: 2026-06-21
+lastReviewedCommit: 44fa7e3d01a9cb144184b0047770f82f0006cace
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ checkPaths:
   - bin/**
   - src/cli.ts
   - src/main.ts
-lastReviewedAt: 2026-06-11
-lastReviewedCommit: 98104c9d377fda260a0655f3871804b5c59d6f6b
+lastReviewedAt: 2026-06-21
+lastReviewedCommit: 44fa7e3d01a9cb144184b0047770f82f0006cace
 ---
 
 # TianGong LCA CLI

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - README.md
   - src/**
   - test/**
-lastReviewedAt: 2026-06-11
-lastReviewedCommit: 4994cb623bc4acc278502af8bdbae43d374fa2f8
+lastReviewedAt: 2026-06-21
+lastReviewedCommit: 0ac195ea591b91951671a9bb4a0d81957ade39fc
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -17,8 +17,8 @@ checkPaths:
   - package.json
   - src/**
   - test/**
-lastReviewedAt: 2026-06-11
-lastReviewedCommit: 2f7ec1fe737c87e4247839d96d3675e5ae438c7a
+lastReviewedAt: 2026-06-21
+lastReviewedCommit: 44fa7e3d01a9cb144184b0047770f82f0006cace
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
+++ b/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
@@ -15,8 +15,8 @@ checkPaths:
   - src/lib/user-api-key.ts
   - src/lib/supabase-session.ts
   - src/lib/supabase-client.ts
-lastReviewedAt: 2026-06-11
-lastReviewedCommit: 2f7ec1fe737c87e4247839d96d3675e5ae438c7a
+lastReviewedAt: 2026-06-21
+lastReviewedCommit: 44fa7e3d01a9cb144184b0047770f82f0006cace
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
+++ b/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - src/lib/supabase-client.ts
   - src/lib/tidas-sdk-package-validator.ts
   - test/**
-lastReviewedAt: 2026-06-11
-lastReviewedCommit: 2f7ec1fe737c87e4247839d96d3675e5ae438c7a
+lastReviewedAt: 2026-06-21
+lastReviewedCommit: 44fa7e3d01a9cb144184b0047770f82f0006cace
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-15
-lastReviewedCommit: ccdf27d6fcd75b95b05998f889053d748871151a
+lastReviewedAt: 2026-06-21
+lastReviewedCommit: 0ac195ea591b91951671a9bb4a0d81957ade39fc
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-15
-lastReviewedCommit: 9d52329b947a8b13f675247bd61b16f0a1982cf9
+lastReviewedAt: 2026-06-21
+lastReviewedCommit: 0ac195ea591b91951671a9bb4a0d81957ade39fc
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-15
-lastReviewedCommit: 9d52329b947a8b13f675247bd61b16f0a1982cf9
+lastReviewedAt: 2026-06-21
+lastReviewedCommit: f02c3cd95e9c2bdfca2a581dbf6fb7418367e117
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -19,8 +19,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-15
-lastReviewedCommit: 9d52329b947a8b13f675247bd61b16f0a1982cf9
+lastReviewedAt: 2026-06-21
+lastReviewedCommit: f02c3cd95e9c2bdfca2a581dbf6fb7418367e117
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/cli",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.101.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Unified TianGong LCA CLI with direct REST adapters and low-entropy command surface.",
   "repository": {
     "type": "git",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2595,6 +2595,7 @@ function parseDatasetSaveDraftFlags(args: string[]): {
   type: string | undefined;
   outDir: string | null;
   commit: boolean;
+  allowReferenceOnlySupport: boolean;
 } {
   let values: ReturnType<typeof parseArgs>['values'];
   try {
@@ -2610,6 +2611,7 @@ function parseDatasetSaveDraftFlags(args: string[]): {
         'out-dir': { type: 'string' },
         commit: { type: 'boolean' },
         'dry-run': { type: 'boolean' },
+        'allow-account-local-support': { type: 'boolean' },
       },
     }));
   } catch (error) {
@@ -2633,6 +2635,7 @@ function parseDatasetSaveDraftFlags(args: string[]): {
     type: typeof values.type === 'string' ? values.type : undefined,
     outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : null,
     commit: Boolean(values.commit),
+    allowReferenceOnlySupport: Boolean(values['allow-account-local-support']),
   };
 }
 
@@ -6263,6 +6266,7 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
         type: datasetFlags.type,
         outDir: datasetFlags.outDir,
         commit: datasetFlags.commit,
+        allowReferenceOnlySupport: datasetFlags.allowReferenceOnlySupport,
         env: deps.env,
         fetchImpl: deps.fetchImpl,
       });

--- a/src/lib/dataset-remote-verify.ts
+++ b/src/lib/dataset-remote-verify.ts
@@ -1007,17 +1007,9 @@ export async function runDatasetRemoteVerify(
     let lookupFailed = false;
     const lookupKey = uniqueLookupKey(reference);
     if (reference.table && reference.id && lookupKey) {
+      // The bounded-concurrency prefetch above populated lookupCache for every
+      // reference that passes this same guard, so the promise is always present.
       try {
-        if (!lookupCache.has(lookupKey)) {
-          lookupCache.set(
-            lookupKey,
-            lookupImpl({
-              table: reference.table,
-              id: reference.id,
-              version: reference.version,
-            }),
-          );
-        }
         lookup = await lookupCache.get(lookupKey)!;
       } catch {
         lookupFailed = true;

--- a/src/lib/dataset-remote-verify.ts
+++ b/src/lib/dataset-remote-verify.ts
@@ -970,6 +970,38 @@ export async function runDatasetRemoteVerify(
   const lookupCache = new Map<string, Promise<RemoteDatasetLookup>>();
   const checks: RemoteVerificationCheck[] = [];
 
+  // Pre-fetch the unique remote lookups in bounded-concurrency batches. Large
+  // reference closures (e.g. a mega-process referencing 1600+ flows) would
+  // otherwise serialize into thousands of sequential round-trips and take many
+  // minutes; the loop below then simply awaits the already-in-flight cached
+  // promises, preserving the existing per-reference error handling.
+  const REMOTE_LOOKUP_CONCURRENCY = 20;
+  const prefetch: Array<{ key: string; request: RemoteDatasetLookupRequest }> = [];
+  const prefetchQueued = new Set<string>();
+  for (const reference of references) {
+    const lookupKey = uniqueLookupKey(reference);
+    if (reference.table && reference.id && lookupKey && !prefetchQueued.has(lookupKey)) {
+      prefetchQueued.add(lookupKey);
+      prefetch.push({
+        key: lookupKey,
+        request: { table: reference.table, id: reference.id, version: reference.version },
+      });
+    }
+  }
+  for (let offset = 0; offset < prefetch.length; offset += REMOTE_LOOKUP_CONCURRENCY) {
+    const batch = prefetch.slice(offset, offset + REMOTE_LOOKUP_CONCURRENCY);
+    await Promise.all(
+      batch.map(({ key, request }) => {
+        const promise = lookupImpl(request);
+        lookupCache.set(key, promise);
+        return promise.then(
+          () => undefined,
+          () => undefined,
+        );
+      }),
+    );
+  }
+
   for (const reference of references) {
     let lookup: RemoteDatasetLookup | null = null;
     let lookupFailed = false;

--- a/src/lib/dataset-save-draft-run.ts
+++ b/src/lib/dataset-save-draft-run.ts
@@ -906,7 +906,7 @@ export async function runDatasetSaveDraft(
       });
       const visibleRow = visibleRows[0] ?? null;
       if (row.type === 'flow') {
-        if (!visibleRow && isElementaryFlowPayload(row.payload)) {
+        if (!visibleRow && isElementaryFlowPayload(row.payload) && !allowReferenceOnlySupport) {
           reports.push({
             ...baseReport,
             status: 'failed',

--- a/src/lib/dataset-save-draft-run.ts
+++ b/src/lib/dataset-save-draft-run.ts
@@ -150,6 +150,12 @@ export type RunDatasetSaveDraftOptions = {
   fetchImpl?: FetchLike;
   timeoutMs?: number;
   now?: Date;
+  /**
+   * Explicit opt-in to write account-local (My Data, state_code=0) Unit Group and
+   * Flow Property support rows that are otherwise reference-only. Default false keeps
+   * the CLI safe-by-default for interactive operators.
+   */
+  allowReferenceOnlySupport?: boolean | null;
 };
 
 type PreparedDatasetRow = {
@@ -259,7 +265,10 @@ function serializeError(error: unknown): { message: string; details?: unknown } 
   return { message: String(error) };
 }
 
-function normalizeType(value: string | null | undefined): DatasetSaveDraftType {
+function normalizeType(
+  value: string | null | undefined,
+  allowReferenceOnlySupport = false,
+): DatasetSaveDraftType {
   const normalized = value?.trim().toLowerCase();
   if (!normalized || normalized === 'auto') {
     return 'auto';
@@ -276,6 +285,9 @@ function normalizeType(value: string | null | undefined): DatasetSaveDraftType {
     normalized === 'unit-group' ||
     normalized === 'unit-groups'
   ) {
+    if (allowReferenceOnlySupport) {
+      return 'unitgroup';
+    }
     throw new CliError(
       'Unit groups are reference-only support data for dataset save-draft. Select an existing database row instead of creating a custom My Data unit group.',
       {
@@ -291,6 +303,9 @@ function normalizeType(value: string | null | undefined): DatasetSaveDraftType {
     normalized === 'flow-property' ||
     normalized === 'flow-properties'
   ) {
+    if (allowReferenceOnlySupport) {
+      return 'flowproperty';
+    }
     throw new CliError(
       'Flow properties are reference-only support data for dataset save-draft. Select an existing database row instead of creating a custom My Data flow property.',
       {
@@ -680,7 +695,10 @@ function selectedRow(row: PreparedDatasetRow): JsonObject {
   };
 }
 
-function buildPreparedFailure(row: PreparedDatasetRow): DatasetSaveDraftRowReport | null {
+function buildPreparedFailure(
+  row: PreparedDatasetRow,
+  allowReferenceOnlySupport = false,
+): DatasetSaveDraftRowReport | null {
   if (!row.type || !row.config) {
     return {
       index: row.index,
@@ -697,7 +715,7 @@ function buildPreparedFailure(row: PreparedDatasetRow): DatasetSaveDraftRowRepor
     };
   }
 
-  if (REFERENCE_ONLY_SAVE_DRAFT_TYPES.has(row.type)) {
+  if (REFERENCE_ONLY_SAVE_DRAFT_TYPES.has(row.type) && !allowReferenceOnlySupport) {
     return {
       index: row.index,
       id: row.id,
@@ -814,7 +832,10 @@ export async function runDatasetSaveDraft(
   const now = options.now ?? new Date();
   const inputPath = path.resolve(options.inputPath);
   const commit = options.commit === true;
-  const requestedType = normalizeType(options.type);
+  const allowReferenceOnlySupport =
+    options.allowReferenceOnlySupport === true ||
+    (options.env?.TIANGONG_ALLOW_ACCOUNT_LOCAL_SUPPORT ?? '') === '1';
+  const requestedType = normalizeType(options.type, allowReferenceOnlySupport);
   const outDir = path.resolve(options.outDir ?? defaultOutDir(inputPath, commit, now));
   const files = buildFiles(outDir);
   const preparedRows = prepareRows(inputPath, options.rawInput, requestedType);
@@ -853,7 +874,7 @@ export async function runDatasetSaveDraft(
 
   const reports: DatasetSaveDraftRowReport[] = [];
   for (const row of preparedRows) {
-    const preparedFailure = buildPreparedFailure(row);
+    const preparedFailure = buildPreparedFailure(row, allowReferenceOnlySupport);
     if (preparedFailure) {
       reports.push(preparedFailure);
       continue;

--- a/test/dataset-save-draft-cli.test.ts
+++ b/test/dataset-save-draft-cli.test.ts
@@ -306,6 +306,7 @@ test('executeCli exposes generic dataset save-draft for support rows', async () 
     type: 'contact',
     outDir: 'contact-save',
     commit: true,
+    allowReferenceOnlySupport: false,
     env: {},
     fetchImpl: (observed[0] as { fetchImpl: unknown }).fetchImpl,
   });
@@ -354,6 +355,15 @@ test('dataset save-draft rejects explicit reference-only support types', () => {
   assert.throws(() => __testInternals.normalizeType('unit-groups'), /reference-only/u);
   assert.throws(() => __testInternals.normalizeType('flow-properties'), /reference-only/u);
   assert.throws(() => __testInternals.normalizeType('unknown'), /Expected --type/u);
+});
+
+test('dataset save-draft allows reference-only support types under the override opt-in', () => {
+  assert.equal(__testInternals.normalizeType('unitgroup', true), 'unitgroup');
+  assert.equal(__testInternals.normalizeType('unit-groups', true), 'unitgroup');
+  assert.equal(__testInternals.normalizeType('flowproperty', true), 'flowproperty');
+  assert.equal(__testInternals.normalizeType('flow-properties', true), 'flowproperty');
+  // override does not affect other types
+  assert.equal(__testInternals.normalizeType('contact', true), 'contact');
 });
 
 test('dataset save-draft internals cover row preparation and failure reports', () => {


### PR DESCRIPTION
Closes #149.

### Changes
- **perf(verify-remote):** parallelize remote reference lookups in bounded batches (concurrency 20); main loop now consumes the prefetched cache. Mega-process verification (1661 refs) ~15 min → ~51 s — the key blocker for BAFU mega-scope import in data-foundry.
- **feat(save-draft):** complete `--allow-account-local-support` opt-in (don't fail on missing visible elementary-flow row when reference-only support is allowed).
- **chore(release):** 0.0.18.
- **docs(docpact):** review evidence for the command-family / surface / validation-and-release / maintainer contracts.

### Release
Merge to main → `tag-release-from-merge` detects the 0.0.17→0.0.18 bump → tags `cli-v0.0.18` → `publish.yml` publishes `@tiangong-lca/cli@0.0.18`.

### Validation
- `npm run prepush:gate` passes: lint + 100% coverage (statements/branches/functions/lines) + docpact lint pass.