### PR TITLE
fix: tolerate protected preflight clock skew

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -6,8 +6,9 @@ layout: repo
 # Review note, 2026-07-14: derivative rebuild remains inside the existing dataset-maintenance command/runtime and remote-adapter domains. Existing `src/lib/dataset-*.ts`, `src/cli.ts`, and `test/**` wildcards already cover its guarded-RPC adapter, action-scoped snapshot, terminal verification, and proof tests; no ownership or route changes are required.
 # Review note, 2026-07-15: the production-only protected owner-draft runner remains inside the existing dataset-maintenance command/runtime and remote-adapter domains. Existing `src/lib/dataset-*.ts`, `src/cli.ts`, and `test/**` wildcards cover its sealed request contract, one-shot admission, immutable local evidence, status-only recovery, and 23-flow + 27-process terminal proof; no ownership, routing, dependency, or release-rule change is required.
 # Review note, 2026-07-15: Issue #171 protected freeze/seal preparation remains inside the existing dataset-maintenance command/runtime, remote-adapter, artifact, and validation domains. Existing `src/lib/dataset-*.ts`, `src/cli.ts`, `test/**`, and governed-doc wildcards cover production-read-only capture, offline byte-exact approval sealing, canonical toolchain evidence, and their tests; no ownership, routing, dependency, auth, or release-rule change is required.
-lastReviewedAt: "2026-07-15"
-lastReviewedCommit: "ea0aceef09d9b4fee11c26dd11d34ae50d387162"
+# Review note, 2026-07-16: Issue #175 changes only the protected preflight proof's bounded client clock-skew validation and safe timing diagnostics. Existing dataset-maintenance and test wildcards already cover the implementation, tests, and governed docs; no ownership, routing, dependency, auth, database, or release-rule change is required.
+lastReviewedAt: "2026-07-16"
+lastReviewedCommit: "c44415cacc78fea6ac63dfe256d748cb6ab95782"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-15
-lastReviewedCommit: ea0aceef09d9b4fee11c26dd11d34ae50d387162
+lastReviewedAt: 2026-07-16
+lastReviewedCommit: c44415cacc78fea6ac63dfe256d748cb6ab95782
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -68,6 +68,8 @@ Review note, 2026-07-14: `rebuild-derivatives` extends the maintenance contract 
 Review note, 2026-07-15: `dataset maintenance run-protected` is the CLI-owned production-only path for one already sealed and exactly approved owner-draft alias execution. It completes full account and derivative-baseline checks before server preflight, binds three ordered live gates to a server window of at most 180 seconds, writes an immutable local marker before at most one admission POST, and permits only status/readback recovery afterward. Terminal success requires the database proof and independent RLS reads to agree on 52 rows, 59 exchanges, 55 audits, and exactly 23 flow plus 27 process derivative targets. It has no Dev replay, legacy alias RPC, automatic retry, publication, or state-code fallback.
 
 Review note, 2026-07-15: Issue #171 keeps protected preparation in the same CLI-owned maintenance boundary. `freeze-protected` may authenticate only to the explicitly confirmed production project and is limited to complete RLS reads plus the protected derivative snapshot RPC; `seal-protected-approval` is local-only and receives no environment, session, or network client. Only `run-protected` owns preflight/admission/execution. Foundry and skills remain thin published-CLI callers and must not duplicate database access, canonical hashing, or approval construction.
