### PR TITLE
feat(dataset): add auditable row-level maintenance workflow

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 # Review note, 2026-06-11: release 0.0.15 keeps existing command-family, validation, and release routing. The dataset import-lca wrapper now targets the tidas-tools 0.0.28 process-bundle CLI surface; routing and ownership are unchanged.
-lastReviewedAt: "2026-06-29"
-lastReviewedCommit: "695e6d6fe718cb92d499f3ce8be2dc24c3f6ce29"
+lastReviewedAt: "2026-07-11"
+lastReviewedCommit: "b11482ca0dae414719336525c580cab1126897cd"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-29
+lastReviewedAt: 2026-07-11
 lastReviewedCommit: 695e6d6fe718cb92d499f3ce8be2dc24c3f6ce29
 related:
   - .docpact/config.yaml
@@ -56,6 +56,8 @@ Review note, 2026-06-05: release 0.0.12 only updates CLI package version metadat
 Review note, 2026-06-07: release 0.0.14 keeps the CLI-owned dataset classification command family and release workflow boundaries unchanged. `dataset classification apply --type location` may create an explicit missing location field such as `locationOfSupply`, but path ambiguity still blocks.
 
 Review note, 2026-06-11: release 0.0.15 keeps command nouns/verbs, repo ownership, and release workflow boundaries unchanged. `dataset import-lca convert` now matches the tidas-tools 0.0.28 import_lca CLI surface: the wrapper no longer passes a bare `--process-bundles` flag, forwards `--no-process-bundles` when bundles are disabled, and derives report bundle/mapping file fields from on-disk state.
+
+Review note, 2026-07-11: `dataset maintenance plan/apply/verify` is now the CLI-owned v1 row-level maintenance contract. It freezes exact current-user RLS scope and audit artifacts before any write, executes only approved `save_draft` / `delete` actions through platform command paths, and verifies the result with an independent readback.
 
 ## Bootstrap Order
 
@@ -112,6 +114,7 @@ Route those tasks to:
 - Newly added process-maintenance commands such as `process identity-preflight`, `process build-plan`, `process scope-statistics`, `process dedup-review`, `process refresh-references`, and `process verify-rows` still belong to the native CLI command surface in `src/cli.ts` and `src/lib/process-*.ts` / shared CLI-native helpers.
 - `process save-draft` now has a local `ProcessSchema` validation gate before any commit path writes remote state, and `--target-user-id` is a hard current-session/visible-draft owner guard for account-scoped batch imports.
 - Dataset-level local governance commands such as `dataset validate`, `dataset curation-queue build/next/verify`, and `dataset references rewrite` belong to the same native CLI command surface in `src/cli.ts` and `src/lib/dataset-*.ts`.
+- `dataset maintenance plan/apply/verify` owns current-user RLS-scoped row maintenance in `src/lib/dataset-maintenance-{contract,remote,plan,apply,verify}.ts`. V1 requires exact `id` + `version`, `state_code=0`, and current-session ownership; it can plan `save_draft` / `delete` actions only for `contacts`, `sources`, `flows`, and `processes`. `lifecyclemodels`, `unitgroups`, `flowproperties`, public rows, non-owner rows, and non-draft rows are protected.
 - `lifecyclemodel save-draft` validates canonical lifecyclemodel payloads with `LifeCycleModelSchema` before any commit path writes remote state; `lifecyclemodel graph` remains a local artifact command.
 - `flow publish-version` validates canonical flow payloads with `FlowSchema` before remote visibility planning or writes, and emits `flow-publish-version-gate-report.json` as the blocking ruleset artifact.
 - `process publish-build` validates canonical process payloads with `ProcessSchema` before publish handoff artifacts are written, and emits `reports/process-publish-schema-gate.json`.
@@ -127,6 +130,7 @@ Route those tasks to:
 
 - Do not add orchestration frameworks or new npm dependencies without explicit approval
 - Do not publish `@tiangong-lca/cli` from a local workstation for routine releases; local npm auth state is not part of the release contract.
+- Do not implement dataset maintenance through direct SQL, service-role credentials, raw REST mutation, or Foundry-local database code. Foundry and skills may prepare scope and orchestrate the CLI, but the native CLI must own current-user RLS preflight, platform-command mutation, per-action audit logging, and independent readback verification.
 - Do not move business logic into skill wrappers when the native `tiangong-lca` CLI should own it
 - Do not weaken the coverage gate with ignore pragmas; cover the branch or remove dead code
 - Do not treat governed docs as optional when command-surface, validation, or release-gate behavior changes; `docpact` should either require a matching source-doc update or record explicit review evidence.

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -39,6 +39,8 @@ Review note, 2026-06-07: release 0.0.14 keeps maintainer runtime and release gui
 
 Review note, 2026-06-11: release 0.0.15 keeps maintainer runtime and release guidance unchanged. `dataset import-lca convert` now adapts to the tidas-tools 0.0.28 process-bundle flags (no bare `--process-bundles`, `--no-process-bundles` only when disabled) and reports bundle/mapping files from actual on-disk state.
 
+Review note, 2026-07-11: `dataset maintenance plan/apply/verify` is now an implemented current-user RLS command family. It adds no environment variables or release-path changes; commit remains bound to an immutable plan hash, current account confirmation, append-only per-action logs, and independent readback verification.
+
 设计原则：
 
 - 统一入口：所有 TianGong 平台能力最终收敛到 `tiangong-lca` 一个命令树
@@ -72,6 +74,7 @@ Review note, 2026-06-11: release 0.0.15 keeps maintainer runtime and release gui
 - `tiangong-lca dataset classification children/path/audit/apply`
 - `tiangong-lca dataset curation-queue build`
 - `tiangong-lca dataset references rewrite`
+- `tiangong-lca dataset maintenance plan/apply/verify`
 - `tiangong-lca lifecyclemodel auto-build`
 - `tiangong-lca lifecyclemodel validate-build`
 - `tiangong-lca lifecyclemodel publish-build`
@@ -207,6 +210,7 @@ TIANGONG_LCA_UNSTRUCTURED_RETURN_TXT=true
 | `dataset classification children/path/audit/apply` | 无 |
 | `dataset curation-queue build` | 无 |
 | `dataset references rewrite` | 本地 rewrite 默认无；若 `--commit` 写入 patched rows，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` |
+| `dataset maintenance plan/apply/verify` | 都需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY`；`plan`/`verify` 只读，`apply` 还必须显式提供 plan hash 与当前账号邮箱确认 |
 | `lifecyclemodel auto-build \| validate-build \| publish-build \| graph \| orchestrate` | 无 |
 | `lifecyclemodel save-draft` | 本地 dry-run 默认无；若 `--commit` 写入 lifecyclemodel draft，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` |
 | `lifecyclemodel build-resulting-process` | 本地运行默认无；若 request 打开 `process_sources.allow_remote_lookup=true`，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` |
@@ -255,6 +259,9 @@ npm exec tiangong-lca -- dataset validate --input ./rows.jsonl --type auto --out
 npm exec tiangong-lca -- dataset classification audit --type location --input ./rows/rows.jsonl --out-dir ./location-audit --json
 npm exec tiangong-lca -- dataset curation-queue build --processes ./rows/processes.jsonl --flows ./rows/flows.jsonl --support ./rows/sources.jsonl --out-dir ./curation-queue --json
 npm exec tiangong-lca -- dataset references rewrite --input ./rows.jsonl --from flow:<old-id>@<old-version> --to flow:<new-id>@<new-version> --out-dir ./dataset-rewrite --json
+npm exec tiangong-lca -- dataset maintenance plan --scope ./maintenance-scope.json --operation repair-references --out-dir ./dataset-maintenance --json
+npm exec tiangong-lca -- dataset maintenance apply --plan ./dataset-maintenance/maintenance-plan.json --commit --approve-plan <sha256> --confirm <current-account-email> --json
+npm exec tiangong-lca -- dataset maintenance verify --plan ./dataset-maintenance/maintenance-plan.json --out-dir ./dataset-maintenance/verify --json
 npm exec tiangong-lca -- lifecyclemodel auto-build --input ./examples/lifecyclemodel-auto-build.request.json --out-dir /abs/path/to/lifecyclemodel-run --json
 npm exec tiangong-lca -- lifecyclemodel validate-build --run-dir /abs/path/to/lifecyclemodel-run --json
 npm exec tiangong-lca -- lifecyclemodel publish-build --run-dir /abs/path/to/lifecyclemodel-run --json
