### PR TITLE
test: make protected maintenance suite Windows-portable

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -7,8 +7,9 @@ layout: repo
 # Review note, 2026-07-15: the production-only protected owner-draft runner remains inside the existing dataset-maintenance command/runtime and remote-adapter domains. Existing `src/lib/dataset-*.ts`, `src/cli.ts`, and `test/**` wildcards cover its sealed request contract, one-shot admission, immutable local evidence, status-only recovery, and 23-flow + 27-process terminal proof; no ownership, routing, dependency, or release-rule change is required.
 # Review note, 2026-07-15: Issue #171 protected freeze/seal preparation remains inside the existing dataset-maintenance command/runtime, remote-adapter, artifact, and validation domains. Existing `src/lib/dataset-*.ts`, `src/cli.ts`, `test/**`, and governed-doc wildcards cover production-read-only capture, offline byte-exact approval sealing, canonical toolchain evidence, and their tests; no ownership, routing, dependency, auth, or release-rule change is required.
 # Review note, 2026-07-16: Issue #175 changes only the protected preflight proof's bounded client clock-skew validation and safe timing diagnostics. Existing dataset-maintenance and test wildcards already cover the implementation, tests, and governed docs; no ownership, routing, dependency, auth, database, or release-rule change is required.
+# Review note, 2026-07-16: Issue #177 removes Windows-only assumptions from existing CLI tests. The same test and validation wildcards cover native path handling, deterministic spawn doubles, and platform-appropriate permission assertions; no runtime, ownership, routing, dependency, auth, database, protected-execution, or release-rule change is required.
 lastReviewedAt: "2026-07-16"
-lastReviewedCommit: "c44415cacc78fea6ac63dfe256d748cb6ab95782"
+lastReviewedCommit: "65a446a8650ec2aa5712d6d13dbab57a400b433d"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: c44415cacc78fea6ac63dfe256d748cb6ab95782
+lastReviewedCommit: 65a446a8650ec2aa5712d6d13dbab57a400b433d
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -70,6 +70,8 @@ Review note, 2026-07-15: `dataset maintenance run-protected` is the CLI-owned pr
 Review note, 2026-07-15: Issue #171 keeps protected preparation in the same CLI-owned maintenance boundary. `freeze-protected` may authenticate only to the explicitly confirmed production project and is limited to complete RLS reads plus the protected derivative snapshot RPC; `seal-protected-approval` is local-only and receives no environment, session, or network client. Only `run-protected` owns preflight/admission/execution. Foundry and skills remain thin published-CLI callers and must not duplicate database access, canonical hashing, or approval construction.
 
 Review note, 2026-07-16: Issue #175 keeps protected preflight validation fail-closed while allowing up to five seconds of server-ahead clock skew only for the client-side `completed_at` comparison. Expired, reversed, over-180-second, foreign, and malformed proofs still fail before gates or admission, the database remains authoritative for token expiry and one-shot consumption, and timing diagnostics never include the preflight token. The command, ownership, release, and workspace-integration boundaries are unchanged.
+
+Review note, 2026-07-16: Issue #177 changes tests only: native path helpers replace POSIX separators, the default-spawn failure uses a guaranteed-missing temporary executable, successful spawn remains injected, and POSIX mode-bit assertions run only where those semantics exist. Runtime behavior, raw protected bytes, ownership, release, and workspace-integration boundaries are unchanged.
 
 ## Bootstrap Order
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: c44415cacc78fea6ac63dfe256d748cb6ab95782
+lastReviewedCommit: 65a446a8650ec2aa5712d6d13dbab57a400b433d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -63,6 +63,8 @@ Review note, 2026-07-15: `run-protected` remains in the native dataset-maintenan
 Review note, 2026-07-15: Issue #171 adds two preparation commands without broadening the mutation surface. `freeze-protected` owns production-authenticated read-only census/support/derivative capture and canonical unapproved artifacts; `seal-protected-approval` owns byte-exact offline human-approval recording and receives no session, environment, or network client. Only the existing `run-protected` module owns preflight, admission, execution, or recovery. Foundry remains a thin published-CLI caller and must not duplicate canonical hashing or database access.
 
 Review note, 2026-07-16: Issue #175 remains inside `protected-contract` parsing and tests. The client accepts at most five seconds of server-ahead skew for `completed_at`, but does not extend token expiry or the 180-second duration; the database still owns authoritative server-clock gate/admission expiry and one-shot uniqueness. No new runtime, adapter, dependency, artifact family, or database behavior is introduced.
