### PR TITLE
chore: release cli 0.0.24

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -5,7 +5,7 @@ layout: repo
 # Review note, 2026-07-13: exact-count maintenance pagination remains inside the existing dataset-maintenance command/runtime domain. Wildcard routing already covers its shared paginator, account scans, tests, and governed command/validation docs, so no ownership or route changes are required.
 # Review note, 2026-07-14: derivative rebuild remains inside the existing dataset-maintenance command/runtime and remote-adapter domains. Existing `src/lib/dataset-*.ts`, `src/cli.ts`, and `test/**` wildcards already cover its guarded-RPC adapter, action-scoped snapshot, terminal verification, and proof tests; no ownership or route changes are required.
 lastReviewedAt: '2026-07-14'
-lastReviewedCommit: 'ce8c18f270725adad789ada8f4582ca0e97e4117'
+lastReviewedCommit: '95734b0f224e06a8d674f6e602e00ac4da8e8059'
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-14
-lastReviewedCommit: ce8c18f270725adad789ada8f4582ca0e97e4117
+lastReviewedCommit: 95734b0f224e06a8d674f6e602e00ac4da8e8059
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-14
-lastReviewedCommit: ce8c18f270725adad789ada8f4582ca0e97e4117
+lastReviewedCommit: 95734b0f224e06a8d674f6e602e00ac4da8e8059
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-14
-lastReviewedCommit: ce8c18f270725adad789ada8f4582ca0e97e4117
+lastReviewedCommit: 95734b0f224e06a8d674f6e602e00ac4da8e8059
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-14
-lastReviewedCommit: ce8c18f270725adad789ada8f4582ca0e97e4117
+lastReviewedCommit: 95734b0f224e06a8d674f6e602e00ac4da8e8059
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-14
-lastReviewedCommit: ce8c18f270725adad789ada8f4582ca0e97e4117
+lastReviewedCommit: 95734b0f224e06a8d674f6e602e00ac4da8e8059
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/cli",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.101.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "Unified TianGong LCA CLI with direct REST adapters and low-entropy command surface.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #165

## Summary
- Bumps only @tiangong-lca/cli package metadata and governed review markers from 0.0.23 to 0.0.24 after feature PR #166.

## Key Decisions
- Uses the canonical merge-to-main tag workflow and npm Trusted Publishing; no local npm publish or manual tag is performed.

## Validation
- 0.0.24 is unpublished and npm latest remains 0.0.23 before merge.
- Full prepush gate passed both before commit and in the actual push hook: 853 tests, 849 passed, 4 skipped, 0 failed; src coverage is 100 percent.
- npm pack --dry-run reports @tiangong-lca/cli@0.0.24, 218 entries, and includes dist/src/lib/dataset-maintenance-derivatives.js.
- Strict docpact config/staged lint and git diff --check passed.

## Risks / Rollback
- Release completion depends on Tag Release From Merge and Publish Package workflows plus npm registry propagation; do not root-integrate until all agree on the release merge SHA.

## Follow-ups
- After merge verify cli-v0.0.24, both workflows, npm latest/version/gitHead/integrity/provenance, and then root-integrate the exact release commit.

## Workspace Integration
- Actual BAFU compensation remains separately approval-gated and is not executed by this release PR.