+
+Review note, 2026-07-16: Issue #175 keeps protected preflight validation fail-closed while allowing up to five seconds of server-ahead clock skew only for the client-side `completed_at` comparison. Expired, reversed, over-180-second, foreign, and malformed proofs still fail before gates or admission, the database remains authoritative for token expiry and one-shot consumption, and timing diagnostics never include the preflight token. The command, ownership, release, and workspace-integration boundaries are unchanged.
 
 ## Bootstrap Order
 

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -18,8 +18,8 @@ checkPaths:
   - src/**
   - scripts/**
   - .github/workflows/**
-lastReviewedAt: 2026-07-15
-lastReviewedCommit: bd145f692b3fd11e398302dd6a1d2831e058883a
+lastReviewedAt: 2026-07-16
+lastReviewedCommit: c44415cacc78fea6ac63dfe256d748cb6ab95782
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -50,6 +50,8 @@ Review note, 2026-07-14: `rebuild-derivatives` 扩展现有 maintenance command 
 Review note, 2026-07-15: `dataset maintenance run-protected` 为已经冻结和人工批准的 private alias 计划提供 production-only 的一次性执行/恢复入口。受保护写入由服务器调度，以认证 owner 及精确 actor/user_id/state_code=0、plan/closure 栅栏限制范围；RLS 继续保护公开入口与独立读回。commit 路径只做一次 server preflight、在唯一 admission POST 前写 immutable attempt marker；marker 或不明确响应之后只能 `--status-only`。它不回退 dev、旧 alias RPC、发布或 state-code 修改。
 
 Review note, 2026-07-15: `dataset maintenance freeze-protected` 与 `seal-protected-approval` 补齐 protected runner 之前的准备链。freeze 使用既有用户 session 直接对显式确认的 production project 做只读 census/support/50-target snapshot，且不会 preflight、gate、admit 或 mutate；seal 不接收 env、session 或网络 client，只按人类返回原始 UTF-8 字节及显式 hash/account/timestamp 生成 approval。二者不新增依赖、认证变量或发布路径。
+
+Review note, 2026-07-16: Issue #175 只修正 `run-protected` 对服务端领先本机时钟的有界判断：`completed_at` 最多允许领先 5 秒，过期、时间倒序、超过 180 秒与一次性 admission 约束不变。它不新增 env、依赖、认证路径、命令面或发布机制。
 
 设计原则：
 

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - README.md
   - src/**
   - test/**
-lastReviewedAt: 2026-07-15
-lastReviewedCommit: bd145f692b3fd11e398302dd6a1d2831e058883a
+lastReviewedAt: 2026-07-16
+lastReviewedCommit: c44415cacc78fea6ac63dfe256d748cb6ab95782
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -37,6 +37,8 @@ Review note, 2026-07-14: `rebuild-derivatives` 已进入 maintenance v1 固定�
 Review note, 2026-07-15: `dataset maintenance run-protected` 为 seal 绑定且已经人工批准的 private alias 计划增加 production-only 的一次性执行与恢复契约。受保护写入由服务器调度，并以认证 owner 及精确 actor/user_id/state_code=0、plan/closure 栅栏限制范围；RLS 继续保护公开入口与独立读回。它在 preflight 前完成完整扫描，随后使用服务器给出的三项 gate 期望摘要与最长 180 秒 token 捕获 live receipt，写入 immutable attempt marker 后最多发送一次 admission POST；marker 或不明确 admission 响应之后只能 `--status-only`。终态必须精确证明 52 行、59 exchanges、55 audits 与 50 个 derivative targets（23 flows + 27 processes），且不回退 dev、旧 alias RPC、发布或 state-code 修改。
 
 Review note, 2026-07-15: `dataset maintenance freeze-protected` 与 `seal-protected-approval` 把生产只读冻结和人工批准记录拆成两个不可混淆的命令。前者只对显式确认的 production project 做完整 owner-draft census/support/projected-reference 与 23+27 derivative snapshot 读取，输出未批准请求，绝不 preflight/gate/admit/mutate；后者不接收 env 或 HTTP client，只按原始 UTF-8 字节核对人类返回文本及 freeze/request/text/account/timestamp 后生成 approval。真正执行仍只属于后续 `run-protected`。
+
+Review note, 2026-07-16: `run-protected` 的 preflight proof 客户端时间校验允许服务端 `completed_at` 最多领先本机 5 秒，仅用于吸收正常时钟偏差。过期、时间倒序、超过 180 秒、foreign 或 malformed proof 仍在 gate/marker/admission 前阻断；数据库继续用 server clock 强制 token 到期与一次性消费。错误只输出 `completed_at`、`expires_at`、观察时间和差值等无 token 诊断，不持久化或暴露 preflight token。
 
 ## 1. 目标
 

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -17,8 +17,8 @@ checkPaths:
   - package.json
   - src/**
   - test/**
-lastReviewedAt: 2026-07-15
-lastReviewedCommit: bd145f692b3fd11e398302dd6a1d2831e058883a
+lastReviewedAt: 2026-07-16
+lastReviewedCommit: c44415cacc78fea6ac63dfe256d748cb6ab95782
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -51,6 +51,7 @@ related:
 - 2026-07-14 复核：`dataset maintenance rebuild-derivatives` 继续作为 TypeScript / Node 原生命令通过既有用户 session 和受保护 RPC 执行，不新增 Python、POSIX shell、MCP runtime 或私有 skill runtime 前提
 - 2026-07-15 复核：`dataset maintenance run-protected` 继续由 TypeScript / Node 原生 CLI 负责 sealed request、一次 admission、本地 immutable evidence 与只读恢复；不新增 Python、POSIX shell、MCP runtime、私有 skill runtime 或新 npm 依赖，skills 仍只能薄编排 CLI。
 - 2026-07-15 复核：`dataset maintenance freeze-protected` 与 `seal-protected-approval` 继续由 TypeScript / Node 原生 CLI 分别负责生产只读冻结和完全离线的人类批准记录；不新增 Python、POSIX shell、MCP runtime、私有 skill runtime 或 npm 依赖。Foundry/skills 只能调用已发布 CLI 并保留其产物，不得读取数据库 env、直调 RPC、重算 canonical JSON/hash 或复制 freeze/seal 逻辑。
+- 2026-07-16 复核：Issue #175 只在 TypeScript protected contract parser 中加入固定 5 秒的服务端领先时钟容差与无 token 诊断；不新增 Python、POSIX shell、MCP runtime、私有 skill runtime 或 npm 依赖，也不改变 skills 薄调用边界。
 
 这份文档记录的是：
 

--- a/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
+++ b/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
@@ -15,8 +15,8 @@ checkPaths:
   - src/lib/user-api-key.ts
   - src/lib/supabase-session.ts
   - src/lib/supabase-client.ts
-lastReviewedAt: 2026-07-15
-lastReviewedCommit: bd145f692b3fd11e398302dd6a1d2831e058883a
+lastReviewedAt: 2026-07-16
+lastReviewedCommit: c44415cacc78fea6ac63dfe256d748cb6ab95782
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -41,6 +41,7 @@ related:
 - 2026-07-14 复核：`dataset maintenance rebuild-derivatives` 复用既有用户 session 与 authenticated PostgREST RPC，不新增认证 env、alternate bearer、service-role、Edge/admin 或 raw queue 路径；本历史设计结论不变。
 - 2026-07-15 复核：`dataset maintenance run-protected` 继续复用同一用户 session、publishable key 与 authenticated PostgREST RPC。CLI 不持有 service-role；服务器调度的内部执行器不改变 CLI bearer/env contract。状态读取仍绑定 `auth.uid()`、actor 与 plan，独立表读回继续走用户 RLS；本历史设计结论不变。
 - 2026-07-15 复核：`dataset maintenance freeze-protected` 只复用现有用户 session，对显式确认的 production project 做 RLS 表读取与受保护 derivative snapshot RPC；不新增 service-role、alternate bearer、Edge/admin 或 Dev 回放链。`seal-protected-approval` 的 CLI dispatch 不传 env、session、HTTP 或 remote client，完全离线；本历史设计结论不变。
+- 2026-07-16 复核：Issue #175 只调整已认证 preflight proof 的本地时间边界判断，不改变用户 API key、publishable key、session cache、bearer、RLS、RPC 或 service-role 边界；本历史设计结论不变。
 
 ## 1. 已确认事实
 

--- a/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
+++ b/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - src/lib/supabase-client.ts
   - src/lib/tidas-sdk-package-validator.ts
   - test/**
-lastReviewedAt: 2026-07-15
-lastReviewedCommit: bd145f692b3fd11e398302dd6a1d2831e058883a
+lastReviewedAt: 2026-07-16
+lastReviewedCommit: c44415cacc78fea6ac63dfe256d748cb6ab95782
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -44,6 +44,8 @@ related:
 - 直到 repo 级验证、PR、workspace integration 全部完成，才算结束。
 
 当前状态：
+
+2026-07-16 复核：Issue #175 的 protected preflight 时钟边界修复只使用现有 TypeScript、`Date` 与 `CliError` 能力，不新增或改变 Supabase JS、TIDAS SDK 或其他直接依赖；本文件继续保持历史 TODO 记录用途。
 
 2026-07-15 复核：`dataset maintenance run-protected` 复用现有 `@supabase/supabase-js` 用户 session / authenticated RPC 与 direct TIDAS SDK 依赖模型，不新增依赖，也不改变 Issue #55 的历史结论；本文件继续保持历史 TODO 记录用途。
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-15
-lastReviewedCommit: ea0aceef09d9b4fee11c26dd11d34ae50d387162
+lastReviewedAt: 2026-07-16
+lastReviewedCommit: c44415cacc78fea6ac63dfe256d748cb6ab95782
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -61,6 +61,8 @@ Review note, 2026-07-14: `rebuild-derivatives` stays inside the native dataset-m
 Review note, 2026-07-15: `run-protected` remains in the native dataset-maintenance family and adds no second orchestration runtime. The command separates sealed request parsing, one-shot execution/recovery, and terminal independent verification into dedicated modules; it is production-only, admits at most once, and requires exact 23-flow + 27-process derivative closure without adding a Dev data replay or legacy-RPC fallback.
 
 Review note, 2026-07-15: Issue #171 adds two preparation commands without broadening the mutation surface. `freeze-protected` owns production-authenticated read-only census/support/derivative capture and canonical unapproved artifacts; `seal-protected-approval` owns byte-exact offline human-approval recording and receives no session, environment, or network client. Only the existing `run-protected` module owns preflight, admission, execution, or recovery. Foundry remains a thin published-CLI caller and must not duplicate canonical hashing or database access.
+
+Review note, 2026-07-16: Issue #175 remains inside `protected-contract` parsing and tests. The client accepts at most five seconds of server-ahead skew for `completed_at`, but does not extend token expiry or the 180-second duration; the database still owns authoritative server-clock gate/admission expiry and one-shot uniqueness. No new runtime, adapter, dependency, artifact family, or database behavior is introduced.
 
 ## Stable Path Map
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-15
-lastReviewedCommit: ea0aceef09d9b4fee11c26dd11d34ae50d387162
+lastReviewedAt: 2026-07-16
+lastReviewedCommit: c44415cacc78fea6ac63dfe256d748cb6ab95782
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -83,6 +83,8 @@ Review note, 2026-07-14: `rebuild-derivatives` proof requires exactly one owner-
 Review note, 2026-07-15: protected alias-runner proof requires production-only environment binding, a complete pre-token account/support/50-target scan, three server-derived ordered gates inside the at-most-180-second window, immutable attempt evidence before exactly zero or one admission POST, and status-only recovery after every consumed or ambiguous attempt. Terminal verification must prove the exact 52-row/59-exchange/55-audit primary closure plus 23-flow + 27-process causal derivative closure and independent live RLS parity. Zero-child terminal `failed`/`indeterminate` is valid only with the exact not-started envelope; `completed` and `derivatives_pending` must reject that shape.
 
 Review note, 2026-07-15: Issue #171 preparation proof additionally requires a strict freeze/seal split. Freeze tests must prove complete production owner-draft reads, stable exact 23-flow + 27-process capture, canonical toolchain evidence, zero preflight/gate/admission/mutation/approval artifacts, and rejection of public/foreign/stale/malformed closure. Seal tests must prove zero authentication/network/database calls, exact UTF-8 whitespace and final-newline preservation, explicit freeze-file/request/text/account/timestamp hashes, historical-plan rejection, immutable artifacts, and builder/parser/runner round-trip compatibility. The full `src/**/*.ts` coverage gate remains exactly 100%.
+
+Review note, 2026-07-16: Issue #175 proof requires a fixed five-second allowance only when server `completed_at` is slightly ahead of the client clock. Tests must accept the exact tolerance boundary, reject one millisecond beyond it, retain strict stale/reversed/over-180-second rejection, expose only token-free timing diagnostics, and prove parse failure still occurs before gate capture, submission-marker creation, or admission. Server-side expiry and one-shot enforcement are unchanged.
 
 ## Validation Matrix
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-15
-lastReviewedCommit: ea0aceef09d9b4fee11c26dd11d34ae50d387162
+lastReviewedAt: 2026-07-16
+lastReviewedCommit: c44415cacc78fea6ac63dfe256d748cb6ab95782
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -40,6 +40,8 @@ Review note, 2026-07-14: Issue #165 adds the guarded `dataset maintenance rebuil
 Review note, 2026-07-15: Issue #168 adds the production-only protected alias runner without changing package-version, tag, Trusted Publishing, or workspace follow-up mechanics. The feature PR must pass docpact and the full pre-push gate without changing package metadata. A separate patch release may start only after database-engine#262 reaches production and its schema/function/ACL readback passes; the release is still a dedicated version-bump PR and never a local publish.
 
 Review note, 2026-07-15: Issue #171 adds production-read-only protected freeze generation and completely offline human-approval sealing without changing release mechanics. Its feature PR must keep package metadata at the current released version and pass focused contract/zero-write tests, exact 100% coverage, docpact, and the full pre-push gate. Only after that feature PR merges may a separate patch version-bump PR publish through the existing tag/Trusted Publishing workflows. A fresh production freeze is not permitted until the published package provenance/registry integrity is verified and the exact release commit is merged into root-workspace integration Issue #406.