+
+Review note, 2026-07-16: Issue #177 modifies only `test/**` portability assumptions. Native path helpers, a guaranteed-missing temporary executable for the default-spawn failure path, an injected successful spawn, and platform-appropriate permission assertions preserve the existing launcher, artifact, protected-maintenance, dependency, and release architecture.
 
 ## Stable Path Map
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: c44415cacc78fea6ac63dfe256d748cb6ab95782
+lastReviewedCommit: 65a446a8650ec2aa5712d6d13dbab57a400b433d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -85,6 +85,8 @@ Review note, 2026-07-15: protected alias-runner proof requires production-only e
 Review note, 2026-07-15: Issue #171 preparation proof additionally requires a strict freeze/seal split. Freeze tests must prove complete production owner-draft reads, stable exact 23-flow + 27-process capture, canonical toolchain evidence, zero preflight/gate/admission/mutation/approval artifacts, and rejection of public/foreign/stale/malformed closure. Seal tests must prove zero authentication/network/database calls, exact UTF-8 whitespace and final-newline preservation, explicit freeze-file/request/text/account/timestamp hashes, historical-plan rejection, immutable artifacts, and builder/parser/runner round-trip compatibility. The full `src/**/*.ts` coverage gate remains exactly 100%.
 
 Review note, 2026-07-16: Issue #175 proof requires a fixed five-second allowance only when server `completed_at` is slightly ahead of the client clock. Tests must accept the exact tolerance boundary, reject one millisecond beyond it, retain strict stale/reversed/over-180-second rejection, expose only token-free timing diagnostics, and prove parse failure still occurs before gate capture, submission-marker creation, or admission. Server-side expiry and one-shot enforcement are unchanged.
+
+Review note, 2026-07-16: Issue #177 keeps the validation contract unchanged while making existing tests portable across the four-platform quality matrix. Tests use native path helpers and deterministic spawn doubles; POSIX permission-bit checks remain required on non-Windows platforms, while byte preservation, immutability, hashing, and overwrite rejection remain required everywhere.
 
 ## Validation Matrix
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: c44415cacc78fea6ac63dfe256d748cb6ab95782
+lastReviewedCommit: 65a446a8650ec2aa5712d6d13dbab57a400b433d
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -42,6 +42,8 @@ Review note, 2026-07-15: Issue #168 adds the production-only protected alias run
 Review note, 2026-07-15: Issue #171 adds production-read-only protected freeze generation and completely offline human-approval sealing without changing release mechanics. Its feature PR must keep package metadata at the current released version and pass focused contract/zero-write tests, exact 100% coverage, docpact, and the full pre-push gate. Only after that feature PR merges may a separate patch version-bump PR publish through the existing tag/Trusted Publishing workflows. A fresh production freeze is not permitted until the published package provenance/registry integrity is verified and the exact release commit is merged into root-workspace integration Issue #406.
 
 Review note, 2026-07-16: Issue #175 fixes bounded client clock-skew validation without changing release mechanics. The feature PR keeps package metadata unchanged and must pass focused timing/one-shot tests, exact coverage, docpact, and the full pre-push gate. Recovery then requires a separate patch version-bump PR, Trusted Publishing verification, and a new root-workspace integration before any fresh protected freeze.
+
+Review note, 2026-07-16: Issue #177 changes only cross-platform tests needed to make the existing four-platform quality matrix authoritative. It does not alter package metadata, tag creation, Trusted Publishing, release eligibility, protected-execution behavior, or the requirement for a separate 0.0.27 release PR after all matrix jobs pass.
 
 Use this document for:
 

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: c44415cacc78fea6ac63dfe256d748cb6ab95782
+lastReviewedCommit: 65a446a8650ec2aa5712d6d13dbab57a400b433d
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -56,6 +56,8 @@ Review note, 2026-07-15: Issue #168's protected owner-draft runner requires no n
 Review note, 2026-07-15: Issue #171's protected freeze/seal commands require no new npm secret, GitHub environment, Trusted Publisher setting, workflow filename, tag rule, database service-role credential, or alternate CLI authentication variable. Freeze reuses the existing user-session contract; seal receives no authentication or network input. The feature still follows a normal feature PR, separate version-bump PR, automated tag, and npm Trusted Publishing path.
 
 Review note, 2026-07-16: Issue #175's bounded preflight clock-skew fix requires no new secret, environment, Trusted Publisher setting, workflow, tag rule, credential, or database change. It follows the unchanged feature-then-patch-release path.
+
+Review note, 2026-07-16: Issue #177's test-only Windows portability changes require no new secret, environment, runner configuration, Trusted Publisher setting, workflow, tag rule, credential, or database change.
 
 Review note, 2026-07-13: exact-count maintenance pagination requires no repository secret, Trusted Publisher, environment, workflow filename, or tag-semantics change.
 

