### PR TITLE
chore: release CLI 0.0.23

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -4,7 +4,7 @@ layout: repo
 # Review note, 2026-07-12: owner-draft BAFU `merge-support-aliases` now sends both frozen dimensions through one whole-plan RPC; it remains inside the existing dataset-maintenance command/runtime domain, and wildcard routing already covers its request/proof adapter, alias-rewrite, tests, and governed command/validation docs, so no ownership or route changes are required.
 # Review note, 2026-07-13: exact-count maintenance pagination remains inside the existing dataset-maintenance command/runtime domain. Wildcard routing already covers its shared paginator, account scans, tests, and governed command/validation docs, so no ownership or route changes are required.
 lastReviewedAt: '2026-07-13'
-lastReviewedCommit: '4c79df4623e3cf296bc8d1baeea688d78351570a'
+lastReviewedCommit: '0bb51e1fe17a5caf08d1fdc341f519a685e48fc6'
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-13
-lastReviewedCommit: 4c79df4623e3cf296bc8d1baeea688d78351570a
+lastReviewedCommit: 0bb51e1fe17a5caf08d1fdc341f519a685e48fc6
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-13
-lastReviewedCommit: 4c79df4623e3cf296bc8d1baeea688d78351570a
+lastReviewedCommit: 0bb51e1fe17a5caf08d1fdc341f519a685e48fc6
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-13
-lastReviewedCommit: 4c79df4623e3cf296bc8d1baeea688d78351570a
+lastReviewedCommit: 0bb51e1fe17a5caf08d1fdc341f519a685e48fc6
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-13
-lastReviewedCommit: 4c79df4623e3cf296bc8d1baeea688d78351570a
+lastReviewedCommit: 0bb51e1fe17a5caf08d1fdc341f519a685e48fc6
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-13
-lastReviewedCommit: 4c79df4623e3cf296bc8d1baeea688d78351570a
+lastReviewedCommit: 0bb51e1fe17a5caf08d1fdc341f519a685e48fc6
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/cli",
-      "version": "0.0.22",
+      "version": "0.0.23",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.101.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "Unified TianGong LCA CLI with direct REST adapters and low-entropy command surface.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- bump `@tiangong-lca/cli` package and lockfile metadata from 0.0.22 to 0.0.23
- refresh the docpact review baseline for the release-only change
- publish the exact-count maintenance pagination fix merged in #162

## Validation
- `node ./scripts/ci/release-version.cjs assert-unpublished --version 0.0.23`
- `npm run prepush:gate` — 840 tests, 836 passed, 4 intentional skips, 0 failures; 100% statements/branches/functions/lines
- `npm pack --dry-run`
- `scripts/docpact validate-config --root . --strict`
- `scripts/docpact lint --root . --worktree --mode enforce`
- local pre-push hook reran docpact and the full test gate successfully

## Release / risk
- routine publication remains merge → `cli-v0.0.23` tag workflow → npm Trusted Publishing
- no local `npm publish` was used
- this PR performs no database writes and does not authorize or rebind the frozen BAFU P0-A plan
- root workspace gitlink integration is tracked separately after npm verification

## Post-Merge Release Evidence
- merge: `ce8c18f270725adad789ada8f4582ca0e97e4117`
- tag `cli-v0.0.23` points to the merge commit
- Tag Release From Merge run 29249813181 succeeded
- Publish Package run 29249982258 succeeded
- npm `latest` and exact version resolve to 0.0.23; npm `gitHead` equals the merge commit
- SRI: `sha512-j/r7AmbRE3kcoF/VNaKgzZB2eVWNlvDY3xowiEk2qPspnYlXJD2oGv7pSzd7rCXHDZ8Q6k0PjeNnFaX1asFdZQ==`
- SLSA provenance binds `publish.yml`, `refs/tags/cli-v0.0.23`, repository `tiangong-lca/tiangong-cli`, and workflow run 29249982258
- isolated install/version/help and `npm audit signatures` passed

Closes #163
Refs #161
Refs #162
Refs tiangong-lca/workspace#385