+
+Review note, 2026-07-16: Issue #175 fixes bounded client clock-skew validation without changing release mechanics. The feature PR keeps package metadata unchanged and must pass focused timing/one-shot tests, exact coverage, docpact, and the full pre-push gate. Recovery then requires a separate patch version-bump PR, Trusted Publishing verification, and a new root-workspace integration before any fresh protected freeze.
 
 Use this document for:
 

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -19,8 +19,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-15
-lastReviewedCommit: ea0aceef09d9b4fee11c26dd11d34ae50d387162
+lastReviewedAt: 2026-07-16
+lastReviewedCommit: c44415cacc78fea6ac63dfe256d748cb6ab95782
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -54,6 +54,8 @@ Review note, 2026-07-14: Issue #165's guarded derivative-rebuild command require
 Review note, 2026-07-15: Issue #168's protected owner-draft runner requires no new npm secret, GitHub environment, Trusted Publisher setting, workflow filename, or tag rule. The released database-engine#262 production contract is a runtime prerequisite for the later CLI patch release, not a change to release setup.
 
 Review note, 2026-07-15: Issue #171's protected freeze/seal commands require no new npm secret, GitHub environment, Trusted Publisher setting, workflow filename, tag rule, database service-role credential, or alternate CLI authentication variable. Freeze reuses the existing user-session contract; seal receives no authentication or network input. The feature still follows a normal feature PR, separate version-bump PR, automated tag, and npm Trusted Publishing path.
