### PR TITLE
chore: release cli 0.0.26

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -7,7 +7,7 @@ layout: repo
 # Review note, 2026-07-15: the production-only protected owner-draft runner remains inside the existing dataset-maintenance command/runtime and remote-adapter domains. Existing `src/lib/dataset-*.ts`, `src/cli.ts`, and `test/**` wildcards cover its sealed request contract, one-shot admission, immutable local evidence, status-only recovery, and 23-flow + 27-process terminal proof; no ownership, routing, dependency, or release-rule change is required.
 # Review note, 2026-07-15: Issue #171 protected freeze/seal preparation remains inside the existing dataset-maintenance command/runtime, remote-adapter, artifact, and validation domains. Existing `src/lib/dataset-*.ts`, `src/cli.ts`, `test/**`, and governed-doc wildcards cover production-read-only capture, offline byte-exact approval sealing, canonical toolchain evidence, and their tests; no ownership, routing, dependency, auth, or release-rule change is required.
 lastReviewedAt: "2026-07-15"
-lastReviewedCommit: "bd145f692b3fd11e398302dd6a1d2831e058883a"
+lastReviewedCommit: "ea0aceef09d9b4fee11c26dd11d34ae50d387162"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-15
-lastReviewedCommit: bd145f692b3fd11e398302dd6a1d2831e058883a
+lastReviewedCommit: ea0aceef09d9b4fee11c26dd11d34ae50d387162
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-15
-lastReviewedCommit: bd145f692b3fd11e398302dd6a1d2831e058883a
+lastReviewedCommit: ea0aceef09d9b4fee11c26dd11d34ae50d387162
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-15
-lastReviewedCommit: bd145f692b3fd11e398302dd6a1d2831e058883a
+lastReviewedCommit: ea0aceef09d9b4fee11c26dd11d34ae50d387162
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-15
-lastReviewedCommit: bd145f692b3fd11e398302dd6a1d2831e058883a
+lastReviewedCommit: ea0aceef09d9b4fee11c26dd11d34ae50d387162
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-15
-lastReviewedCommit: bd145f692b3fd11e398302dd6a1d2831e058883a
+lastReviewedCommit: ea0aceef09d9b4fee11c26dd11d34ae50d387162
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/cli",
-      "version": "0.0.25",
+      "version": "0.0.26",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.101.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "Unified TianGong LCA CLI with direct REST adapters and low-entropy command surface.",
   "repository": {
     "type": "git",

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1064,7 +1064,7 @@ test('executeCli separates production read-only freeze from offline approval sea
     outDir: './protected-freeze',
     expectedProjectRef: 'production-ref',
     confirm: 'bafudata@126.com',
-    cliVersion: '0.0.25',
+    cliVersion: '0.0.26',
     pageSize: 250,
     timeoutMs: 12000,
     env: deps.env,


### PR DESCRIPTION
## Summary
- bump `@tiangong-lca/cli` from 0.0.25 to 0.0.26
- align the protected-freeze CLI dispatch version fixture
- record the mandatory no-semantic-change Docpact review metadata for release/validation/bootstrap governance

## Included capability
Publishes the protected BAFU production-read-only freeze and fully offline approval-seal surface merged in PR #172.

## Validation
- target 0.0.26 confirmed unpublished; npm latest is 0.0.25
- `npm pack --dry-run`: pass
- `npm run prepush:gate`: pass
- push hook: Docpact strict/enforced + full gate pass
- coverage: statements / branches / functions / lines = 100%
- no local publish, tag, database access, freeze, approval, or data mutation

## Post-merge
Verify the automated tag and Trusted Publishing workflows, npm latest/gitHead/integrity/provenance, then hand the exact release commit to tiangong-lca/workspace#406. No production BAFU freeze may be generated before that root integration merges.

Closes #173