@@ -285,6 +292,10 @@ npm exec tiangong-lca -- admin embedding-run --input ./jobs.json --dry-run
 ```
 
 ## process / review / publish / validation 边界
+
+`tiangong-lca dataset maintenance plan/apply/verify` 是错误导入后 row-level 修复的 CLI-owned 入口。`plan` 冻结当前用户 RLS 可见快照、保护行、引用影响、desired payload 和 canonical plan SHA-256；`apply` 只允许精确 `id + version` 的当前账号 `state_code=0` draft，通过 `cmd_dataset_save_draft` / `cmd_dataset_delete` 执行，并把相同 plan/action correlation 写入 `p_audit` 和本地 `apply-progress.jsonl`；`verify` 独立读回 payload、owner/state、保护行和引用闭包。Foundry/skills 只能编排这些命令，不得实现私有 SQL、service-role 或 raw REST mutation。
+
+`apply` 是 commit-only：必须同时提供 `--commit`、精确 `--approve-plan <sha256>` 和 `--confirm <current-account-email>`。首写前会持久化 approval 并做全计划 drift preflight，每条 pending action 在 RPC 前再做 exact read；update 先于 delete，首个失败会停止后续动作，同一计划可从已记录成功项安全续跑。`lifecyclemodels`、`unitgroups`、`flowproperties`、public/shared、非 owner、非 draft 和不可见行在 v1 中一律保护或阻断。
 
 `tiangong-lca process get` 现在是统一 CLI 持有的只读 process 详情命令，负责：
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@ checkPaths:
   - bin/**
   - src/cli.ts
   - src/main.ts
-lastReviewedAt: 2026-06-29
+lastReviewedAt: 2026-07-11
 lastReviewedCommit: 695e6d6fe718cb92d499f3ce8be2dc24c3f6ce29
 ---
 
 # TianGong LCA CLI
 
 Package: `@tiangong-lca/cli` Executable: `tiangong-lca` Node: `24.x`
+
+Review note, 2026-07-11: `dataset maintenance plan/apply/verify` is an implemented v1 command family for current-user RLS-scoped, exact-row draft maintenance with immutable plans, explicit approval, per-action logs, platform audit correlation, and independent readback verification.
 
 ## Run
 
@@ -273,7 +275,9 @@ tiangong-lca dataset curation-queue verify --queue-dir /abs/path/to/curation-que
 tiangong-lca dataset evidence-search plan --query "中国2026年电力结构数据" --out-dir /abs/path/to/evidence-search --json
 tiangong-lca dataset evidence-search run --input ./evidence-search.request.json --results ./search-results.json --out-dir /abs/path/to/evidence-search --json
 tiangong-lca dataset references rewrite --input ./rows.jsonl --from flow:<old-id>@<old-version> --to flow:<new-id>@<new-version> --out-dir /abs/path/to/dataset-rewrite --json
-tiangong-lca dataset maintenance plan --scope ./maintenance-scope.json --operation redo-import --out-dir /abs/path/to/dataset-maintenance
+tiangong-lca dataset maintenance plan --scope ./maintenance-scope.json --operation redo-import --out-dir /abs/path/to/dataset-maintenance --page-size 1000 --timeout-ms 10000 --json
+tiangong-lca dataset maintenance apply --plan /abs/path/to/dataset-maintenance/maintenance-plan.json --commit --approve-plan <sha256> --confirm <current-account-email> --timeout-ms 10000 --json
+tiangong-lca dataset maintenance verify --plan /abs/path/to/dataset-maintenance/maintenance-plan.json --out-dir /abs/path/to/dataset-maintenance/verify --page-size 1000 --timeout-ms 10000 --json
 tiangong-lca lifecyclemodel auto-build --input ./examples/lifecyclemodel-auto-build.request.json --out-dir /abs/path/to/lifecyclemodel-run --json
 tiangong-lca lifecyclemodel validate-build --run-dir /abs/path/to/lifecyclemodel-run --json
 tiangong-lca lifecyclemodel publish-build --run-dir /abs/path/to/lifecyclemodel-run --json
@@ -316,7 +320,50 @@ For `dataset curation-queue build/next/verify`, the CLI owns entity-level Foundr
 
 For `dataset references rewrite`, `--commit` executes the state-aware save-draft path for patched process and lifecyclemodel rows; without `--commit`, the command only writes local rewrite artifacts.
 
-For `dataset maintenance plan/apply/verify`, the planned command family owns RLS-scoped delete/redo workflows for bad imports. The contract requires a frozen scope manifest, current-user visible snapshot, protected rows list, reference impact report, dry-run report, explicit commit report, and readback verification. Foundry and skills may orchestrate it, but they must not add private Supabase delete logic.
+## Dataset Maintenance
+
+`dataset maintenance plan/apply/verify` is the v1 row-level cleanup surface for bad imports. It runs as the currently authenticated user and relies on RLS for visibility and ownership enforcement.
+
+```bash
+tiangong-lca dataset maintenance plan \
+  --scope ./maintenance-scope.json \
+  --operation redo-import \
+  --out-dir ./dataset-maintenance \
+  --page-size 1000 \
+  --timeout-ms 10000 \
+  --json
+
+tiangong-lca dataset maintenance apply \
+  --plan ./dataset-maintenance/maintenance-plan.json \
+  --commit \
+  --approve-plan <sha256> \
+  --confirm <current-account-email> \
+  --timeout-ms 10000 \
+  --json
+
+tiangong-lca dataset maintenance verify \
+  --plan ./dataset-maintenance/maintenance-plan.json \
+  --out-dir ./dataset-maintenance/verify \
+  --page-size 1000 \
+  --timeout-ms 10000 \
+  --json
+```
+
+V1 scope is intentionally narrow:
+
+- Each requested row must name its table, exact `id`, exact `version`, expected current owner, and draft `state_code=0` state.
+- `--operation` accepts `delete`, `retire`, `redo-import`, or `repair-references`; it records the operator's maintenance intent and does not broaden the eligible row actions.
+- Only current-user `contacts`, `sources`, `flows`, and `processes` can become `save_draft` or `delete` actions.
+- `lifecyclemodels`, `unitgroups`, `flowproperties`, public/shared rows, non-owner rows, and non-draft rows are protected.
+- The CLI classifies and executes an operator-authored scope; it does not decide whether rows are semantically duplicates, canonical replacements, or safe business-level cleanup targets.
+
+`plan` writes the frozen `maintenance-scope.json`, `rls-visible-snapshot.json`, `protected-rows.jsonl`, `reference-impact-report.json`, `maintenance-plan.json`, and `dry-run-report.json`. The plan SHA-256 is the approval identity; do not edit the plan after review.
+
+`apply` is write-disabled unless all three commit guards are present: `--commit`, `--approve-plan <sha256>`, and `--confirm <current-account-email>`. Before the first write it re-checks the whole plan for drift and persists `approval-record.json`. It then executes updates before deletes through the platform dataset command path, correlates the plan and action ids in `p_audit`, and appends one durable record per attempted action to `apply-progress.jsonl`. Each record includes at least the plan SHA-256, operation/action ids, exact table/id/version, actor, start/finish times, before/after SHA-256, result or error, and rollback guidance. `commit-report.json` summarizes the ledger. A failure stops later actions; recorded successful actions are recognized on a safe rerun.
+
+`verify` performs a fresh remote readback rather than trusting the apply report and writes `readback-verify-report.json` in its own output directory.
+
+Foundry and skills may prepare the scope, invoke these commands, and retain their artifacts. They must not replace the CLI with direct SQL, service-role access, raw REST mutation, or private Supabase delete/update code.
 
 ## More Docs
 

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -16,7 +16,7 @@ checkPaths:
   - README.md
   - src/**
   - test/**
-lastReviewedAt: 2026-06-29
+lastReviewedAt: 2026-07-11
 lastReviewedCommit: 695e6d6fe718cb92d499f3ce8be2dc24c3f6ce29
 related:
   - ../AGENTS.md
@@ -27,6 +27,8 @@ related:
 ---
 
 # TianGong LCA CLI 实施指南
+
+Review note, 2026-07-11: `dataset maintenance plan/apply/verify` 已实现为 v1 current-user RLS row-level maintenance 契约；scope 冻结、全计划 drift preflight、显式审批、逐 action 日志、平台审计关联与独立 readback verification 都由原生 CLI 持有。
 
 ## 1. 目标
 
@@ -91,7 +93,9 @@ tiangong-lca
     curation-queue next
     curation-queue verify
     references rewrite
-    maintenance plan/apply/verify（规划中）
+    maintenance plan
+    maintenance apply
+    maintenance verify
   lifecyclemodel
     auto-build
     validate-build
@@ -147,7 +151,7 @@ tiangong-lca
 | `tiangong-lca dataset import-lca convert` | 外部 LCA 包转换入口；调用 `tidas-tools import_lca` 生成 TIDAS/ILCD/conversion report；tidas-tools >= 0.0.28 默认产出每个 process 的依赖子目录（可用 `--no-process-bundles` 关闭、`--process-bundles-dir` 自定义目录），便于后续 entity-level curation |
 | `tiangong-lca dataset references rewrite` | 本地 process / lifecyclemodel rows 的 flow reference rewrite、patch evidence 输出，并可选走 state-aware save-draft commit |
 | `tiangong-lca dataset maintenance clear-account` | 已实现的当前账号 draft 清理入口；先生成当前用户 RLS 可见 snapshot，默认 dry-run，只有显式 `--commit --confirm <当前账号邮箱>` 才按 `lifecyclemodels -> processes -> flows -> sources -> contacts` 顺序执行。普通 dataset rows 通过 `app_dataset_delete` / `cmd_dataset_delete` 删除，读回验证剩余行数；`unitgroups` / `flowproperties` 默认保护不删 |
-| `tiangong-lca dataset maintenance plan/apply/verify` | 规划中的用户 RLS 约束 row-level 数据维护入口；用于错误导入后的删除、退役、重新导入和引用修复。必须先生成不可变 maintenance plan、当前用户可见 snapshot、protected rows、reference impact、dry-run、commit 与 readback verify artifacts；不得绕过 RLS，也不得由 Foundry 私有实现 delete |
+| `tiangong-lca dataset maintenance plan/apply/verify` | 已实现的 current-user RLS row-level draft 维护入口。`plan` 冻结 exact `id/version` scope、可见快照、保护行、引用影响、不可变计划与 dry-run；`apply` 要求 plan SHA-256 + 当前账号邮箱显式审批，整计划 drift preflight 通过后按 update-before-delete 顺序调用平台 `save_draft` / `delete` 路径并逐 action 留痕；`verify` 独立重新读取受影响行与引用。V1 只允许 current-user `state_code=0` 的 contacts/sources/flows/processes，其他类型与 public/non-owner/non-draft rows 受保护 |
 | `tiangong-lca lifecyclemodel auto-build` | 本地 lifecyclemodel local-run intake、graph 推断、reference process 选择、`json_ordered` artifact 输出 |
 | `tiangong-lca lifecyclemodel validate-build` | 本地 lifecyclemodel build run 校验重跑、per-model 校验报告与 aggregate report 输出 |
 | `tiangong-lca lifecyclemodel publish-build` | 本地 lifecyclemodel publish handoff、publish bundle/request/intent 产出、validation 摘要复用 |
@@ -211,6 +215,9 @@ tiangong-lca
 - `tiangong-lca dataset curation-queue next` 已可执行
 - `tiangong-lca dataset curation-queue verify` 已可执行
 - `tiangong-lca dataset references rewrite` 已可执行
+- `tiangong-lca dataset maintenance plan` 已可执行
+- `tiangong-lca dataset maintenance apply` 已可执行
+- `tiangong-lca dataset maintenance verify` 已可执行
 
 注意：
 
@@ -230,7 +237,7 @@ tiangong-lca
 - 已实现的 `dataset curation-queue build/next/verify` 把 Foundry external dataset import 的 support / flow / process rows 收口成 entity-level queue artifact contract：`build` 生成 `curation-queue-manifest.json`、`curation-queue-tasks.jsonl`、`curation-queue-locks.json`、`curation-queue-blockers.jsonl`，以及每个 entity 的 `input.jsonl`、`closure.json`、`entity-run-plan.json`；`next` 读取 task checkpoint 并返回下一条 runnable entity task；`verify` 确认目标 scope 的 checkpoint 完成且没有 build blocker。CLI 只负责稳定状态机、依赖闭包、锁和 blocker；AI authoring 仍必须通过 skill/Codex 输出 structured patch 或 build plan，并在 deterministic apply、schema/QA、prewrite verify、readback 后才允许进入远端写入。
 - 已实现的 `dataset references rewrite` 把 process / lifecyclemodel rows 中的 flow reference rewrite 收口到一个 deterministic 本地入口，默认只写 patch artifacts，只有显式 `--commit` 时才调用 state-aware save-draft 写入路径
 - 已实现的 `dataset maintenance clear-account` 只覆盖当前认证账号的 draft 清空场景：CLI 先写出 `rls-visible-snapshot.json` / `dry-run-report.json`，commit 时要求 `--confirm` 匹配当前账号邮箱，并逐行调用平台 `app_dataset_delete`，最后写出 `approval-record.json`、`commit-report.json` 和 `readback-verify-report.json`。该命令不绕过 RLS，不直接 REST DELETE，不删除默认保护的 `unitgroups` / `flowproperties`。
-- 规划中的 `dataset maintenance plan/apply/verify` 是错误导入清理和 redo 的 row-level 归属面。`plan` 固化 scope manifest、当前用户 RLS 可见快照、引用影响和保护行；`apply` 只能按计划通过官方平台路径执行显式 commit；`verify` 重新读取受影响行和引用，证明 deleted/updated/skipped/protected/redone rows 与计划一致。Foundry 只保存 task ledger、调用命令和报告，不实现删除逻辑。
+- 已实现的 `dataset maintenance plan/apply/verify` 是错误导入清理和 redo 的 row-level 归属面。`plan` 固化 scope manifest、当前用户 RLS 可见快照、引用影响、保护行、不可变 plan 和 dry-run；`apply` 只接受 plan SHA-256 与当前账号邮箱都匹配的显式 commit，先做全计划 drift preflight 并持久化 approval，再按 update-before-delete 顺序通过官方平台路径执行，每条 action 追加日志并用 `p_audit` 关联 plan/action；任一失败立即停止，已成功 action 可由后续重跑识别恢复。`verify` 独立重新读取受影响行和引用，不依赖 apply 的内存或报告结论。Foundry 只保存 task ledger、调用命令和报告，不实现删除逻辑。
 - 已实现的 `lifecyclemodel auto-build` 走本地只读、artifact-first 路径，输入固定为 local run manifest，不依赖 Python、MCP、KB、LLM 或远端 CRUD
 - `lifecyclemodel auto-build` 当前负责 graph 推断、reference process 选择、`@multiplicationFactor` 计算与 `json_ordered` lifecyclemodel 产物输出，并保留 `run-plan.json`、`resolved-manifest.json`、`selection/selection-brief.md`、`discovery/reference-model-summary.json`、`connections.json`、`process-catalog.json` 等 CLI 契约
 - `lifecyclemodel auto-build` 当前明确不负责 reference-model discovery、任何远端 lifecyclemodel 写入，也不会自动串接 validate-build / publish-build
@@ -264,6 +271,67 @@ tiangong-lca
 - 已实现的 `flow validate-processes` 把治理后 patched process rows 的独立校验切片收口到 CLI，固定 original/patched/scope 三类输入契约，并直接写出 `validation-report.json` / `validation-failures.jsonl`
 - 现有命令族里已经没有残留的 Python / shell validation fallback；其余 review / build / publish CLI 面已经进入可执行状态，未迁移子命令只剩 `auth` / `job` 这类 placeholder surface
 - 这样做的目的不是“假装已完成”，而是先固定命令树，再逐个把 workflow 迁入 TypeScript CLI
+
+### 2.1.1 `dataset maintenance plan/apply/verify` v1 契约
+
+公开命令面固定为：
+
+```bash
+tiangong-lca dataset maintenance plan \
+  --scope ./maintenance-scope.json \
+  --operation <delete|retire|redo-import|repair-references> \
+  --out-dir ./dataset-maintenance \
+  [--page-size <n>] \
+  [--timeout-ms <n>] \
+  [--json]
+
+tiangong-lca dataset maintenance apply \
+  --plan ./dataset-maintenance/maintenance-plan.json \
+  --commit \
+  --approve-plan <sha256> \
+  --confirm <current-account-email> \
+  [--timeout-ms <n>] \
+  [--json]
+
+tiangong-lca dataset maintenance verify \
+  --plan ./dataset-maintenance/maintenance-plan.json \
+  [--out-dir ./dataset-maintenance/verify] \
+  [--page-size <n>] \
+  [--timeout-ms <n>] \
+  [--json]
+```
+
+Scope 与保护规则：
+
+- 远端读取和写入都使用当前认证用户 session 与数据库 RLS，不接受 target user 覆盖。
+- 每条 scope row 必须给出表、exact `id`、exact `version`、expected owner、expected `state_code=0` 与 operator-authored intended action/reason；`--operation` 只接受 `delete`、`retire`、`redo-import`、`repair-references`，且不允许只按 broad `state_code=0` 或其他宽过滤器清理。
+- V1 可执行对象只有 `contacts`、`sources`、`flows`、`processes`，可执行 action 只有 `save_draft` 与 `delete`。
+- `lifecyclemodels`、`unitgroups`、`flowproperties`、public/shared、非当前 owner、非 draft、不可见或 exact version 不一致的 rows 一律进入 protected/blocked，不会降级成可执行 action。
+- CLI 只执行人工/上游已经做出的清洗决策，不判断 public canonical、语义重复、引用替代或 redo 内容是否正确。
+
+`plan` 在任何 mutation 之前写出并固定：
+
+- `maintenance-scope.json`
+- `rls-visible-snapshot.json`
+- `protected-rows.jsonl`
+- `reference-impact-report.json`
+- `maintenance-plan.json`
+- `dry-run-report.json`
+
+`maintenance-plan.json` 的 canonical SHA-256 是后续审批身份。plan 生成后不得原地编辑；需要变更 scope 或 action 时重新运行 `plan` 并重新审批。
+
+`apply` 的 commit gate 同时要求 `--commit`、`--approve-plan <sha256>` 与 `--confirm <current-account-email>`。执行顺序固定为：
+
+1. 重新认证当前用户并校验账号邮箱。
+2. 对整份计划重新抓取 exact rows 与引用，任何 drift 都在首写前阻断。
+3. 在首写前持久化 `approval-record.json`。
+4. 先执行 `save_draft`，再执行 `delete`；所有写入都通过平台 dataset command path，而不是 raw REST mutation。
+5. 为每条尝试的 action 向 `apply-progress.jsonl` 追加 durable log，并在平台命令的 `p_audit` 中带入 plan/action correlation id。每行至少记录 `plan_sha256`、`operation_id`、`action_id`、table/id/version、actor、started/finished、`before_sha256`、`after_sha256`、result/error 与 rollback。
+6. 任一 action 失败即停止后续动作并写出 `commit-report.json`；已成功 action 保留在日志中，重跑时据此识别已完成状态，避免盲目重复写入。
+
+`verify` 必须启动独立 remote readback，重新读取受影响 rows 和 references，并写出 `readback-verify-report.json`；它不能把 apply report 当作数据库事实。
+
+安全边界是强约束：不允许 direct SQL、service-role credential、raw REST mutation 或 Foundry 私有 DB maintenance 代码。Foundry 和 skills 只能准备 scope、编排 CLI、保存 task ledger 与上述 artifacts。
 
 ### 2.2 已经固定的工程约束
 

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -17,8 +17,8 @@ checkPaths:
   - package.json
   - src/**
   - test/**
-lastReviewedAt: 2026-06-29
-lastReviewedCommit: 695e6d6fe718cb92d499f3ce8be2dc24c3f6ce29
+lastReviewedAt: 2026-07-11
+lastReviewedCommit: b11482ca0dae414719336525c580cab1126897cd
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
+++ b/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
@@ -15,8 +15,8 @@ checkPaths:
   - src/lib/user-api-key.ts
   - src/lib/supabase-session.ts
   - src/lib/supabase-client.ts
-lastReviewedAt: 2026-06-29
-lastReviewedCommit: 695e6d6fe718cb92d499f3ce8be2dc24c3f6ce29
+lastReviewedAt: 2026-07-11
+lastReviewedCommit: b11482ca0dae414719336525c580cab1126897cd
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
+++ b/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - src/lib/supabase-client.ts
   - src/lib/tidas-sdk-package-validator.ts
   - test/**
-lastReviewedAt: 2026-06-29
-lastReviewedCommit: 695e6d6fe718cb92d499f3ce8be2dc24c3f6ce29
+lastReviewedAt: 2026-07-11
+lastReviewedCommit: b11482ca0dae414719336525c580cab1126897cd
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-29
+lastReviewedAt: 2026-07-11
 lastReviewedCommit: 695e6d6fe718cb92d499f3ce8be2dc24c3f6ce29
 related:
   - ../../AGENTS.md
@@ -49,6 +49,8 @@ Review note, 2026-06-06: release 0.0.13 keeps the release architecture unchanged
 Review note, 2026-06-07: release 0.0.14 keeps the architecture in the existing TypeScript dataset classification command family. The location apply helper now creates only explicit schema-derived missing location targets and does not introduce a new orchestration layer or release path.
 
 Review note, 2026-06-11: release 0.0.15 keeps the import-lca wrapper inside the existing TypeScript dataset command family. Only the tidas-tools spawn argument construction and report file derivation changed to match tidas-tools 0.0.28; no new orchestration layer or release path.
+
+Review note, 2026-07-11: row-level dataset maintenance is implemented in the native CLI as `dataset maintenance plan/apply/verify`. The architecture keeps scope freezing, current-user RLS reads, protected-row classification, approved platform-command writes, append-only action logging, and independent verification in separate maintenance modules.
 
 ## Stable Path Map
 
@@ -137,11 +139,24 @@ Dataset-local governance now uses the same CLI-native command layer:
 - `src/lib/dataset-curation-queue.ts`
 - `src/lib/dataset-references-rewrite.ts`
 - `src/lib/dataset-maintenance-clear-account.ts`
+- `src/lib/dataset-maintenance-{contract,remote,plan,apply,verify}.ts`
 - `src/lib/dataset-local.ts`
 - `src/lib/lifecyclemodel-save-draft-run.ts`
 - `src/lib/lifecyclemodel-graph.ts`
 
-These modules keep validation, entity-level curation queue build/next/verify state, reference rewrites, RLS-scoped account cleanup, save-draft preparation, graph extraction, and local artifact reports inside the CLI instead of routing through skills or MCP transports.
+These modules keep validation, entity-level curation queue build/next/verify state, reference rewrites, RLS-scoped account and exact-row maintenance, save-draft preparation, graph extraction, and local artifact reports inside the CLI instead of routing through skills or MCP transports.
+
+The row-level maintenance family is deliberately split by responsibility:
+
+- `contract` owns the versioned scope, immutable plan, action, approval, and report shapes.
+- `remote` owns current-session authentication, current-user RLS reads, exact `id` + `version` row lookup, reference-impact reads, platform `save_draft` / `delete` command execution, and audit correlation.
+- `plan` freezes `maintenance-scope.json`, `rls-visible-snapshot.json`, `protected-rows.jsonl`, `reference-impact-report.json`, `maintenance-plan.json`, and `dry-run-report.json` before any write.
+- `apply` re-runs a full-plan drift preflight, verifies `--approve-plan <sha256>` and `--confirm <email>`, persists approval before the first write, appends one durable `apply-progress.jsonl` record per action, executes updates before deletes, and stops on the first failure so a rerun can resume from the recorded outcomes. Each ledger row carries at least the plan SHA-256, operation/action ids, exact entity ref, actor, start/finish times, before/after SHA-256, result/error, and rollback guidance.
+- `verify` performs a fresh readback independently of apply and writes `readback-verify-report.json`.
+
+V1 only permits current-user, `state_code=0`, exact-version `contacts`, `sources`, `flows`, and `processes` to become `save_draft` or `delete` actions. `lifecyclemodels`, `unitgroups`, `flowproperties`, public/shared rows, rows owned by another account, and non-draft rows stay protected. The CLI records the operator-supplied maintenance operation but does not make semantic cleanup or canonicalization decisions.
+
+All mutation continues through the public platform dataset command path. Direct SQL, service-role access, raw REST mutation, and Foundry-local delete/update implementations are outside this architecture; Foundry may only prepare scope, invoke the CLI, and retain its artifacts.
 
 ### Artifact and filesystem behavior
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-29
+lastReviewedAt: 2026-07-11
 lastReviewedCommit: 695e6d6fe718cb92d499f3ce8be2dc24c3f6ce29
 related:
   - ../../AGENTS.md
@@ -72,13 +72,15 @@ Review note, 2026-06-07: release 0.0.14 requires the same local proof plus focus
 
 Review note, 2026-06-11: release 0.0.15 requires the same local proof plus focused dataset import-lca coverage for the tidas-tools 0.0.28 bundle-flag adaptation and disk-derived report fields. Publication remains PR merge to upstream `main`, tag workflow, and npm Trusted Publishing.
 
+Review note, 2026-07-11: `dataset maintenance plan/apply/verify` adds focused proof for exact-row scope freezing, current-user RLS guards, immutable plan hashing, protected-row classification, full-plan drift preflight, approval-before-write, per-action logs, platform audit correlation, failure/resume behavior, and independent readback verification.
+
 ## Validation Matrix
 
 | Change type | Minimum local proof | Additional proof when risk is higher | Notes |
 | --- | --- | --- | --- |
 | `bin/**`, `src/main.ts`, or `src/cli.ts` | `npm run lint`; `npm test`; `npm run build` | run the relevant `tiangong-lca --help` or subcommand help path after build | Launcher and dispatch changes affect the public command surface directly. |
 | session, auth, env, or remote adapter helpers under `src/lib/{dotenv,env,user-api-key,supabase-*,remote,http}*`, plus command-local remote adapters such as explicit identity-preflight hybrid search | `npm run lint`; `npm test`; `npm run build` | run focused tests for the touched helper plus one command that exercises the changed path | Record any required live env assumptions in the PR note. |
-| flow, process, dataset, lifecyclemodel, review, publish, or run command families | `npm run lint`; `npm test`; `npm run build` | run focused tests for the touched command family; run `npm run test:coverage:assert-full` if the change touched uncovered branches; prefer `npm run prepush:gate` when the change adds new command paths | Preserve the low-entropy command contract and structured artifact outputs, including BuildPlan, review/dedup ruleset, publish schema, and verification gate reports when authoring or publish commands are involved. |
+| flow, process, dataset, lifecyclemodel, review, publish, or run command families | `npm run lint`; `npm test`; `npm run build` | run focused tests for the touched command family; run `npm run test:coverage:assert-full` if the change touched uncovered branches; prefer `npm run prepush:gate` when the change adds new command paths | Preserve the low-entropy command contract and structured artifact outputs, including BuildPlan, review/dedup ruleset, publish schema, and verification gate reports when authoring or publish commands are involved. Dataset maintenance proof must also cover plan immutability, current-user RLS/protected-row guards, drift rejection, approval-before-write, append-only action logs, stop/resume behavior, and fresh readback. |
 | artifact, IO, or state-lock behavior | `npm run lint`; `npm test`; `npm run build` | run one representative command path that writes the changed artifact layout, if safe | Path and file layout regressions matter for downstream automation. |
 | `test/**` or coverage gate scripts | `npm run lint`; `npm test`; `npm run test:coverage`; `npm run test:coverage:assert-full` | run `npm run prepush:gate` when the change affects the protected-branch gate directly | Coverage for `src/**/*.ts` is expected to remain at `100%`. |
 | `package.json`, `.nvmrc`, `scripts/ci/**`, or `.github/workflows/**` | `npm run lint`; `npm test`; `npm run build` | run `npm run prepush:gate`; run `docpact lint` when the change affects release or documentation gates | Release-tag checks, workflow guards, and dependency baselines change the repo contract. |
@@ -94,6 +96,8 @@ Facts that matter:
 - the local `pre-push` hook runs docpact first and then `npm run prepush:gate`
 - `.github/workflows/quality-gate.yml` is manual-dispatch only for remote reproduction, not an ordinary push-triggered test runner
 - `process save-draft`, `lifecyclemodel save-draft`, dataset governance commands such as curation queue build/next/verify, BuildPlan gates, publish schema/verification gates, and the newer process maintenance commands are expected to preserve `100%` coverage even when they add schema-validation, rewrite, or fallback branches
+- Dataset maintenance tests must prove that exact `id` + `version`, `state_code=0`, and current-account ownership are enforced; `lifecyclemodels`, `unitgroups`, `flowproperties`, public/non-owner/non-draft rows remain protected; no action runs after full-plan drift or approval mismatch; approval is persisted before the first mutation; each attempted action is appended durably to `apply-progress.jsonl` with plan/action correlation, actor, timing, before/after hashes, result/error, and rollback fields; and `verify` performs its own remote readback instead of trusting `apply` output.
+- Live maintenance validation, when explicitly authorized, must use a disposable current-user draft scope and the official platform command path. Direct SQL, service-role credentials, or raw REST mutation are never acceptable test evidence.
 - release-tag and docpact lint workflow changes should be described in the PR note when they alter the local or protected-branch proof
 - `tag-release-from-merge.yml` is idempotent when the expected `cli-v*` tag already points at the merge commit, and `publish.yml` can be re-run with `workflow_dispatch` only for an existing `cli-v*` tag on `origin/main`
 - local npm authentication is not release validation evidence; routine publication is verified by the upstream tag workflow and npm Trusted Publishing workflow after merge

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-29
-lastReviewedCommit: 695e6d6fe718cb92d499f3ce8be2dc24c3f6ce29
+lastReviewedAt: 2026-07-11
+lastReviewedCommit: b11482ca0dae414719336525c580cab1126897cd
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -19,8 +19,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-29
-lastReviewedCommit: 695e6d6fe718cb92d499f3ce8be2dc24c3f6ce29
+lastReviewedAt: 2026-07-11
+lastReviewedCommit: b11482ca0dae414719336525c580cab1126897cd
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -279,6 +279,10 @@ import {
   type DatasetMaintenanceClearAccountReport,
   type RunDatasetMaintenanceClearAccountOptions,
 } from './lib/dataset-maintenance-clear-account.js';
+import { runDatasetMaintenancePlan } from './lib/dataset-maintenance-plan.js';
+import { runDatasetMaintenanceApply } from './lib/dataset-maintenance-apply.js';
+import { runDatasetMaintenanceVerify } from './lib/dataset-maintenance-verify.js';
+import type { DatasetMaintenanceOperation } from './lib/dataset-maintenance-contract.js';
 import {
   runDatasetSourceUploadAttachments,
   type DatasetSourceUploadAttachmentsReport,
@@ -458,6 +462,9 @@ export type CliDeps = {
   runDatasetMaintenanceClearAccountImpl?: (
     options: RunDatasetMaintenanceClearAccountOptions,
   ) => Promise<DatasetMaintenanceClearAccountReport>;
+  runDatasetMaintenancePlanImpl?: typeof runDatasetMaintenancePlan;
+  runDatasetMaintenanceApplyImpl?: typeof runDatasetMaintenanceApply;
+  runDatasetMaintenanceVerifyImpl?: typeof runDatasetMaintenanceVerify;
   runDatasetSourceUploadAttachmentsImpl?: (
     options: RunDatasetSourceUploadAttachmentsOptions,
   ) => Promise<DatasetSourceUploadAttachmentsReport>;
@@ -493,7 +500,7 @@ Implemented Commands:
   doctor     show environment diagnostics
   search     flow | process | lifecyclemodel
   process    get | list | identity-preflight | build-plan | scope-statistics | dedup-review | auto-build | resume-build | publish-build | complete-required-fields | save-draft | batch-build | refresh-references | verify-rows
-  dataset    contract get | context-pack | classification children/path/audit/apply | curation-queue build/next/verify | import-lca convert | author | patch apply | save-draft | source upload-attachments | validate | verify-remote | bilingual extract/apply/validate | evidence-search plan/run | references rewrite/refresh-remote | maintenance clear-account
+  dataset    contract get | context-pack | classification children/path/audit/apply | curation-queue build/next/verify | import-lca convert | author | patch apply | save-draft | source upload-attachments | validate | verify-remote | bilingual extract/apply/validate | evidence-search plan/run | references rewrite/refresh-remote | maintenance clear-account/plan/apply/verify
   flow       get | list | identity-preflight | build-plan | fetch-rows | materialize-decisions | remediate | publish-version | publish-reviewed-data | build-alias-map | scan-process-flow-refs | plan-process-flow-repairs | apply-process-flow-repairs | regen-product | validate-processes
   lifecyclemodel auto-build | validate-build | publish-build | save-draft | graph | build-resulting-process | publish-resulting-process | orchestrate
   qa         process | flow | lifecyclemodel
@@ -504,7 +511,6 @@ Implemented Commands:
 Planned Surface (not implemented yet):
   auth       whoami | doctor-auth
   job        get | wait | logs
-  dataset maintenance plan | apply | verify
 
 Planned commands currently print an explicit "not implemented yet" message and exit with code 2.
 
@@ -704,9 +710,9 @@ Implemented Subcommands:
   references rewrite   Rewrite flow references in local process and lifecyclemodel rows
   references refresh-remote Refresh local TIDAS reference versions to latest reachable remote rows
   maintenance clear-account Dry-run or clear current authenticated account-owned dataset rows through RLS
-
-Planned Subcommands:
-  maintenance plan/apply/verify Plan, execute, and verify RLS-scoped dataset delete/redo maintenance
+  maintenance plan    Build an immutable, RLS-visible row-level maintenance plan
+  maintenance apply   Execute an explicitly approved maintenance plan through current-user RLS
+  maintenance verify  Read back affected rows and references against the immutable plan
 
 Examples:
   tiangong-lca dataset contract get --type process --include schema,methodology,ruleset --out-dir ./contract --help
@@ -740,17 +746,15 @@ function renderDatasetMaintenanceHelp(): string {
   return `Usage:
   tiangong-lca dataset maintenance <clear-account|plan|apply|verify> [options]
 
-Status:
-  clear-account is implemented for current authenticated account cleanup.
-  plan/apply/verify remain reserved for row-level RLS-scoped cleanup and redo workflows and currently exit with code 2 for executable actions.
-
-Implemented Actions:
+Actions:
   clear-account Dry-run or delete current authenticated account-owned lifecyclemodels, processes, flows, sources, and contacts.
-
-Planned Actions:
   plan    Build an immutable maintenance plan from a scope manifest, visible remote snapshot, dependency impact report, and intended operation.
   apply   Execute an approved plan through current-user RLS and platform dataset command paths; never bypass RLS or delete rows outside the visible scope.
   verify  Re-fetch affected rows and references, then prove that deleted, updated, skipped, protected, and redone rows match the plan.
+
+Safety:
+  plan and verify are read-only.
+  apply is commit-only and requires --commit, the exact plan SHA-256 via --approve-plan, and the current account email via --confirm.
 
 Required Artifact Contract:
   - maintenance-plan.json
@@ -765,8 +769,66 @@ Examples:
   tiangong-lca dataset maintenance clear-account --out-dir ./account-clear --json
   tiangong-lca dataset maintenance clear-account --commit --confirm user@example.com --out-dir ./account-clear
   tiangong-lca dataset maintenance plan --scope ./maintenance-scope.json --operation redo-import --out-dir ./dataset-maintenance
-  tiangong-lca dataset maintenance apply --plan ./dataset-maintenance/maintenance-plan.json --commit
+  tiangong-lca dataset maintenance apply --plan ./dataset-maintenance/maintenance-plan.json --commit --approve-plan <sha256> --confirm user@example.com
   tiangong-lca dataset maintenance verify --plan ./dataset-maintenance/maintenance-plan.json --out-dir ./dataset-maintenance/verify
+`.trim();
+}
+
+function renderDatasetMaintenancePlanHelp(): string {
+  return `Usage:
+  tiangong-lca dataset maintenance plan --scope <file> --operation <operation> --out-dir <dir> [options]
+
+Operations:
+  delete | retire | redo-import | repair-references
+
+Options:
+  --scope <file>       Maintenance scope manifest
+  --operation <value> Intended row-level maintenance operation
+  --out-dir <dir>      Artifact directory
+  --page-size <n>      Snapshot page size
+  --timeout-ms <n>     Request timeout in milliseconds
+  --json               Print compact JSON
+  -h, --help
+
+Outputs written under --out-dir include the immutable maintenance-plan.json, visible snapshot,
+protected-row ledger, reference-impact report, and dry-run report.
+`.trim();
+}
+
+function renderDatasetMaintenanceApplyHelp(): string {
+  return `Usage:
+  tiangong-lca dataset maintenance apply --plan <file> --commit --approve-plan <sha256> --confirm <email> [options]
+
+Behavior:
+  Commit-only. The command rejects dry-run mode, a missing --commit flag, a plan hash mismatch,
+  or a confirmation email that does not match the current authenticated account.
+
+Options:
+  --plan <file>          Immutable maintenance-plan.json
+  --commit               Execute the approved plan
+  --approve-plan <sha256> Exact SHA-256 recorded for the plan
+  --confirm <email>      Current authenticated account email
+  --timeout-ms <n>       Request timeout in milliseconds
+  --json                 Print compact JSON
+  -h, --help
+
+Outputs include approval-record.json and commit-report.json alongside an append-only action ledger.
+`.trim();
+}
+
+function renderDatasetMaintenanceVerifyHelp(): string {
+  return `Usage:
+  tiangong-lca dataset maintenance verify --plan <file> [options]
+
+Options:
+  --plan <file>       Immutable maintenance-plan.json
+  --out-dir <dir>     Optional verification artifact directory
+  --page-size <n>     Readback page size
+  --timeout-ms <n>    Request timeout in milliseconds
+  --json              Print compact JSON
+  -h, --help
+
+Outputs include readback-verify-report.json with affected-row and reference checks.
 `.trim();
 }
 
@@ -3729,6 +3791,167 @@ function parseDatasetMaintenanceClearAccountFlags(args: string[]): {
   };
 }
 
+function parseDatasetMaintenancePositiveInteger(
+  value: unknown,
+  flagName: '--page-size' | '--timeout-ms',
+): number | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  if (!/^\d+$/u.test(value.trim()) || Number.parseInt(value.trim(), 10) <= 0) {
+    throw new CliError(`${flagName} must be a positive integer.`, {
+      code: 'DATASET_MAINTENANCE_INTEGER_INVALID',
+      exitCode: 2,
+      details: { flag: flagName, value },
+    });
+  }
+  return Number.parseInt(value.trim(), 10);
+}
+
+function parseDatasetMaintenancePlanFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  scopePath: string;
+  operation: DatasetMaintenanceOperation | null;
+  outDir: string;
+  pageSize: number | undefined;
+  timeoutMs: number | undefined;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        scope: { type: 'string' },
+        operation: { type: 'string' },
+        'out-dir': { type: 'string' },
+        'page-size': { type: 'string' },
+        'timeout-ms': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  const rawOperation = typeof values.operation === 'string' ? values.operation : null;
+  if (
+    rawOperation !== null &&
+    !['delete', 'retire', 'redo-import', 'repair-references'].includes(rawOperation)
+  ) {
+    throw new CliError(
+      "--operation must be 'delete', 'retire', 'redo-import', or 'repair-references'.",
+      {
+        code: 'DATASET_MAINTENANCE_OPERATION_INVALID',
+        exitCode: 2,
+        details: rawOperation,
+      },
+    );
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    scopePath: typeof values.scope === 'string' ? values.scope : '',
+    operation: rawOperation as DatasetMaintenanceOperation | null,
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : '',
+    pageSize: parseDatasetMaintenancePositiveInteger(values['page-size'], '--page-size'),
+    timeoutMs: parseDatasetMaintenancePositiveInteger(values['timeout-ms'], '--timeout-ms'),
+  };
+}
+
+function parseDatasetMaintenanceApplyFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  planPath: string;
+  commit: boolean;
+  approvePlan: string;
+  confirm: string;
+  timeoutMs: number | undefined;
+  dryRun: boolean;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        plan: { type: 'string' },
+        commit: { type: 'boolean' },
+        'approve-plan': { type: 'string' },
+        confirm: { type: 'string' },
+        'timeout-ms': { type: 'string' },
+        'dry-run': { type: 'boolean' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    planPath: typeof values.plan === 'string' ? values.plan : '',
+    commit: Boolean(values.commit),
+    approvePlan: typeof values['approve-plan'] === 'string' ? values['approve-plan'] : '',
+    confirm: typeof values.confirm === 'string' ? values.confirm : '',
+    timeoutMs: parseDatasetMaintenancePositiveInteger(values['timeout-ms'], '--timeout-ms'),
+    dryRun: Boolean(values['dry-run']),
+  };
+}
+
+function parseDatasetMaintenanceVerifyFlags(args: string[]): {
+  help: boolean;
+  json: boolean;
+  planPath: string;
+  outDir: string | undefined;
+  pageSize: number | undefined;
+  timeoutMs: number | undefined;
+} {
+  let values: ReturnType<typeof parseArgs>['values'];
+  try {
+    ({ values } = parseArgs({
+      args,
+      allowPositionals: false,
+      strict: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        json: { type: 'boolean' },
+        plan: { type: 'string' },
+        'out-dir': { type: 'string' },
+        'page-size': { type: 'string' },
+        'timeout-ms': { type: 'string' },
+      },
+    }));
+  } catch (error) {
+    throw new CliError(String(error), {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    help: Boolean(values.help),
+    json: Boolean(values.json),
+    planPath: typeof values.plan === 'string' ? values.plan : '',
+    outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : undefined,
+    pageSize: parseDatasetMaintenancePositiveInteger(values['page-size'], '--page-size'),
+    timeoutMs: parseDatasetMaintenancePositiveInteger(values['timeout-ms'], '--timeout-ms'),
+  };
+}
+
 function parseIdentityPreflightFlags(args: string[]): {
   help: boolean;
   json: boolean;
@@ -6018,6 +6241,12 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
       deps.runDatasetClassificationApplyImpl ?? runDatasetClassificationApply;
     const datasetMaintenanceClearAccountImpl =
       deps.runDatasetMaintenanceClearAccountImpl ?? runDatasetMaintenanceClearAccount;
+    const datasetMaintenancePlanImpl =
+      deps.runDatasetMaintenancePlanImpl ?? runDatasetMaintenancePlan;
+    const datasetMaintenanceApplyImpl =
+      deps.runDatasetMaintenanceApplyImpl ?? runDatasetMaintenanceApply;
+    const datasetMaintenanceVerifyImpl =
+      deps.runDatasetMaintenanceVerifyImpl ?? runDatasetMaintenanceVerify;
     const datasetSourceUploadAttachmentsImpl =
       deps.runDatasetSourceUploadAttachmentsImpl ?? runDatasetSourceUploadAttachments;
 
@@ -6675,16 +6904,151 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
           stderr: '',
         };
       }
-      if (!['plan', 'apply', 'verify'].includes(action)) {
-        throw new CliError(
-          "dataset maintenance action must be 'clear-account', 'plan', 'apply', or 'verify'.",
-          {
-            code: 'DATASET_MAINTENANCE_ACTION_INVALID',
+
+      if (action === 'plan') {
+        const datasetFlags = parseDatasetMaintenancePlanFlags(commandArgs.slice(1));
+        if (datasetFlags.help) {
+          return {
+            exitCode: 0,
+            stdout: `${renderDatasetMaintenancePlanHelp()}\n`,
+            stderr: '',
+          };
+        }
+        if (!datasetFlags.scopePath) {
+          throw new CliError('dataset maintenance plan requires --scope.', {
+            code: 'DATASET_MAINTENANCE_SCOPE_REQUIRED',
             exitCode: 2,
-          },
-        );
+          });
+        }
+        if (!datasetFlags.operation) {
+          throw new CliError('dataset maintenance plan requires --operation.', {
+            code: 'DATASET_MAINTENANCE_OPERATION_REQUIRED',
+            exitCode: 2,
+          });
+        }
+        if (!datasetFlags.outDir) {
+          throw new CliError('dataset maintenance plan requires --out-dir.', {
+            code: 'DATASET_MAINTENANCE_OUT_DIR_REQUIRED',
+            exitCode: 2,
+          });
+        }
+        const report = await datasetMaintenancePlanImpl({
+          scopePath: datasetFlags.scopePath,
+          operation: datasetFlags.operation,
+          outDir: datasetFlags.outDir,
+          pageSize: datasetFlags.pageSize,
+          timeoutMs: datasetFlags.timeoutMs,
+          env: deps.env,
+          fetchImpl: deps.fetchImpl,
+        });
+        return {
+          exitCode: report.status === 'blocked' ? 1 : 0,
+          stdout: stringifyJson(report, datasetFlags.json),
+          stderr: '',
+        };
       }
-      return plannedCommand('dataset', `maintenance ${action}`);
+
+      if (action === 'apply') {
+        const datasetFlags = parseDatasetMaintenanceApplyFlags(commandArgs.slice(1));
+        if (datasetFlags.help) {
+          return {
+            exitCode: 0,
+            stdout: `${renderDatasetMaintenanceApplyHelp()}\n`,
+            stderr: '',
+          };
+        }
+        if (!datasetFlags.planPath) {
+          throw new CliError('dataset maintenance apply requires --plan.', {
+            code: 'DATASET_MAINTENANCE_PLAN_REQUIRED',
+            exitCode: 2,
+          });
+        }
+        if (datasetFlags.commit && datasetFlags.dryRun) {
+          throw new CliError('Cannot pass both --commit and --dry-run.', {
+            code: 'DATASET_MAINTENANCE_APPLY_MODE_CONFLICT',
+            exitCode: 2,
+          });
+        }
+        if (datasetFlags.dryRun) {
+          throw new CliError(
+            'dataset maintenance apply is commit-only; use dataset maintenance plan for a dry run.',
+            {
+              code: 'DATASET_MAINTENANCE_APPLY_COMMIT_ONLY',
+              exitCode: 2,
+            },
+          );
+        }
+        if (!datasetFlags.commit) {
+          throw new CliError('dataset maintenance apply requires --commit.', {
+            code: 'DATASET_MAINTENANCE_APPLY_COMMIT_REQUIRED',
+            exitCode: 2,
+          });
+        }
+        if (!datasetFlags.approvePlan) {
+          throw new CliError('dataset maintenance apply requires --approve-plan <sha256>.', {
+            code: 'DATASET_MAINTENANCE_APPROVAL_REQUIRED',
+            exitCode: 2,
+          });
+        }
+        if (!datasetFlags.confirm) {
+          throw new CliError('dataset maintenance apply requires --confirm <email>.', {
+            code: 'DATASET_MAINTENANCE_CONFIRM_REQUIRED',
+            exitCode: 2,
+          });
+        }
+        const report = await datasetMaintenanceApplyImpl({
+          planPath: datasetFlags.planPath,
+          commit: datasetFlags.commit,
+          approvePlan: datasetFlags.approvePlan,
+          confirm: datasetFlags.confirm,
+          timeoutMs: datasetFlags.timeoutMs,
+          env: deps.env,
+          fetchImpl: deps.fetchImpl,
+        });
+        return {
+          exitCode: report.status === 'completed_with_failures' ? 1 : 0,
+          stdout: stringifyJson(report, datasetFlags.json),
+          stderr: '',
+        };
+      }
+
+      if (action === 'verify') {
+        const datasetFlags = parseDatasetMaintenanceVerifyFlags(commandArgs.slice(1));
+        if (datasetFlags.help) {
+          return {
+            exitCode: 0,
+            stdout: `${renderDatasetMaintenanceVerifyHelp()}\n`,
+            stderr: '',
+          };
+        }
+        if (!datasetFlags.planPath) {
+          throw new CliError('dataset maintenance verify requires --plan.', {
+            code: 'DATASET_MAINTENANCE_PLAN_REQUIRED',
+            exitCode: 2,
+          });
+        }
+        const report = await datasetMaintenanceVerifyImpl({
+          planPath: datasetFlags.planPath,
+          outDir: datasetFlags.outDir,
+          pageSize: datasetFlags.pageSize,
+          timeoutMs: datasetFlags.timeoutMs,
+          env: deps.env,
+          fetchImpl: deps.fetchImpl,
+        });
+        return {
+          exitCode: report.status === 'failed' ? 1 : 0,
+          stdout: stringifyJson(report, datasetFlags.json),
+          stderr: '',
+        };
+      }
+
+      throw new CliError(
+        "dataset maintenance action must be 'clear-account', 'plan', 'apply', or 'verify'.",
+        {
+          code: 'DATASET_MAINTENANCE_ACTION_INVALID',
+          exitCode: 2,
+        },
+      );
     }
 
     if (command === 'lifecyclemodel' && !subcommand) {

--- a/src/lib/dataset-maintenance-apply.ts
+++ b/src/lib/dataset-maintenance-apply.ts
@@ -1,0 +1,659 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { writeJsonArtifact } from './artifacts.js';
+import { CliError } from './errors.js';
+import type { FetchLike } from './http.js';
+import { withStateFileLock } from './state-lock.js';
+import {
+  appendStableJsonLine,
+  isJsonObject,
+  maintenanceRowKey,
+  parseMaintenancePlan,
+  readJsonFile,
+  readJsonLinesIfPresent,
+  resolveMaintenancePlanArtifactPath,
+  sha256Json,
+  snapshotRemoteRow,
+  writeImmutableJson,
+  type DatasetMaintenancePlan,
+  type DatasetMaintenancePlanAction,
+  type DatasetMaintenanceProgressEntry,
+  type DatasetMaintenanceRemoteRow,
+  type JsonObject,
+} from './dataset-maintenance-contract.js';
+import { maintenanceProjectedReferenceFingerprint } from './dataset-maintenance-plan.js';
+import {
+  deleteMaintenanceRow,
+  fetchMaintenanceAccountRows,
+  fetchMaintenanceExactRows,
+  resolveMaintenanceRemoteContext,
+  saveDraftMaintenanceRow,
+  type DatasetMaintenanceRemoteContext,
+} from './dataset-maintenance-remote.js';
+
+export type DatasetMaintenanceApplyReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: 'completed' | 'completed_with_failures';
+  task_id: string;
+  operation: DatasetMaintenancePlan['operation'];
+  operation_id: string;
+  plan_sha256: string;
+  actor: { user_id: string; email: string };
+  summary: {
+    actions: number;
+    success: number;
+    failed: number;
+    pending: number;
+    resumed_successes: number;
+  };
+  actions: Array<{
+    action_id: string;
+    action: DatasetMaintenancePlanAction['action'];
+    table: DatasetMaintenancePlanAction['table'];
+    id: string;
+    version: string;
+    status: 'success' | 'failed' | 'pending';
+    error: string | null;
+  }>;
+  artifacts: {
+    approval_record: string;
+    apply_progress: string;
+    commit_report: string;
+    attempt_report: string;
+  };
+  database_audit: {
+    rpc_transaction_log: 'public.command_audit_log';
+    source: 'tiangong-lca dataset maintenance apply';
+    correlation_fields: ['plan_sha256', 'operation_id', 'action_id', 'reason_code'];
+  };
+};
+
+export type RunDatasetMaintenanceApplyOptions = {
+  planPath: string;
+  commit: boolean;
+  approvePlan: string;
+  confirm: string;
+  timeoutMs?: number;
+  env: NodeJS.ProcessEnv;
+  fetchImpl: FetchLike;
+  now?: Date;
+};
+
+type ProgressState = {
+  entries: DatasetMaintenanceProgressEntry[];
+  successes: Map<string, DatasetMaintenanceProgressEntry>;
+  latestFailures: Map<string, DatasetMaintenanceProgressEntry>;
+};
+
+function clock(options: RunDatasetMaintenanceApplyOptions): string {
+  return (options.now ?? new Date()).toISOString();
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function loadDesiredPayload(planDir: string, action: DatasetMaintenancePlanAction): JsonObject {
+  if (!action.desired_payload) {
+    throw new CliError(`save_draft action lacks desired payload: ${action.action_id}`, {
+      code: 'DATASET_MAINTENANCE_PLAN_INVALID',
+      exitCode: 2,
+    });
+  }
+  const payloadPath = resolveMaintenancePlanArtifactPath(
+    planDir,
+    action.desired_payload.path,
+    'Maintenance desired payload path',
+  );
+  const payload = readJsonFile(payloadPath, 'Maintenance desired payload');
+  if (!isJsonObject(payload) || sha256Json(payload) !== action.desired_payload.sha256) {
+    throw new CliError(`Desired payload hash mismatch for action ${action.action_id}.`, {
+      code: 'DATASET_MAINTENANCE_DESIRED_PAYLOAD_HASH_MISMATCH',
+      exitCode: 1,
+    });
+  }
+  return payload;
+}
+
+function parseProgress(plan: DatasetMaintenancePlan, progressPath: string): ProgressState {
+  const rawEntries = readJsonLinesIfPresent(progressPath);
+  const entries: DatasetMaintenanceProgressEntry[] = [];
+  const actionsById = new Map(plan.actions.map((action) => [action.action_id, action]));
+  for (const value of rawEntries) {
+    const action =
+      isJsonObject(value) && typeof value.action_id === 'string'
+        ? actionsById.get(value.action_id)
+        : null;
+    if (
+      !isJsonObject(value) ||
+      value.schema_version !== 1 ||
+      value.plan_sha256 !== plan.plan_sha256 ||
+      value.operation_id !== plan.operation_id ||
+      typeof value.action_id !== 'string' ||
+      !action ||
+      value.action !== action.action ||
+      value.reason_code !== action.reason_code ||
+      typeof value.before_sha256 !== 'string' ||
+      !isJsonObject(value.audit_context) ||
+      value.audit_context.plan_sha256 !== plan.plan_sha256 ||
+      value.audit_context.operation_id !== plan.operation_id ||
+      value.audit_context.action_id !== action.action_id ||
+      value.audit_context.reason_code !== action.reason_code ||
+      value.audit_context.source !== 'tiangong-lca dataset maintenance apply' ||
+      !['success', 'failed'].includes(String(value.result)) ||
+      (value.result === 'success' && typeof value.remote_result_sha256 !== 'string') ||
+      (value.result === 'failed' && value.remote_result_sha256 !== null)
+    ) {
+      throw new CliError('Apply progress contains an invalid or foreign entry.', {
+        code: 'DATASET_MAINTENANCE_PROGRESS_INVALID',
+        exitCode: 1,
+        details: value,
+      });
+    }
+    entries.push(value as DatasetMaintenanceProgressEntry);
+  }
+  const successes = new Map<string, DatasetMaintenanceProgressEntry>();
+  const latestFailures = new Map<string, DatasetMaintenanceProgressEntry>();
+  for (const entry of entries) {
+    if (entry.result === 'success') {
+      successes.set(entry.action_id, entry);
+      latestFailures.delete(entry.action_id);
+    } else if (!successes.has(entry.action_id)) {
+      latestFailures.set(entry.action_id, entry);
+    }
+  }
+  return { entries, successes, latestFailures };
+}
+
+function finalProjectedRows(options: {
+  rows: DatasetMaintenanceRemoteRow[];
+  plan: DatasetMaintenancePlan;
+  planDir: string;
+}): DatasetMaintenanceRemoteRow[] {
+  const projected = new Map(options.rows.map((row) => [maintenanceRowKey(row), { ...row }]));
+  for (const action of options.plan.actions.filter((entry) => entry.action === 'save_draft')) {
+    const row = projected.get(maintenanceRowKey(action));
+    if (row) {
+      projected.set(maintenanceRowKey(action), {
+        ...row,
+        json_ordered: loadDesiredPayload(options.planDir, action),
+      });
+    }
+  }
+  for (const action of options.plan.actions.filter((entry) => entry.action === 'delete')) {
+    projected.delete(maintenanceRowKey(action));
+  }
+  return [...projected.values()].sort((left, right) =>
+    maintenanceRowKey(left).localeCompare(maintenanceRowKey(right)),
+  );
+}
+
+function assertApplyPreconditions(options: {
+  plan: DatasetMaintenancePlan;
+  planDir: string;
+  currentRows: DatasetMaintenanceRemoteRow[];
+  progress: ProgressState;
+}): void {
+  const current = new Map(options.currentRows.map((row) => [maintenanceRowKey(row), row]));
+  const baselineKeys = new Set([
+    ...options.plan.protected_rows.map(maintenanceRowKey),
+    ...options.plan.actions.filter((action) => action.before).map(maintenanceRowKey),
+  ]);
+  for (const row of options.currentRows) {
+    if (!baselineKeys.has(maintenanceRowKey(row))) {
+      throw new CliError(`Unexpected current-account row appeared after planning: ${row.id}`, {
+        code: 'DATASET_MAINTENANCE_PREFLIGHT_DRIFT',
+        exitCode: 1,
+        details: { table: row.table, id: row.id, version: row.version },
+      });
+    }
+  }
+  for (const protectedRow of options.plan.protected_rows) {
+    const currentRow = current.get(maintenanceRowKey(protectedRow));
+    if (!currentRow || snapshotRemoteRow(currentRow).row_sha256 !== protectedRow.row_sha256) {
+      throw new CliError(`Protected row drifted after planning: ${protectedRow.id}`, {
+        code: 'DATASET_MAINTENANCE_PROTECTED_ROW_DRIFT',
+        exitCode: 1,
+        details: protectedRow,
+      });
+    }
+  }
+  for (const action of options.plan.actions) {
+    if (!action.before) {
+      throw new CliError(`Ready plan action lacks before snapshot: ${action.action_id}`, {
+        code: 'DATASET_MAINTENANCE_PLAN_INVALID',
+        exitCode: 2,
+      });
+    }
+    const currentRow = current.get(maintenanceRowKey(action));
+    const alreadySucceeded = options.progress.successes.has(action.action_id);
+    if (alreadySucceeded && action.action === 'delete') {
+      if (currentRow) {
+        throw new CliError(`Previously deleted row is visible again: ${action.action_id}`, {
+          code: 'DATASET_MAINTENANCE_RESUME_DRIFT',
+          exitCode: 1,
+        });
+      }
+      continue;
+    }
+    if (
+      !currentRow ||
+      currentRow.user_id !== action.expected_user_id ||
+      currentRow.state_code !== 0
+    ) {
+      throw new CliError(`Action row is missing, non-draft, or not owned: ${action.action_id}`, {
+        code: 'DATASET_MAINTENANCE_ACTION_ROW_DRIFT',
+        exitCode: 1,
+      });
+    }
+    const currentSnapshot = snapshotRemoteRow(currentRow);
+    if (alreadySucceeded) {
+      const desired = loadDesiredPayload(options.planDir, action);
+      if (currentSnapshot.payload_sha256 !== sha256Json(desired)) {
+        throw new CliError(`Previously saved row payload drifted: ${action.action_id}`, {
+          code: 'DATASET_MAINTENANCE_RESUME_DRIFT',
+          exitCode: 1,
+        });
+      }
+    } else if (currentSnapshot.row_sha256 !== action.before.row_sha256) {
+      throw new CliError(`Pending action row drifted after planning: ${action.action_id}`, {
+        code: 'DATASET_MAINTENANCE_ACTION_ROW_DRIFT',
+        exitCode: 1,
+      });
+    }
+  }
+  const projected = finalProjectedRows({
+    rows: options.currentRows,
+    plan: options.plan,
+    planDir: options.planDir,
+  });
+  const projectedReferenceSha256 = sha256Json(maintenanceProjectedReferenceFingerprint(projected));
+  if (projectedReferenceSha256 !== options.plan.projected_reference_sha256) {
+    throw new CliError('Projected reference closure drifted after planning.', {
+      code: 'DATASET_MAINTENANCE_REFERENCE_PREFLIGHT_DRIFT',
+      exitCode: 1,
+      details: {
+        expected: options.plan.projected_reference_sha256,
+        actual: projectedReferenceSha256,
+      },
+    });
+  }
+}
+
+function validateApprovalRecord(options: {
+  path: string;
+  plan: DatasetMaintenancePlan;
+  context: DatasetMaintenanceRemoteContext;
+}): void {
+  if (!existsSync(options.path)) {
+    return;
+  }
+  const record = readJsonFile(options.path, 'Maintenance approval record');
+  if (
+    !isJsonObject(record) ||
+    record.plan_sha256 !== options.plan.plan_sha256 ||
+    !isJsonObject(record.account) ||
+    record.account.user_id !== options.context.account.user_id ||
+    record.account.email !== options.context.account.email
+  ) {
+    throw new CliError('Existing approval record does not match this plan and actor.', {
+      code: 'DATASET_MAINTENANCE_APPROVAL_RECORD_MISMATCH',
+      exitCode: 1,
+    });
+  }
+}
+
+async function executeAction(options: {
+  action: DatasetMaintenancePlanAction;
+  plan: DatasetMaintenancePlan;
+  planDir: string;
+  context: DatasetMaintenanceRemoteContext;
+}): Promise<{ afterSha256: string | null; remoteResultSha256: string }> {
+  if (!options.action.before) {
+    throw new CliError(`Action lacks a before snapshot: ${options.action.action_id}`, {
+      code: 'DATASET_MAINTENANCE_PLAN_INVALID',
+      exitCode: 2,
+    });
+  }
+  const justInTime = await fetchMaintenanceExactRows({
+    context: options.context,
+    table: options.action.table,
+    id: options.action.id,
+    version: options.action.version,
+  });
+  const pendingRow = justInTime.rows.length === 1 ? justInTime.rows[0] : null;
+  if (
+    !pendingRow ||
+    pendingRow.user_id !== options.action.expected_user_id ||
+    pendingRow.state_code !== 0 ||
+    snapshotRemoteRow(pendingRow).row_sha256 !== options.action.before.row_sha256
+  ) {
+    throw new CliError(`Action row drifted immediately before write: ${options.action.action_id}`, {
+      code: 'DATASET_MAINTENANCE_ACTION_JUST_IN_TIME_DRIFT',
+      exitCode: 1,
+    });
+  }
+  const audit = {
+    plan_sha256: options.plan.plan_sha256,
+    operation_id: options.plan.operation_id,
+    action_id: options.action.action_id,
+    reason_code: options.action.reason_code,
+    source: 'tiangong-lca dataset maintenance apply' as const,
+  };
+  if (options.action.action === 'save_draft') {
+    const remoteResult = await saveDraftMaintenanceRow({
+      context: options.context,
+      table: options.action.table,
+      id: options.action.id,
+      version: options.action.version,
+      payload: loadDesiredPayload(options.planDir, options.action),
+      modelId: options.action.before?.model_id ?? null,
+      ruleVerification: options.action.before?.rule_verification ?? null,
+      audit,
+    });
+    const readback = await fetchMaintenanceExactRows({
+      context: options.context,
+      table: options.action.table,
+      id: options.action.id,
+      version: options.action.version,
+    });
+    const row = readback.rows[0];
+    if (readback.rows.length !== 1 || !row) {
+      throw new CliError(`save_draft readback failed for ${options.action.action_id}.`, {
+        code: 'DATASET_MAINTENANCE_ACTION_READBACK_FAILED',
+        exitCode: 1,
+      });
+    }
+    const expectedPayload = options.action.desired_payload?.sha256;
+    const readbackSnapshot = snapshotRemoteRow(row);
+    if (
+      readbackSnapshot.payload_sha256 !== expectedPayload ||
+      row.user_id !== options.action.expected_user_id ||
+      row.state_code !== 0
+    ) {
+      throw new CliError(`save_draft readback mismatch for ${options.action.action_id}.`, {
+        code: 'DATASET_MAINTENANCE_ACTION_READBACK_FAILED',
+        exitCode: 1,
+      });
+    }
+    return {
+      afterSha256: readbackSnapshot.row_sha256,
+      remoteResultSha256: sha256Json(remoteResult),
+    };
+  }
+  const remoteResult = await deleteMaintenanceRow({
+    context: options.context,
+    table: options.action.table,
+    id: options.action.id,
+    version: options.action.version,
+    audit,
+  });
+  const readback = await fetchMaintenanceExactRows({
+    context: options.context,
+    table: options.action.table,
+    id: options.action.id,
+    version: options.action.version,
+  });
+  if (readback.rows.length !== 0) {
+    throw new CliError(`delete readback failed for ${options.action.action_id}.`, {
+      code: 'DATASET_MAINTENANCE_ACTION_READBACK_FAILED',
+      exitCode: 1,
+    });
+  }
+  return { afterSha256: null, remoteResultSha256: sha256Json(remoteResult) };
+}
+
+function nextAttemptPath(planDir: string): string {
+  let attempt = 1;
+  while (
+    existsSync(path.join(planDir, `commit-report.attempt-${String(attempt).padStart(4, '0')}.json`))
+  ) {
+    attempt += 1;
+  }
+  return path.join(planDir, `commit-report.attempt-${String(attempt).padStart(4, '0')}.json`);
+}
+
+export async function runDatasetMaintenanceApply(
+  options: RunDatasetMaintenanceApplyOptions,
+): Promise<DatasetMaintenanceApplyReport> {
+  if (!options.commit) {
+    throw new CliError('Dataset maintenance apply requires commit=true.', {
+      code: 'DATASET_MAINTENANCE_COMMIT_REQUIRED',
+      exitCode: 2,
+    });
+  }
+  const planPath = path.resolve(options.planPath);
+  const planDir = path.dirname(planPath);
+  const plan = parseMaintenancePlan(readJsonFile(planPath, 'Maintenance plan'));
+  if (options.approvePlan !== plan.plan_sha256) {
+    throw new CliError('approvePlan must exactly match the canonical maintenance plan hash.', {
+      code: 'DATASET_MAINTENANCE_PLAN_APPROVAL_REQUIRED',
+      exitCode: 2,
+    });
+  }
+  if (plan.status !== 'ready' || plan.blockers.length > 0) {
+    throw new CliError('Blocked maintenance plan cannot be applied.', {
+      code: 'DATASET_MAINTENANCE_PLAN_BLOCKED',
+      exitCode: 1,
+      details: plan.blockers,
+    });
+  }
+  if (
+    plan.operation === 'redo-import' &&
+    !plan.source_import_run_id &&
+    plan.source_lineage === null
+  ) {
+    throw new CliError('redo-import apply requires frozen redo source/import lineage.', {
+      code: 'DATASET_MAINTENANCE_REDO_NOT_READY',
+      exitCode: 1,
+    });
+  }
+
+  const progressPath = path.join(planDir, 'apply-progress.jsonl');
+  return withStateFileLock(
+    progressPath,
+    { reason: `dataset_maintenance_apply_${plan.operation_id}` },
+    async () => {
+      const context = await resolveMaintenanceRemoteContext({
+        env: options.env,
+        fetchImpl: options.fetchImpl,
+        timeoutMs: options.timeoutMs,
+        now: options.now,
+      });
+      if (
+        context.account.user_id !== plan.account.user_id ||
+        context.account.email !== plan.account.email
+      ) {
+        throw new CliError('Current authenticated account does not match the maintenance plan.', {
+          code: 'DATASET_MAINTENANCE_ACCOUNT_MISMATCH',
+          exitCode: 1,
+        });
+      }
+      if (options.confirm !== context.account.email) {
+        throw new CliError('confirm must exactly match the current authenticated account email.', {
+          code: 'DATASET_MAINTENANCE_CONFIRMATION_REQUIRED',
+          exitCode: 2,
+        });
+      }
+      const progress = parseProgress(plan, progressPath);
+      const resumedSuccesses = progress.successes.size;
+      const current = await fetchMaintenanceAccountRows({
+        context,
+        userId: plan.account.user_id,
+      });
+      assertApplyPreconditions({
+        plan,
+        planDir,
+        currentRows: current.rows,
+        progress,
+      });
+
+      const approvalPath = path.join(planDir, 'approval-record.json');
+      validateApprovalRecord({ path: approvalPath, plan, context });
+      if (!existsSync(approvalPath)) {
+        writeImmutableJson(approvalPath, {
+          schema_version: 1,
+          approved_at_utc: clock(options),
+          plan_path: planPath,
+          plan_sha256: plan.plan_sha256,
+          task_id: plan.task_id,
+          operation: plan.operation,
+          operation_id: plan.operation_id,
+          account: {
+            user_id: context.account.user_id,
+            email: context.account.email,
+          },
+          confirmed_email: options.confirm,
+          row_counts: plan.summary,
+          redo_rows_ready:
+            plan.operation === 'redo-import'
+              ? Boolean(plan.source_import_run_id || plan.source_lineage !== null)
+              : null,
+        });
+      }
+
+      const ordered = [...plan.actions].sort((left, right) => {
+        const actionOrder = Number(left.action === 'delete') - Number(right.action === 'delete');
+        return actionOrder || left.ordinal - right.ordinal;
+      });
+      for (const action of ordered) {
+        if (progress.successes.has(action.action_id)) {
+          continue;
+        }
+        const startedAt = clock(options);
+        try {
+          const actionResult = await executeAction({ action, plan, planDir, context });
+          const entry: DatasetMaintenanceProgressEntry = {
+            schema_version: 1,
+            plan_sha256: plan.plan_sha256,
+            operation_id: plan.operation_id,
+            action_id: action.action_id,
+            action: action.action,
+            table: action.table,
+            id: action.id,
+            version: action.version,
+            reason_code: action.reason_code,
+            audit_context: {
+              plan_sha256: plan.plan_sha256,
+              operation_id: plan.operation_id,
+              action_id: action.action_id,
+              reason_code: action.reason_code,
+              source: 'tiangong-lca dataset maintenance apply',
+            },
+            actor: { user_id: context.account.user_id, email: context.account.email },
+            started_at_utc: startedAt,
+            ended_at_utc: clock(options),
+            before_sha256: action.before!.row_sha256,
+            after_sha256: actionResult.afterSha256,
+            remote_result_sha256: actionResult.remoteResultSha256,
+            result: 'success',
+            error: null,
+            rollback: action.rollback,
+          };
+          appendStableJsonLine(progressPath, entry);
+          progress.entries.push(entry);
+          progress.successes.set(action.action_id, entry);
+          progress.latestFailures.delete(action.action_id);
+        } catch (error) {
+          const entry: DatasetMaintenanceProgressEntry = {
+            schema_version: 1,
+            plan_sha256: plan.plan_sha256,
+            operation_id: plan.operation_id,
+            action_id: action.action_id,
+            action: action.action,
+            table: action.table,
+            id: action.id,
+            version: action.version,
+            reason_code: action.reason_code,
+            audit_context: {
+              plan_sha256: plan.plan_sha256,
+              operation_id: plan.operation_id,
+              action_id: action.action_id,
+              reason_code: action.reason_code,
+              source: 'tiangong-lca dataset maintenance apply',
+            },
+            actor: { user_id: context.account.user_id, email: context.account.email },
+            started_at_utc: startedAt,
+            ended_at_utc: clock(options),
+            before_sha256: action.before!.row_sha256,
+            after_sha256: null,
+            remote_result_sha256: null,
+            result: 'failed',
+            error: errorMessage(error),
+            rollback: action.rollback,
+          };
+          appendStableJsonLine(progressPath, entry);
+          progress.entries.push(entry);
+          progress.latestFailures.set(action.action_id, entry);
+          break;
+        }
+      }
+
+      const actions = plan.actions.map((action) => {
+        const success = progress.successes.get(action.action_id);
+        const failure = progress.latestFailures.get(action.action_id);
+        return {
+          action_id: action.action_id,
+          action: action.action,
+          table: action.table,
+          id: action.id,
+          version: action.version,
+          status: success
+            ? ('success' as const)
+            : failure
+              ? ('failed' as const)
+              : ('pending' as const),
+          error: failure?.error ?? null,
+        };
+      });
+      const successCount = actions.filter((action) => action.status === 'success').length;
+      const failureCount = actions.filter((action) => action.status === 'failed').length;
+      const attemptPath = nextAttemptPath(planDir);
+      const report: DatasetMaintenanceApplyReport = {
+        schema_version: 1,
+        generated_at_utc: clock(options),
+        status: successCount === actions.length ? 'completed' : 'completed_with_failures',
+        task_id: plan.task_id,
+        operation: plan.operation,
+        operation_id: plan.operation_id,
+        plan_sha256: plan.plan_sha256,
+        actor: { user_id: context.account.user_id, email: context.account.email },
+        summary: {
+          actions: actions.length,
+          success: successCount,
+          failed: failureCount,
+          pending: actions.length - successCount - failureCount,
+          resumed_successes: resumedSuccesses,
+        },
+        actions,
+        artifacts: {
+          approval_record: approvalPath,
+          apply_progress: progressPath,
+          commit_report: path.join(planDir, 'commit-report.json'),
+          attempt_report: attemptPath,
+        },
+        database_audit: {
+          rpc_transaction_log: 'public.command_audit_log',
+          source: 'tiangong-lca dataset maintenance apply',
+          correlation_fields: ['plan_sha256', 'operation_id', 'action_id', 'reason_code'],
+        },
+      };
+      writeImmutableJson(attemptPath, report);
+      writeJsonArtifact(report.artifacts.commit_report, report);
+      return report;
+    },
+  );
+}
+
+export const __testInternals = {
+  assertApplyPreconditions,
+  clock,
+  errorMessage,
+  executeAction,
+  finalProjectedRows,
+  loadDesiredPayload,
+  nextAttemptPath,
+  parseProgress,
+  validateApprovalRecord,
+};

--- a/src/lib/dataset-maintenance-contract.ts
+++ b/src/lib/dataset-maintenance-contract.ts
@@ -1,0 +1,686 @@
+import crypto from 'node:crypto';
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { CliError } from './errors.js';
+
+export type JsonObject = Record<string, unknown>;
+
+export const MAINTENANCE_MUTABLE_TABLES = ['contacts', 'sources', 'flows', 'processes'] as const;
+
+export const MAINTENANCE_SCAN_TABLES = [
+  ...MAINTENANCE_MUTABLE_TABLES,
+  'lifecyclemodels',
+  'unitgroups',
+  'flowproperties',
+] as const;
+
+export type DatasetMaintenanceMutableTable = (typeof MAINTENANCE_MUTABLE_TABLES)[number];
+export type DatasetMaintenanceScanTable = (typeof MAINTENANCE_SCAN_TABLES)[number];
+export type DatasetMaintenanceOperation = 'delete' | 'retire' | 'redo-import' | 'repair-references';
+export type DatasetMaintenanceActionKind = 'save_draft' | 'delete';
+
+export type DatasetMaintenanceScopeAction = {
+  action_id: string;
+  action: DatasetMaintenanceActionKind;
+  table: DatasetMaintenanceMutableTable;
+  id: string;
+  version: string;
+  expected_user_id: string;
+  expected_state_code: 0;
+  reason_code: string;
+  reason: string;
+  evidence: unknown[];
+  desired_payload_path?: string;
+  expected_before_sha256?: string;
+};
+
+export type DatasetMaintenanceScope = {
+  schema_version: 1;
+  task_id: string;
+  operation: DatasetMaintenanceOperation;
+  account: {
+    user_id: string;
+    email?: string;
+  };
+  source_import_run_id?: string;
+  source_lineage?: unknown;
+  actions: DatasetMaintenanceScopeAction[];
+};
+
+export type DatasetMaintenanceRemoteRow = {
+  table: DatasetMaintenanceScanTable;
+  id: string;
+  version: string;
+  user_id: string | null;
+  state_code: number | null;
+  modified_at: string | null;
+  json_ordered: JsonObject | null;
+  model_id: string | null;
+  rule_verification: boolean | null;
+};
+
+export type DatasetMaintenanceRowSnapshot = DatasetMaintenanceRemoteRow & {
+  row_sha256: string;
+  payload_sha256: string | null;
+};
+
+export type DatasetMaintenanceBlocker = {
+  code: string;
+  message: string;
+  action_id?: string;
+  table?: DatasetMaintenanceScanTable;
+  id?: string;
+  version?: string;
+  details?: unknown;
+};
+
+export type DatasetMaintenanceProtectedRow = {
+  table: DatasetMaintenanceScanTable;
+  id: string;
+  version: string;
+  modified_at: string | null;
+  row_sha256: string;
+  payload_sha256: string | null;
+  reason: 'non_action_visible_row' | 'blocked_action_row';
+};
+
+export type DatasetMaintenanceReferenceImpact = {
+  target_action_id: string;
+  target_table: DatasetMaintenanceMutableTable;
+  target_id: string;
+  target_version: string;
+  phase: 'current' | 'projected';
+  source_table: DatasetMaintenanceScanTable;
+  source_id: string;
+  source_version: string;
+  reference_path: string;
+  reference_version: string | null;
+};
+
+export type DatasetMaintenancePlanAction = DatasetMaintenanceScopeAction & {
+  ordinal: number;
+  status: 'ready' | 'blocked';
+  before: DatasetMaintenanceRowSnapshot | null;
+  desired_payload: {
+    path: string;
+    sha256: string;
+  } | null;
+  blockers: DatasetMaintenanceBlocker[];
+  rollback: {
+    strategy: 'save_before_snapshot' | 'restore_deleted_before_snapshot';
+    before_payload_sha256: string | null;
+    before_payload: JsonObject | null;
+    model_id: string | null;
+    rule_verification: boolean | null;
+  };
+};
+
+export type DatasetMaintenancePlan = {
+  schema_version: 1;
+  generated_at_utc: string;
+  task_id: string;
+  operation: DatasetMaintenanceOperation;
+  operation_id: string;
+  account: {
+    user_id: string;
+    email: string | null;
+  };
+  source_import_run_id: string | null;
+  source_lineage: unknown;
+  status: 'ready' | 'blocked';
+  scope_sha256: string;
+  visible_snapshot_sha256: string;
+  projected_reference_sha256: string;
+  plan_sha256: string;
+  summary: {
+    actions: number;
+    save_draft: number;
+    delete: number;
+    protected_rows: number;
+    blockers: number;
+    current_reference_impacts: number;
+    projected_reference_impacts: number;
+  };
+  artifacts: {
+    maintenance_scope: string;
+    rls_visible_snapshot: string;
+    protected_rows: string;
+    reference_impact_report: string;
+    maintenance_plan: string;
+    dry_run_report: string;
+    payload_dir: string;
+  };
+  actions: DatasetMaintenancePlanAction[];
+  protected_rows: DatasetMaintenanceProtectedRow[];
+  blockers: DatasetMaintenanceBlocker[];
+};
+
+export type DatasetMaintenanceProgressEntry = {
+  schema_version: 1;
+  plan_sha256: string;
+  operation_id: string;
+  action_id: string;
+  action: DatasetMaintenanceActionKind;
+  table: DatasetMaintenanceMutableTable;
+  id: string;
+  version: string;
+  reason_code: string;
+  audit_context: {
+    plan_sha256: string;
+    operation_id: string;
+    action_id: string;
+    reason_code: string;
+    source: 'tiangong-lca dataset maintenance apply';
+  };
+  actor: {
+    user_id: string;
+    email: string;
+  };
+  started_at_utc: string;
+  ended_at_utc: string;
+  before_sha256: string;
+  after_sha256: string | null;
+  remote_result_sha256: string | null;
+  result: 'success' | 'failed';
+  error: string | null;
+  rollback: DatasetMaintenancePlanAction['rollback'];
+};
+
+function token(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.trim();
+  return normalized || null;
+}
+
+export function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function stableJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stableJsonValue);
+  }
+  if (isJsonObject(value)) {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, stableJsonValue(value[key])]),
+    );
+  }
+  return value;
+}
+
+export function stableJsonText(value: unknown): string {
+  return JSON.stringify(stableJsonValue(value));
+}
+
+export function sha256Text(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+export function sha256Json(value: unknown): string {
+  return sha256Text(stableJsonText(value));
+}
+
+export function snapshotRemoteRow(row: DatasetMaintenanceRemoteRow): DatasetMaintenanceRowSnapshot {
+  return {
+    ...row,
+    row_sha256: sha256Json(row),
+    payload_sha256: row.json_ordered ? sha256Json(row.json_ordered) : null,
+  };
+}
+
+export function maintenanceRowKey(row: {
+  table: DatasetMaintenanceScanTable;
+  id: string;
+  version: string;
+}): string {
+  return `${row.table}\u0000${row.id}\u0000${row.version}`;
+}
+
+function requireToken(value: unknown, label: string): string {
+  const normalized = token(value);
+  if (!normalized) {
+    throw new CliError(`Maintenance scope ${label} must be a non-empty string.`, {
+      code: 'DATASET_MAINTENANCE_SCOPE_INVALID',
+      exitCode: 2,
+      details: { field: label },
+    });
+  }
+  return normalized;
+}
+
+function parseAction(
+  value: unknown,
+  index: number,
+  accountUserId: string,
+): DatasetMaintenanceScopeAction {
+  if (!isJsonObject(value)) {
+    throw new CliError(`Maintenance scope action ${index} must be an object.`, {
+      code: 'DATASET_MAINTENANCE_SCOPE_INVALID',
+      exitCode: 2,
+    });
+  }
+  const action = requireToken(value.action, `actions[${index}].action`);
+  const table = requireToken(value.table, `actions[${index}].table`);
+  if (!['save_draft', 'delete'].includes(action)) {
+    throw new CliError(`Unsupported maintenance action: ${action}`, {
+      code: 'DATASET_MAINTENANCE_ACTION_UNSUPPORTED',
+      exitCode: 2,
+    });
+  }
+  if (!(MAINTENANCE_MUTABLE_TABLES as readonly string[]).includes(table)) {
+    throw new CliError(
+      `Maintenance cannot mutate protected or unsupported dataset table: ${table}`,
+      {
+        code: 'DATASET_MAINTENANCE_TABLE_PROTECTED',
+        exitCode: 2,
+      },
+    );
+  }
+  if (value.expected_state_code !== 0) {
+    throw new CliError(`Maintenance action ${index} must require expected_state_code=0.`, {
+      code: 'DATASET_MAINTENANCE_NON_DRAFT_FORBIDDEN',
+      exitCode: 2,
+    });
+  }
+  const expectedUserId = requireToken(value.expected_user_id, `actions[${index}].expected_user_id`);
+  if (expectedUserId !== accountUserId) {
+    throw new CliError(`Maintenance action ${index} owner does not match scope account.`, {
+      code: 'DATASET_MAINTENANCE_SCOPE_OWNER_MISMATCH',
+      exitCode: 2,
+    });
+  }
+  if (!Array.isArray(value.evidence)) {
+    throw new CliError(`Maintenance action ${index} evidence must be an array.`, {
+      code: 'DATASET_MAINTENANCE_SCOPE_INVALID',
+      exitCode: 2,
+    });
+  }
+  const desiredPayloadPath = token(value.desired_payload_path);
+  if (action === 'save_draft' && !desiredPayloadPath) {
+    throw new CliError(`Maintenance save_draft action ${index} requires desired_payload_path.`, {
+      code: 'DATASET_MAINTENANCE_DESIRED_PAYLOAD_REQUIRED',
+      exitCode: 2,
+    });
+  }
+  const expectedBeforeSha256 = token(value.expected_before_sha256);
+  if (expectedBeforeSha256 && !/^[a-f0-9]{64}$/u.test(expectedBeforeSha256)) {
+    throw new CliError(`Maintenance action ${index} expected_before_sha256 is invalid.`, {
+      code: 'DATASET_MAINTENANCE_SCOPE_INVALID',
+      exitCode: 2,
+    });
+  }
+
+  return {
+    action_id: requireToken(value.action_id, `actions[${index}].action_id`),
+    action: action as DatasetMaintenanceActionKind,
+    table: table as DatasetMaintenanceMutableTable,
+    id: requireToken(value.id, `actions[${index}].id`),
+    version: requireToken(value.version, `actions[${index}].version`),
+    expected_user_id: expectedUserId,
+    expected_state_code: 0,
+    reason_code: requireToken(value.reason_code, `actions[${index}].reason_code`),
+    reason: requireToken(value.reason, `actions[${index}].reason`),
+    evidence: value.evidence,
+    ...(desiredPayloadPath ? { desired_payload_path: desiredPayloadPath } : {}),
+    ...(expectedBeforeSha256 ? { expected_before_sha256: expectedBeforeSha256 } : {}),
+  };
+}
+
+export function parseMaintenanceScope(
+  value: unknown,
+  expectedOperation?: DatasetMaintenanceOperation,
+): DatasetMaintenanceScope {
+  if (!isJsonObject(value) || value.schema_version !== 1 || !isJsonObject(value.account)) {
+    throw new CliError('Maintenance scope must use schema_version=1 and include account.', {
+      code: 'DATASET_MAINTENANCE_SCOPE_INVALID',
+      exitCode: 2,
+    });
+  }
+  const operation = requireToken(value.operation, 'operation');
+  if (!['delete', 'retire', 'redo-import', 'repair-references'].includes(operation)) {
+    throw new CliError(`Unsupported maintenance operation: ${operation}`, {
+      code: 'DATASET_MAINTENANCE_OPERATION_UNSUPPORTED',
+      exitCode: 2,
+    });
+  }
+  if (expectedOperation && operation !== expectedOperation) {
+    throw new CliError(
+      `Scope operation ${operation} does not match requested operation ${expectedOperation}.`,
+      {
+        code: 'DATASET_MAINTENANCE_OPERATION_MISMATCH',
+        exitCode: 2,
+      },
+    );
+  }
+  const userId = requireToken(value.account.user_id, 'account.user_id');
+  if (!Array.isArray(value.actions) || value.actions.length === 0) {
+    throw new CliError('Maintenance scope actions must be a non-empty array.', {
+      code: 'DATASET_MAINTENANCE_SCOPE_INVALID',
+      exitCode: 2,
+    });
+  }
+  const actions = value.actions.map((entry, index) => parseAction(entry, index, userId));
+  const actionIds = new Set<string>();
+  const rowKeys = new Set<string>();
+  const payloadNames = new Set<string>();
+  for (const action of actions) {
+    if (actionIds.has(action.action_id)) {
+      throw new CliError(`Duplicate maintenance action_id: ${action.action_id}`, {
+        code: 'DATASET_MAINTENANCE_ACTION_ID_DUPLICATE',
+        exitCode: 2,
+      });
+    }
+    actionIds.add(action.action_id);
+    const rowKey = maintenanceRowKey(action);
+    if (rowKeys.has(rowKey)) {
+      throw new CliError(`Multiple maintenance actions target the same row: ${action.id}`, {
+        code: 'DATASET_MAINTENANCE_TARGET_DUPLICATE',
+        exitCode: 2,
+      });
+    }
+    rowKeys.add(rowKey);
+    const payloadName = safeActionFileName(action.action_id);
+    if (payloadNames.has(payloadName)) {
+      throw new CliError(`Maintenance action ids collide as payload filenames: ${payloadName}`, {
+        code: 'DATASET_MAINTENANCE_ACTION_FILENAME_COLLISION',
+        exitCode: 2,
+      });
+    }
+    payloadNames.add(payloadName);
+  }
+  const email = token(value.account.email);
+  const sourceImportRunId = token(value.source_import_run_id);
+  return {
+    schema_version: 1,
+    task_id: requireToken(value.task_id, 'task_id'),
+    operation: operation as DatasetMaintenanceOperation,
+    account: {
+      user_id: userId,
+      ...(email ? { email } : {}),
+    },
+    ...(sourceImportRunId ? { source_import_run_id: sourceImportRunId } : {}),
+    ...('source_lineage' in value ? { source_lineage: value.source_lineage } : {}),
+    actions,
+  };
+}
+
+export function readJsonFile(filePath: string, label: string): unknown {
+  const resolved = path.resolve(filePath);
+  if (!existsSync(resolved)) {
+    throw new CliError(`${label} not found: ${resolved}`, {
+      code: 'DATASET_MAINTENANCE_ARTIFACT_NOT_FOUND',
+      exitCode: 2,
+    });
+  }
+  try {
+    return JSON.parse(readFileSync(resolved, 'utf8'));
+  } catch (error) {
+    throw new CliError(`${label} is not valid JSON: ${resolved}`, {
+      code: 'DATASET_MAINTENANCE_ARTIFACT_INVALID',
+      exitCode: 2,
+      details: String(error),
+    });
+  }
+}
+
+function writeImmutableText(filePath: string, text: string): string {
+  const resolved = path.resolve(filePath);
+  if (existsSync(resolved)) {
+    if (readFileSync(resolved, 'utf8') === text) {
+      return resolved;
+    }
+    throw new CliError(`Refusing to overwrite immutable maintenance artifact: ${resolved}`, {
+      code: 'DATASET_MAINTENANCE_ARTIFACT_IMMUTABLE',
+      exitCode: 1,
+    });
+  }
+  mkdirSync(path.dirname(resolved), { recursive: true });
+  writeFileSync(resolved, text, { encoding: 'utf8', flag: 'wx' });
+  return resolved;
+}
+
+export function writeImmutableJson(filePath: string, value: unknown): string {
+  return writeImmutableText(filePath, `${stableJsonText(value)}\n`);
+}
+
+export function writeImmutableJsonLines(filePath: string, values: unknown[]): string {
+  const text = values.length ? `${values.map(stableJsonText).join('\n')}\n` : '';
+  return writeImmutableText(filePath, text);
+}
+
+export function appendStableJsonLine(filePath: string, value: unknown): string {
+  const resolved = path.resolve(filePath);
+  mkdirSync(path.dirname(resolved), { recursive: true });
+  appendFileSync(resolved, `${stableJsonText(value)}\n`, 'utf8');
+  return resolved;
+}
+
+export function readJsonLinesIfPresent(filePath: string): unknown[] {
+  const resolved = path.resolve(filePath);
+  if (!existsSync(resolved)) {
+    return [];
+  }
+  return readFileSync(resolved, 'utf8')
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line, index) => {
+      try {
+        return JSON.parse(line);
+      } catch (error) {
+        throw new CliError(`Invalid maintenance JSONL at ${resolved}:${index + 1}`, {
+          code: 'DATASET_MAINTENANCE_ARTIFACT_INVALID',
+          exitCode: 1,
+          details: String(error),
+        });
+      }
+    });
+}
+
+export function safeActionFileName(actionId: string): string {
+  const safe = actionId.replace(/[^a-zA-Z0-9._-]+/gu, '_').replace(/^_+|_+$/gu, '');
+  return safe || sha256Text(actionId).slice(0, 16);
+}
+
+export function resolveMaintenancePlanArtifactPath(
+  planDir: string,
+  relativePath: string,
+  label: string,
+): string {
+  const root = path.resolve(planDir);
+  if (!relativePath.trim() || path.isAbsolute(relativePath)) {
+    throw new CliError(`${label} must be a relative path inside the maintenance plan directory.`, {
+      code: 'DATASET_MAINTENANCE_PLAN_ARTIFACT_PATH_INVALID',
+      exitCode: 2,
+      details: relativePath,
+    });
+  }
+  const resolved = path.resolve(root, relativePath);
+  const withinRoot = path.relative(root, resolved);
+  if (!withinRoot || withinRoot === '..' || withinRoot.startsWith(`..${path.sep}`)) {
+    throw new CliError(`${label} must stay inside the maintenance plan directory.`, {
+      code: 'DATASET_MAINTENANCE_PLAN_ARTIFACT_PATH_INVALID',
+      exitCode: 2,
+      details: relativePath,
+    });
+  }
+  return resolved;
+}
+
+export function computePlanSha256(plan: DatasetMaintenancePlan): string {
+  const body = { ...plan, plan_sha256: '' };
+  return sha256Json(body);
+}
+
+export function parseMaintenancePlan(value: unknown): DatasetMaintenancePlan {
+  if (
+    !isJsonObject(value) ||
+    value.schema_version !== 1 ||
+    !Array.isArray(value.actions) ||
+    !Array.isArray(value.protected_rows) ||
+    !Array.isArray(value.blockers) ||
+    !isJsonObject(value.account) ||
+    !isJsonObject(value.artifacts)
+  ) {
+    throw new CliError('Maintenance plan is not a valid schema_version=1 plan.', {
+      code: 'DATASET_MAINTENANCE_PLAN_INVALID',
+      exitCode: 2,
+    });
+  }
+  const plan = value as DatasetMaintenancePlan;
+  const expected = computePlanSha256(plan);
+  if (plan.plan_sha256 !== expected) {
+    throw new CliError('Maintenance plan hash does not match its canonical contents.', {
+      code: 'DATASET_MAINTENANCE_PLAN_HASH_MISMATCH',
+      exitCode: 2,
+      details: { expected, received: plan.plan_sha256 },
+    });
+  }
+
+  const normalizedScope = parseMaintenanceScope(
+    {
+      schema_version: 1,
+      task_id: plan.task_id,
+      operation: plan.operation,
+      account: plan.account,
+      ...(plan.source_import_run_id ? { source_import_run_id: plan.source_import_run_id } : {}),
+      source_lineage: plan.source_lineage,
+      actions: plan.actions,
+    },
+    plan.operation,
+  );
+  const actionIds = new Set<string>();
+  const ordinals = new Set<number>();
+  for (const [index, action] of plan.actions.entries()) {
+    const normalizedAction = normalizedScope.actions[index];
+    if (
+      !normalizedAction ||
+      action.action_id !== normalizedAction.action_id ||
+      !Number.isInteger(action.ordinal) ||
+      action.ordinal < 0 ||
+      ordinals.has(action.ordinal) ||
+      !['ready', 'blocked'].includes(action.status) ||
+      !Array.isArray(action.blockers) ||
+      !isJsonObject(action.rollback)
+    ) {
+      throw new CliError('Maintenance plan contains an invalid action contract.', {
+        code: 'DATASET_MAINTENANCE_PLAN_INVALID',
+        exitCode: 2,
+        details: { index, action_id: action.action_id },
+      });
+    }
+    actionIds.add(action.action_id);
+    ordinals.add(action.ordinal);
+    if (action.status === 'ready') {
+      const before = action.before;
+      if (
+        !isJsonObject(before) ||
+        before.table !== action.table ||
+        before.id !== action.id ||
+        before.version !== action.version ||
+        before.user_id !== action.expected_user_id ||
+        before.state_code !== 0 ||
+        !isJsonObject(before.json_ordered) ||
+        typeof before.row_sha256 !== 'string' ||
+        typeof before.payload_sha256 !== 'string' ||
+        action.blockers.length > 0
+      ) {
+        throw new CliError('Ready maintenance plan action has an invalid before snapshot.', {
+          code: 'DATASET_MAINTENANCE_PLAN_INVALID',
+          exitCode: 2,
+          details: { action_id: action.action_id },
+        });
+      }
+      const remoteRow: DatasetMaintenanceRemoteRow = {
+        table: before.table,
+        id: before.id,
+        version: before.version,
+        user_id: before.user_id,
+        state_code: before.state_code,
+        modified_at: before.modified_at,
+        json_ordered: before.json_ordered,
+        model_id: before.model_id,
+        rule_verification: before.rule_verification,
+      };
+      const expectedSnapshot = snapshotRemoteRow(remoteRow);
+      if (
+        before.row_sha256 !== expectedSnapshot.row_sha256 ||
+        before.payload_sha256 !== expectedSnapshot.payload_sha256
+      ) {
+        throw new CliError('Ready maintenance plan action before snapshot hash is invalid.', {
+          code: 'DATASET_MAINTENANCE_PLAN_INVALID',
+          exitCode: 2,
+          details: { action_id: action.action_id },
+        });
+      }
+      const expectedRollbackStrategy =
+        action.action === 'save_draft' ? 'save_before_snapshot' : 'restore_deleted_before_snapshot';
+      if (
+        action.rollback.strategy !== expectedRollbackStrategy ||
+        action.rollback.before_payload_sha256 !== before.payload_sha256 ||
+        !isJsonObject(action.rollback.before_payload) ||
+        sha256Json(action.rollback.before_payload) !== before.payload_sha256 ||
+        action.rollback.model_id !== before.model_id ||
+        action.rollback.rule_verification !== before.rule_verification
+      ) {
+        throw new CliError('Ready maintenance plan action rollback snapshot is invalid.', {
+          code: 'DATASET_MAINTENANCE_PLAN_INVALID',
+          exitCode: 2,
+          details: { action_id: action.action_id },
+        });
+      }
+    }
+    if (
+      (action.action === 'save_draft' &&
+        (!isJsonObject(action.desired_payload) ||
+          typeof action.desired_payload.path !== 'string' ||
+          !/^[a-f0-9]{64}$/u.test(String(action.desired_payload.sha256)))) ||
+      (action.action === 'delete' && action.desired_payload !== null)
+    ) {
+      throw new CliError('Maintenance plan action desired payload contract is invalid.', {
+        code: 'DATASET_MAINTENANCE_PLAN_INVALID',
+        exitCode: 2,
+        details: { action_id: action.action_id },
+      });
+    }
+  }
+  const flattenedBlockers = plan.actions.flatMap((action) => action.blockers);
+  const summaryMatches =
+    isJsonObject(plan.summary) &&
+    plan.summary.actions === plan.actions.length &&
+    plan.summary.save_draft ===
+      plan.actions.filter((action) => action.action === 'save_draft').length &&
+    plan.summary.delete === plan.actions.filter((action) => action.action === 'delete').length &&
+    plan.summary.protected_rows === plan.protected_rows.length &&
+    plan.summary.blockers === plan.blockers.length &&
+    Number.isInteger(plan.summary.current_reference_impacts) &&
+    plan.summary.current_reference_impacts >= 0 &&
+    Number.isInteger(plan.summary.projected_reference_impacts) &&
+    plan.summary.projected_reference_impacts >= 0;
+  const ready =
+    plan.status === 'ready' &&
+    plan.blockers.length === 0 &&
+    flattenedBlockers.length === 0 &&
+    plan.actions.every((action) => action.status === 'ready');
+  const blocked =
+    plan.status === 'blocked' &&
+    plan.blockers.length > 0 &&
+    flattenedBlockers.length > 0 &&
+    plan.actions.some((action) => action.status === 'blocked');
+  if (
+    actionIds.size !== plan.actions.length ||
+    !summaryMatches ||
+    (!ready && !blocked) ||
+    sha256Json(plan.blockers) !== sha256Json(flattenedBlockers)
+  ) {
+    throw new CliError('Maintenance plan status or blocker contract is inconsistent.', {
+      code: 'DATASET_MAINTENANCE_PLAN_INVALID',
+      exitCode: 2,
+    });
+  }
+  return plan;
+}

--- a/src/lib/dataset-maintenance-plan.ts
+++ b/src/lib/dataset-maintenance-plan.ts
@@ -1,0 +1,517 @@
+import path from 'node:path';
+import { collectRemoteReferences } from './dataset-remote-verify.js';
+import { CliError } from './errors.js';
+import type { FetchLike } from './http.js';
+import {
+  computePlanSha256,
+  isJsonObject,
+  maintenanceRowKey,
+  parseMaintenanceScope,
+  readJsonFile,
+  safeActionFileName,
+  sha256Json,
+  snapshotRemoteRow,
+  writeImmutableJson,
+  writeImmutableJsonLines,
+  type DatasetMaintenanceBlocker,
+  type DatasetMaintenanceOperation,
+  type DatasetMaintenancePlan,
+  type DatasetMaintenancePlanAction,
+  type DatasetMaintenanceProtectedRow,
+  type DatasetMaintenanceReferenceImpact,
+  type DatasetMaintenanceRemoteRow,
+  type DatasetMaintenanceRowSnapshot,
+  type DatasetMaintenanceScopeAction,
+  type JsonObject,
+} from './dataset-maintenance-contract.js';
+import {
+  fetchMaintenanceAccountRows,
+  fetchMaintenanceExactRows,
+  normalizeMaintenancePageSize,
+  resolveMaintenanceRemoteContext,
+} from './dataset-maintenance-remote.js';
+
+export type RunDatasetMaintenancePlanOptions = {
+  scopePath: string;
+  operation: DatasetMaintenanceOperation;
+  outDir: string;
+  pageSize?: number;
+  timeoutMs?: number;
+  env: NodeJS.ProcessEnv;
+  fetchImpl: FetchLike;
+  now?: Date;
+};
+
+function normalizeEmail(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function blocker(
+  action: DatasetMaintenanceScopeAction,
+  code: string,
+  message: string,
+  details?: unknown,
+): DatasetMaintenanceBlocker {
+  return {
+    code,
+    message,
+    action_id: action.action_id,
+    table: action.table,
+    id: action.id,
+    version: action.version,
+    ...(details === undefined ? {} : { details }),
+  };
+}
+
+function desiredPayloadIdentity(payload: JsonObject): {
+  id: string | null;
+  version: string | null;
+} {
+  const root = collectRemoteReferences([{ json_ordered: payload }]).find(
+    (reference) => reference.role === 'root',
+  );
+  return { id: root?.id ?? null, version: root?.version ?? null };
+}
+
+function referenceImpacts(options: {
+  rows: DatasetMaintenanceRemoteRow[];
+  deletes: DatasetMaintenanceScopeAction[];
+  phase: DatasetMaintenanceReferenceImpact['phase'];
+}): DatasetMaintenanceReferenceImpact[] {
+  const payloadRows = options.rows
+    .filter((row) => row.json_ordered !== null)
+    .map((row) => ({
+      table: row.table,
+      id: row.id,
+      version: row.version,
+      json_ordered: row.json_ordered as JsonObject,
+    }));
+  const references = collectRemoteReferences(payloadRows).filter(
+    (reference) => reference.role === 'reference',
+  );
+  const impacts: DatasetMaintenanceReferenceImpact[] = [];
+  for (const reference of references) {
+    const source = payloadRows[reference.row_index];
+    if (!reference.table || !reference.id) {
+      continue;
+    }
+    for (const target of options.deletes) {
+      const sameTarget =
+        reference.table === target.table &&
+        reference.id === target.id &&
+        (!reference.version || reference.version === target.version);
+      if (sameTarget) {
+        impacts.push({
+          target_action_id: target.action_id,
+          target_table: target.table,
+          target_id: target.id,
+          target_version: target.version,
+          phase: options.phase,
+          source_table: source!.table,
+          source_id: source!.id,
+          source_version: source!.version,
+          reference_path: reference.path,
+          reference_version: reference.version,
+        });
+      }
+    }
+  }
+  return impacts.sort((left, right) =>
+    [
+      left.target_action_id,
+      left.source_table,
+      left.source_id,
+      left.source_version,
+      left.reference_path,
+    ]
+      .join('\u0000')
+      .localeCompare(
+        [
+          right.target_action_id,
+          right.source_table,
+          right.source_id,
+          right.source_version,
+          right.reference_path,
+        ].join('\u0000'),
+      ),
+  );
+}
+
+function projectedRows(options: {
+  current: DatasetMaintenanceRemoteRow[];
+  actions: DatasetMaintenancePlanAction[];
+  desiredPayloads: Map<string, JsonObject>;
+}): DatasetMaintenanceRemoteRow[] {
+  const projected = new Map(options.current.map((row) => [maintenanceRowKey(row), { ...row }]));
+  for (const action of options.actions.filter((entry) => entry.action === 'save_draft')) {
+    const key = maintenanceRowKey(action);
+    const row = projected.get(key);
+    const payload = options.desiredPayloads.get(action.action_id);
+    if (row && payload) {
+      projected.set(key, { ...row, json_ordered: payload });
+    }
+  }
+  for (const action of options.actions.filter((entry) => entry.action === 'delete')) {
+    projected.delete(maintenanceRowKey(action));
+  }
+  return [...projected.values()].sort((left, right) =>
+    maintenanceRowKey(left).localeCompare(maintenanceRowKey(right)),
+  );
+}
+
+export function maintenanceProjectedReferenceFingerprint(
+  rows: DatasetMaintenanceRemoteRow[],
+): unknown[] {
+  const payloadRows = rows
+    .filter((row) => row.json_ordered !== null)
+    .map((row) => ({
+      table: row.table,
+      id: row.id,
+      version: row.version,
+      json_ordered: row.json_ordered as JsonObject,
+    }));
+  return collectRemoteReferences(payloadRows)
+    .filter((reference) => reference.role === 'reference')
+    .map((reference) => ({
+      source: maintenanceRowKey(payloadRows[reference.row_index]!),
+      table: reference.table,
+      id: reference.id,
+      version: reference.version,
+      path: reference.path,
+    }))
+    .sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+}
+
+function protectedRows(options: {
+  snapshot: DatasetMaintenanceRowSnapshot[];
+  actions: DatasetMaintenancePlanAction[];
+}): DatasetMaintenanceProtectedRow[] {
+  const readyActionKeys = new Set(
+    options.actions
+      .filter((action) => action.before && action.status === 'ready')
+      .map(maintenanceRowKey),
+  );
+  const blockedActionKeys = new Set(
+    options.actions
+      .filter((action) => action.before && action.status === 'blocked')
+      .map(maintenanceRowKey),
+  );
+  return options.snapshot
+    .filter((row) => !readyActionKeys.has(maintenanceRowKey(row)))
+    .map((row) => ({
+      table: row.table,
+      id: row.id,
+      version: row.version,
+      modified_at: row.modified_at,
+      row_sha256: row.row_sha256,
+      payload_sha256: row.payload_sha256,
+      reason: blockedActionKeys.has(maintenanceRowKey(row))
+        ? ('blocked_action_row' as const)
+        : ('non_action_visible_row' as const),
+    }));
+}
+
+export async function runDatasetMaintenancePlan(
+  options: RunDatasetMaintenancePlanOptions,
+): Promise<DatasetMaintenancePlan> {
+  const scopePath = path.resolve(options.scopePath);
+  const outDir = path.resolve(options.outDir);
+  const pageSize = normalizeMaintenancePageSize(options.pageSize);
+  const generatedAtUtc = (options.now ?? new Date()).toISOString();
+  const scope = parseMaintenanceScope(
+    readJsonFile(scopePath, 'Maintenance scope'),
+    options.operation,
+  );
+  const context = await resolveMaintenanceRemoteContext({
+    env: options.env,
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.timeoutMs,
+    now: options.now,
+  });
+  if (context.account.user_id !== scope.account.user_id) {
+    throw new CliError('Current authenticated user does not match maintenance scope account.', {
+      code: 'DATASET_MAINTENANCE_ACCOUNT_MISMATCH',
+      exitCode: 1,
+      details: {
+        expected_user_id: scope.account.user_id,
+        current_user_id: context.account.user_id,
+      },
+    });
+  }
+  if (
+    scope.account.email &&
+    normalizeEmail(scope.account.email) !== normalizeEmail(context.account.email)
+  ) {
+    throw new CliError('Current authenticated email does not match maintenance scope account.', {
+      code: 'DATASET_MAINTENANCE_ACCOUNT_EMAIL_MISMATCH',
+      exitCode: 1,
+      details: {
+        expected_email: scope.account.email,
+        current_email: context.account.email,
+      },
+    });
+  }
+
+  const accountSnapshot = await fetchMaintenanceAccountRows({
+    context,
+    userId: scope.account.user_id,
+    pageSize,
+  });
+  const snapshotRows = accountSnapshot.rows
+    .map(snapshotRemoteRow)
+    .sort((left, right) => maintenanceRowKey(left).localeCompare(maintenanceRowKey(right)));
+  const snapshotByKey = new Map(snapshotRows.map((row) => [maintenanceRowKey(row), row]));
+  const desiredPayloads = new Map<string, JsonObject>();
+  const actionPlans: DatasetMaintenancePlanAction[] = [];
+
+  for (const [ordinal, action] of scope.actions.entries()) {
+    const actionBlockers: DatasetMaintenanceBlocker[] = [];
+    const exact = await fetchMaintenanceExactRows({
+      context,
+      table: action.table,
+      id: action.id,
+      version: action.version,
+    });
+    const remote = exact.rows[0] ?? null;
+    if (exact.rows.length === 0) {
+      actionBlockers.push(
+        blocker(
+          action,
+          'TARGET_NOT_VISIBLE',
+          'Exact target row is not visible under the current authenticated RLS session.',
+        ),
+      );
+    }
+    if (exact.rows.length > 1) {
+      actionBlockers.push(
+        blocker(action, 'TARGET_NOT_UNIQUE', 'Exact target lookup returned multiple rows.'),
+      );
+    }
+    const before = remote ? snapshotRemoteRow(remote) : null;
+    if (before && before.user_id !== action.expected_user_id) {
+      actionBlockers.push(
+        blocker(action, 'TARGET_OWNER_MISMATCH', 'Target row is not owned by the expected user.', {
+          visible_user_id: before.user_id,
+        }),
+      );
+    }
+    if (before && before.state_code !== 0) {
+      actionBlockers.push(
+        blocker(action, 'TARGET_NOT_DRAFT', 'Target row is not a draft with state_code=0.', {
+          visible_state_code: before.state_code,
+        }),
+      );
+    }
+    if (before && !before.json_ordered) {
+      actionBlockers.push(
+        blocker(action, 'TARGET_PAYLOAD_MISSING', 'Target row has no object json_ordered payload.'),
+      );
+    }
+    if (
+      before &&
+      action.expected_before_sha256 &&
+      action.expected_before_sha256 !== before.row_sha256
+    ) {
+      actionBlockers.push(
+        blocker(action, 'EXPECTED_BEFORE_HASH_MISMATCH', 'Target row hash differs from scope.', {
+          expected: action.expected_before_sha256,
+          actual: before.row_sha256,
+        }),
+      );
+    }
+    const snapshotRow = snapshotByKey.get(maintenanceRowKey(action));
+    if (before && (!snapshotRow || snapshotRow.row_sha256 !== before.row_sha256)) {
+      actionBlockers.push(
+        blocker(
+          action,
+          'SNAPSHOT_DRIFT',
+          'Exact target row differs from the same-account visible snapshot.',
+        ),
+      );
+    }
+
+    let desiredPayload: DatasetMaintenancePlanAction['desired_payload'] = null;
+    if (action.action === 'save_draft' && action.desired_payload_path) {
+      const sourcePayloadPath = path.resolve(path.dirname(scopePath), action.desired_payload_path);
+      const rawPayload = readJsonFile(sourcePayloadPath, 'Maintenance desired payload');
+      if (!isJsonObject(rawPayload)) {
+        throw new CliError(`Desired payload must be a JSON object: ${sourcePayloadPath}`, {
+          code: 'DATASET_MAINTENANCE_DESIRED_PAYLOAD_INVALID',
+          exitCode: 2,
+        });
+      }
+      const payloadPath = path.join(
+        outDir,
+        'payloads',
+        `${safeActionFileName(action.action_id)}.json`,
+      );
+      writeImmutableJson(payloadPath, rawPayload);
+      desiredPayloads.set(action.action_id, rawPayload);
+      desiredPayload = {
+        path: path.relative(outDir, payloadPath),
+        sha256: sha256Json(rawPayload),
+      };
+      const identity = desiredPayloadIdentity(rawPayload);
+      if (identity.id !== action.id || identity.version !== action.version) {
+        actionBlockers.push(
+          blocker(
+            action,
+            'DESIRED_PAYLOAD_IDENTITY_MISMATCH',
+            'Desired payload root id/version does not match the target row.',
+            identity,
+          ),
+        );
+      }
+    }
+    actionPlans.push({
+      ...action,
+      ordinal,
+      status: actionBlockers.length ? 'blocked' : 'ready',
+      before,
+      desired_payload: desiredPayload,
+      blockers: actionBlockers,
+      rollback: {
+        strategy:
+          action.action === 'save_draft'
+            ? 'save_before_snapshot'
+            : 'restore_deleted_before_snapshot',
+        before_payload_sha256: before?.payload_sha256 ?? null,
+        before_payload: before?.json_ordered ?? null,
+        model_id: before?.model_id ?? null,
+        rule_verification: before?.rule_verification ?? null,
+      },
+    });
+  }
+
+  const intendedRows = projectedRows({
+    current: accountSnapshot.rows,
+    actions: actionPlans,
+    desiredPayloads,
+  });
+  const deleteActions = scope.actions.filter((action) => action.action === 'delete');
+  const currentImpacts = referenceImpacts({
+    rows: accountSnapshot.rows,
+    deletes: deleteActions,
+    phase: 'current',
+  });
+  const projectedImpacts = referenceImpacts({
+    rows: intendedRows,
+    deletes: deleteActions,
+    phase: 'projected',
+  });
+  for (const action of actionPlans.filter((entry) => entry.action === 'delete')) {
+    const impacts = projectedImpacts.filter(
+      (impact) => impact.target_action_id === action.action_id,
+    );
+    if (impacts.length) {
+      action.blockers.push(
+        blocker(
+          action,
+          'PROJECTED_INBOUND_REFERENCES',
+          `Projected state still contains ${impacts.length} inbound reference(s) to this delete target.`,
+          impacts,
+        ),
+      );
+      action.status = 'blocked';
+    }
+  }
+  const allBlockers = actionPlans.flatMap((action) => action.blockers);
+  const protectedRowList = protectedRows({ snapshot: snapshotRows, actions: actionPlans });
+  const scopeSha256 = sha256Json(scope);
+  const plan: DatasetMaintenancePlan = {
+    schema_version: 1,
+    generated_at_utc: generatedAtUtc,
+    task_id: scope.task_id,
+    operation: scope.operation,
+    operation_id: `maintenance-${scopeSha256.slice(0, 20)}`,
+    account: {
+      user_id: scope.account.user_id,
+      email: context.account.email,
+    },
+    source_import_run_id: scope.source_import_run_id ?? null,
+    source_lineage: scope.source_lineage ?? null,
+    status: allBlockers.length ? 'blocked' : 'ready',
+    scope_sha256: scopeSha256,
+    visible_snapshot_sha256: sha256Json(snapshotRows),
+    projected_reference_sha256: sha256Json(maintenanceProjectedReferenceFingerprint(intendedRows)),
+    plan_sha256: '',
+    summary: {
+      actions: actionPlans.length,
+      save_draft: actionPlans.filter((action) => action.action === 'save_draft').length,
+      delete: actionPlans.filter((action) => action.action === 'delete').length,
+      protected_rows: protectedRowList.length,
+      blockers: allBlockers.length,
+      current_reference_impacts: currentImpacts.length,
+      projected_reference_impacts: projectedImpacts.length,
+    },
+    artifacts: {
+      maintenance_scope: 'maintenance-scope.json',
+      rls_visible_snapshot: 'rls-visible-snapshot.json',
+      protected_rows: 'protected-rows.jsonl',
+      reference_impact_report: 'reference-impact-report.json',
+      maintenance_plan: 'maintenance-plan.json',
+      dry_run_report: 'dry-run-report.json',
+      payload_dir: 'payloads',
+    },
+    actions: actionPlans,
+    protected_rows: protectedRowList,
+    blockers: allBlockers,
+  };
+  plan.plan_sha256 = computePlanSha256(plan);
+
+  writeImmutableJson(path.join(outDir, plan.artifacts.maintenance_scope), scope);
+  writeImmutableJson(path.join(outDir, plan.artifacts.rls_visible_snapshot), {
+    schema_version: 1,
+    generated_at_utc: generatedAtUtc,
+    account: {
+      user_id: scope.account.user_id,
+      email: context.account.email,
+      session_source: context.account.session_source,
+    },
+    page_size: pageSize,
+    source_urls: accountSnapshot.source_urls,
+    row_count: snapshotRows.length,
+    snapshot_sha256: plan.visible_snapshot_sha256,
+    rows: snapshotRows,
+  });
+  writeImmutableJsonLines(path.join(outDir, plan.artifacts.protected_rows), protectedRowList);
+  writeImmutableJson(path.join(outDir, plan.artifacts.reference_impact_report), {
+    schema_version: 1,
+    generated_at_utc: generatedAtUtc,
+    plan_sha256: plan.plan_sha256,
+    status: plan.status,
+    current: currentImpacts,
+    projected: projectedImpacts,
+    projected_reference_sha256: plan.projected_reference_sha256,
+  });
+  writeImmutableJson(path.join(outDir, plan.artifacts.dry_run_report), {
+    schema_version: 1,
+    generated_at_utc: generatedAtUtc,
+    status: plan.status,
+    operation: plan.operation,
+    task_id: plan.task_id,
+    plan_sha256: plan.plan_sha256,
+    account: plan.account,
+    summary: plan.summary,
+    actions: plan.actions.map((action) => ({
+      action_id: action.action_id,
+      action: action.action,
+      table: action.table,
+      id: action.id,
+      version: action.version,
+      status: action.status,
+      blockers: action.blockers,
+    })),
+    blockers: plan.blockers,
+  });
+  writeImmutableJson(path.join(outDir, plan.artifacts.maintenance_plan), plan);
+  return plan;
+}
+
+export const __testInternals = {
+  desiredPayloadIdentity,
+  maintenanceProjectedReferenceFingerprint,
+  projectedRows,
+  protectedRows,
+  referenceImpacts,
+};

--- a/src/lib/dataset-maintenance-remote.ts
+++ b/src/lib/dataset-maintenance-remote.ts
@@ -1,0 +1,353 @@
+import { CliError } from './errors.js';
+import type { FetchLike } from './http.js';
+import {
+  buildSupabaseAuthHeaders,
+  deriveSupabaseProjectBaseUrl,
+  requireSupabaseRestRuntime,
+} from './supabase-client.js';
+import { resolveSupabaseUserSession } from './supabase-session.js';
+import {
+  isJsonObject,
+  MAINTENANCE_SCAN_TABLES,
+  type DatasetMaintenanceMutableTable,
+  type DatasetMaintenanceRemoteRow,
+  type DatasetMaintenanceScanTable,
+  type JsonObject,
+} from './dataset-maintenance-contract.js';
+
+const DEFAULT_PAGE_SIZE = 1_000;
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export type DatasetMaintenanceRemoteContext = {
+  rest_base_url: string;
+  publishable_key: string;
+  access_token: string;
+  account: {
+    user_id: string;
+    email: string;
+    session_source: string;
+  };
+  fetch_impl: FetchLike;
+  timeout_ms: number;
+};
+
+function trimToken(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function normalizeStateCode(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isInteger(value)) {
+    return value;
+  }
+  return typeof value === 'string' && /^-?\d+$/u.test(value.trim())
+    ? Number.parseInt(value.trim(), 10)
+    : null;
+}
+
+export function normalizeMaintenancePageSize(value?: number): number {
+  const normalized = value ?? DEFAULT_PAGE_SIZE;
+  if (!Number.isInteger(normalized) || normalized < 1 || normalized > 5_000) {
+    throw new CliError('Maintenance page size must be an integer between 1 and 5000.', {
+      code: 'DATASET_MAINTENANCE_PAGE_SIZE_INVALID',
+      exitCode: 2,
+      details: value,
+    });
+  }
+  return normalized;
+}
+
+export function normalizeMaintenanceTimeout(value?: number): number {
+  const normalized = value ?? DEFAULT_TIMEOUT_MS;
+  if (!Number.isInteger(normalized) || normalized < 1) {
+    throw new CliError('Maintenance timeout must be a positive integer.', {
+      code: 'DATASET_MAINTENANCE_TIMEOUT_INVALID',
+      exitCode: 2,
+      details: value,
+    });
+  }
+  return normalized;
+}
+
+async function fetchJson(options: {
+  context: Pick<
+    DatasetMaintenanceRemoteContext,
+    'publishable_key' | 'access_token' | 'fetch_impl' | 'timeout_ms'
+  >;
+  url: string;
+  init?: RequestInit;
+  label: string;
+}): Promise<unknown> {
+  const response = await options.context.fetch_impl(options.url, {
+    ...options.init,
+    headers: {
+      ...buildSupabaseAuthHeaders(options.context.publishable_key, options.context.access_token),
+      ...(options.init?.headers ?? {}),
+    },
+    signal: AbortSignal.timeout(options.context.timeout_ms),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new CliError(`HTTP ${response.status} returned from ${options.label}`, {
+      code: 'DATASET_MAINTENANCE_REMOTE_REQUEST_FAILED',
+      exitCode: 1,
+      details: { url: options.url, response: text },
+    });
+  }
+  if (!text.trim()) {
+    return null;
+  }
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new CliError(`Remote response was not valid JSON for ${options.label}`, {
+      code: 'DATASET_MAINTENANCE_REMOTE_INVALID_JSON',
+      exitCode: 1,
+      details: {
+        url: options.url,
+        error: String(error),
+      },
+    });
+  }
+}
+
+function selectForTable(table: DatasetMaintenanceScanTable): string {
+  const common = 'id,version,user_id,state_code,modified_at,json_ordered,rule_verification';
+  return table === 'processes' ? `${common},model_id` : common;
+}
+
+function normalizeRemoteRow(
+  table: DatasetMaintenanceScanTable,
+  value: unknown,
+): DatasetMaintenanceRemoteRow | null {
+  if (!isJsonObject(value)) {
+    return null;
+  }
+  const id = trimToken(value.id);
+  const version = trimToken(value.version);
+  if (!id || !version) {
+    return null;
+  }
+  return {
+    table,
+    id,
+    version,
+    user_id: trimToken(value.user_id),
+    state_code: normalizeStateCode(value.state_code),
+    modified_at: trimToken(value.modified_at),
+    json_ordered: isJsonObject(value.json_ordered) ? value.json_ordered : null,
+    model_id: trimToken(value.model_id),
+    rule_verification:
+      typeof value.rule_verification === 'boolean' ? value.rule_verification : null,
+  };
+}
+
+function normalizeRemoteRows(
+  table: DatasetMaintenanceScanTable,
+  value: unknown,
+  label: string,
+): DatasetMaintenanceRemoteRow[] {
+  if (!Array.isArray(value)) {
+    throw new CliError(`Remote response was not an array for ${label}.`, {
+      code: 'DATASET_MAINTENANCE_REMOTE_ROWS_INVALID',
+      exitCode: 1,
+      details: value,
+    });
+  }
+  const rows = value.map((entry) => normalizeRemoteRow(table, entry));
+  if (rows.some((row) => row === null)) {
+    throw new CliError(`Remote response contained an invalid row for ${label}.`, {
+      code: 'DATASET_MAINTENANCE_REMOTE_ROW_INVALID',
+      exitCode: 1,
+    });
+  }
+  return rows as DatasetMaintenanceRemoteRow[];
+}
+
+export async function resolveMaintenanceRemoteContext(options: {
+  env: NodeJS.ProcessEnv;
+  fetchImpl: FetchLike;
+  timeoutMs?: number;
+  now?: Date;
+}): Promise<DatasetMaintenanceRemoteContext> {
+  const timeoutMs = normalizeMaintenanceTimeout(options.timeoutMs);
+  const runtime = requireSupabaseRestRuntime(options.env);
+  const session = await resolveSupabaseUserSession({
+    runtime,
+    fetchImpl: options.fetchImpl,
+    timeoutMs,
+    now: options.now,
+  });
+  const projectBaseUrl = deriveSupabaseProjectBaseUrl(runtime.apiBaseUrl);
+  const partialContext = {
+    publishable_key: runtime.publishableKey,
+    access_token: session.accessToken,
+    fetch_impl: options.fetchImpl,
+    timeout_ms: timeoutMs,
+  };
+  const currentUser = await fetchJson({
+    context: partialContext,
+    url: `${projectBaseUrl}/auth/v1/user`,
+    label: 'supabase current-user lookup',
+  });
+  const userId = isJsonObject(currentUser) ? trimToken(currentUser.id) : null;
+  const email = isJsonObject(currentUser)
+    ? (trimToken(currentUser.email) ?? trimToken(session.userEmail))
+    : trimToken(session.userEmail);
+  if (!userId || !email) {
+    throw new CliError('Supabase current-user lookup did not return id and email.', {
+      code: 'DATASET_MAINTENANCE_CURRENT_USER_INVALID',
+      exitCode: 1,
+    });
+  }
+  return {
+    rest_base_url: `${projectBaseUrl}/rest/v1`,
+    publishable_key: runtime.publishableKey,
+    access_token: session.accessToken,
+    account: {
+      user_id: userId,
+      email,
+      session_source: session.source,
+    },
+    fetch_impl: options.fetchImpl,
+    timeout_ms: timeoutMs,
+  };
+}
+
+export async function fetchMaintenanceExactRows(options: {
+  context: DatasetMaintenanceRemoteContext;
+  table: DatasetMaintenanceScanTable;
+  id: string;
+  version: string;
+}): Promise<{ rows: DatasetMaintenanceRemoteRow[]; source_url: string }> {
+  const url = new URL(`${options.context.rest_base_url}/${options.table}`);
+  url.searchParams.set('select', selectForTable(options.table));
+  url.searchParams.set('id', `eq.${options.id}`);
+  url.searchParams.set('version', `eq.${options.version}`);
+  url.searchParams.set('limit', '2');
+  const sourceUrl = url.toString();
+  const body = await fetchJson({
+    context: options.context,
+    url: sourceUrl,
+    label: `${options.table} exact maintenance lookup`,
+  });
+  return {
+    rows: normalizeRemoteRows(options.table, body, sourceUrl),
+    source_url: sourceUrl,
+  };
+}
+
+export async function fetchMaintenanceAccountRows(options: {
+  context: DatasetMaintenanceRemoteContext;
+  userId: string;
+  pageSize?: number;
+}): Promise<{ rows: DatasetMaintenanceRemoteRow[]; source_urls: string[] }> {
+  const pageSize = normalizeMaintenancePageSize(options.pageSize);
+  const rows: DatasetMaintenanceRemoteRow[] = [];
+  const sourceUrls: string[] = [];
+  for (const table of MAINTENANCE_SCAN_TABLES) {
+    let offset = 0;
+    while (true) {
+      const url = new URL(`${options.context.rest_base_url}/${table}`);
+      url.searchParams.set('select', selectForTable(table));
+      url.searchParams.set('user_id', `eq.${options.userId}`);
+      url.searchParams.set('order', 'id.asc,version.asc');
+      url.searchParams.set('limit', String(pageSize));
+      url.searchParams.set('offset', String(offset));
+      const sourceUrl = url.toString();
+      const body = await fetchJson({
+        context: options.context,
+        url: sourceUrl,
+        label: `${table} account maintenance snapshot`,
+      });
+      const page = normalizeRemoteRows(table, body, sourceUrl);
+      rows.push(...page);
+      sourceUrls.push(sourceUrl);
+      if (page.length < pageSize) {
+        break;
+      }
+      offset += pageSize;
+    }
+  }
+  return { rows, source_urls: sourceUrls };
+}
+
+async function invokeMaintenanceRpc(options: {
+  context: DatasetMaintenanceRemoteContext;
+  rpc: 'cmd_dataset_save_draft' | 'cmd_dataset_delete';
+  body: JsonObject;
+}): Promise<JsonObject> {
+  const url = `${options.context.rest_base_url}/rpc/${options.rpc}`;
+  const body = await fetchJson({
+    context: options.context,
+    url,
+    init: {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(options.body),
+    },
+    label: options.rpc,
+  });
+  if (!isJsonObject(body) || body.ok !== true) {
+    throw new CliError(`${options.rpc} returned an unexpected response.`, {
+      code: 'DATASET_MAINTENANCE_RPC_FAILED',
+      exitCode: 1,
+      details: body,
+    });
+  }
+  return body;
+}
+
+export async function saveDraftMaintenanceRow(options: {
+  context: DatasetMaintenanceRemoteContext;
+  table: DatasetMaintenanceMutableTable;
+  id: string;
+  version: string;
+  payload: JsonObject;
+  modelId: string | null;
+  ruleVerification: boolean | null;
+  audit: JsonObject;
+}): Promise<JsonObject> {
+  return invokeMaintenanceRpc({
+    context: options.context,
+    rpc: 'cmd_dataset_save_draft',
+    body: {
+      p_table: options.table,
+      p_id: options.id,
+      p_version: options.version,
+      p_json_ordered: options.payload,
+      p_model_id: options.modelId,
+      p_rule_verification: options.ruleVerification,
+      p_audit: options.audit,
+    },
+  });
+}
+
+export async function deleteMaintenanceRow(options: {
+  context: DatasetMaintenanceRemoteContext;
+  table: DatasetMaintenanceMutableTable;
+  id: string;
+  version: string;
+  audit: JsonObject;
+}): Promise<JsonObject> {
+  return invokeMaintenanceRpc({
+    context: options.context,
+    rpc: 'cmd_dataset_delete',
+    body: {
+      p_table: options.table,
+      p_id: options.id,
+      p_version: options.version,
+      p_audit: options.audit,
+    },
+  });
+}
+
+export const __testInternals = {
+  fetchJson,
+  normalizeRemoteRow,
+  normalizeRemoteRows,
+  selectForTable,
+};

--- a/src/lib/dataset-maintenance-verify.ts
+++ b/src/lib/dataset-maintenance-verify.ts
@@ -1,0 +1,469 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { writeJsonArtifact } from './artifacts.js';
+import { collectRemoteReferences } from './dataset-remote-verify.js';
+import { CliError } from './errors.js';
+import type { FetchLike } from './http.js';
+import {
+  isJsonObject,
+  maintenanceRowKey,
+  parseMaintenancePlan,
+  readJsonFile,
+  readJsonLinesIfPresent,
+  resolveMaintenancePlanArtifactPath,
+  sha256Json,
+  snapshotRemoteRow,
+  type DatasetMaintenancePlan,
+  type DatasetMaintenancePlanAction,
+  type DatasetMaintenanceRemoteRow,
+  type JsonObject,
+} from './dataset-maintenance-contract.js';
+import { maintenanceProjectedReferenceFingerprint } from './dataset-maintenance-plan.js';
+import {
+  fetchMaintenanceAccountRows,
+  fetchMaintenanceExactRows,
+  normalizeMaintenancePageSize,
+  resolveMaintenanceRemoteContext,
+} from './dataset-maintenance-remote.js';
+
+export type DatasetMaintenanceVerifyIssue = {
+  code: string;
+  message: string;
+  action_id?: string;
+  table?: string;
+  id?: string;
+  version?: string;
+  details?: unknown;
+};
+
+export type DatasetMaintenanceVerifyReport = {
+  schema_version: 1;
+  generated_at_utc: string;
+  status: 'passed' | 'failed';
+  task_id: string;
+  operation: DatasetMaintenancePlan['operation'];
+  operation_id: string;
+  plan_sha256: string;
+  actor: { user_id: string; email: string };
+  summary: {
+    actions: number;
+    action_checks_passed: number;
+    protected_rows: number;
+    protected_checks_passed: number;
+    progress_successes: number;
+    dangling_deleted_target_references: number;
+    issues: number;
+  };
+  action_checks: Array<{
+    action_id: string;
+    status: 'passed' | 'failed';
+    observed: 'desired_payload' | 'absent' | 'mismatch';
+  }>;
+  issues: DatasetMaintenanceVerifyIssue[];
+  artifacts: {
+    plan: string;
+    approval_record: string;
+    apply_progress: string;
+    commit_report: string;
+    report: string;
+  };
+};
+
+export type RunDatasetMaintenanceVerifyOptions = {
+  planPath: string;
+  outDir?: string;
+  pageSize?: number;
+  timeoutMs?: number;
+  env: NodeJS.ProcessEnv;
+  fetchImpl: FetchLike;
+  now?: Date;
+};
+
+function issue(
+  code: string,
+  message: string,
+  action?: DatasetMaintenancePlanAction,
+  details?: unknown,
+): DatasetMaintenanceVerifyIssue {
+  return {
+    code,
+    message,
+    ...(action
+      ? {
+          action_id: action.action_id,
+          table: action.table,
+          id: action.id,
+          version: action.version,
+        }
+      : {}),
+    ...(details === undefined ? {} : { details }),
+  };
+}
+
+function desiredPayload(planDir: string, action: DatasetMaintenancePlanAction): JsonObject | null {
+  if (!action.desired_payload) {
+    return null;
+  }
+  const raw = readJsonFile(
+    resolveMaintenancePlanArtifactPath(
+      planDir,
+      action.desired_payload.path,
+      'Maintenance desired payload path',
+    ),
+    'Maintenance desired payload',
+  );
+  return isJsonObject(raw) && sha256Json(raw) === action.desired_payload.sha256 ? raw : null;
+}
+
+function deletedTargetReferences(options: {
+  rows: DatasetMaintenanceRemoteRow[];
+  deletes: DatasetMaintenancePlanAction[];
+}): Array<{
+  target_action_id: string;
+  source_key: string;
+  path: string;
+}> {
+  const payloadRows = options.rows
+    .filter((row) => row.json_ordered)
+    .map((row) => ({ ...row, json_ordered: row.json_ordered as JsonObject }));
+  const references = collectRemoteReferences(payloadRows).filter(
+    (reference) => reference.role === 'reference',
+  );
+  return references.flatMap((reference) => {
+    const source = payloadRows[reference.row_index];
+    if (!reference.table || !reference.id) {
+      return [];
+    }
+    return options.deletes
+      .filter(
+        (target) =>
+          target.table === reference.table &&
+          target.id === reference.id &&
+          (!reference.version || target.version === reference.version),
+      )
+      .map((target) => ({
+        target_action_id: target.action_id,
+        source_key: maintenanceRowKey(source!),
+        path: reference.path,
+      }));
+  });
+}
+
+export async function runDatasetMaintenanceVerify(
+  options: RunDatasetMaintenanceVerifyOptions,
+): Promise<DatasetMaintenanceVerifyReport> {
+  const planPath = path.resolve(options.planPath);
+  const planDir = path.dirname(planPath);
+  const outDir = path.resolve(options.outDir ?? path.join(planDir, 'verify'));
+  const reportPath = path.join(outDir, 'readback-verify-report.json');
+  const approvalRecordPath = path.join(planDir, 'approval-record.json');
+  const progressPath = path.join(planDir, 'apply-progress.jsonl');
+  const commitReportPath = path.join(planDir, 'commit-report.json');
+  const pageSize = normalizeMaintenancePageSize(options.pageSize);
+  const plan = parseMaintenancePlan(readJsonFile(planPath, 'Maintenance plan'));
+  const context = await resolveMaintenanceRemoteContext({
+    env: options.env,
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.timeoutMs,
+    now: options.now,
+  });
+  if (
+    context.account.user_id !== plan.account.user_id ||
+    context.account.email !== plan.account.email
+  ) {
+    throw new CliError('Current authenticated account does not match the maintenance plan.', {
+      code: 'DATASET_MAINTENANCE_ACCOUNT_MISMATCH',
+      exitCode: 1,
+    });
+  }
+
+  const problems: DatasetMaintenanceVerifyIssue[] = [];
+  const current = await fetchMaintenanceAccountRows({
+    context,
+    userId: plan.account.user_id,
+    pageSize,
+  });
+  const currentByKey = new Map(current.rows.map((row) => [maintenanceRowKey(row), row]));
+  const actionChecks: DatasetMaintenanceVerifyReport['action_checks'] = [];
+  for (const action of plan.actions) {
+    const exact = await fetchMaintenanceExactRows({
+      context,
+      table: action.table,
+      id: action.id,
+      version: action.version,
+    });
+    if (action.action === 'delete') {
+      const passed = exact.rows.length === 0;
+      if (!passed) {
+        problems.push(
+          issue('DELETE_TARGET_STILL_VISIBLE', 'Deleted target is still visible.', action),
+        );
+      }
+      actionChecks.push({
+        action_id: action.action_id,
+        status: passed ? 'passed' : 'failed',
+        observed: passed ? 'absent' : 'mismatch',
+      });
+      continue;
+    }
+    const payload = desiredPayload(planDir, action);
+    const row = exact.rows.length === 1 ? exact.rows[0] : null;
+    const snapshot = row ? snapshotRemoteRow(row) : null;
+    const passed = Boolean(
+      row &&
+      payload &&
+      snapshot?.payload_sha256 === action.desired_payload?.sha256 &&
+      row.user_id === action.expected_user_id &&
+      row.state_code === 0 &&
+      row.model_id === action.before?.model_id &&
+      row.rule_verification === action.before?.rule_verification,
+    );
+    if (!passed) {
+      problems.push(
+        issue(
+          'SAVE_DRAFT_READBACK_MISMATCH',
+          'Saved draft payload, owner, state, model_id, or rule_verification did not match the plan.',
+          action,
+        ),
+      );
+    }
+    actionChecks.push({
+      action_id: action.action_id,
+      status: passed ? 'passed' : 'failed',
+      observed: passed ? 'desired_payload' : 'mismatch',
+    });
+  }
+
+  let protectedPassed = 0;
+  for (const protectedRow of plan.protected_rows) {
+    const row = currentByKey.get(maintenanceRowKey(protectedRow));
+    if (row && snapshotRemoteRow(row).row_sha256 === protectedRow.row_sha256) {
+      protectedPassed += 1;
+    } else {
+      problems.push({
+        code: 'PROTECTED_ROW_CHANGED',
+        message: 'Protected row changed or disappeared after maintenance.',
+        table: protectedRow.table,
+        id: protectedRow.id,
+        version: protectedRow.version,
+      });
+    }
+  }
+  const expectedFinalKeys = new Set([
+    ...plan.protected_rows.map(maintenanceRowKey),
+    ...plan.actions.filter((action) => action.action === 'save_draft').map(maintenanceRowKey),
+  ]);
+  for (const row of current.rows) {
+    if (!expectedFinalKeys.has(maintenanceRowKey(row))) {
+      problems.push({
+        code: 'UNEXPECTED_ACCOUNT_ROW',
+        message: 'Unexpected current-account row exists after maintenance.',
+        table: row.table,
+        id: row.id,
+        version: row.version,
+      });
+    }
+  }
+
+  const referenceSha256 = sha256Json(maintenanceProjectedReferenceFingerprint(current.rows));
+  if (referenceSha256 !== plan.projected_reference_sha256) {
+    problems.push({
+      code: 'PROJECTED_REFERENCE_CLOSURE_MISMATCH',
+      message: 'Readback reference closure differs from the approved plan.',
+      details: { expected: plan.projected_reference_sha256, actual: referenceSha256 },
+    });
+  }
+  const danglingReferences = deletedTargetReferences({
+    rows: current.rows,
+    deletes: plan.actions.filter((action) => action.action === 'delete'),
+  });
+  if (danglingReferences.length) {
+    problems.push({
+      code: 'DELETED_TARGET_REFERENCED',
+      message: 'Readback contains references to a deleted target.',
+      details: danglingReferences,
+    });
+  }
+
+  if (!existsSync(approvalRecordPath)) {
+    problems.push({
+      code: 'APPROVAL_RECORD_MISSING',
+      message: 'approval-record.json is missing.',
+    });
+  } else {
+    const approvalRecord = readJsonFile(approvalRecordPath, 'Maintenance approval record');
+    if (
+      !isJsonObject(approvalRecord) ||
+      approvalRecord.schema_version !== 1 ||
+      approvalRecord.plan_sha256 !== plan.plan_sha256 ||
+      approvalRecord.task_id !== plan.task_id ||
+      approvalRecord.operation !== plan.operation ||
+      approvalRecord.operation_id !== plan.operation_id ||
+      !isJsonObject(approvalRecord.account) ||
+      approvalRecord.account.user_id !== plan.account.user_id ||
+      approvalRecord.account.email !== plan.account.email ||
+      approvalRecord.confirmed_email !== plan.account.email ||
+      !isJsonObject(approvalRecord.row_counts) ||
+      sha256Json(approvalRecord.row_counts) !== sha256Json(plan.summary)
+    ) {
+      problems.push({
+        code: 'APPROVAL_RECORD_INVALID',
+        message: 'approval-record.json does not match the immutable plan and actor.',
+      });
+    }
+  }
+
+  const progress = readJsonLinesIfPresent(progressPath);
+  const actionsById = new Map(plan.actions.map((action) => [action.action_id, action]));
+  const successfulActionIds = new Set<string>();
+  for (const [index, entry] of progress.entries()) {
+    const action =
+      isJsonObject(entry) && typeof entry.action_id === 'string'
+        ? actionsById.get(entry.action_id)
+        : null;
+    const valid = Boolean(
+      isJsonObject(entry) &&
+      entry.schema_version === 1 &&
+      action &&
+      entry.plan_sha256 === plan.plan_sha256 &&
+      entry.operation_id === plan.operation_id &&
+      entry.action === action.action &&
+      entry.table === action.table &&
+      entry.id === action.id &&
+      entry.version === action.version &&
+      entry.reason_code === action.reason_code &&
+      entry.before_sha256 === action.before?.row_sha256 &&
+      typeof entry.started_at_utc === 'string' &&
+      typeof entry.ended_at_utc === 'string' &&
+      isJsonObject(entry.actor) &&
+      entry.actor.user_id === plan.account.user_id &&
+      entry.actor.email === plan.account.email &&
+      isJsonObject(entry.audit_context) &&
+      entry.audit_context.plan_sha256 === plan.plan_sha256 &&
+      entry.audit_context.operation_id === plan.operation_id &&
+      entry.audit_context.action_id === action.action_id &&
+      entry.audit_context.reason_code === action.reason_code &&
+      entry.audit_context.source === 'tiangong-lca dataset maintenance apply' &&
+      isJsonObject(entry.rollback) &&
+      sha256Json(entry.rollback) === sha256Json(action.rollback) &&
+      (entry.result === 'success' || entry.result === 'failed') &&
+      (entry.result === 'success'
+        ? typeof entry.remote_result_sha256 === 'string' &&
+          entry.error === null &&
+          (action.action === 'delete'
+            ? entry.after_sha256 === null
+            : typeof entry.after_sha256 === 'string')
+        : entry.remote_result_sha256 === null &&
+          entry.after_sha256 === null &&
+          typeof entry.error === 'string'),
+    );
+    if (!valid) {
+      problems.push({
+        code: 'APPLY_PROGRESS_ENTRY_INVALID',
+        message: 'apply-progress.jsonl contains an invalid or foreign entry.',
+        details: { line: index + 1, action_id: action?.action_id ?? null },
+      });
+      continue;
+    }
+    if (isJsonObject(entry) && entry.result === 'success' && action) {
+      successfulActionIds.add(action.action_id);
+    }
+  }
+  for (const action of plan.actions) {
+    if (!successfulActionIds.has(action.action_id)) {
+      problems.push(
+        issue('ACTION_SUCCESS_LOG_MISSING', 'No successful apply-progress entry exists.', action),
+      );
+    }
+  }
+  if (!existsSync(commitReportPath)) {
+    problems.push({ code: 'COMMIT_REPORT_MISSING', message: 'commit-report.json is missing.' });
+  } else {
+    const commitReport = readJsonFile(commitReportPath, 'Maintenance commit report');
+    const commitActions =
+      isJsonObject(commitReport) && Array.isArray(commitReport.actions) ? commitReport.actions : [];
+    const commitActionsById = new Map(
+      commitActions
+        .filter(
+          (entry): entry is JsonObject =>
+            isJsonObject(entry) && typeof entry.action_id === 'string',
+        )
+        .map((entry) => [entry.action_id as string, entry]),
+    );
+    const commitActionsMatch =
+      commitActions.length === plan.actions.length &&
+      commitActionsById.size === plan.actions.length &&
+      plan.actions.every((action) => {
+        const entry = commitActionsById.get(action.action_id);
+        return Boolean(
+          entry &&
+          entry.action === action.action &&
+          entry.table === action.table &&
+          entry.id === action.id &&
+          entry.version === action.version &&
+          entry.status === 'success' &&
+          entry.error === null,
+        );
+      });
+    if (
+      !isJsonObject(commitReport) ||
+      commitReport.schema_version !== 1 ||
+      commitReport.plan_sha256 !== plan.plan_sha256 ||
+      commitReport.task_id !== plan.task_id ||
+      commitReport.operation !== plan.operation ||
+      commitReport.operation_id !== plan.operation_id ||
+      commitReport.status !== 'completed' ||
+      !isJsonObject(commitReport.actor) ||
+      commitReport.actor.user_id !== plan.account.user_id ||
+      commitReport.actor.email !== plan.account.email ||
+      !isJsonObject(commitReport.summary) ||
+      commitReport.summary.actions !== plan.actions.length ||
+      commitReport.summary.success !== plan.actions.length ||
+      commitReport.summary.failed !== 0 ||
+      commitReport.summary.pending !== 0 ||
+      !commitActionsMatch
+    ) {
+      problems.push({
+        code: 'COMMIT_REPORT_INCOMPLETE',
+        message: 'commit-report.json does not prove full successful completion for this plan.',
+      });
+    }
+  }
+
+  const report: DatasetMaintenanceVerifyReport = {
+    schema_version: 1,
+    generated_at_utc: (options.now ?? new Date()).toISOString(),
+    status: problems.length ? 'failed' : 'passed',
+    task_id: plan.task_id,
+    operation: plan.operation,
+    operation_id: plan.operation_id,
+    plan_sha256: plan.plan_sha256,
+    actor: { user_id: context.account.user_id, email: context.account.email },
+    summary: {
+      actions: plan.actions.length,
+      action_checks_passed: actionChecks.filter((check) => check.status === 'passed').length,
+      protected_rows: plan.protected_rows.length,
+      protected_checks_passed: protectedPassed,
+      progress_successes: successfulActionIds.size,
+      dangling_deleted_target_references: danglingReferences.length,
+      issues: problems.length,
+    },
+    action_checks: actionChecks,
+    issues: problems,
+    artifacts: {
+      plan: planPath,
+      approval_record: approvalRecordPath,
+      apply_progress: progressPath,
+      commit_report: commitReportPath,
+      report: reportPath,
+    },
+  };
+  writeJsonArtifact(reportPath, report);
+  return report;
+}
+
+export const __testInternals = {
+  deletedTargetReferences,
+  desiredPayload,
+  issue,
+};

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -68,8 +68,8 @@ test('executeCli prints main help when no command is given', async () => {
   assert.match(result.stdout, /lifecyclemodel auto-build \| validate-build \| publish-build/u);
   assert.match(result.stdout, /publish-resulting-process/u);
   assert.match(result.stdout, /qa\s+process \| flow \| lifecyclemodel/u);
-  assert.match(result.stdout, /maintenance clear-account/u);
-  assert.match(result.stdout, /dataset maintenance plan \| apply \| verify/u);
+  assert.match(result.stdout, /maintenance clear-account\/plan\/apply\/verify/u);
+  assert.doesNotMatch(result.stdout, /dataset maintenance plan \| apply \| verify/u);
   assert.match(result.stdout, /exit with code 2/u);
   assert.equal(result.stderr, '');
 });
@@ -440,7 +440,9 @@ test('executeCli exposes dataset and lifecyclemodel friction-fix commands', asyn
   assert.match(datasetHelp.stdout, /validate/u);
   assert.match(datasetHelp.stdout, /references rewrite/u);
   assert.match(datasetHelp.stdout, /maintenance clear-account/u);
-  assert.match(datasetHelp.stdout, /maintenance plan\/apply\/verify/u);
+  assert.match(datasetHelp.stdout, /maintenance plan\s+Build an immutable/u);
+  assert.match(datasetHelp.stdout, /maintenance apply\s+Execute an explicitly approved/u);
+  assert.match(datasetHelp.stdout, /maintenance verify\s+Read back affected rows/u);
 
   const datasetValidateHelp = await executeCli(['dataset', 'validate', '--help'], makeDeps());
   assert.equal(datasetValidateHelp.exitCode, 0);
@@ -467,8 +469,11 @@ test('executeCli exposes dataset and lifecyclemodel friction-fix commands', asyn
 
   const datasetMaintenanceHelp = await executeCli(['dataset', 'maintenance', '--help'], makeDeps());
   assert.equal(datasetMaintenanceHelp.exitCode, 0);
-  assert.match(datasetMaintenanceHelp.stdout, /RLS-scoped cleanup and redo workflows/u);
-  assert.match(datasetMaintenanceHelp.stdout, /clear-account is implemented/u);
+  assert.match(
+    datasetMaintenanceHelp.stdout,
+    /current-user RLS and platform dataset command paths/u,
+  );
+  assert.match(datasetMaintenanceHelp.stdout, /apply is commit-only/u);
   assert.match(datasetMaintenanceHelp.stdout, /maintenance-plan\.json/u);
 
   const datasetMaintenanceClearHelp = await executeCli(
@@ -483,12 +488,27 @@ test('executeCli exposes dataset and lifecyclemodel friction-fix commands', asyn
   assert.match(datasetMaintenanceClearHelp.stdout, /--confirm <email>/u);
   assert.doesNotMatch(datasetMaintenanceClearHelp.stdout, /Planned command/u);
 
-  const datasetMaintenancePlan = await executeCli(['dataset', 'maintenance', 'plan'], makeDeps());
-  assert.equal(datasetMaintenancePlan.exitCode, 2);
-  assert.match(
-    datasetMaintenancePlan.stderr,
-    /Command 'dataset maintenance plan' is part of the planned unified surface/u,
+  const datasetMaintenancePlanHelp = await executeCli(
+    ['dataset', 'maintenance', 'plan', '--help'],
+    makeDeps(),
   );
+  assert.equal(datasetMaintenancePlanHelp.exitCode, 0);
+  assert.match(datasetMaintenancePlanHelp.stdout, /--operation <operation>/u);
+
+  const datasetMaintenanceApplyHelp = await executeCli(
+    ['dataset', 'maintenance', 'apply', '--help'],
+    makeDeps(),
+  );
+  assert.equal(datasetMaintenanceApplyHelp.exitCode, 0);
+  assert.match(datasetMaintenanceApplyHelp.stdout, /--approve-plan <sha256>/u);
+  assert.match(datasetMaintenanceApplyHelp.stdout, /Commit-only/u);
+
+  const datasetMaintenanceVerifyHelp = await executeCli(
+    ['dataset', 'maintenance', 'verify', '--help'],
+    makeDeps(),
+  );
+  assert.equal(datasetMaintenanceVerifyHelp.exitCode, 0);
+  assert.match(datasetMaintenanceVerifyHelp.stdout, /readback-verify-report\.json/u);
 
   let observedClearAccountOptions: unknown = null;
   const clearAccountDeps = makeDeps();
@@ -623,6 +643,120 @@ test('executeCli exposes dataset and lifecyclemodel friction-fix commands', asyn
   assert.match(lifecyclemodelGraphHelp.stdout, /tiangong-lca lifecyclemodel graph --input <file>/u);
   assert.match(lifecyclemodelGraphHelp.stdout, /--check-connections/u);
   assert.doesNotMatch(lifecyclemodelGraphHelp.stdout, /Planned command/u);
+});
+
+test('executeCli dispatches dataset maintenance plan, apply, and verify', async () => {
+  const deps = makeDeps();
+  let observedPlanOptions: unknown = null;
+  const planResult = await executeCli(
+    [
+      'dataset',
+      'maintenance',
+      'plan',
+      '--scope',
+      './maintenance-scope.json',
+      '--operation',
+      'repair-references',
+      '--out-dir',
+      './maintenance-run',
+      '--page-size',
+      '250',
+      '--timeout-ms',
+      '12000',
+      '--json',
+    ],
+    {
+      ...deps,
+      runDatasetMaintenancePlanImpl: async (options) => {
+        observedPlanOptions = options;
+        return { status: 'ready', marker: 'plan' } as never;
+      },
+    },
+  );
+  assert.equal(planResult.exitCode, 0);
+  assert.deepEqual(JSON.parse(planResult.stdout), { status: 'ready', marker: 'plan' });
+  assert.deepEqual(observedPlanOptions, {
+    scopePath: './maintenance-scope.json',
+    operation: 'repair-references',
+    outDir: './maintenance-run',
+    pageSize: 250,
+    timeoutMs: 12000,
+    env: deps.env,
+    fetchImpl: deps.fetchImpl,
+  });
+
+  const approvePlan = 'a'.repeat(64);
+  let observedApplyOptions: unknown = null;
+  const applyResult = await executeCli(
+    [
+      'dataset',
+      'maintenance',
+      'apply',
+      '--plan',
+      './maintenance-run/maintenance-plan.json',
+      '--commit',
+      '--approve-plan',
+      approvePlan,
+      '--confirm',
+      'user@example.com',
+      '--timeout-ms',
+      '15000',
+      '--json',
+    ],
+    {
+      ...deps,
+      runDatasetMaintenanceApplyImpl: async (options) => {
+        observedApplyOptions = options;
+        return { status: 'completed', marker: 'apply' } as never;
+      },
+    },
+  );
+  assert.equal(applyResult.exitCode, 0);
+  assert.deepEqual(JSON.parse(applyResult.stdout), { status: 'completed', marker: 'apply' });
+  assert.deepEqual(observedApplyOptions, {
+    planPath: './maintenance-run/maintenance-plan.json',
+    commit: true,
+    approvePlan,
+    confirm: 'user@example.com',
+    timeoutMs: 15000,
+    env: deps.env,
+    fetchImpl: deps.fetchImpl,
+  });
+
+  let observedVerifyOptions: unknown = null;
+  const verifyResult = await executeCli(
+    [
+      'dataset',
+      'maintenance',
+      'verify',
+      '--plan',
+      './maintenance-run/maintenance-plan.json',
+      '--out-dir',
+      './maintenance-run/verify',
+      '--page-size',
+      '100',
+      '--timeout-ms',
+      '9000',
+      '--json',
+    ],
+    {
+      ...deps,
+      runDatasetMaintenanceVerifyImpl: async (options) => {
+        observedVerifyOptions = options;
+        return { status: 'passed', marker: 'verify' } as never;
+      },
+    },
+  );
+  assert.equal(verifyResult.exitCode, 0);
+  assert.deepEqual(JSON.parse(verifyResult.stdout), { status: 'passed', marker: 'verify' });
+  assert.deepEqual(observedVerifyOptions, {
+    planPath: './maintenance-run/maintenance-plan.json',
+    outDir: './maintenance-run/verify',
+    pageSize: 100,
+    timeoutMs: 9000,
+    env: deps.env,
+    fetchImpl: deps.fetchImpl,
+  });
 });
 
 test('executeCli dispatches dataset and lifecyclemodel friction-fix commands', async () => {

--- a/test/dataset-maintenance-row-level.test.ts
+++ b/test/dataset-maintenance-row-level.test.ts
@@ -1,0 +1,1890 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  __testInternals as applyInternals,
+  runDatasetMaintenanceApply,
+} from '../src/lib/dataset-maintenance-apply.js';
+import {
+  appendStableJsonLine,
+  computePlanSha256,
+  isJsonObject,
+  maintenanceRowKey,
+  parseMaintenancePlan,
+  parseMaintenanceScope,
+  readJsonFile,
+  readJsonLinesIfPresent,
+  resolveMaintenancePlanArtifactPath,
+  safeActionFileName,
+  sha256Text,
+  snapshotRemoteRow,
+  stableJsonText,
+  stableJsonValue,
+  writeImmutableJson,
+  writeImmutableJsonLines,
+  type DatasetMaintenancePlan,
+  type DatasetMaintenancePlanAction,
+  type DatasetMaintenanceProgressEntry,
+  type DatasetMaintenanceRemoteRow,
+  type DatasetMaintenanceScopeAction,
+  type JsonObject,
+} from '../src/lib/dataset-maintenance-contract.js';
+import {
+  __testInternals as planInternals,
+  runDatasetMaintenancePlan,
+} from '../src/lib/dataset-maintenance-plan.js';
+import {
+  __testInternals as remoteInternals,
+  deleteMaintenanceRow,
+  fetchMaintenanceAccountRows,
+  fetchMaintenanceExactRows,
+  normalizeMaintenancePageSize,
+  normalizeMaintenanceTimeout,
+  resolveMaintenanceRemoteContext,
+  saveDraftMaintenanceRow,
+} from '../src/lib/dataset-maintenance-remote.js';
+import {
+  __testInternals as verifyInternals,
+  runDatasetMaintenanceVerify,
+} from '../src/lib/dataset-maintenance-verify.js';
+import type { FetchLike, ResponseLike } from '../src/lib/http.js';
+import {
+  buildSupabaseTestEnv,
+  isSupabaseAuthTokenUrl,
+  makeSupabaseAuthResponse,
+} from './helpers/supabase-auth.js';
+
+type StoredRow = Omit<DatasetMaintenanceRemoteRow, 'table'>;
+
+function jsonResponse(body: unknown, status = 200): ResponseLike {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get(name: string): string | null {
+        return name.toLowerCase() === 'content-type' ? 'application/json' : null;
+      },
+    },
+    async text(): Promise<string> {
+      return JSON.stringify(body);
+    },
+  };
+}
+
+function processPayload(options: { id: string; version: string; sourceId?: string }): JsonObject {
+  return {
+    processDataSet: {
+      processInformation: {
+        dataSetInformation: { 'common:UUID': options.id },
+      },
+      ...(options.sourceId
+        ? {
+            modellingAndValidation: {
+              dataSourcesTreatmentAndRepresentativeness: {
+                referenceToDataSource: {
+                  '@refObjectId': options.sourceId,
+                  '@version': '01.00.000',
+                  '@type': 'source data set',
+                },
+              },
+            },
+          }
+        : {}),
+      administrativeInformation: {
+        publicationAndOwnership: { 'common:dataSetVersion': options.version },
+      },
+    },
+  };
+}
+
+function sourcePayload(id: string, version = '01.00.000'): JsonObject {
+  return {
+    sourceDataSet: {
+      sourceInformation: { dataSetInformation: { 'common:UUID': id } },
+      administrativeInformation: {
+        publicationAndOwnership: { 'common:dataSetVersion': version },
+      },
+    },
+  };
+}
+
+function flowPayload(id: string, version = '01.00.000'): JsonObject {
+  return {
+    flowDataSet: {
+      flowInformation: { dataSetInformation: { 'common:UUID': id } },
+      administrativeInformation: {
+        publicationAndOwnership: { 'common:dataSetVersion': version },
+      },
+    },
+  };
+}
+
+class FakeMaintenanceRemote {
+  readonly userId = '11111111-1111-4111-8111-111111111111';
+  readonly email = 'owner@example.com';
+  readonly env: NodeJS.ProcessEnv;
+  readonly rows = new Map<string, StoredRow[]>();
+  readonly rpcOrder: string[] = [];
+  failDeleteOnce = false;
+  invalidJson = false;
+
+  constructor(label: string) {
+    this.env = buildSupabaseTestEnv({
+      TIANGONG_LCA_API_BASE_URL: `https://${label}.example.com/functions/v1`,
+      TIANGONG_LCA_DISABLE_SESSION_CACHE: '1',
+      TIANGONG_LCA_FORCE_REAUTH: '1',
+    });
+    for (const table of [
+      'contacts',
+      'sources',
+      'flows',
+      'processes',
+      'lifecyclemodels',
+      'unitgroups',
+      'flowproperties',
+    ]) {
+      this.rows.set(table, []);
+    }
+  }
+
+  add(table: string, id: string, payload: JsonObject, extras: Partial<StoredRow> = {}): void {
+    this.rows.get(table)?.push({
+      id,
+      version: '01.00.000',
+      user_id: this.userId,
+      state_code: 0,
+      modified_at: '2026-07-01T00:00:00.000Z',
+      json_ordered: payload,
+      model_id: null,
+      rule_verification: null,
+      ...extras,
+    });
+  }
+
+  readonly fetch: FetchLike = async (input, init) => {
+    const textUrl = String(input);
+    if (isSupabaseAuthTokenUrl(textUrl)) {
+      return makeSupabaseAuthResponse({ email: this.email, userId: this.userId });
+    }
+    if (textUrl.endsWith('/auth/v1/user')) {
+      return jsonResponse({ id: this.userId, email: this.email });
+    }
+    if (this.invalidJson) {
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        async text() {
+          return '{bad';
+        },
+      };
+    }
+    const url = new URL(textUrl);
+    const rpc = url.pathname.split('/rpc/')[1];
+    if (rpc) {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      this.rpcOrder.push(rpc);
+      if (rpc === 'cmd_dataset_delete' && this.failDeleteOnce) {
+        this.failDeleteOnce = false;
+        return jsonResponse({ message: 'injected delete failure' }, 500);
+      }
+      const table = String(body.p_table);
+      const tableRows = this.rows.get(table) ?? [];
+      const rowIndex = tableRows.findIndex(
+        (row) => row.id === body.p_id && row.version === body.p_version,
+      );
+      if (rpc === 'cmd_dataset_delete') {
+        if (rowIndex >= 0) {
+          tableRows.splice(rowIndex, 1);
+        }
+      } else if (rowIndex >= 0) {
+        tableRows[rowIndex] = {
+          ...tableRows[rowIndex]!,
+          json_ordered: body.p_json_ordered as JsonObject,
+          model_id: (body.p_model_id as string | null) ?? null,
+          rule_verification: (body.p_rule_verification as boolean | null) ?? null,
+          modified_at: '2026-07-02T00:00:00.000Z',
+        };
+      }
+      return jsonResponse({ ok: true, audit: body.p_audit });
+    }
+    const table = url.pathname.split('/rest/v1/')[1] ?? '';
+    let values = [...(this.rows.get(table) ?? [])];
+    const id = url.searchParams.get('id')?.replace(/^eq\./u, '');
+    const version = url.searchParams.get('version')?.replace(/^eq\./u, '');
+    const userId = url.searchParams.get('user_id')?.replace(/^eq\./u, '');
+    if (id) values = values.filter((row) => row.id === id);
+    if (version) values = values.filter((row) => row.version === version);
+    if (userId) values = values.filter((row) => row.user_id === userId);
+    const offset = Number(url.searchParams.get('offset') ?? 0);
+    const limit = Number(url.searchParams.get('limit') ?? values.length);
+    return jsonResponse(values.slice(offset, offset + limit));
+  };
+}
+
+function buildScopeFiles(options: {
+  root: string;
+  remote: FakeMaintenanceRemote;
+  includeSave?: boolean;
+}): { scopePath: string; desiredPath: string; outDir: string } {
+  const desiredPath = path.join(options.root, 'desired-process.json');
+  writeFileSync(
+    desiredPath,
+    JSON.stringify(
+      processPayload({ id: '22222222-2222-4222-8222-222222222222', version: '01.00.000' }),
+    ),
+  );
+  const actions: object[] = [
+    {
+      action_id: 'delete-source',
+      action: 'delete',
+      table: 'sources',
+      id: '33333333-3333-4333-8333-333333333333',
+      version: '01.00.000',
+      expected_user_id: options.remote.userId,
+      expected_state_code: 0,
+      reason_code: 'DUPLICATE_SOURCE',
+      reason: 'Source is superseded after references are repaired.',
+      evidence: ['assessment/source-audit.json'],
+    },
+  ];
+  if (options.includeSave !== false) {
+    actions.push({
+      action_id: 'repair-process-source',
+      action: 'save_draft',
+      table: 'processes',
+      id: '22222222-2222-4222-8222-222222222222',
+      version: '01.00.000',
+      expected_user_id: options.remote.userId,
+      expected_state_code: 0,
+      reason_code: 'REWRITE_SOURCE_REFERENCE',
+      reason: 'Remove reference to the superseded source.',
+      evidence: ['assessment/source-audit.json'],
+      desired_payload_path: path.basename(desiredPath),
+    });
+  }
+  const scopePath = path.join(options.root, 'scope.json');
+  writeFileSync(
+    scopePath,
+    JSON.stringify({
+      schema_version: 1,
+      task_id: 'bafu-cleanup-test',
+      operation: 'repair-references',
+      account: { user_id: options.remote.userId, email: options.remote.email },
+      actions,
+    }),
+  );
+  return { scopePath, desiredPath, outDir: path.join(options.root, 'maintenance') };
+}
+
+function seed(remote: FakeMaintenanceRemote): void {
+  remote.add(
+    'processes',
+    '22222222-2222-4222-8222-222222222222',
+    processPayload({
+      id: '22222222-2222-4222-8222-222222222222',
+      version: '01.00.000',
+      sourceId: '33333333-3333-4333-8333-333333333333',
+    }),
+    { model_id: '44444444-4444-4444-8444-444444444444', rule_verification: true },
+  );
+  remote.add(
+    'sources',
+    '33333333-3333-4333-8333-333333333333',
+    sourcePayload('33333333-3333-4333-8333-333333333333'),
+  );
+  remote.add(
+    'flows',
+    '55555555-5555-4555-8555-555555555555',
+    flowPayload('55555555-5555-4555-8555-555555555555'),
+  );
+}
+
+async function prepareSeededScenario(
+  root: string,
+  label: string,
+): Promise<{
+  remote: FakeMaintenanceRemote;
+  files: ReturnType<typeof buildScopeFiles>;
+  plan: DatasetMaintenancePlan;
+  context: Awaited<ReturnType<typeof resolveMaintenanceRemoteContext>>;
+}> {
+  const scenarioRoot = path.join(root, label);
+  mkdirSync(scenarioRoot, { recursive: true });
+  const remote = new FakeMaintenanceRemote(label);
+  seed(remote);
+  const files = buildScopeFiles({ root: scenarioRoot, remote });
+  const plan = await runDatasetMaintenancePlan({
+    scopePath: files.scopePath,
+    operation: 'repair-references',
+    outDir: files.outDir,
+    env: remote.env,
+    fetchImpl: remote.fetch,
+    now: new Date('2026-07-11T00:00:00.000Z'),
+  });
+  const context = await resolveMaintenanceRemoteContext({
+    env: remote.env,
+    fetchImpl: remote.fetch,
+    now: new Date('2026-07-11T00:00:00.000Z'),
+  });
+  return { remote, files, plan, context };
+}
+
+function scopeAction(
+  remote: FakeMaintenanceRemote,
+  overrides: Record<string, unknown> = {},
+): DatasetMaintenanceScopeAction {
+  return {
+    action_id: 'delete-source',
+    action: 'delete',
+    table: 'sources',
+    id: '33333333-3333-4333-8333-333333333333',
+    version: '01.00.000',
+    expected_user_id: remote.userId,
+    expected_state_code: 0,
+    reason_code: 'TEST',
+    reason: 'test reason',
+    evidence: [],
+    ...overrides,
+  } as DatasetMaintenanceScopeAction;
+}
+
+function scopeValue(
+  remote: FakeMaintenanceRemote,
+  actions: unknown[] = [scopeAction(remote)],
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    task_id: 'edge-task',
+    operation: 'delete',
+    account: { user_id: remote.userId },
+    actions,
+    ...overrides,
+  };
+}
+
+function successProgressEntry(
+  plan: DatasetMaintenancePlan,
+  action: DatasetMaintenancePlanAction,
+): DatasetMaintenanceProgressEntry {
+  return {
+    schema_version: 1,
+    plan_sha256: plan.plan_sha256,
+    operation_id: plan.operation_id,
+    action_id: action.action_id,
+    action: action.action,
+    table: action.table,
+    id: action.id,
+    version: action.version,
+    reason_code: action.reason_code,
+    audit_context: {
+      plan_sha256: plan.plan_sha256,
+      operation_id: plan.operation_id,
+      action_id: action.action_id,
+      reason_code: action.reason_code,
+      source: 'tiangong-lca dataset maintenance apply',
+    },
+    actor: { user_id: plan.account.user_id, email: plan.account.email ?? '' },
+    started_at_utc: '2026-07-11T00:00:00.000Z',
+    ended_at_utc: '2026-07-11T00:00:00.000Z',
+    before_sha256: action.before?.row_sha256 ?? '',
+    after_sha256: action.desired_payload?.sha256 ?? null,
+    remote_result_sha256: 'a'.repeat(64),
+    result: 'success',
+    error: null,
+    rollback: action.rollback,
+  };
+}
+
+test('row-level maintenance plans update-first closure, resumes failure, and verifies readback', async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'tg-maintenance-row-'));
+  const remote = new FakeMaintenanceRemote('row-maintenance-main');
+  seed(remote);
+  const files = buildScopeFiles({ root, remote });
+  const now = new Date('2026-07-11T01:02:03.000Z');
+  try {
+    const plan = await runDatasetMaintenancePlan({
+      scopePath: files.scopePath,
+      operation: 'repair-references',
+      outDir: files.outDir,
+      pageSize: 1,
+      timeoutMs: 1000,
+      env: remote.env,
+      fetchImpl: remote.fetch,
+      now,
+    });
+    assert.equal(plan.status, 'ready');
+    assert.equal(plan.summary.current_reference_impacts, 1);
+    assert.equal(plan.summary.projected_reference_impacts, 0);
+    assert.equal(plan.summary.protected_rows, 1);
+    assert.equal(plan.plan_sha256, computePlanSha256(plan));
+    assert.equal(parseMaintenancePlan(plan).plan_sha256, plan.plan_sha256);
+    assert.equal(existsSync(path.join(files.outDir, 'maintenance-scope.json')), true);
+    assert.equal(existsSync(path.join(files.outDir, 'protected-rows.jsonl')), true);
+
+    remote.failDeleteOnce = true;
+    const partial = await runDatasetMaintenanceApply({
+      planPath: path.join(files.outDir, 'maintenance-plan.json'),
+      commit: true,
+      approvePlan: plan.plan_sha256,
+      confirm: remote.email,
+      timeoutMs: 1000,
+      env: remote.env,
+      fetchImpl: remote.fetch,
+      now,
+    });
+    assert.equal(partial.status, 'completed_with_failures');
+    assert.equal(partial.summary.success, 1);
+    assert.equal(partial.summary.failed, 1);
+    assert.deepEqual(remote.rpcOrder, ['cmd_dataset_save_draft', 'cmd_dataset_delete']);
+
+    const failedVerify = await runDatasetMaintenanceVerify({
+      planPath: path.join(files.outDir, 'maintenance-plan.json'),
+      outDir: path.join(files.outDir, 'verify-partial'),
+      pageSize: 2,
+      timeoutMs: 1000,
+      env: remote.env,
+      fetchImpl: remote.fetch,
+      now,
+    });
+    assert.equal(failedVerify.status, 'failed');
+    assert.match(failedVerify.issues.map((entry) => entry.code).join(','), /DELETE_TARGET/u);
+
+    const completed = await runDatasetMaintenanceApply({
+      planPath: path.join(files.outDir, 'maintenance-plan.json'),
+      commit: true,
+      approvePlan: plan.plan_sha256,
+      confirm: remote.email,
+      timeoutMs: 1000,
+      env: remote.env,
+      fetchImpl: remote.fetch,
+      now,
+    });
+    assert.equal(completed.status, 'completed');
+    assert.equal(completed.summary.resumed_successes, 1);
+    assert.deepEqual(remote.rpcOrder, [
+      'cmd_dataset_save_draft',
+      'cmd_dataset_delete',
+      'cmd_dataset_delete',
+    ]);
+    const progress = readJsonLinesIfPresent(path.join(files.outDir, 'apply-progress.jsonl'));
+    assert.deepEqual(
+      progress.map((entry) => (entry as { result: string }).result),
+      ['success', 'failed', 'success'],
+    );
+    const firstProgress = progress[0] as Record<string, unknown>;
+    assert.equal(firstProgress.action, 'save_draft');
+    assert.equal(firstProgress.reason_code, 'REWRITE_SOURCE_REFERENCE');
+    assert.equal(typeof firstProgress.before_sha256, 'string');
+    assert.equal(typeof firstProgress.after_sha256, 'string');
+    assert.equal(typeof firstProgress.remote_result_sha256, 'string');
+    assert.deepEqual(firstProgress.audit_context, {
+      plan_sha256: plan.plan_sha256,
+      operation_id: plan.operation_id,
+      action_id: 'repair-process-source',
+      reason_code: 'REWRITE_SOURCE_REFERENCE',
+      source: 'tiangong-lca dataset maintenance apply',
+    });
+    assert.equal(completed.database_audit.rpc_transaction_log, 'public.command_audit_log');
+    assert.match(
+      readFileSync(path.join(files.outDir, 'approval-record.json'), 'utf8'),
+      /plan_sha256/u,
+    );
+
+    const verified = await runDatasetMaintenanceVerify({
+      planPath: path.join(files.outDir, 'maintenance-plan.json'),
+      pageSize: 1,
+      timeoutMs: 1000,
+      env: remote.env,
+      fetchImpl: remote.fetch,
+      now,
+    });
+    assert.equal(verified.status, 'passed');
+    assert.equal(verified.summary.action_checks_passed, 2);
+    assert.equal(verified.summary.protected_checks_passed, 1);
+    assert.equal(verified.summary.dangling_deleted_target_references, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('row-level plan blocks a delete with projected inbound references', async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'tg-maintenance-blocked-'));
+  const remote = new FakeMaintenanceRemote('row-maintenance-blocked');
+  seed(remote);
+  const files = buildScopeFiles({ root, remote, includeSave: false });
+  try {
+    const plan = await runDatasetMaintenancePlan({
+      scopePath: files.scopePath,
+      operation: 'repair-references',
+      outDir: files.outDir,
+      env: remote.env,
+      fetchImpl: remote.fetch,
+      now: new Date('2026-07-11T00:00:00.000Z'),
+    });
+    assert.equal(plan.status, 'blocked');
+    assert.equal(plan.summary.projected_reference_impacts, 1);
+    assert.match(plan.blockers.map((entry) => entry.code).join(','), /PROJECTED_INBOUND/u);
+    await assert.rejects(
+      () =>
+        runDatasetMaintenanceApply({
+          planPath: path.join(files.outDir, 'maintenance-plan.json'),
+          commit: true,
+          approvePlan: plan.plan_sha256,
+          confirm: remote.email,
+          env: remote.env,
+          fetchImpl: remote.fetch,
+        }),
+      /Blocked maintenance plan/u,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('maintenance contracts and remote adapters reject unsafe inputs and invalid responses', async () => {
+  const remote = new FakeMaintenanceRemote('row-maintenance-edges');
+  seed(remote);
+  assert.equal(normalizeMaintenancePageSize(), 1000);
+  assert.equal(normalizeMaintenanceTimeout(), 10000);
+  assert.throws(() => normalizeMaintenancePageSize(0), /page size/u);
+  assert.throws(() => normalizeMaintenancePageSize(5001), /page size/u);
+  assert.throws(() => normalizeMaintenanceTimeout(0), /timeout/u);
+  assert.equal(safeActionFileName(' / '), sha256Text(' / ').slice(0, 16));
+  assert.throws(
+    () =>
+      parseMaintenanceScope({
+        schema_version: 1,
+        task_id: 'bad',
+        operation: 'delete',
+        account: { user_id: remote.userId },
+        actions: [
+          {
+            action_id: 'bad',
+            action: 'delete',
+            table: 'unitgroups',
+            id: 'id',
+            version: '01.00.000',
+            expected_user_id: remote.userId,
+            expected_state_code: 0,
+            reason_code: 'bad',
+            reason: 'bad',
+            evidence: [],
+          },
+        ],
+      }),
+    /protected or unsupported/u,
+  );
+  const context = await resolveMaintenanceRemoteContext({
+    env: remote.env,
+    fetchImpl: remote.fetch,
+    timeoutMs: 1000,
+  });
+  const exact = await fetchMaintenanceExactRows({
+    context,
+    table: 'sources',
+    id: '33333333-3333-4333-8333-333333333333',
+    version: '01.00.000',
+  });
+  assert.equal(exact.rows.length, 1);
+  const account = await fetchMaintenanceAccountRows({
+    context,
+    userId: remote.userId,
+    pageSize: 1,
+  });
+  assert.equal(account.rows.length, 3);
+  await saveDraftMaintenanceRow({
+    context,
+    table: 'processes',
+    id: '22222222-2222-4222-8222-222222222222',
+    version: '01.00.000',
+    payload: processPayload({
+      id: '22222222-2222-4222-8222-222222222222',
+      version: '01.00.000',
+    }),
+    modelId: null,
+    ruleVerification: false,
+    audit: { source: 'test' },
+  });
+  await deleteMaintenanceRow({
+    context,
+    table: 'sources',
+    id: '33333333-3333-4333-8333-333333333333',
+    version: '01.00.000',
+    audit: { source: 'test' },
+  });
+
+  remote.invalidJson = true;
+  await assert.rejects(
+    () =>
+      fetchMaintenanceExactRows({
+        context,
+        table: 'flows',
+        id: '55555555-5555-4555-8555-555555555555',
+        version: '01.00.000',
+      }),
+    /not valid JSON/u,
+  );
+  assert.equal(remoteInternals.selectForTable('processes').includes('model_id'), true);
+  assert.equal(remoteInternals.selectForTable('flows').includes('model_id'), false);
+  assert.equal(remoteInternals.normalizeRemoteRow('flows', null), null);
+  assert.equal(remoteInternals.normalizeRemoteRow('flows', { id: '', version: '' }), null);
+  assert.deepEqual(
+    remoteInternals.normalizeRemoteRow('flows', {
+      id: ' id ',
+      version: ' 01.00.000 ',
+      user_id: 2,
+      state_code: '0',
+      modified_at: '',
+      json_ordered: [],
+      model_id: ' ',
+      rule_verification: 'no',
+    }),
+    {
+      table: 'flows',
+      id: 'id',
+      version: '01.00.000',
+      user_id: null,
+      state_code: 0,
+      modified_at: null,
+      json_ordered: null,
+      model_id: null,
+      rule_verification: null,
+    },
+  );
+  assert.equal(
+    remoteInternals.normalizeRemoteRow('flows', {
+      id: 'id',
+      version: '01.00.000',
+      state_code: 'bad',
+    })?.state_code,
+    null,
+  );
+  assert.throws(() => remoteInternals.normalizeRemoteRows('flows', {}, 'test'), /not an array/u);
+  assert.throws(() => remoteInternals.normalizeRemoteRows('flows', [{}], 'test'), /invalid row/u);
+  const partialContext = {
+    publishable_key: 'key',
+    access_token: 'token',
+    timeout_ms: 1000,
+    fetch_impl: (async () => jsonResponse({}, 500)) as FetchLike,
+  };
+  await assert.rejects(
+    () =>
+      remoteInternals.fetchJson({
+        context: partialContext,
+        url: 'https://example.test/fail',
+        label: 'fail',
+      }),
+    /HTTP 500/u,
+  );
+  assert.equal(
+    await remoteInternals.fetchJson({
+      context: {
+        ...partialContext,
+        fetch_impl: async () => ({
+          ...jsonResponse(null),
+          async text() {
+            return '';
+          },
+        }),
+      },
+      url: 'https://example.test/empty',
+      label: 'empty',
+    }),
+    null,
+  );
+
+  const fallbackRemote = new FakeMaintenanceRemote('row-maintenance-email-fallback');
+  const fallbackContext = await resolveMaintenanceRemoteContext({
+    env: fallbackRemote.env,
+    fetchImpl: async (input, init) => {
+      if (String(input).endsWith('/auth/v1/user')) {
+        return jsonResponse({ id: fallbackRemote.userId });
+      }
+      return fallbackRemote.fetch(input, init);
+    },
+  });
+  assert.equal(fallbackContext.account.email, fallbackRemote.email);
+  const invalidUserRemote = new FakeMaintenanceRemote('row-maintenance-invalid-user');
+  await assert.rejects(
+    () =>
+      resolveMaintenanceRemoteContext({
+        env: invalidUserRemote.env,
+        fetchImpl: async (input, init) =>
+          String(input).endsWith('/auth/v1/user')
+            ? jsonResponse({ email: invalidUserRemote.email })
+            : invalidUserRemote.fetch(input, init),
+      }),
+    /did not return id and email/u,
+  );
+  const badRpcContext = {
+    ...context,
+    fetch_impl: (async (input, init) =>
+      String(input).includes('/rpc/')
+        ? jsonResponse({ ok: false })
+        : remote.fetch(input, init)) as FetchLike,
+  };
+  await assert.rejects(
+    () =>
+      deleteMaintenanceRow({
+        context: badRpcContext,
+        table: 'sources',
+        id: 'missing',
+        version: '01.00.000',
+        audit: {},
+      }),
+    /unexpected response/u,
+  );
+});
+
+test('maintenance contract validates every frozen scope guard and immutable artifact edge', () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'tg-maintenance-contract-'));
+  const remote = new FakeMaintenanceRemote('row-maintenance-contract');
+  try {
+    assert.equal(isJsonObject({}), true);
+    assert.equal(isJsonObject(null), false);
+    assert.equal(isJsonObject([]), false);
+    assert.deepEqual(stableJsonValue({ z: [2, { b: 1, a: 0 }], a: null }), {
+      a: null,
+      z: [2, { a: 0, b: 1 }],
+    });
+    assert.equal(stableJsonText({ b: 1, a: 2 }), '{"a":2,"b":1}');
+    assert.equal(
+      snapshotRemoteRow({
+        table: 'contacts',
+        id: 'id',
+        version: '01.00.000',
+        user_id: null,
+        state_code: null,
+        modified_at: null,
+        json_ordered: null,
+        model_id: null,
+        rule_verification: null,
+      }).payload_sha256,
+      null,
+    );
+    assert.equal(
+      maintenanceRowKey({ table: 'flows', id: 'id', version: '01.00.000' }),
+      'flows\u0000id\u000001.00.000',
+    );
+
+    const invalidScopes: unknown[] = [
+      null,
+      {},
+      scopeValue(remote, [null]),
+      scopeValue(remote, [scopeAction(remote, { action: 'publish' })]),
+      scopeValue(remote, [scopeAction(remote, { expected_state_code: 100 })]),
+      scopeValue(remote, [scopeAction(remote, { expected_user_id: 'other' })]),
+      scopeValue(remote, [scopeAction(remote, { evidence: 'no' })]),
+      scopeValue(remote, [scopeAction(remote, { action: 'save_draft' })]),
+      scopeValue(remote, [scopeAction(remote, { expected_before_sha256: 'bad' })]),
+      scopeValue(remote, [scopeAction(remote, { id: ' ' })]),
+      scopeValue(remote, [scopeAction(remote)], { operation: 'unsupported' }),
+      scopeValue(remote, []),
+      scopeValue(remote, [scopeAction(remote), scopeAction(remote)]),
+      scopeValue(remote, [
+        scopeAction(remote, { action_id: 'one' }),
+        scopeAction(remote, { action_id: 'two' }),
+      ]),
+      scopeValue(remote, [
+        scopeAction(remote, { action_id: 'a/b' }),
+        scopeAction(remote, {
+          action_id: 'a_b',
+          id: '66666666-6666-4666-8666-666666666666',
+        }),
+      ]),
+    ];
+    for (const invalid of invalidScopes) {
+      assert.throws(() => parseMaintenanceScope(invalid));
+    }
+    assert.throws(
+      () => parseMaintenanceScope(scopeValue(remote), 'repair-references'),
+      /does not match requested/u,
+    );
+    const optional = parseMaintenanceScope(
+      scopeValue(
+        remote,
+        [
+          scopeAction(remote, {
+            action: 'save_draft',
+            desired_payload_path: 'payload.json',
+            expected_before_sha256: 'a'.repeat(64),
+          }),
+        ],
+        {
+          account: { user_id: remote.userId, email: ' OWNER@EXAMPLE.COM ' },
+          source_import_run_id: ' run ',
+          source_lineage: { manifest: 'redo.json' },
+        },
+      ),
+      'delete',
+    );
+    assert.equal(optional.account.email, 'OWNER@EXAMPLE.COM');
+    assert.equal(optional.source_import_run_id, 'run');
+    assert.deepEqual(optional.source_lineage, { manifest: 'redo.json' });
+
+    const jsonPath = path.join(root, 'immutable.json');
+    const jsonlPath = path.join(root, 'immutable.jsonl');
+    assert.equal(writeImmutableJson(jsonPath, { b: 1, a: 2 }), path.resolve(jsonPath));
+    assert.equal(writeImmutableJson(jsonPath, { a: 2, b: 1 }), path.resolve(jsonPath));
+    assert.throws(() => writeImmutableJson(jsonPath, { a: 3 }), /immutable/u);
+    assert.equal(writeImmutableJsonLines(jsonlPath, []), path.resolve(jsonlPath));
+    assert.equal(writeImmutableJsonLines(jsonlPath, []), path.resolve(jsonlPath));
+    const appendedPath = path.join(root, 'append.jsonl');
+    appendStableJsonLine(appendedPath, { b: 1, a: 2 });
+    assert.deepEqual(readJsonLinesIfPresent(appendedPath), [{ a: 2, b: 1 }]);
+    assert.deepEqual(readJsonLinesIfPresent(path.join(root, 'missing.jsonl')), []);
+    writeFileSync(path.join(root, 'bad.json'), '{bad');
+    assert.throws(() => readJsonFile(path.join(root, 'missing.json'), 'Missing'), /not found/u);
+    assert.throws(() => readJsonFile(path.join(root, 'bad.json'), 'Bad'), /not valid JSON/u);
+    writeFileSync(path.join(root, 'bad.jsonl'), '{}\n{bad\n');
+    assert.throws(() => readJsonLinesIfPresent(path.join(root, 'bad.jsonl')), /Invalid/u);
+    assert.throws(() => parseMaintenancePlan({}), /valid schema_version/u);
+    assert.throws(
+      () =>
+        parseMaintenancePlan({
+          schema_version: 1,
+          actions: [],
+          protected_rows: [],
+          blockers: [],
+          account: {},
+          artifacts: {},
+          plan_sha256: 'bad',
+        }),
+      /hash does not match/u,
+    );
+    assert.equal(
+      resolveMaintenancePlanArtifactPath(root, 'payloads/action.json', 'Desired payload'),
+      path.join(root, 'payloads/action.json'),
+    );
+    for (const unsafePath of [
+      '',
+      path.resolve(root, 'absolute.json'),
+      '.',
+      '..',
+      '../escape.json',
+    ]) {
+      assert.throws(
+        () => resolveMaintenancePlanArtifactPath(root, unsafePath, 'Desired payload'),
+        /must (?:be a relative path|stay inside)/u,
+      );
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('maintenance plan parser rejects tampered action, snapshot, summary, and blocker contracts', async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'tg-maintenance-plan-contract-'));
+  try {
+    const scenario = await prepareSeededScenario(root, 'valid-plan');
+    const basePlan = structuredClone(scenario.plan);
+    const invalidPlan = (
+      mutate: (plan: DatasetMaintenancePlan) => void,
+      message: RegExp = /invalid|inconsistent|protected or unsupported|does not match|must|unsupported/iu,
+    ): void => {
+      const plan = structuredClone(basePlan);
+      mutate(plan);
+      plan.plan_sha256 = computePlanSha256(plan);
+      assert.throws(() => parseMaintenancePlan(plan), message);
+    };
+
+    const withImportRun = structuredClone(basePlan);
+    withImportRun.source_import_run_id = 'bafu-import-run';
+    withImportRun.plan_sha256 = computePlanSha256(withImportRun);
+    assert.equal(parseMaintenancePlan(withImportRun).source_import_run_id, 'bafu-import-run');
+
+    invalidPlan((plan) => Object.assign(plan.actions[0]!, { table: 'unitgroups' }));
+    invalidPlan((plan) => Object.assign(plan.actions[0]!, { expected_user_id: 'other-user' }));
+    invalidPlan((plan) => Object.assign(plan.actions[0]!, { expected_state_code: 100 }));
+    invalidPlan((plan) => Object.assign(plan.actions[0]!, { action: 'publish' }));
+    invalidPlan((plan) => Object.assign(plan.actions[0]!, { ordinal: -1 }));
+    invalidPlan((plan) => Object.assign(plan.actions[0]!, { status: 'unknown' }));
+    invalidPlan((plan) => Object.assign(plan.actions[0]!, { blockers: 'not-an-array' }));
+    invalidPlan((plan) => Object.assign(plan.actions[0]!, { rollback: null }));
+
+    invalidPlan((plan) => Object.assign(plan.actions[0]!.before!, { state_code: 100 }));
+    invalidPlan((plan) => Object.assign(plan.actions[0]!.before!, { user_id: 'other-user' }));
+    invalidPlan((plan) => Object.assign(plan.actions[0]!.before!, { json_ordered: null }));
+    invalidPlan((plan) => {
+      plan.actions[0]!.before!.row_sha256 = '0'.repeat(64);
+    });
+    invalidPlan((plan) => Object.assign(plan.actions[0]!.rollback, { strategy: 'unknown' }));
+    invalidPlan((plan) =>
+      Object.assign(plan.actions[0]!.rollback, { before_payload_sha256: '0'.repeat(64) }),
+    );
+    invalidPlan((plan) => Object.assign(plan.actions[0]!.rollback, { before_payload: null }));
+    invalidPlan((plan) => Object.assign(plan.actions[0]!.rollback, { before_payload: {} }));
+    invalidPlan((plan) =>
+      Object.assign(plan.actions[0]!.rollback, {
+        model_id: '44444444-4444-4444-8444-444444444444',
+      }),
+    );
+    invalidPlan((plan) => Object.assign(plan.actions[0]!.rollback, { rule_verification: true }));
+    invalidPlan((plan) => {
+      const saveAction = plan.actions.find((action) => action.action === 'save_draft')!;
+      saveAction.desired_payload = null;
+    });
+    invalidPlan((plan) => {
+      const deleteAction = plan.actions.find((action) => action.action === 'delete')!;
+      deleteAction.desired_payload = { path: 'unexpected.json', sha256: '0'.repeat(64) };
+    });
+
+    const summaryMutations: Array<(plan: DatasetMaintenancePlan) => void> = [
+      (plan) => {
+        plan.summary.actions += 1;
+      },
+      (plan) => {
+        plan.summary.save_draft += 1;
+      },
+      (plan) => {
+        plan.summary.delete += 1;
+      },
+      (plan) => {
+        plan.summary.protected_rows += 1;
+      },
+      (plan) => {
+        plan.summary.blockers += 1;
+      },
+      (plan) => {
+        plan.summary.current_reference_impacts = -1;
+      },
+      (plan) => {
+        plan.summary.current_reference_impacts = 0.5;
+      },
+      (plan) => {
+        plan.summary.projected_reference_impacts = -1;
+      },
+      (plan) => {
+        plan.summary.projected_reference_impacts = 0.5;
+      },
+    ];
+    for (const mutate of summaryMutations) {
+      invalidPlan(mutate, /status or blocker contract is inconsistent/u);
+    }
+    invalidPlan((plan) => {
+      plan.status = 'blocked';
+    }, /status or blocker contract is inconsistent/u);
+
+    const blocker = {
+      code: 'TEST_BLOCKER',
+      message: 'test blocker',
+      action_id: basePlan.actions[0]!.action_id,
+      table: basePlan.actions[0]!.table,
+      id: basePlan.actions[0]!.id,
+      version: basePlan.actions[0]!.version,
+    };
+    const validBlockedPlan = structuredClone(basePlan);
+    validBlockedPlan.status = 'blocked';
+    validBlockedPlan.actions[0]!.status = 'blocked';
+    validBlockedPlan.actions[0]!.blockers = [blocker];
+    validBlockedPlan.blockers = [blocker];
+    validBlockedPlan.summary.blockers = 1;
+    validBlockedPlan.plan_sha256 = computePlanSha256(validBlockedPlan);
+    assert.equal(parseMaintenancePlan(validBlockedPlan).status, 'blocked');
+
+    const mismatchedBlockers = structuredClone(validBlockedPlan);
+    mismatchedBlockers.blockers[0] = {
+      ...mismatchedBlockers.blockers[0]!,
+      message: 'different global blocker',
+    };
+    mismatchedBlockers.plan_sha256 = computePlanSha256(mismatchedBlockers);
+    assert.throws(
+      () => parseMaintenancePlan(mismatchedBlockers),
+      /status or blocker contract is inconsistent/u,
+    );
+
+    const saveAction = basePlan.actions.find((action) => action.action === 'save_draft')!;
+    assert.throws(
+      () =>
+        applyInternals.loadDesiredPayload(scenario.files.outDir, {
+          ...saveAction,
+          desired_payload: {
+            path: '../escaped-payload.json',
+            sha256: saveAction.desired_payload!.sha256,
+          },
+        }),
+      /stay inside/u,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('maintenance apply guards reject artifact, preflight, approval, and just-in-time drift', async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'tg-maintenance-apply-edges-'));
+  const remote = new FakeMaintenanceRemote('row-maintenance-apply-edges');
+  seed(remote);
+  const files = buildScopeFiles({ root, remote });
+  const now = new Date('2026-07-11T00:00:00.000Z');
+  try {
+    const plan = await runDatasetMaintenancePlan({
+      scopePath: files.scopePath,
+      operation: 'repair-references',
+      outDir: files.outDir,
+      env: remote.env,
+      fetchImpl: remote.fetch,
+      now,
+    });
+    const planDir = files.outDir;
+    const context = await resolveMaintenanceRemoteContext({
+      env: remote.env,
+      fetchImpl: remote.fetch,
+      now,
+    });
+    const current = await fetchMaintenanceAccountRows({ context, userId: remote.userId });
+    const emptyProgress = applyInternals.parseProgress(plan, path.join(root, 'no-progress.jsonl'));
+    const saveAction = plan.actions.find((action) => action.action === 'save_draft')!;
+    const deleteAction = plan.actions.find((action) => action.action === 'delete')!;
+
+    assert.equal(applyInternals.clock({ now } as never), now.toISOString());
+    assert.equal(typeof applyInternals.clock({} as never), 'string');
+    assert.equal(applyInternals.errorMessage(new Error('error')), 'error');
+    assert.equal(applyInternals.errorMessage('string-error'), 'string-error');
+    assert.throws(
+      () =>
+        applyInternals.loadDesiredPayload(planDir, {
+          ...saveAction,
+          desired_payload: null,
+        }),
+      /lacks desired payload/u,
+    );
+    const wrongPayloadPath = path.join(planDir, 'payloads', 'wrong.json');
+    writeFileSync(wrongPayloadPath, '{}');
+    assert.throws(
+      () =>
+        applyInternals.loadDesiredPayload(planDir, {
+          ...saveAction,
+          desired_payload: { path: 'payloads/wrong.json', sha256: '0'.repeat(64) },
+        }),
+      /hash mismatch/u,
+    );
+    const invalidProgressPath = path.join(root, 'invalid-progress.jsonl');
+    writeFileSync(invalidProgressPath, '{}\n');
+    assert.throws(
+      () => applyInternals.parseProgress(plan, invalidProgressPath),
+      /invalid or foreign/u,
+    );
+
+    assert.throws(
+      () =>
+        applyInternals.assertApplyPreconditions({
+          plan,
+          planDir,
+          currentRows: [
+            ...current.rows,
+            {
+              ...current.rows[0]!,
+              id: '77777777-7777-4777-8777-777777777777',
+            },
+          ],
+          progress: emptyProgress,
+        }),
+      /Unexpected current-account row/u,
+    );
+    assert.throws(
+      () =>
+        applyInternals.assertApplyPreconditions({
+          plan,
+          planDir,
+          currentRows: current.rows.filter((row) => row.table !== 'flows'),
+          progress: emptyProgress,
+        }),
+      /Protected row drifted/u,
+    );
+    const noBeforePlan = structuredClone(plan);
+    noBeforePlan.actions[0]!.before = null;
+    assert.throws(
+      () =>
+        applyInternals.assertApplyPreconditions({
+          plan: noBeforePlan,
+          planDir,
+          currentRows: current.rows.filter((row) => row.table !== 'sources'),
+          progress: emptyProgress,
+        }),
+      /lacks before snapshot/u,
+    );
+    const deleteSuccessProgress = applyInternals.parseProgress(
+      plan,
+      path.join(root, 'delete-success.jsonl'),
+    );
+    deleteSuccessProgress.successes.set(
+      deleteAction.action_id,
+      successProgressEntry(plan, deleteAction),
+    );
+    assert.throws(
+      () =>
+        applyInternals.assertApplyPreconditions({
+          plan,
+          planDir,
+          currentRows: current.rows,
+          progress: deleteSuccessProgress,
+        }),
+      /visible again/u,
+    );
+    assert.throws(
+      () =>
+        applyInternals.assertApplyPreconditions({
+          plan,
+          planDir,
+          currentRows: current.rows.filter((row) => row.table !== 'sources'),
+          progress: emptyProgress,
+        }),
+      /missing, non-draft, or not owned/u,
+    );
+    const saveSuccessProgress = applyInternals.parseProgress(
+      plan,
+      path.join(root, 'save-success.jsonl'),
+    );
+    saveSuccessProgress.successes.set(saveAction.action_id, successProgressEntry(plan, saveAction));
+    assert.throws(
+      () =>
+        applyInternals.assertApplyPreconditions({
+          plan,
+          planDir,
+          currentRows: current.rows,
+          progress: saveSuccessProgress,
+        }),
+      /Previously saved row payload drifted/u,
+    );
+    assert.throws(
+      () =>
+        applyInternals.assertApplyPreconditions({
+          plan,
+          planDir,
+          currentRows: current.rows.map((row) =>
+            row.table === 'sources' ? { ...row, modified_at: 'changed' } : row,
+          ),
+          progress: emptyProgress,
+        }),
+      /Pending action row drifted/u,
+    );
+    const referenceDriftPlan = structuredClone(plan);
+    referenceDriftPlan.projected_reference_sha256 = '0'.repeat(64);
+    assert.throws(
+      () =>
+        applyInternals.assertApplyPreconditions({
+          plan: referenceDriftPlan,
+          planDir,
+          currentRows: current.rows,
+          progress: emptyProgress,
+        }),
+      /reference closure drifted/u,
+    );
+    const approvalPath = path.join(root, 'bad-approval.json');
+    writeFileSync(approvalPath, '{}');
+    assert.throws(
+      () => applyInternals.validateApprovalRecord({ path: approvalPath, plan, context }),
+      /does not match/u,
+    );
+    applyInternals.validateApprovalRecord({
+      path: path.join(root, 'missing-approval.json'),
+      plan,
+      context,
+    });
+
+    const processRow = remote.rows.get('processes')!.find((row) => row.id === saveAction.id)!;
+    processRow.modified_at = '2026-07-11T00:00:01.000Z';
+    await assert.rejects(
+      () => applyInternals.executeAction({ action: saveAction, plan, planDir, context }),
+      /immediately before write/u,
+    );
+    assert.equal(remote.rpcOrder.length, 0);
+    processRow.modified_at = saveAction.before!.modified_at;
+
+    await assert.rejects(
+      () =>
+        runDatasetMaintenanceApply({
+          planPath: path.join(planDir, 'maintenance-plan.json'),
+          commit: false,
+          approvePlan: plan.plan_sha256,
+          confirm: remote.email,
+          env: remote.env,
+          fetchImpl: remote.fetch,
+        }),
+      /requires commit/u,
+    );
+    await assert.rejects(
+      () =>
+        runDatasetMaintenanceApply({
+          planPath: path.join(planDir, 'maintenance-plan.json'),
+          commit: true,
+          approvePlan: 'wrong',
+          confirm: remote.email,
+          env: remote.env,
+          fetchImpl: remote.fetch,
+        }),
+      /exactly match/u,
+    );
+    await assert.rejects(
+      () =>
+        runDatasetMaintenanceApply({
+          planPath: path.join(planDir, 'maintenance-plan.json'),
+          commit: true,
+          approvePlan: plan.plan_sha256,
+          confirm: 'wrong@example.com',
+          env: remote.env,
+          fetchImpl: remote.fetch,
+        }),
+      /confirm must exactly match/u,
+    );
+
+    const redoPlan = structuredClone(plan);
+    redoPlan.operation = 'redo-import';
+    redoPlan.source_import_run_id = null;
+    redoPlan.source_lineage = null;
+    redoPlan.plan_sha256 = computePlanSha256(redoPlan);
+    const redoPath = path.join(root, 'redo-plan.json');
+    writeImmutableJson(redoPath, redoPlan);
+    await assert.rejects(
+      () =>
+        runDatasetMaintenanceApply({
+          planPath: redoPath,
+          commit: true,
+          approvePlan: redoPlan.plan_sha256,
+          confirm: remote.email,
+          env: remote.env,
+          fetchImpl: remote.fetch,
+        }),
+      /requires frozen redo/u,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('maintenance planning records target visibility, ownership, draft, payload, and identity blockers', async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'tg-maintenance-plan-edges-'));
+  const now = new Date('2026-07-11T00:00:00.000Z');
+  async function planScenario(
+    label: string,
+    remote: FakeMaintenanceRemote,
+    scope: Record<string, unknown>,
+    payload?: unknown,
+  ): Promise<DatasetMaintenancePlan> {
+    const scenario = path.join(root, label);
+    mkdirSync(scenario, { recursive: true });
+    const scopePath = path.join(scenario, 'scope.json');
+    const desiredPath = path.join(scenario, 'desired.json');
+    writeFileSync(scopePath, JSON.stringify(scope));
+    if (payload !== undefined) writeFileSync(desiredPath, JSON.stringify(payload));
+    return runDatasetMaintenancePlan({
+      scopePath,
+      operation: scope.operation as 'delete' | 'repair-references',
+      outDir: path.join(scenario, 'out'),
+      env: remote.env,
+      fetchImpl: remote.fetch,
+      now,
+    });
+  }
+  try {
+    const accountRemote = new FakeMaintenanceRemote('plan-account-mismatch');
+    await assert.rejects(
+      () =>
+        planScenario(
+          'account',
+          accountRemote,
+          scopeValue(accountRemote, [scopeAction(accountRemote, { expected_user_id: 'other' })], {
+            account: { user_id: 'other' },
+          }),
+        ),
+      /authenticated user does not match/u,
+    );
+    const emailRemote = new FakeMaintenanceRemote('plan-email-mismatch');
+    await assert.rejects(
+      () =>
+        planScenario(
+          'email',
+          emailRemote,
+          scopeValue(emailRemote, [scopeAction(emailRemote)], {
+            account: { user_id: emailRemote.userId, email: 'wrong@example.com' },
+          }),
+        ),
+      /authenticated email does not match/u,
+    );
+
+    const missingRemote = new FakeMaintenanceRemote('plan-missing');
+    const missing = await planScenario('missing', missingRemote, scopeValue(missingRemote));
+    assert.match(missing.blockers.map((entry) => entry.code).join(','), /TARGET_NOT_VISIBLE/u);
+    assert.equal(missing.actions[0]?.before, null);
+
+    const duplicateRemote = new FakeMaintenanceRemote('plan-duplicate');
+    duplicateRemote.add(
+      'sources',
+      '33333333-3333-4333-8333-333333333333',
+      sourcePayload('33333333-3333-4333-8333-333333333333'),
+    );
+    duplicateRemote.add(
+      'sources',
+      '33333333-3333-4333-8333-333333333333',
+      sourcePayload('33333333-3333-4333-8333-333333333333'),
+    );
+    const duplicate = await planScenario('duplicate', duplicateRemote, scopeValue(duplicateRemote));
+    assert.match(duplicate.blockers.map((entry) => entry.code).join(','), /TARGET_NOT_UNIQUE/u);
+
+    const protectedRemote = new FakeMaintenanceRemote('plan-protected');
+    protectedRemote.add(
+      'sources',
+      '33333333-3333-4333-8333-333333333333',
+      sourcePayload('33333333-3333-4333-8333-333333333333'),
+      { user_id: 'other', state_code: 100, json_ordered: null },
+    );
+    const protectedPlan = await planScenario(
+      'protected',
+      protectedRemote,
+      scopeValue(protectedRemote, [
+        scopeAction(protectedRemote, { expected_before_sha256: '0'.repeat(64) }),
+      ]),
+    );
+    const protectedCodes = protectedPlan.blockers.map((entry) => entry.code).join(',');
+    assert.match(protectedCodes, /TARGET_OWNER_MISMATCH/u);
+    assert.match(protectedCodes, /TARGET_NOT_DRAFT/u);
+    assert.match(protectedCodes, /TARGET_PAYLOAD_MISSING/u);
+    assert.match(protectedCodes, /EXPECTED_BEFORE_HASH_MISMATCH/u);
+    assert.match(protectedCodes, /SNAPSHOT_DRIFT/u);
+
+    const desiredRemote = new FakeMaintenanceRemote('plan-desired');
+    desiredRemote.add(
+      'processes',
+      '22222222-2222-4222-8222-222222222222',
+      processPayload({ id: '22222222-2222-4222-8222-222222222222', version: '01.00.000' }),
+    );
+    const desiredAction = scopeAction(desiredRemote, {
+      action_id: 'save',
+      action: 'save_draft',
+      table: 'processes',
+      id: '22222222-2222-4222-8222-222222222222',
+      desired_payload_path: 'desired.json',
+    });
+    await assert.rejects(
+      () =>
+        planScenario(
+          'desired-invalid',
+          desiredRemote,
+          scopeValue(desiredRemote, [desiredAction]),
+          [],
+        ),
+      /must be a JSON object/u,
+    );
+    const wrongIdentity = await planScenario(
+      'desired-identity',
+      desiredRemote,
+      scopeValue(desiredRemote, [desiredAction]),
+      processPayload({ id: 'wrong-id', version: '01.00.000' }),
+    );
+    assert.match(
+      wrongIdentity.blockers.map((entry) => entry.code).join(','),
+      /DESIRED_PAYLOAD_IDENTITY_MISMATCH/u,
+    );
+    assert.equal(wrongIdentity.protected_rows[0]?.reason, 'blocked_action_row');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('maintenance internals preserve canonical hashes and detect deleted-target references', () => {
+  const row: DatasetMaintenanceRemoteRow = {
+    table: 'processes',
+    id: 'proc',
+    version: '01.00.000',
+    user_id: 'user',
+    state_code: 0,
+    modified_at: null,
+    json_ordered: processPayload({
+      id: 'proc',
+      version: '01.00.000',
+      sourceId: 'source',
+    }),
+    model_id: null,
+    rule_verification: null,
+  };
+  const action = {
+    action_id: 'delete',
+    action: 'delete' as const,
+    table: 'sources' as const,
+    id: 'source',
+    version: '01.00.000',
+    expected_user_id: 'user',
+    expected_state_code: 0 as const,
+    reason_code: 'test',
+    reason: 'test',
+    evidence: [],
+    ordinal: 0,
+    status: 'ready' as const,
+    before: null,
+    desired_payload: null,
+    blockers: [],
+    rollback: {
+      strategy: 'restore_deleted_before_snapshot' as const,
+      before_payload_sha256: null,
+      before_payload: null,
+      model_id: null,
+      rule_verification: null,
+    },
+  };
+  assert.equal(snapshotRemoteRow(row).row_sha256.length, 64);
+  assert.equal(
+    planInternals.referenceImpacts({ rows: [row], deletes: [action], phase: 'current' }).length,
+    1,
+  );
+  assert.equal(
+    verifyInternals.deletedTargetReferences({ rows: [row], deletes: [action] }).length,
+    1,
+  );
+  assert.equal(typeof applyInternals.parseProgress, 'function');
+});
+
+test('maintenance planning and remote helpers cover sparse references and runtime fallbacks', async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'tg-maintenance-plan-fallbacks-'));
+  const remote = new FakeMaintenanceRemote('plan-runtime-fallbacks');
+  try {
+    assert.deepEqual(planInternals.desiredPayloadIdentity({}), { id: null, version: null });
+
+    const unsupportedReferenceRow: DatasetMaintenanceRemoteRow = {
+      table: 'processes',
+      id: 'unsupported-reference',
+      version: '01.00.000',
+      user_id: remote.userId,
+      state_code: 0,
+      modified_at: null,
+      json_ordered: {
+        processDataSet: {
+          customReference: { '@refObjectId': 'source-without-a-table-hint' },
+        },
+      },
+      model_id: null,
+      rule_verification: null,
+    };
+    const deleteAction = scopeAction(remote);
+    assert.deepEqual(
+      planInternals.referenceImpacts({
+        rows: [unsupportedReferenceRow],
+        deletes: [deleteAction],
+        phase: 'current',
+      }),
+      [],
+    );
+    assert.deepEqual(
+      verifyInternals.deletedTargetReferences({
+        rows: [unsupportedReferenceRow],
+        deletes: [
+          {
+            ...deleteAction,
+            ordinal: 0,
+            status: 'ready',
+            before: null,
+            desired_payload: null,
+            blockers: [],
+            rollback: {
+              strategy: 'restore_deleted_before_snapshot',
+              before_payload_sha256: null,
+              before_payload: null,
+              model_id: null,
+              rule_verification: null,
+            },
+          } as DatasetMaintenancePlanAction,
+        ],
+      }),
+      [],
+    );
+
+    const referencedRows = ['process-b', 'process-a'].map(
+      (id): DatasetMaintenanceRemoteRow => ({
+        table: 'processes',
+        id,
+        version: '01.00.000',
+        user_id: remote.userId,
+        state_code: 0,
+        modified_at: null,
+        json_ordered: processPayload({
+          id,
+          version: '01.00.000',
+          sourceId: '33333333-3333-4333-8333-333333333333',
+        }),
+        model_id: null,
+        rule_verification: null,
+      }),
+    );
+    const sortedImpacts = planInternals.referenceImpacts({
+      rows: referencedRows,
+      deletes: [deleteAction],
+      phase: 'current',
+    });
+    assert.deepEqual(
+      sortedImpacts.map((impact) => impact.source_id),
+      ['process-a', 'process-b'],
+    );
+
+    remote.add(
+      'sources',
+      '33333333-3333-4333-8333-333333333333',
+      sourcePayload('33333333-3333-4333-8333-333333333333'),
+    );
+    const scopePath = path.join(root, 'scope.json');
+    writeFileSync(scopePath, JSON.stringify(scopeValue(remote)));
+    const plan = await runDatasetMaintenancePlan({
+      scopePath,
+      operation: 'delete',
+      outDir: path.join(root, 'out'),
+      env: remote.env,
+      fetchImpl: remote.fetch,
+    });
+    assert.match(plan.generated_at_utc, /^\d{4}-\d{2}-\d{2}T/u);
+
+    const nonObjectUserRemote = new FakeMaintenanceRemote('non-object-current-user');
+    await assert.rejects(
+      () =>
+        resolveMaintenanceRemoteContext({
+          env: nonObjectUserRemote.env,
+          fetchImpl: async (input, init) =>
+            String(input).endsWith('/auth/v1/user')
+              ? jsonResponse([])
+              : nonObjectUserRemote.fetch(input, init),
+        }),
+      /did not return id and email/u,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('maintenance apply defensively records resume, readback, actor, redo, and pending edges', async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'tg-maintenance-apply-defensive-'));
+  try {
+    const resume = await prepareSeededScenario(root, 'resume-delete');
+    const saveAction = resume.plan.actions.find((action) => action.action === 'save_draft')!;
+    const deleteAction = resume.plan.actions.find((action) => action.action === 'delete')!;
+    const current = await fetchMaintenanceAccountRows({
+      context: resume.context,
+      userId: resume.remote.userId,
+    });
+    const resumedProgress = applyInternals.parseProgress(
+      resume.plan,
+      path.join(root, 'missing-progress.jsonl'),
+    );
+    resumedProgress.successes.set(
+      deleteAction.action_id,
+      successProgressEntry(resume.plan, deleteAction),
+    );
+    applyInternals.assertApplyPreconditions({
+      plan: resume.plan,
+      planDir: resume.files.outDir,
+      currentRows: current.rows.filter((row) => row.table !== 'sources'),
+      progress: resumedProgress,
+    });
+
+    await assert.rejects(
+      () =>
+        applyInternals.executeAction({
+          action: { ...saveAction, before: null },
+          plan: resume.plan,
+          planDir: resume.files.outDir,
+          context: resume.context,
+        }),
+      /lacks a before snapshot/u,
+    );
+    await assert.rejects(
+      () =>
+        applyInternals.executeAction({
+          action: {
+            ...saveAction,
+            id: 'missing-row',
+          },
+          plan: resume.plan,
+          planDir: resume.files.outDir,
+          context: resume.context,
+        }),
+      /immediately before write/u,
+    );
+
+    const fallback = await prepareSeededScenario(root, 'optional-before-metadata');
+    const fallbackAction = fallback.plan.actions.find((action) => action.action === 'save_draft')!;
+    let beforeReads = 0;
+    const actionWithVanishingOptionalMetadata = { ...fallbackAction };
+    Object.defineProperty(actionWithVanishingOptionalMetadata, 'before', {
+      enumerable: true,
+      get() {
+        beforeReads += 1;
+        return beforeReads <= 2 ? fallbackAction.before : null;
+      },
+    });
+    const fallbackResult = await applyInternals.executeAction({
+      action: actionWithVanishingOptionalMetadata,
+      plan: fallback.plan,
+      planDir: fallback.files.outDir,
+      context: fallback.context,
+    });
+    assert.equal(fallbackResult.afterSha256?.length, 64);
+    assert.equal(beforeReads, 4);
+
+    const missingReadback = await prepareSeededScenario(root, 'missing-save-readback');
+    const missingReadbackAction = missingReadback.plan.actions.find(
+      (action) => action.action === 'save_draft',
+    )!;
+    const missingReadbackContext = {
+      ...missingReadback.context,
+      fetch_impl: (async (input, init) => {
+        const response = await missingReadback.remote.fetch(input, init);
+        if (String(input).includes('/rpc/cmd_dataset_save_draft')) {
+          missingReadback.remote.rows.set('processes', []);
+        }
+        return response;
+      }) as FetchLike,
+    };
+    await assert.rejects(
+      () =>
+        applyInternals.executeAction({
+          action: missingReadbackAction,
+          plan: missingReadback.plan,
+          planDir: missingReadback.files.outDir,
+          context: missingReadbackContext,
+        }),
+      /save_draft readback failed/u,
+    );
+
+    const mismatchReadback = await prepareSeededScenario(root, 'mismatch-save-readback');
+    const mismatchAction = mismatchReadback.plan.actions.find(
+      (action) => action.action === 'save_draft',
+    )!;
+    const mismatchContext = {
+      ...mismatchReadback.context,
+      fetch_impl: (async (input, init) => {
+        const response = await mismatchReadback.remote.fetch(input, init);
+        if (String(input).includes('/rpc/cmd_dataset_save_draft')) {
+          mismatchReadback.remote.rows.get('processes')![0]!.state_code = 100;
+        }
+        return response;
+      }) as FetchLike,
+    };
+    await assert.rejects(
+      () =>
+        applyInternals.executeAction({
+          action: mismatchAction,
+          plan: mismatchReadback.plan,
+          planDir: mismatchReadback.files.outDir,
+          context: mismatchContext,
+        }),
+      /save_draft readback mismatch/u,
+    );
+
+    const deleteReadback = await prepareSeededScenario(root, 'delete-readback');
+    const deleteReadbackAction = deleteReadback.plan.actions.find(
+      (action) => action.action === 'delete',
+    )!;
+    const deleteReadbackContext = {
+      ...deleteReadback.context,
+      fetch_impl: (async (input, init) =>
+        String(input).includes('/rpc/cmd_dataset_delete')
+          ? jsonResponse({ ok: true })
+          : deleteReadback.remote.fetch(input, init)) as FetchLike,
+    };
+    await assert.rejects(
+      () =>
+        applyInternals.executeAction({
+          action: deleteReadbackAction,
+          plan: deleteReadback.plan,
+          planDir: deleteReadback.files.outDir,
+          context: deleteReadbackContext,
+        }),
+      /delete readback failed/u,
+    );
+
+    const actorMismatch = await prepareSeededScenario(root, 'actor-mismatch');
+    await assert.rejects(
+      () =>
+        runDatasetMaintenanceApply({
+          planPath: path.join(actorMismatch.files.outDir, 'maintenance-plan.json'),
+          commit: true,
+          approvePlan: actorMismatch.plan.plan_sha256,
+          confirm: actorMismatch.remote.email,
+          env: actorMismatch.remote.env,
+          fetchImpl: async (input, init) =>
+            String(input).endsWith('/auth/v1/user')
+              ? jsonResponse({ id: actorMismatch.remote.userId, email: 'other@example.com' })
+              : actorMismatch.remote.fetch(input, init),
+        }),
+      /does not match the maintenance plan/u,
+    );
+
+    const pending = await prepareSeededScenario(root, 'pending-after-failure');
+    const pendingReport = await runDatasetMaintenanceApply({
+      planPath: path.join(pending.files.outDir, 'maintenance-plan.json'),
+      commit: true,
+      approvePlan: pending.plan.plan_sha256,
+      confirm: pending.remote.email,
+      env: pending.remote.env,
+      fetchImpl: async (input, init) =>
+        String(input).includes('/rpc/cmd_dataset_save_draft')
+          ? jsonResponse({ message: 'save failed' }, 500)
+          : pending.remote.fetch(input, init),
+    });
+    assert.deepEqual(
+      pendingReport.actions.map((action) => action.status),
+      ['pending', 'failed'],
+    );
+
+    const redoRoot = path.join(root, 'redo-delete');
+    mkdirSync(redoRoot, { recursive: true });
+    const redoRemote = new FakeMaintenanceRemote('redo-delete');
+    for (const id of [
+      '33333333-3333-4333-8333-333333333333',
+      '66666666-6666-4666-8666-666666666666',
+    ]) {
+      redoRemote.add('sources', id, sourcePayload(id));
+    }
+    const redoScopePath = path.join(redoRoot, 'scope.json');
+    writeFileSync(
+      redoScopePath,
+      JSON.stringify(
+        scopeValue(redoRemote, [
+          scopeAction(redoRemote),
+          scopeAction(redoRemote, {
+            action_id: 'delete-source-2',
+            id: '66666666-6666-4666-8666-666666666666',
+          }),
+        ]),
+      ),
+    );
+    const deletePlan = await runDatasetMaintenancePlan({
+      scopePath: redoScopePath,
+      operation: 'delete',
+      outDir: path.join(redoRoot, 'planned'),
+      env: redoRemote.env,
+      fetchImpl: redoRemote.fetch,
+      now: new Date('2026-07-11T00:00:00.000Z'),
+    });
+    const redoPlan = structuredClone(deletePlan);
+    redoPlan.operation = 'redo-import';
+    redoPlan.source_import_run_id = null;
+    redoPlan.source_lineage = { manifest: 'bafu-redo-source-manifest.json' };
+    redoPlan.plan_sha256 = computePlanSha256(redoPlan);
+    const redoPlanPath = path.join(redoRoot, 'apply', 'maintenance-plan.json');
+    writeImmutableJson(redoPlanPath, redoPlan);
+    const redoReport = await runDatasetMaintenanceApply({
+      planPath: redoPlanPath,
+      commit: true,
+      approvePlan: redoPlan.plan_sha256,
+      confirm: redoRemote.email,
+      env: redoRemote.env,
+      fetchImpl: redoRemote.fetch,
+    });
+    assert.equal(redoReport.status, 'completed');
+    assert.match(
+      readFileSync(path.join(path.dirname(redoPlanPath), 'approval-record.json'), 'utf8'),
+      /"redo_rows_ready":true/u,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('maintenance verify reports every incomplete readback proof without mutating rows', async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'tg-maintenance-verify-defensive-'));
+  try {
+    const scenario = await prepareSeededScenario(root, 'pre-apply');
+    const planPath = path.join(scenario.files.outDir, 'maintenance-plan.json');
+    const report = await runDatasetMaintenanceVerify({
+      planPath,
+      outDir: path.join(root, 'verify-before-apply'),
+      env: scenario.remote.env,
+      fetchImpl: scenario.remote.fetch,
+    });
+    const codes = report.issues.map((entry) => entry.code).join(',');
+    assert.match(codes, /DELETE_TARGET_STILL_VISIBLE/u);
+    assert.match(codes, /SAVE_DRAFT_READBACK_MISMATCH/u);
+    assert.match(codes, /PROJECTED_REFERENCE_CLOSURE_MISMATCH/u);
+    assert.match(codes, /DELETED_TARGET_REFERENCED/u);
+    assert.match(codes, /ACTION_SUCCESS_LOG_MISSING/u);
+    assert.match(codes, /COMMIT_REPORT_MISSING/u);
+
+    writeFileSync(path.join(scenario.files.outDir, 'approval-record.json'), '{}');
+    const malformedRollbackEntry = {
+      ...successProgressEntry(scenario.plan, scenario.plan.actions[0]!),
+      rollback: null,
+    };
+    writeFileSync(
+      path.join(scenario.files.outDir, 'apply-progress.jsonl'),
+      [
+        'null',
+        '{"action_id":"foreign-action"}',
+        '{"action_id":"delete-source"}',
+        JSON.stringify(malformedRollbackEntry),
+        '',
+      ].join('\n'),
+    );
+    writeFileSync(path.join(scenario.files.outDir, 'commit-report.json'), '{}');
+    const invalidProofReport = await runDatasetMaintenanceVerify({
+      planPath,
+      outDir: path.join(root, 'verify-invalid-proof-chain'),
+      env: scenario.remote.env,
+      fetchImpl: scenario.remote.fetch,
+      now: new Date('2026-07-11T00:00:00.000Z'),
+    });
+    const invalidProofCodes = invalidProofReport.issues.map((entry) => entry.code).join(',');
+    assert.match(invalidProofCodes, /APPROVAL_RECORD_INVALID/u);
+    assert.match(invalidProofCodes, /APPLY_PROGRESS_ENTRY_INVALID/u);
+    assert.match(invalidProofCodes, /COMMIT_REPORT_INCOMPLETE/u);
+
+    scenario.remote.rows.set('flows', []);
+    scenario.remote.rows.set('processes', []);
+    const protectedReport = await runDatasetMaintenanceVerify({
+      planPath,
+      outDir: path.join(root, 'verify-protected-change'),
+      env: scenario.remote.env,
+      fetchImpl: scenario.remote.fetch,
+      now: new Date('2026-07-11T00:00:00.000Z'),
+    });
+    assert.match(
+      protectedReport.issues.map((entry) => entry.code).join(','),
+      /PROTECTED_ROW_CHANGED/u,
+    );
+
+    await assert.rejects(
+      () =>
+        runDatasetMaintenanceVerify({
+          planPath,
+          env: scenario.remote.env,
+          fetchImpl: async (input, init) =>
+            String(input).endsWith('/auth/v1/user')
+              ? jsonResponse({ id: scenario.remote.userId, email: 'other@example.com' })
+              : scenario.remote.fetch(input, init),
+        }),
+      /does not match the maintenance plan/u,
+    );
+
+    assert.deepEqual(verifyInternals.issue('CODE', 'message'), {
+      code: 'CODE',
+      message: 'message',
+    });
+    assert.deepEqual(verifyInternals.issue('CODE', 'message', undefined, { detail: true }), {
+      code: 'CODE',
+      message: 'message',
+      details: { detail: true },
+    });
+    const saveAction = scenario.plan.actions.find((action) => action.action === 'save_draft')!;
+    assert.equal(
+      verifyInternals.desiredPayload(scenario.files.outDir, {
+        ...saveAction,
+        desired_payload: null,
+      }),
+      null,
+    );
+    const invalidPayloadPath = path.join(scenario.files.outDir, 'payloads', 'invalid.json');
+    writeFileSync(invalidPayloadPath, '[]');
+    assert.equal(
+      verifyInternals.desiredPayload(scenario.files.outDir, {
+        ...saveAction,
+        desired_payload: {
+          path: 'payloads/invalid.json',
+          sha256: '0'.repeat(64),
+        },
+      }),
+      null,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/prepush-coverage-edges.test.ts
+++ b/test/prepush-coverage-edges.test.ts
@@ -134,6 +134,71 @@ test('prepush coverage covers CLI parser error and help branches', async () => {
     ['dataset', 'maintenance', 'clear-account', '--commit', '--dry-run'],
     ['dataset', 'maintenance', 'clear-account', '--state-code', 'bad'],
     ['dataset', 'maintenance', 'clear-account', '--page-size', 'bad'],
+    ['dataset', 'maintenance', 'plan', '--bad-flag'],
+    ['dataset', 'maintenance', 'plan'],
+    ['dataset', 'maintenance', 'plan', '--scope', 'scope.json'],
+    ['dataset', 'maintenance', 'plan', '--scope', 'scope.json', '--operation', 'delete'],
+    [
+      'dataset',
+      'maintenance',
+      'plan',
+      '--scope',
+      'scope.json',
+      '--operation',
+      'bad',
+      '--out-dir',
+      'out',
+    ],
+    [
+      'dataset',
+      'maintenance',
+      'plan',
+      '--scope',
+      'scope.json',
+      '--operation',
+      'delete',
+      '--out-dir',
+      'out',
+      '--page-size',
+      'bad',
+    ],
+    [
+      'dataset',
+      'maintenance',
+      'plan',
+      '--scope',
+      'scope.json',
+      '--operation',
+      'delete',
+      '--out-dir',
+      'out',
+      '--page-size',
+      '0',
+    ],
+    ['dataset', 'maintenance', 'apply', '--bad-flag'],
+    ['dataset', 'maintenance', 'apply', '--commit'],
+    ['dataset', 'maintenance', 'apply', '--plan', 'plan.json', '--commit', '--dry-run'],
+    ['dataset', 'maintenance', 'apply', '--plan', 'plan.json', '--dry-run'],
+    ['dataset', 'maintenance', 'apply', '--plan', 'plan.json'],
+    ['dataset', 'maintenance', 'apply', '--plan', 'plan.json', '--commit'],
+    ['dataset', 'maintenance', 'apply', '--plan', 'plan.json', '--commit', '--approve-plan', 'abc'],
+    [
+      'dataset',
+      'maintenance',
+      'apply',
+      '--plan',
+      'plan.json',
+      '--commit',
+      '--approve-plan',
+      'abc',
+      '--confirm',
+      'user@example.com',
+      '--timeout-ms',
+      '0',
+    ],
+    ['dataset', 'maintenance', 'verify', '--bad-flag'],
+    ['dataset', 'maintenance', 'verify'],
+    ['dataset', 'maintenance', 'verify', '--plan', 'plan.json', '--timeout-ms', 'bad'],
     ['dataset', 'maintenance', 'bad-action'],
     ['process', 'identity-preflight', '--timeout-ms', '0'],
   ];
@@ -426,6 +491,54 @@ test('prepush coverage covers CLI parser error and help branches', async () => {
     },
   );
   assert.equal(maintenanceFailed.exitCode, 1);
+
+  const maintenancePlanBlocked = await executeCli(
+    [
+      'dataset',
+      'maintenance',
+      'plan',
+      '--scope',
+      'scope.json',
+      '--operation',
+      'delete',
+      '--out-dir',
+      'out',
+    ],
+    {
+      ...makeDeps(),
+      runDatasetMaintenancePlanImpl: async () => ({ status: 'blocked' }) as never,
+    },
+  );
+  assert.equal(maintenancePlanBlocked.exitCode, 1);
+
+  const maintenanceApplyFailed = await executeCli(
+    [
+      'dataset',
+      'maintenance',
+      'apply',
+      '--plan',
+      'plan.json',
+      '--commit',
+      '--approve-plan',
+      'abc',
+      '--confirm',
+      'user@example.com',
+    ],
+    {
+      ...makeDeps(),
+      runDatasetMaintenanceApplyImpl: async () => ({ status: 'completed_with_failures' }) as never,
+    },
+  );
+  assert.equal(maintenanceApplyFailed.exitCode, 1);
+
+  const maintenanceVerifyFailed = await executeCli(
+    ['dataset', 'maintenance', 'verify', '--plan', 'plan.json'],
+    {
+      ...makeDeps(),
+      runDatasetMaintenanceVerifyImpl: async () => ({ status: 'failed' }) as never,
+    },
+  );
+  assert.equal(maintenanceVerifyFailed.exitCode, 1);
 
   const lifecycleRows = await executeCli(
     ['qa', 'lifecyclemodel', '--rows-file', 'models.jsonl', '--out-dir', 'qa-out'],


### PR DESCRIPTION
Closes #151

## Summary
- Implement dataset maintenance plan/apply/verify with immutable current-user RLS snapshots, protected-row ledgers, reference-impact evidence, and canonical plan hashes.
- Execute only exact current-owner state_code=0 drafts through cmd_dataset_save_draft/cmd_dataset_delete, with approval, append-only progress, immutable attempt, and commit reports.
- Verify DB readback plus approval/progress/commit log integrity independently of the apply result.

## Key Decisions
- Keep Foundry as the scope/evidence orchestrator; the native CLI exclusively owns authenticated database maintenance.
- Limit v1 mutations to contacts, sources, flows, and processes; protect lifecyclemodels, unitgroups, flowproperties, public/shared, non-owner, and non-draft rows.

## Validation
- npm run prepush:gate: 816 tests, 812 passed, 4 skipped, 0 failed; statements/branches/functions/lines all 100%.
- docpact strict config and base/head lint passed with 21 changed paths, coverage=ok, freshness=ok, 0 findings.
- Generated a real read-only BAFU P0-A plan for 65 process reference repairs with 0 blockers and 0 database mutations; execution plan will be regenerated from commit 192ce9c before approval.

## Risks / Rollback
- Commit-only apply requires the exact plan SHA-256 and current account email, runs full-plan plus just-in-time drift checks, and stops on the first failed action.
- No direct SQL, service-role credential, or raw REST table mutation is introduced; rollback snapshots and per-action p_audit correlation are frozen in the plan/logs.

## Follow-ups
- Regenerate the BAFU P0-A maintenance plan from the committed CLI, request exact operator approval, then apply and verify as a separate controlled step.
- After merge, complete the normal CLI release and root-workspace submodule integration flow.

## Workspace Integration
- Root workspace integration is required after the CLI PR and release are complete; this PR does not update the root submodule pointer.