+
+Review note, 2026-07-16: Issue #175's bounded preflight clock-skew fix requires no new secret, environment, Trusted Publisher setting, workflow, tag rule, credential, or database change. It follows the unchanged feature-then-patch-release path.
 
 Review note, 2026-07-13: exact-count maintenance pagination requires no repository secret, Trusted Publisher, environment, workflow filename, or tag-semantics change.
 

--- a/src/lib/dataset-maintenance-protected-contract.ts
+++ b/src/lib/dataset-maintenance-protected-contract.ts
@@ -41,6 +41,8 @@ export const PROTECTED_EXECUTION_COUNTS = {
 const SHA256 = /^[a-f0-9]{64}$/u;
 const UUID = /^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/iu;
 const VERSION = /^[0-9]{2}\.[0-9]{2}\.[0-9]{3}$/u;
+const PROTECTED_PREFLIGHT_MAX_WINDOW_MS = 180_000;
+const PROTECTED_SERVER_CLOCK_SKEW_TOLERANCE_MS = 5_000;
 
 export type ProtectedExecutionStatus =
   | 'not_admitted'
@@ -355,10 +357,11 @@ export type ProtectedExecutionStatusProof = {
   failure: JsonObject | null;
 };
 
-function fail(message: string): never {
+function fail(message: string, details?: unknown): never {
   throw new CliError(message, {
     code: 'DATASET_MAINTENANCE_PROTECTED_CONTRACT_INVALID',
     exitCode: 2,
+    details,
   });
 }
 
@@ -958,8 +961,30 @@ export function parseProtectedPreflightProof(
   }
   const issued = Date.parse(proof.completed_at);
   const expires = Date.parse(proof.expires_at);
-  if (issued > now.getTime() || expires <= now.getTime() || expires - issued > 180_000) {
-    fail('Preflight token is stale, future-issued, or exceeds the 180-second admission window.');
+  const nowMs = now.getTime();
+  const windowMs = expires - issued;
+  const timingDetails = {
+    completed_at: proof.completed_at,
+    expires_at: proof.expires_at,
+    observed_at: now.toISOString(),
+    window_ms: windowMs,
+    future_skew_ms: issued - nowMs,
+    allowed_future_skew_ms: PROTECTED_SERVER_CLOCK_SKEW_TOLERANCE_MS,
+  };
+  if (windowMs <= 0) {
+    fail('Preflight token expiry must be later than its completion time.', timingDetails);
+  }
+  if (windowMs > PROTECTED_PREFLIGHT_MAX_WINDOW_MS) {
+    fail('Preflight token exceeds the 180-second admission window.', timingDetails);
+  }
+  if (issued - nowMs > PROTECTED_SERVER_CLOCK_SKEW_TOLERANCE_MS) {
+    fail(
+      'Preflight token is future-issued beyond the 5-second clock-skew allowance.',
+      timingDetails,
+    );
+  }
+  if (expires <= nowMs) {
+    fail('Preflight token is stale.', timingDetails);
   }
   return proof;
 }

--- a/test/dataset-maintenance-protected-contract-coverage.test.ts
+++ b/test/dataset-maintenance-protected-contract-coverage.test.ts
@@ -966,7 +966,71 @@ test('preflight, gate, and admission reject foreign, stale, or mismatched proofs
   const expired = preflightResponse(identity);
   rejects(
     () => parseProtectedPreflightProof(expired, identity, new Date('2026-07-15T00:03:01.000Z')),
-    /stale, future-issued/u,
+    /token is stale/u,
+  );
+
+  const atExpiry = preflightResponse(identity);
+  rejects(
+    () => parseProtectedPreflightProof(atExpiry, identity, new Date(atExpiry.expires_at)),
+    /token is stale/u,
+  );
+
+  const exactWindow = preflightResponse(identity);
+  assert.equal(
+    parseProtectedPreflightProof(exactWindow, identity, new Date('2026-07-15T00:00:00.000Z'))
+      .request_id,
+    identity.request_id,
+  );
+
+  const withinClockSkew = preflightResponse(identity);
+  withinClockSkew.completed_at = '2026-07-15T00:00:05.000Z';
+  withinClockSkew.expires_at = '2026-07-15T00:03:05.000Z';
+  assert.equal(
+    parseProtectedPreflightProof(withinClockSkew, identity, new Date('2026-07-15T00:00:00.000Z'))
+      .completed_at,
+    withinClockSkew.completed_at,
+  );
+
+  const beyondClockSkew = preflightResponse(identity);
+  beyondClockSkew.completed_at = '2026-07-15T00:00:05.001Z';
+  beyondClockSkew.expires_at = '2026-07-15T00:03:05.001Z';
+  assert.throws(
+    () =>
+      parseProtectedPreflightProof(beyondClockSkew, identity, new Date('2026-07-15T00:00:00.000Z')),
+    (error: unknown) => {
+      assert.ok(error instanceof CliError);
+      assert.match(error.message, /future-issued beyond the 5-second/u);
+      assert.deepEqual(error.details, {
+        completed_at: beyondClockSkew.completed_at,
+        expires_at: beyondClockSkew.expires_at,
+        observed_at: '2026-07-15T00:00:00.000Z',
+        window_ms: 180_000,
+        future_skew_ms: 5_001,
+        allowed_future_skew_ms: 5_000,
+      });
+      return true;
+    },
+  );
+
+  const overlong = preflightResponse(identity);
+  overlong.expires_at = '2026-07-15T00:03:00.001Z';
+  rejects(
+    () => parseProtectedPreflightProof(overlong, identity, new Date('2026-07-15T00:00:30.000Z')),
+    /exceeds the 180-second/u,
+  );
+
+  const zeroWindow = preflightResponse(identity);
+  zeroWindow.expires_at = zeroWindow.completed_at;
+  rejects(
+    () => parseProtectedPreflightProof(zeroWindow, identity, new Date('2026-07-14T23:59:59.000Z')),
+    /expiry must be later/u,
+  );
+
+  const reversed = preflightResponse(identity);
+  reversed.expires_at = '2026-07-14T23:59:59.999Z';
+  rejects(
+    () => parseProtectedPreflightProof(reversed, identity, new Date('2026-07-14T23:59:59.000Z')),
+    /expiry must be later/u,
   );
 
   const preflight = preflightFixture(identity);

--- a/test/dataset-maintenance-protected-run.test.ts
+++ b/test/dataset-maintenance-protected-run.test.ts
@@ -1149,6 +1149,7 @@ function runtimeDependencies(options: {
     verification: ProtectedVerificationResult;
   };
   admissionError?: Error;
+  preflightParseError?: Error;
   counters: Record<string, number>;
 }) {
   const bump = (name: string) => {
@@ -1177,7 +1178,10 @@ function runtimeDependencies(options: {
       bump('preflight');
       return { raw: 'preflight' };
     },
-    parsePreflight: () => preflight,
+    parsePreflight: () => {
+      if (options.preflightParseError) throw options.preflightParseError;
+      return preflight;
+    },
     captureGates: async () => {
       bump('gates');
       return gateBundle();
@@ -1378,6 +1382,37 @@ test('commit core writes one-shot evidence and treats admission exceptions as co
     assert.equal(ambiguousCounters.admit, 1);
     assert.equal(ambiguousCounters.read, 1);
     assert.equal(existsSync(ambiguous.prepared.artifacts.admission_transport_error), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('commit core stops before gates, marker, and admission when preflight proof parsing fails', async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'tg-protected-preflight-rejected-'));
+  try {
+    const fixture = preparedFixture(root, true);
+    const counters: Record<string, number> = {};
+    await assert.rejects(
+      () =>
+        runInternals.runPreparedProtectedExecution(
+          fixture.command,
+          fixture.prepared,
+          runtimeDependencies({
+            counters,
+            rows: fixture.rows,
+            completeness: fixture.plan.snapshot_completeness,
+            preflightParseError: new Error('future-issued proof rejected'),
+          }),
+        ),
+      /future-issued proof rejected/u,
+    );
+    assert.equal(counters.preflight, 1);
+    assert.equal(counters.gates ?? 0, 0);
+    assert.equal(counters.admit ?? 0, 0);
+    assert.equal(counters.read ?? 0, 0);
+    assert.equal(existsSync(fixture.prepared.artifacts.execution_seal), true);
+    assert.equal(existsSync(fixture.prepared.artifacts.preflight_evidence), false);
+    assert.equal(existsSync(fixture.prepared.artifacts.submission_attempt), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- Accept at most 5,000 ms of server-ahead skew for the protected preflight completed_at comparison.
- Keep expiry, invalid time order, and the 180,000 ms maximum proof window strict and independently diagnosed.
- Add token-free timing diagnostics, exhaustive boundary tests, runtime zero-admission proof, and governed documentation reviews.

## Safety

- The allowance is fixed and applies only to completed_at minus the client clock; it does not extend expires_at.
- expires_at less than or equal to the observed client time still fails, zero/negative windows fail, and windows above 180,000 ms fail.
- The database remains authoritative for server-clock expiry, RLS, closure fences, and one-shot admission.
- A rejected preflight proof still produces gate=0, admit=0, read=0, no preflight evidence, and no submission marker.
- Diagnostics include only timestamps and numeric deltas; the preflight token is never included.

## Incident context

The exhausted BAFU request 3548aa87-2ea2-5213-b2c6-2fdbab6b357e failed at this client-only boundary before admission. Production status proved not_admitted, attempt_count=0, gate_count=0, dispatch_count=0, and no data mutation. This PR does not retry or reuse that request. Recovery still requires a separate patch release, root-workspace integration, fresh production freeze, and new exact human approval.

## Validation

- npm test: 926/926 passed
- focused protected contract/runtime tests passed
- npm run prepush:gate passed
- statements, branches, functions, and lines: 100%
- docpact strict validation and enforce lint: zero diagnostics
- independent code review: no blocking findings
- push hook reran docpact and the full pre-push gate successfully

Closes #175

Parent recovery: tiangong-lca/workspace#385
Execution ledger: tiangong-lca/data-foundry#21