### PR TITLE
chore: release cli 0.0.27

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -8,8 +8,9 @@ layout: repo
 # Review note, 2026-07-15: Issue #171 protected freeze/seal preparation remains inside the existing dataset-maintenance command/runtime, remote-adapter, artifact, and validation domains. Existing `src/lib/dataset-*.ts`, `src/cli.ts`, `test/**`, and governed-doc wildcards cover production-read-only capture, offline byte-exact approval sealing, canonical toolchain evidence, and their tests; no ownership, routing, dependency, auth, or release-rule change is required.
 # Review note, 2026-07-16: Issue #175 changes only the protected preflight proof's bounded client clock-skew validation and safe timing diagnostics. Existing dataset-maintenance and test wildcards already cover the implementation, tests, and governed docs; no ownership, routing, dependency, auth, database, or release-rule change is required.
 # Review note, 2026-07-16: Issue #177 removes Windows-only assumptions from existing CLI tests. The same test and validation wildcards cover native path handling, deterministic spawn doubles, and platform-appropriate permission assertions; no runtime, ownership, routing, dependency, auth, database, protected-execution, or release-rule change is required.
+# Review note, 2026-07-16: Issue #178 is the dedicated 0.0.27 package-version release after Issues #175 and #177. It changes only package metadata, the package-version dispatch fixture, and governed review records; ownership, routing, dependencies, protected execution, database behavior, tag automation, Trusted Publishing, and workspace-integration rules remain unchanged.
 lastReviewedAt: "2026-07-16"
-lastReviewedCommit: "65a446a8650ec2aa5712d6d13dbab57a400b433d"
+lastReviewedCommit: "7c9a252226fb411d3ffba2f2e4f37b91b9658be8"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: 65a446a8650ec2aa5712d6d13dbab57a400b433d
+lastReviewedCommit: 7c9a252226fb411d3ffba2f2e4f37b91b9658be8
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -72,6 +72,8 @@ Review note, 2026-07-15: Issue #171 keeps protected preparation in the same CLI-
 Review note, 2026-07-16: Issue #175 keeps protected preflight validation fail-closed while allowing up to five seconds of server-ahead clock skew only for the client-side `completed_at` comparison. Expired, reversed, over-180-second, foreign, and malformed proofs still fail before gates or admission, the database remains authoritative for token expiry and one-shot consumption, and timing diagnostics never include the preflight token. The command, ownership, release, and workspace-integration boundaries are unchanged.
 
 Review note, 2026-07-16: Issue #177 changes tests only: native path helpers replace POSIX separators, the default-spawn failure uses a guaranteed-missing temporary executable, successful spawn remains injected, and POSIX mode-bit assertions run only where those semantics exist. Runtime behavior, raw protected bytes, ownership, release, and workspace-integration boundaries are unchanged.
+
+Review note, 2026-07-16: Issue #178 is the dedicated 0.0.27 version-bump release for the merged protected clock-skew fix and Windows-portable validation suite. It adds no command, runtime, dependency, approval, database, or alternate publication path; automated tag creation, Trusted Publishing, and exact released-commit workspace integration remain mandatory.
 
 ## Bootstrap Order
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: 65a446a8650ec2aa5712d6d13dbab57a400b433d
+lastReviewedCommit: 7c9a252226fb411d3ffba2f2e4f37b91b9658be8
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -65,6 +65,8 @@ Review note, 2026-07-15: Issue #171 adds two preparation commands without broade
 Review note, 2026-07-16: Issue #175 remains inside `protected-contract` parsing and tests. The client accepts at most five seconds of server-ahead skew for `completed_at`, but does not extend token expiry or the 180-second duration; the database still owns authoritative server-clock gate/admission expiry and one-shot uniqueness. No new runtime, adapter, dependency, artifact family, or database behavior is introduced.
 
 Review note, 2026-07-16: Issue #177 modifies only `test/**` portability assumptions. Native path helpers, a guaranteed-missing temporary executable for the default-spawn failure path, an injected successful spawn, and platform-appropriate permission assertions preserve the existing launcher, artifact, protected-maintenance, dependency, and release architecture.
+
+Review note, 2026-07-16: Issue #178 changes the package version to 0.0.27 and updates the one package-version dispatch fixture. No command family, launcher, session, artifact, protected-maintenance, dependency, tag, publication, or workspace-integration architecture changes.
 
 ## Stable Path Map
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: 65a446a8650ec2aa5712d6d13dbab57a400b433d
+lastReviewedCommit: 7c9a252226fb411d3ffba2f2e4f37b91b9658be8
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -87,6 +87,8 @@ Review note, 2026-07-15: Issue #171 preparation proof additionally requires a st
 Review note, 2026-07-16: Issue #175 proof requires a fixed five-second allowance only when server `completed_at` is slightly ahead of the client clock. Tests must accept the exact tolerance boundary, reject one millisecond beyond it, retain strict stale/reversed/over-180-second rejection, expose only token-free timing diagnostics, and prove parse failure still occurs before gate capture, submission-marker creation, or admission. Server-side expiry and one-shot enforcement are unchanged.
 
 Review note, 2026-07-16: Issue #177 keeps the validation contract unchanged while making existing tests portable across the four-platform quality matrix. Tests use native path helpers and deterministic spawn doubles; POSIX permission-bit checks remain required on non-Windows platforms, while byte preservation, immutability, hashing, and overwrite rejection remain required everywhere.
