### PR TITLE
chore: release cli 0.0.25

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -5,8 +5,8 @@ layout: repo
 # Review note, 2026-07-13: exact-count maintenance pagination remains inside the existing dataset-maintenance command/runtime domain. Wildcard routing already covers its shared paginator, account scans, tests, and governed command/validation docs, so no ownership or route changes are required.
 # Review note, 2026-07-14: derivative rebuild remains inside the existing dataset-maintenance command/runtime and remote-adapter domains. Existing `src/lib/dataset-*.ts`, `src/cli.ts`, and `test/**` wildcards already cover its guarded-RPC adapter, action-scoped snapshot, terminal verification, and proof tests; no ownership or route changes are required.
 # Review note, 2026-07-15: the production-only protected owner-draft runner remains inside the existing dataset-maintenance command/runtime and remote-adapter domains. Existing `src/lib/dataset-*.ts`, `src/cli.ts`, and `test/**` wildcards cover its sealed request contract, one-shot admission, immutable local evidence, status-only recovery, and 23-flow + 27-process terminal proof; no ownership, routing, dependency, or release-rule change is required.
-lastReviewedAt: '2026-07-15'
-lastReviewedCommit: 'afd57879ede2e11403803d4e44c4c3c7b28daca3'
+lastReviewedAt: "2026-07-15"
+lastReviewedCommit: "81dcc80e7e2dd4e075446d820a0c836811d98567"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-15
-lastReviewedCommit: afd57879ede2e11403803d4e44c4c3c7b28daca3
+lastReviewedCommit: 81dcc80e7e2dd4e075446d820a0c836811d98567
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-15
-lastReviewedCommit: afd57879ede2e11403803d4e44c4c3c7b28daca3
+lastReviewedCommit: c48c1e0ec4daa078228105fa7da683d64def9013
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-15
-lastReviewedCommit: afd57879ede2e11403803d4e44c4c3c7b28daca3
+lastReviewedCommit: 81dcc80e7e2dd4e075446d820a0c836811d98567
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-15
-lastReviewedCommit: afd57879ede2e11403803d4e44c4c3c7b28daca3
+lastReviewedCommit: 81dcc80e7e2dd4e075446d820a0c836811d98567
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-15
-lastReviewedCommit: afd57879ede2e11403803d4e44c4c3c7b28daca3
+lastReviewedCommit: 81dcc80e7e2dd4e075446d820a0c836811d98567
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/cli",
-      "version": "0.0.24",
+      "version": "0.0.25",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.101.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "Unified TianGong LCA CLI with direct REST adapters and low-entropy command surface.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #168
Related: tiangong-lca/database-engine#262, tiangong-lca/workspace#385, tiangong-lca/workspace#402.

## Summary

- bump `@tiangong-lca/cli` from `0.0.24` to the unpublished patch `0.0.25`
- include the already-merged protected owner-draft runner from #169
- record docpact review metadata required by the release/validation contract; no release rule or command behavior changes in this PR

## Validation

- `release-version.cjs assert-unpublished --version 0.0.25`: passed; npm latest was `0.0.24`
- full pre-push gate: 889 tests, 885 passed, 4 intentional package/bin skips, 0 failed
- statements, branches, functions, and lines: 100%
- ESLint, Prettier, coverage guards, TypeScript, build, full-coverage assertion: passed
- `npm pack --dry-run`: passed for `@tiangong-lca/cli@0.0.25`
- docpact strict validation and enforced lint: passed

## Release contract

Merge this PR to upstream `main`; then GitHub Actions must create `cli-v0.0.25` and publish through npm Trusted Publishing. Do not publish locally. Afterward verify the tag commit, npm version/dist-tag, `gitHead`, integrity, and provenance before root integration.

This release publishes shared tooling only. It does not approve, freeze, admit, retry, or execute any BAFU production data change.