### PR TITLE
chore: release CLI 0.0.22

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -3,7 +3,7 @@ layout: repo
 # Review note, 2026-06-11: release 0.0.15 keeps existing command-family, validation, and release routing. The dataset import-lca wrapper now targets the tidas-tools 0.0.28 process-bundle CLI surface; routing and ownership are unchanged.
 # Review note, 2026-07-12: owner-draft BAFU `merge-support-aliases` now sends both frozen dimensions through one whole-plan RPC; it remains inside the existing dataset-maintenance command/runtime domain, and wildcard routing already covers its request/proof adapter, alias-rewrite, tests, and governed command/validation docs, so no ownership or route changes are required.
 lastReviewedAt: "2026-07-12"
-lastReviewedCommit: "afcd941537cbaeb355e2c753a2e2b847b4c1909e"
+lastReviewedCommit: "d580282ce85d332c77086b49f70834915b9216f9"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: afcd941537cbaeb355e2c753a2e2b847b4c1909e
+lastReviewedCommit: d580282ce85d332c77086b49f70834915b9216f9
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: afcd941537cbaeb355e2c753a2e2b847b4c1909e
+lastReviewedCommit: d580282ce85d332c77086b49f70834915b9216f9
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: afcd941537cbaeb355e2c753a2e2b847b4c1909e
+lastReviewedCommit: d580282ce85d332c77086b49f70834915b9216f9
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: 783171119f3dbd9813d2d8245fdbc5caa08cb919
+lastReviewedCommit: d580282ce85d332c77086b49f70834915b9216f9
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: 783171119f3dbd9813d2d8245fdbc5caa08cb919
+lastReviewedCommit: d580282ce85d332c77086b49f70834915b9216f9
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.19",
+  "version": "0.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/cli",
-      "version": "0.0.19",
+      "version": "0.0.22",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.101.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Unified TianGong LCA CLI with direct REST adapters and low-entropy command surface.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #159

## Summary

- Bump `@tiangong-lca/cli` package and lockfile metadata to `0.0.22` from the current upstream `main` release candidate.
- Refresh only the docpact review evidence required by the release contract; governed document bodies and release semantics are unchanged.

## Key Decisions

- Base the release on `d580282ce85d332c77086b49f70834915b9216f9`, which contains private alias PR #156.
- Keep the user-approved 365-day alias contract (`1/8760`) unchanged.
- Exclude future public-promotion PR #154: `aea2dda6bdb70f3a1ce882b5a54e43d21d1622e9` is not an ancestor of this branch.
- Keep release validation entirely local/registry-facing; no BAFU API or data operation is performed.

## Validation

- `node ./scripts/ci/release-version.cjs assert-unpublished --version 0.0.22` — passed; npm latest was `0.0.21` and the target tag was absent before branch creation.
- `npm ci` — passed with Node `24.13.0` / npm `11.6.2`.
- Local pre-push hook — passed: strict docpact config + enforced lint; 828 tests, 824 passed / 4 skipped / 0 failed; 100% statements, branches, functions, and lines.
- `npm pack --dry-run --json` — passed: 214 files, 1,307,459-byte tarball, 8,055,489 bytes unpacked.
- Exact generated tarball install in an isolated temporary prefix — reports `0.0.22`; root help is non-empty; `dataset maintenance plan --help` exposes `merge-support-aliases`.
- Local tarball proof before merge: SHA-1 `cf85aba5262680f265b862c1b7cce8ede5afc252`, SRI `sha512-xkMZGibZwc+BxHGqwo7uj3jY9RPDVKYyZ+WYTC42xe5ULBezx0dD3ll0LCXkrzjqIwio1uw+SDpPO7kScp2oWA==`.

## Risks / Rollback

- Package dependencies and runtime code are unchanged in this PR; `npm ci` reports four existing audit findings (1 low, 1 moderate, 2 high).
- If tag or Trusted Publishing automation fails, do not update the workspace pointer; repair or rerun the existing release workflow against the immutable tag as documented.

## Follow-ups

- After merge, verify the full Tag Release gate, exact `cli-v0.0.22` target, Publish Package success, npm `latest` / integrity / provenance, and a clean exact registry install.
- Foundry runtime installation and root workspace pointer updates remain separate later integration steps.

## Workspace Integration

- Required later, but only after npm registry verification succeeds. This PR does not update Foundry or the root workspace.

## Post-Merge Release Evidence

- Release merge: `4c79df4623e3cf296bc8d1baeea688d78351570a`.
- `cli-v0.0.22` points exactly to that merge commit.
- [Tag Release run 29192805504](https://github.com/tiangong-lca/tiangong-cli/actions/runs/29192805504) succeeded, including docpact and the full release gate.
- [Publish Package run 29192885530](https://github.com/tiangong-lca/tiangong-cli/actions/runs/29192885530) succeeded through Trusted Publishing.
- npm `latest` resolves `0.0.22`; registry SRI is `sha512-auczA5TZdc1xnQX5OyBLqVjOp5n5Mg4IJVbMUjO2MRdOYFFyvLISh5g380lqYUqVHCenithQ0iAcuLrsHJ4XPQ==`.
- SLSA provenance identifies this repository, `.github/workflows/publish.yml`, tag `cli-v0.0.22`, merge commit `4c79df4623e3cf296bc8d1baeea688d78351570a`, and run `29192885530`.
- An isolated registry install reports `0.0.22`, exposes `merge-support-aliases`, and `npm audit signatures` verifies 130 signatures and 16 attestations.