+
+Review note, 2026-07-16: Issue #178 keeps the validation contract unchanged for the dedicated 0.0.27 release. In addition to the existing exact-coverage and pre-push gates, release proof requires an unpublished-version check, tag-name check, dry-run package inspection, a fresh four-platform matrix, and Docpact with no diagnostics before merge.
 
 ## Validation Matrix
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: 65a446a8650ec2aa5712d6d13dbab57a400b433d
+lastReviewedCommit: 7c9a252226fb411d3ffba2f2e4f37b91b9658be8
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -44,6 +44,8 @@ Review note, 2026-07-15: Issue #171 adds production-read-only protected freeze g
 Review note, 2026-07-16: Issue #175 fixes bounded client clock-skew validation without changing release mechanics. The feature PR keeps package metadata unchanged and must pass focused timing/one-shot tests, exact coverage, docpact, and the full pre-push gate. Recovery then requires a separate patch version-bump PR, Trusted Publishing verification, and a new root-workspace integration before any fresh protected freeze.
 
 Review note, 2026-07-16: Issue #177 changes only cross-platform tests needed to make the existing four-platform quality matrix authoritative. It does not alter package metadata, tag creation, Trusted Publishing, release eligibility, protected-execution behavior, or the requirement for a separate 0.0.27 release PR after all matrix jobs pass.
+
+Review note, 2026-07-16: Issue #178 is that separate 0.0.27 release PR. It must prove the version is unpublished, retain exact coverage and all four platform results, and use the existing merge-triggered tag plus tag-triggered Trusted Publishing workflows. Local publish or manual tag creation remains forbidden; npm provenance and `gitHead` must match the immutable release merge commit before workspace integration starts.
 
 Use this document for:
 

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: 65a446a8650ec2aa5712d6d13dbab57a400b433d
+lastReviewedCommit: 7c9a252226fb411d3ffba2f2e4f37b91b9658be8
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -58,6 +58,8 @@ Review note, 2026-07-15: Issue #171's protected freeze/seal commands require no 
 Review note, 2026-07-16: Issue #175's bounded preflight clock-skew fix requires no new secret, environment, Trusted Publisher setting, workflow, tag rule, credential, or database change. It follows the unchanged feature-then-patch-release path.
 
 Review note, 2026-07-16: Issue #177's test-only Windows portability changes require no new secret, environment, runner configuration, Trusted Publisher setting, workflow, tag rule, credential, or database change.
+
+Review note, 2026-07-16: Issue #178 publishes 0.0.27 through the existing merge-triggered tag and npm Trusted Publishing workflows. It requires no new secret, environment, runner, Trusted Publisher setting, workflow, tag rule, credential, or database change.
 
 Review note, 2026-07-13: exact-count maintenance pagination requires no repository secret, Trusted Publisher, environment, workflow filename, or tag-semantics change.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/cli",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.101.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "Unified TianGong LCA CLI with direct REST adapters and low-entropy command surface.",
   "repository": {
     "type": "git",

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1064,7 +1064,7 @@ test('executeCli separates production read-only freeze from offline approval sea
     outDir: './protected-freeze',
     expectedProjectRef: 'production-ref',
     confirm: 'bafudata@126.com',
-    cliVersion: '0.0.26',
+    cliVersion: '0.0.27',
     pageSize: 250,
     timeoutMs: 12000,
     env: deps.env,


### PR DESCRIPTION
Closes #178

## Summary

- bump `@tiangong-lca/cli` from 0.0.26 to 0.0.27
- update the one package-version dispatch fixture
- record the Docpact-required release review against merge baseline `7c9a252226fb411d3ffba2f2e4f37b91b9658be8`

## Key decisions

- keep the release diff to exactly nine files
- preserve historical self-contained 0.0.26 protected-evidence fixtures
- leave source, dependencies, workflows, database behavior, and protected execution unchanged
- rely only on the existing merge-triggered tag and Trusted Publishing workflows; never publish or create the tag locally

## Validation

- 0.0.27 unpublished check: passed
- release tag-name check: passed; remote tag absent
- `npm ci`: passed
- focused CLI fixture: 105/105
- `npm test`: 926/926
- `npm run prepush:gate`: passed
- exact coverage: 100% statements, branches, functions, and lines
- Docpact strict/enforce and repository gate: zero diagnostics
- `npm pack --dry-run --json`: 1,442,248 bytes, 238 entries
- independent read-only release diff review: no blockers

A fresh four-platform quality matrix and AI Doc Lint run are required before merge.

## Risks / rollback

If npm 0.0.27 or `cli-v0.0.27` appears before merge, stop; do not move a tag or overwrite a package. Before merge, rollback is simply closing this PR. After merge, release evidence must be verified rather than republishing locally.

## Follow-ups

- verify `cli-v0.0.27`, Trusted Publishing, npm `latest`, `gitHead`, integrity, and provenance
- only after registry verification, pin the exact release commit through tiangong-lca/workspace#408
- only after workspace integration, generate a fresh production BAFU freeze

## Workspace integration

Pending in tiangong-lca/workspace#408.