--- a/test/dataset-import-lca.test.ts
+++ b/test/dataset-import-lca.test.ts
@@ -298,15 +298,34 @@ test('runDatasetImportLcaConvert records blocked commands and default spawn outp
     assert.equal(blocked.files.process_bundles_dir, null);
     assert.equal(blocked.files.process_bundles_index, null);
 
-    const completed = runDatasetImportLcaConvert({
+    const missingPython = path.join(dir, 'missing-python-executable');
+    const defaultSpawnBlocked = runDatasetImportLcaConvert({
       inputPath,
-      outputDir: path.join(dir, 'true-out'),
-      pythonBin: '/usr/bin/true',
+      outputDir: path.join(dir, 'missing-python-out'),
+      pythonBin: missingPython,
       tidasToolsDir: toolsDir,
       processBundles: false,
     });
+    assert.equal(defaultSpawnBlocked.status, 'blocked');
+    assert.equal(defaultSpawnBlocked.command.executable, missingPython);
+
+    const completed = runDatasetImportLcaConvert({
+      inputPath,
+      outputDir: path.join(dir, 'completed-out'),
+      pythonBin: 'python-custom',
+      tidasToolsDir: toolsDir,
+      processBundles: false,
+      spawnImpl: (() => ({
+        status: 0,
+        signal: null,
+        output: [],
+        pid: 1,
+        stdout: '',
+        stderr: '',
+      })) as unknown as typeof spawnSync,
+    });
     assert.equal(completed.status, 'completed');
-    assert.equal(completed.command.executable, '/usr/bin/true');
+    assert.equal(completed.command.executable, 'python-custom');
     assert.equal(completed.command.args.includes('--no-process-bundles'), true);
     assert.equal(completed.command.args.includes('--process-bundles'), false);
     assert.equal(completed.files.process_bundles_dir, null);

--- a/test/dataset-maintenance-protected-artifacts.test.ts
+++ b/test/dataset-maintenance-protected-artifacts.test.ts
@@ -25,13 +25,17 @@ function withTempDirectory(run: (root: string) => void): void {
 test('protected artifacts are canonical, private, immutable, and readable', () => {
   withTempDirectory((root) => {
     const directory = ensurePrivateArtifactDirectory(path.join(root, 'nested'));
-    assert.equal(statSync(directory).mode & 0o777, 0o700);
+    if (process.platform !== 'win32') {
+      assert.equal(statSync(directory).mode & 0o777, 0o700);
+    }
 
     const filePath = path.join(directory, 'evidence.json');
     const resolved = writePrivateImmutableJson(filePath, { z: 2, a: 1 });
     assert.equal(resolved, path.resolve(filePath));
     assert.equal(readFileSync(filePath, 'utf8'), '{"a":1,"z":2}\n');
-    assert.equal(statSync(filePath).mode & 0o777, 0o600);
+    if (process.platform !== 'win32') {
+      assert.equal(statSync(filePath).mode & 0o777, 0o600);
+    }
 
     assert.equal(writePrivateImmutableJson(filePath, { a: 1, z: 2 }), resolved);
     const artifact = readProtectedJsonArtifact({ filePath, label: 'Evidence' });

--- a/test/dataset-maintenance-protected-freeze.test.ts
+++ b/test/dataset-maintenance-protected-freeze.test.ts
@@ -5,6 +5,7 @@ import {
   __testInternals,
   type FreezeDatasetMaintenanceProtectedOptions,
 } from '../src/lib/dataset-maintenance-protected-freeze.js';
+import path from 'node:path';
 import { stableJsonText } from '../src/lib/dataset-maintenance-contract.js';
 import type { DatasetMaintenanceRemoteContext } from '../src/lib/dataset-maintenance-remote.js';
 import type { DatasetMaintenanceProtectedToolchainEvidence } from '../src/lib/dataset-maintenance-protected-toolchain.js';
@@ -203,7 +204,7 @@ test('freeze-protected performs one read-only preparation and writes no approval
     'validate-before',
   ]);
   assert.deepEqual(
-    fixture.writes.map(({ filePath }) => filePath.split('/').at(-1)),
+    fixture.writes.map(({ filePath }) => path.basename(filePath)),
     [
       'protected-alias-plan-request.json',
       'protected-derivative-baselines.json',
@@ -214,7 +215,7 @@ test('freeze-protected performs one read-only preparation and writes no approval
     ],
   );
   assert.equal(
-    fixture.writes.some(({ filePath }) => /(^|\/)protected-approval\.json$/u.test(filePath)),
+    fixture.writes.some(({ filePath }) => path.basename(filePath) === 'protected-approval.json'),
     false,
   );
   const baseline = JSON.parse(

--- a/test/dataset-maintenance-protected-run.test.ts
+++ b/test/dataset-maintenance-protected-run.test.ts
@@ -424,8 +424,10 @@ test('protected runner validates scalar options and keeps private evidence immut
     const artifactPath = path.join(root, 'private', 'evidence.json');
     assert.equal(runInternals.writePrivateImmutableJson(artifactPath, { ok: true }), artifactPath);
     assert.equal(runInternals.writePrivateImmutableJson(artifactPath, { ok: true }), artifactPath);
-    assert.equal(statSync(path.dirname(artifactPath)).mode & 0o777, 0o700);
-    assert.equal(statSync(artifactPath).mode & 0o777, 0o600);
+    if (process.platform !== 'win32') {
+      assert.equal(statSync(path.dirname(artifactPath)).mode & 0o777, 0o700);
+      assert.equal(statSync(artifactPath).mode & 0o777, 0o600);
+    }
     assert.throws(
       () => runInternals.writePrivateImmutableJson(artifactPath, { ok: false }),
       /Refusing to overwrite/u,

--- a/test/dataset-maintenance-protected-seal.test.ts
+++ b/test/dataset-maintenance-protected-seal.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../src/lib/dataset-maintenance-protected-seal.js';
 import { stableJsonText } from '../src/lib/dataset-maintenance-contract.js';
 import { PROTECTED_PRODUCTION_PROJECT_REF } from '../src/lib/dataset-maintenance-protected-preparation.js';
+import path from 'node:path';
 
 const HASH_A = 'a'.repeat(64);
 const HASH_B = 'b'.repeat(64);
@@ -118,7 +119,7 @@ test('seal-protected-approval records byte-exact approval entirely offline', asy
     'seal',
   ]);
   assert.deepEqual(
-    fixture.writes.map(({ filePath }) => filePath.split('/').at(-1)),
+    fixture.writes.map(({ filePath }) => path.basename(filePath)),
     [
       'protected-human-approval.txt',
       'protected-approval.json',
@@ -209,10 +210,11 @@ test('seal-protected-approval rejects non-production evidence before reading app
 });
 
 test('seal helper paths and canonical checks are deterministic', () => {
-  assert.deepEqual(__testInternals.artifactPaths('/private/out'), {
-    human_approval_text: '/private/out/protected-human-approval.txt',
-    approval: '/private/out/protected-approval.json',
-    report: '/private/out/protected-approval-seal-report.json',
+  const outDir = path.resolve('/private/out');
+  assert.deepEqual(__testInternals.artifactPaths(outDir), {
+    human_approval_text: path.join(outDir, 'protected-human-approval.txt'),
+    approval: path.join(outDir, 'protected-approval.json'),
+    report: path.join(outDir, 'protected-approval-seal-report.json'),
   });
   assert.doesNotThrow(() =>
     __testInternals.assertCanonicalJsonArtifact({

--- a/test/dataset-save-draft-cli.test.ts
+++ b/test/dataset-save-draft-cli.test.ts
@@ -401,16 +401,19 @@ test('dataset save-draft internals cover row preparation and failure reports', (
     { id: 'row-id', version: 'row-version' },
   );
 
-  const files = __testInternals.buildFiles('/tmp/out');
-  assert.equal(files.summary_json, '/tmp/out/outputs/dataset-save-draft/summary.json');
-  assert.match(
-    __testInternals.defaultOutDir(
-      '/tmp/input/rows.jsonl',
-      true,
-      new Date('2026-06-04T00:00:00.000Z'),
-    ),
-    /dataset-save-draft\/commit-2026-06-04T000000000Z/u,
+  const outDir = path.resolve('/tmp/out');
+  const files = __testInternals.buildFiles(outDir);
+  assert.equal(
+    files.summary_json,
+    path.join(outDir, 'outputs', 'dataset-save-draft', 'summary.json'),
   );
+  const defaultOutDir = __testInternals.defaultOutDir(
+    path.resolve('/tmp/input/rows.jsonl'),
+    true,
+    new Date('2026-06-04T00:00:00.000Z'),
+  );
+  assert.equal(path.basename(defaultOutDir), 'commit-2026-06-04T000000000Z');
+  assert.equal(path.basename(path.dirname(defaultOutDir)), 'dataset-save-draft');
   assert.deepEqual(
     __testInternals.operationCount([
       { operation: 'insert', status: 'executed' },


### PR DESCRIPTION
## Summary

- replace host-specific executable and POSIX path assumptions in existing tests
- keep POSIX mode assertions on platforms that expose those semantics while retaining byte, hashing, and immutability assertions everywhere
- record the test-only governance review required by Docpact

## Safety boundary

- no production source changes
- no package/dependency changes
- no protected approval, execution, database, or BAFU operation
- no skipped tests, retry, or OS exclusion

## Validation

- focused portability suite: 48/48 passed
- `npm test`: 926/926 passed
- `npm run prepush:gate`: passed
- exact coverage: 100% statements, branches, functions, and lines
- Docpact strict validation and enforce lint: zero diagnostics
- independent read-only review: no remaining platform-specific blocker

The manual four-platform quality workflow must still pass, including Windows, before merge.

Closes #177