### PR TITLE
fix: bridge protected derivative hash domains

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -9,8 +9,9 @@ layout: repo
 # Review note, 2026-07-16: Issue #175 changes only the protected preflight proof's bounded client clock-skew validation and safe timing diagnostics. Existing dataset-maintenance and test wildcards already cover the implementation, tests, and governed docs; no ownership, routing, dependency, auth, database, or release-rule change is required.
 # Review note, 2026-07-16: Issue #177 removes Windows-only assumptions from existing CLI tests. The same test and validation wildcards cover native path handling, deterministic spawn doubles, and platform-appropriate permission assertions; no runtime, ownership, routing, dependency, auth, database, protected-execution, or release-rule change is required.
 # Review note, 2026-07-16: Issue #178 is the dedicated 0.0.27 package-version release after Issues #175 and #177. It changes only package metadata, the package-version dispatch fixture, and governed review records; ownership, routing, dependencies, protected execution, database behavior, tag automation, Trusted Publishing, and workspace-integration rules remain unchanged.
+# Review note, 2026-07-16: Issue #182 corrects the protected verifier's cross-hash-domain comparison inside the existing dataset-maintenance runtime and tests. Existing wildcards and ownership cover the CLI-plan, database action-evidence, derivative-snapshot, and terminal-proof bridge; no routing, dependency, auth, database, release, or integration rule changes are required.
 lastReviewedAt: "2026-07-16"
-lastReviewedCommit: "7c9a252226fb411d3ffba2f2e4f37b91b9658be8"
+lastReviewedCommit: "e8a458c63a4c59d7ea1fcf4618cd5034ead6e836"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: 7c9a252226fb411d3ffba2f2e4f37b91b9658be8
+lastReviewedCommit: e8a458c63a4c59d7ea1fcf4618cd5034ead6e836
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -74,6 +74,8 @@ Review note, 2026-07-16: Issue #175 keeps protected preflight validation fail-cl
 Review note, 2026-07-16: Issue #177 changes tests only: native path helpers replace POSIX separators, the default-spawn failure uses a guaranteed-missing temporary executable, successful spawn remains injected, and POSIX mode-bit assertions run only where those semantics exist. Runtime behavior, raw protected bytes, ownership, release, and workspace-integration boundaries are unchanged.
 
 Review note, 2026-07-16: Issue #178 is the dedicated 0.0.27 version-bump release for the merged protected clock-skew fix and Windows-portable validation suite. It adds no command, runtime, dependency, approval, database, or alternate publication path; automated tag creation, Trusted Publishing, and exact released-commit workspace integration remain mandatory.
+
+Review note, 2026-07-16: Issue #182 corrects only the terminal protected verifier's JSON hash-domain bridge. Independent RLS rows remain bound to the approved plan with the CLI canonical hash; the already closure-hash-validated primary action evidence binds PostgreSQL `jsonb::text` hashes to the fresh derivative snapshot; and the snapshot SHA remains bound to the terminal completion proof. Cross-domain hashes are never compared directly. Missing, duplicate, foreign, invalid, or drifting evidence still fails closed, and admission, ownership, database, release, and workspace-integration boundaries are unchanged.
 
 ## Bootstrap Order
 

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -19,7 +19,7 @@ checkPaths:
   - scripts/**
   - .github/workflows/**
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: c44415cacc78fea6ac63dfe256d748cb6ab95782
+lastReviewedCommit: e8a458c63a4c59d7ea1fcf4618cd5034ead6e836
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -52,6 +52,8 @@ Review note, 2026-07-15: `dataset maintenance run-protected` 为已经冻结和�
 Review note, 2026-07-15: `dataset maintenance freeze-protected` 与 `seal-protected-approval` 补齐 protected runner 之前的准备链。freeze 使用既有用户 session 直接对显式确认的 production project 做只读 census/support/50-target snapshot，且不会 preflight、gate、admit 或 mutate；seal 不接收 env、session 或网络 client，只按人类返回原始 UTF-8 字节及显式 hash/account/timestamp 生成 approval。二者不新增依赖、认证变量或发布路径。
 
 Review note, 2026-07-16: Issue #175 只修正 `run-protected` 对服务端领先本机时钟的有界判断：`completed_at` 最多允许领先 5 秒，过期、时间倒序、超过 180 秒与一次性 admission 约束不变。它不新增 env、依赖、认证路径、命令面或发布机制。
+
+Review note, 2026-07-16: Issue #182 只修正 protected 终态 verifier 的跨 JSON 序列化域比较，复用现有 plan、primary closure、RLS readback、snapshot 与 terminal proof；不新增 env、依赖、命令、认证、数据库/RPC 或发布机制。feature PR 不改包版本，后续仍通过独立 patch release、npm provenance 和 root integration 后才对既有 request 做 `--status-only`。
 
 设计原则：
 

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -17,7 +17,7 @@ checkPaths:
   - src/**
   - test/**
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: c44415cacc78fea6ac63dfe256d748cb6ab95782
+lastReviewedCommit: e8a458c63a4c59d7ea1fcf4618cd5034ead6e836
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -39,6 +39,8 @@ Review note, 2026-07-15: `dataset maintenance run-protected` 为 seal 绑定且�
 Review note, 2026-07-15: `dataset maintenance freeze-protected` 与 `seal-protected-approval` 把生产只读冻结和人工批准记录拆成两个不可混淆的命令。前者只对显式确认的 production project 做完整 owner-draft census/support/projected-reference 与 23+27 derivative snapshot 读取，输出未批准请求，绝不 preflight/gate/admit/mutate；后者不接收 env 或 HTTP client，只按原始 UTF-8 字节核对人类返回文本及 freeze/request/text/account/timestamp 后生成 approval。真正执行仍只属于后续 `run-protected`。
 
 Review note, 2026-07-16: `run-protected` 的 preflight proof 客户端时间校验允许服务端 `completed_at` 最多领先本机 5 秒，仅用于吸收正常时钟偏差。过期、时间倒序、超过 180 秒、foreign 或 malformed proof 仍在 gate/marker/admission 前阻断；数据库继续用 server clock 强制 token 到期与一次性消费。错误只输出 `completed_at`、`expires_at`、观察时间和差值等无 token 诊断，不持久化或暴露 preflight token。
+
+Review note, 2026-07-16: Issue #182 修正 protected 终态验证中的 JSON hash 域混用。独立 RLS row 继续用 CLI canonical hash 对齐 approved plan；已经过 closure SHA 校验的 primary `action_evidence` 用 PostgreSQL `jsonb::text` hash 对齐 fresh derivative snapshot；snapshot SHA 再对齐 terminal completed proof。不同序列化域不直接比较，证据缺失、重复、身份/owner/state/JSON 标志错误或任一同域 hash 漂移仍 fail-closed；数据库/RPC 与一次性 admission 契约不变。
 
 ## 1. 目标
 
@@ -414,7 +416,7 @@ Alias plan RPC 在同一事务中锁定 target/source support 与全部 action r
 
 上述 alias plan RPC/replay 描述属于原 V1 artifact 兼容契约，不再是 seal 绑定 production 执行的授权路径。`run-protected` 的执行顺序固定为：校验 plan/freeze/approval 与 production project；在 preflight 前完成完整 current-user RLS before-state、support 与 50-target baseline 校验；只调用一次 server preflight，接受服务器派生的三项 gate 期望摘要和最长 180 秒 token；捕获并核对 live gate receipt；以私有 immutable 文件写入 submission marker；立即发送最多一次 admission POST；服务器以认证 actor、精确 user_id/state_code=0、冻结目标集与 plan/closure 栅栏约束写入；之后状态读取只调用带 `auth.uid`、actor 与 plan 栅栏的受保护 RPC，独立表级读回才使用 RLS。`--status-only` 永远不调用 preflight/admit。marker 已存在、admission timeout、响应丢失或服务器记录不明确时，结果为 `indeterminate` 或后续只读状态，绝不再次 admission；状态读取异常仅在配置等待窗口内按默认 10 秒间隔重试，不会触发 admission 重试。
 
-`run-protected` 只有在数据库终态与独立 RLS readback 同时证明 approved identity、唯一 attempt/dispatch、52 row + 2 batch + 1 plan 的 55 条 audit closure、59 条 exchange closure、精确 23 flows + 27 processes derivative targets，以及 markdown/embedding 因果与 live hash 一致时才输出 `passed`。任一 target 未完成但 proof 结构有效为 `pending`；明确 stale/failure/mismatch 为 `failed`；传输、schema/status 或 marker/server 记录不明确为 `indeterminate`。四态中只有 `passed` 返回 0。
+`run-protected` 只有在数据库终态与独立 RLS readback 同时证明 approved identity、唯一 attempt/dispatch、52 row + 2 batch + 1 plan 的 55 条 audit closure、59 条 exchange closure、精确 23 flows + 27 processes derivative targets，以及 markdown/embedding 因果与同域 hash 证据链一致时才输出 `passed`。其中 RLS live row 的 CLI canonical hash 必须等于 approved payload，primary closure 中 exact/unique/valid action evidence 的 PostgreSQL-domain desired/live hashes 必须彼此相等并等于 fresh snapshot 的 `json_ordered` hash，fresh snapshot SHA 必须等于 terminal completed snapshot proof；CLI 与 PostgreSQL 两种序列化 hash 不直接相等比较。任一 target 未完成但 proof 结构有效为 `pending`；明确 stale/failure/mismatch 为 `failed`；传输、schema/status 或 marker/server 记录不明确为 `indeterminate`。四态中只有 `passed` 返回 0。
 
 Derivative rebuild guarded RPC 必须在 admission 时重新校验 authenticated actor、owner-draft state、exact identity 与 plan-bound action snapshot，并返回 durable request/proof。相同计划重放必须复用原 request，不得生成第二个任务。`accepted`/`queued` 只表示重建请求已受理，不能写成 `completed`；CLI 没有 direct Edge、`admin embedding-run`、raw queue、SQL、service-role 或 raw REST mutation 降级路径。
 

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -18,7 +18,7 @@ checkPaths:
   - src/**
   - test/**
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: c44415cacc78fea6ac63dfe256d748cb6ab95782
+lastReviewedCommit: e8a458c63a4c59d7ea1fcf4618cd5034ead6e836
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -52,6 +52,7 @@ related:
 - 2026-07-15 复核：`dataset maintenance run-protected` 继续由 TypeScript / Node 原生 CLI 负责 sealed request、一次 admission、本地 immutable evidence 与只读恢复；不新增 Python、POSIX shell、MCP runtime、私有 skill runtime 或新 npm 依赖，skills 仍只能薄编排 CLI。
 - 2026-07-15 复核：`dataset maintenance freeze-protected` 与 `seal-protected-approval` 继续由 TypeScript / Node 原生 CLI 分别负责生产只读冻结和完全离线的人类批准记录；不新增 Python、POSIX shell、MCP runtime、私有 skill runtime 或 npm 依赖。Foundry/skills 只能调用已发布 CLI 并保留其产物，不得读取数据库 env、直调 RPC、重算 canonical JSON/hash 或复制 freeze/seal 逻辑。
 - 2026-07-16 复核：Issue #175 只在 TypeScript protected contract parser 中加入固定 5 秒的服务端领先时钟容差与无 token 诊断；不新增 Python、POSIX shell、MCP runtime、私有 skill runtime 或 npm 依赖，也不改变 skills 薄调用边界。
+- 2026-07-16 复核：Issue #182 只在 TypeScript protected verifier 内用既有 primary action evidence 修正 JSON hash 域桥接；不新增 Python、POSIX shell、MCP runtime、私有 skill runtime 或 npm 依赖，也不改变 skills 薄调用边界。
 
 这份文档记录的是：
 

--- a/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
+++ b/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
@@ -16,7 +16,7 @@ checkPaths:
   - src/lib/supabase-session.ts
   - src/lib/supabase-client.ts
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: c44415cacc78fea6ac63dfe256d748cb6ab95782
+lastReviewedCommit: e8a458c63a4c59d7ea1fcf4618cd5034ead6e836
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -42,6 +42,7 @@ related:
 - 2026-07-15 复核：`dataset maintenance run-protected` 继续复用同一用户 session、publishable key 与 authenticated PostgREST RPC。CLI 不持有 service-role；服务器调度的内部执行器不改变 CLI bearer/env contract。状态读取仍绑定 `auth.uid()`、actor 与 plan，独立表读回继续走用户 RLS；本历史设计结论不变。
 - 2026-07-15 复核：`dataset maintenance freeze-protected` 只复用现有用户 session，对显式确认的 production project 做 RLS 表读取与受保护 derivative snapshot RPC；不新增 service-role、alternate bearer、Edge/admin 或 Dev 回放链。`seal-protected-approval` 的 CLI dispatch 不传 env、session、HTTP 或 remote client，完全离线；本历史设计结论不变。
 - 2026-07-16 复核：Issue #175 只调整已认证 preflight proof 的本地时间边界判断，不改变用户 API key、publishable key、session cache、bearer、RLS、RPC 或 service-role 边界；本历史设计结论不变。
+- 2026-07-16 复核：Issue #182 只调整同一已认证状态响应、RLS readback 与 snapshot proof 的本地 hash 域桥接，不改变用户 API key、publishable key、session cache、bearer、RLS、RPC 或 service-role 边界；本历史设计结论不变。
 
 ## 1. 已确认事实
 

--- a/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
+++ b/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
@@ -17,7 +17,7 @@ checkPaths:
   - src/lib/tidas-sdk-package-validator.ts
   - test/**
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: c44415cacc78fea6ac63dfe256d748cb6ab95782
+lastReviewedCommit: e8a458c63a4c59d7ea1fcf4618cd5034ead6e836
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -44,6 +44,8 @@ related:
 - 直到 repo 级验证、PR、workspace integration 全部完成，才算结束。
 
 当前状态：
+
+2026-07-16 复核：Issue #182 的 protected verifier hash 域桥接只使用现有 TypeScript、plan/closure evidence 与 SHA 校验能力，不新增或改变 Supabase JS、TIDAS SDK 或其他直接依赖；本文件继续保持历史 TODO 记录用途。
 
 2026-07-16 复核：Issue #175 的 protected preflight 时钟边界修复只使用现有 TypeScript、`Date` 与 `CliError` 能力，不新增或改变 Supabase JS、TIDAS SDK 或其他直接依赖；本文件继续保持历史 TODO 记录用途。
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: 7c9a252226fb411d3ffba2f2e4f37b91b9658be8
+lastReviewedCommit: e8a458c63a4c59d7ea1fcf4618cd5034ead6e836
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -67,6 +67,8 @@ Review note, 2026-07-16: Issue #175 remains inside `protected-contract` parsing 
 Review note, 2026-07-16: Issue #177 modifies only `test/**` portability assumptions. Native path helpers, a guaranteed-missing temporary executable for the default-spawn failure path, an injected successful spawn, and platform-appropriate permission assertions preserve the existing launcher, artifact, protected-maintenance, dependency, and release architecture.
 
 Review note, 2026-07-16: Issue #178 changes the package version to 0.0.27 and updates the one package-version dispatch fixture. No command family, launcher, session, artifact, protected-maintenance, dependency, tag, publication, or workspace-integration architecture changes.
+
+Review note, 2026-07-16: Issue #182 remains entirely inside `dataset-maintenance-protected-verify`. It replaces one invalid cross-serialization equality with an exact three-part proof bridge: CLI-canonical RLS row to approved plan, PostgreSQL-domain primary action evidence to fresh derivative snapshot, and snapshot SHA to terminal completion proof. It adds no runtime, adapter, artifact schema, RPC, database, dependency, or command surface.
 
 ## Stable Path Map
 
@@ -186,7 +188,7 @@ The row-level maintenance family is deliberately split by responsibility:
 - `protected-freeze` owns production-authenticated read-only preparation. It performs no server preflight, gate, admission, execution, or mutation call and writes only an unapproved alias request, complete 50-row baseline, freeze, approval request text/JSON, and zero-write report.
 - `protected-seal` owns completely offline approval recording. It receives no environment or remote client, preserves the human-returned UTF-8 bytes exactly, verifies explicit freeze/request/text/account/timestamp bindings, and writes approval artifacts without submitting execution.
 - `protected-run` owns the production-only full scan, server preflight, three ordered gate receipts, immutable attempt allocation, single admission transport, and status-only recovery state machine. Commit mode shares the preparation denylist so superseded historical approvals cannot bypass a fresh freeze; it never retries admission or falls back to Dev or the legacy whole-plan alias RPC.
-- `protected-verify` owns the terminal server proof plus independent current-user RLS cross-read of primary rows, audits, and all 23 flow + 27 process derivative snapshots. Local artifacts or a server status alone cannot produce `passed`.
+- `protected-verify` owns the terminal server proof plus independent current-user RLS cross-read of primary rows, audits, and all 23 flow + 27 process derivative snapshots. It compares only like-for-like hash domains: RLS canonical JSON to the approved plan, closure-hash-validated database action evidence to database snapshots, and snapshot SHA to terminal completion. Local artifacts or a server status alone cannot produce `passed`.
 - `alias-rewrite` owns the fixed two-dimension BAFU profile, reviewed target-reference derivation, closure counting, and arbitrary-precision decimal scaling. It never uses JavaScript binary floating point for exchange amounts.
 - `support-validation` validates frozen owner-draft FP/UG payload schemas plus embedded root UUID/version without importing publication behavior.
 - `plan` requires a complete exact-count account scan before writing `maintenance-scope.json`, `rls-visible-snapshot.json`, `protected-rows.jsonl`, `reference-impact-report.json`, `maintenance-plan.json`, and `dry-run-report.json`; newly generated plans bind the aggregate completeness proof into the plan hash. Alias plans additionally freeze `exchange-rewrite-plan.jsonl`, three support snapshots per batch, per-process exchange locators/hashes, desired payloads, and exact postconditions. Derivative rebuild plans additionally bind a database-produced snapshot for only the one target action; markdown/vector fields do not expand the account-wide scan.

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: 7c9a252226fb411d3ffba2f2e4f37b91b9658be8
+lastReviewedCommit: e8a458c63a4c59d7ea1fcf4618cd5034ead6e836
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -87,6 +87,8 @@ Review note, 2026-07-15: Issue #171 preparation proof additionally requires a st
 Review note, 2026-07-16: Issue #175 proof requires a fixed five-second allowance only when server `completed_at` is slightly ahead of the client clock. Tests must accept the exact tolerance boundary, reject one millisecond beyond it, retain strict stale/reversed/over-180-second rejection, expose only token-free timing diagnostics, and prove parse failure still occurs before gate capture, submission-marker creation, or admission. Server-side expiry and one-shot enforcement are unchanged.
 
 Review note, 2026-07-16: Issue #177 keeps the validation contract unchanged while making existing tests portable across the four-platform quality matrix. Tests use native path helpers and deterministic spawn doubles; POSIX permission-bit checks remain required on non-Windows platforms, while byte preservation, immutability, hashing, and overwrite rejection remain required everywhere.
+
+Review note, 2026-07-16: Issue #182 adds a production-shaped protected-verifier regression in which the CLI canonical payload hash deliberately differs from the PostgreSQL `jsonb::text` hash. Passing proof must bind RLS live row to the approved plan in the CLI domain, exact unique valid primary `action_evidence` to the fresh snapshot in the database domain, and snapshot SHA to terminal completion. Missing, duplicate, foreign, wrong-action, false owner/state/JSON flags, malformed or unequal hashes, and snapshot/terminal drift must all remain fail-closed. Exact `src/**/*.ts` coverage remains 100%.
 
 Review note, 2026-07-16: Issue #178 keeps the validation contract unchanged for the dedicated 0.0.27 release. In addition to the existing exact-coverage and pre-push gates, release proof requires an unpublished-version check, tag-name check, dry-run package inspection, a fresh four-platform matrix, and Docpact with no diagnostics before merge.
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: 7c9a252226fb411d3ffba2f2e4f37b91b9658be8
+lastReviewedCommit: e8a458c63a4c59d7ea1fcf4618cd5034ead6e836
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -46,6 +46,8 @@ Review note, 2026-07-16: Issue #175 fixes bounded client clock-skew validation w
 Review note, 2026-07-16: Issue #177 changes only cross-platform tests needed to make the existing four-platform quality matrix authoritative. It does not alter package metadata, tag creation, Trusted Publishing, release eligibility, protected-execution behavior, or the requirement for a separate 0.0.27 release PR after all matrix jobs pass.
 
 Review note, 2026-07-16: Issue #178 is that separate 0.0.27 release PR. It must prove the version is unpublished, retain exact coverage and all four platform results, and use the existing merge-triggered tag plus tag-triggered Trusted Publishing workflows. Local publish or manual tag creation remains forbidden; npm provenance and `gitHead` must match the immutable release merge commit before workspace integration starts.
+
+Review note, 2026-07-16: Issue #182 fixes the protected terminal verifier without changing package metadata or release mechanics. Its feature PR must pass the production-shaped cross-hash-domain regression, exact coverage, docpact, and the full pre-push gate. Only after it merges may a separate patch version-bump PR use the existing tag and Trusted Publishing workflows; npm provenance and exact root-workspace integration must be verified before the existing protected request receives one status-only readback.
 
 Use this document for:
 

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: 7c9a252226fb411d3ffba2f2e4f37b91b9658be8
+lastReviewedCommit: e8a458c63a4c59d7ea1fcf4618cd5034ead6e836
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -60,6 +60,8 @@ Review note, 2026-07-16: Issue #175's bounded preflight clock-skew fix requires 
 Review note, 2026-07-16: Issue #177's test-only Windows portability changes require no new secret, environment, runner configuration, Trusted Publisher setting, workflow, tag rule, credential, or database change.
 
 Review note, 2026-07-16: Issue #178 publishes 0.0.27 through the existing merge-triggered tag and npm Trusted Publishing workflows. It requires no new secret, environment, runner, Trusted Publisher setting, workflow, tag rule, credential, or database change.
+
+Review note, 2026-07-16: Issue #182's protected-verifier hash-domain fix requires no new secret, environment, runner, Trusted Publisher setting, workflow, tag rule, credential, or database change. It follows the unchanged feature-then-patch-release path.
 
 Review note, 2026-07-13: exact-count maintenance pagination requires no repository secret, Trusted Publisher, environment, workflow filename, or tag-semantics change.
 

--- a/src/lib/dataset-maintenance-protected-verify.ts
+++ b/src/lib/dataset-maintenance-protected-verify.ts
@@ -47,6 +47,22 @@ export type ProtectedLiveDerivativeReadback = {
   embedding_ft_at: string;
 };
 
+type ProtectedPrimaryActionEvidence = {
+  action_id: string;
+  table: 'flowproperties' | 'flows' | 'processes';
+  id: string;
+  version: string;
+  row_found: true;
+  owner_matches: true;
+  state_code_matches: true;
+  json_matches: true;
+  json_ordered_matches: true;
+  desired_json_ordered_sha256: string;
+  live_json_sha256: string;
+  live_json_ordered_sha256: string;
+  valid: true;
+};
+
 export type ProtectedVerificationResult = {
   status: ProtectedReportStatus;
   issues: ProtectedVerificationIssue[];
@@ -68,6 +84,79 @@ function issue(code: string, message: string, details?: unknown): ProtectedVerif
 
 function requiredString(value: unknown): string | null {
   return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function parsePrimaryActionEvidence(value: unknown): ProtectedPrimaryActionEvidence | null {
+  if (!isJsonObject(value)) return null;
+  const actionId = requiredString(value.action_id);
+  const id = requiredString(value.id);
+  const version = requiredString(value.version);
+  const desiredJsonOrderedSha256 = requiredString(value.desired_json_ordered_sha256);
+  const liveJsonSha256 = requiredString(value.live_json_sha256);
+  const liveJsonOrderedSha256 = requiredString(value.live_json_ordered_sha256);
+  if (
+    !actionId ||
+    (value.table !== 'flowproperties' && value.table !== 'flows' && value.table !== 'processes') ||
+    !id ||
+    !version ||
+    value.row_found !== true ||
+    value.owner_matches !== true ||
+    value.state_code_matches !== true ||
+    value.json_matches !== true ||
+    value.json_ordered_matches !== true ||
+    !desiredJsonOrderedSha256 ||
+    !SHA256.test(desiredJsonOrderedSha256) ||
+    !liveJsonSha256 ||
+    !SHA256.test(liveJsonSha256) ||
+    !liveJsonOrderedSha256 ||
+    !SHA256.test(liveJsonOrderedSha256) ||
+    value.valid !== true
+  ) {
+    return null;
+  }
+  return {
+    action_id: actionId,
+    table: value.table,
+    id,
+    version,
+    row_found: true,
+    owner_matches: true,
+    state_code_matches: true,
+    json_matches: true,
+    json_ordered_matches: true,
+    desired_json_ordered_sha256: desiredJsonOrderedSha256,
+    live_json_sha256: liveJsonSha256,
+    live_json_ordered_sha256: liveJsonOrderedSha256,
+    valid: true,
+  };
+}
+
+function indexPrimaryActionEvidence(options: {
+  closure: unknown;
+  plan: DatasetMaintenancePlan;
+}): Map<string, ProtectedPrimaryActionEvidence> | null {
+  if (!isJsonObject(options.closure) || !Array.isArray(options.closure.action_evidence)) {
+    return null;
+  }
+  if (options.closure.action_evidence.length !== options.plan.actions.length) return null;
+  const byKey = new Map<string, ProtectedPrimaryActionEvidence>();
+  const actionIds = new Set<string>();
+  for (const raw of options.closure.action_evidence) {
+    const evidence = parsePrimaryActionEvidence(raw);
+    if (!evidence) return null;
+    const key = maintenanceRowKey(evidence);
+    if (byKey.has(key) || actionIds.has(evidence.action_id)) return null;
+    byKey.set(key, evidence);
+    actionIds.add(evidence.action_id);
+  }
+  if (
+    options.plan.actions.some(
+      (action) => byKey.get(maintenanceRowKey(action))?.action_id !== action.action_id,
+    )
+  ) {
+    return null;
+  }
+  return byKey;
 }
 
 export function inspectProtectedLiveDerivative(
@@ -439,6 +528,7 @@ function matchLiveTargets(options: {
   proofs: ProtectedTerminalTargetProof[];
   live: ProtectedLiveDerivativeReadback[];
   snapshots: ProtectedDerivativeSnapshot[];
+  primaryClosure: unknown;
   plan: DatasetMaintenancePlan;
   identity: ProtectedExecutionIdentity;
 }): ProtectedVerificationIssue[] {
@@ -450,6 +540,10 @@ function matchLiveTargets(options: {
   const actions = new Map(
     options.plan.actions.map((action) => [maintenanceRowKey(action), action]),
   );
+  const primaryEvidence = indexPrimaryActionEvidence({
+    closure: options.primaryClosure,
+    plan: options.plan,
+  });
   const issues: ProtectedVerificationIssue[] = [];
   const expectedKeys = new Set(options.identity.derivative_targets.map(terminalTargetKey));
   const liveKeys = options.live.map(terminalTargetKey);
@@ -474,17 +568,21 @@ function matchLiveTargets(options: {
     const proof = proofs.get(key);
     const snapshot = snapshots.get(key);
     const action = actions.get(key);
+    const evidence = primaryEvidence?.get(key);
     if (
       !row ||
       !proof ||
       !snapshot ||
       !action?.desired_payload ||
+      !evidence ||
       row.user_id !== options.identity.actor.user_id ||
       row.state_code !== 0 ||
       snapshot.user_id !== options.identity.actor.user_id ||
       snapshot.state_code !== 0 ||
       row.json_ordered_sha256 !== action.desired_payload.sha256 ||
-      snapshot.json_ordered_sha256 !== row.json_ordered_sha256 ||
+      evidence.live_json_sha256 !== evidence.desired_json_ordered_sha256 ||
+      evidence.live_json_ordered_sha256 !== evidence.desired_json_ordered_sha256 ||
+      snapshot.json_ordered_sha256 !== evidence.desired_json_ordered_sha256 ||
       snapshot.snapshot_sha256 !== proof.completed_snapshot_sha256 ||
       !snapshot.extracted_md_sha256 ||
       !snapshot.embedding_ft_sha256 ||
@@ -657,6 +755,7 @@ async function verifyProtectedExecutionWithDependencies(
         proofs: terminalProofs,
         live: validLive,
         snapshots,
+        primaryClosure: options.proof.primary_readback?.closure,
         plan: options.plan,
         identity: options.identity,
       }),

--- a/test/dataset-maintenance-protected-verify.test.ts
+++ b/test/dataset-maintenance-protected-verify.test.ts
@@ -72,6 +72,55 @@ function derivativeTargets(): ProtectedDerivativeTarget[] {
   ];
 }
 
+function protectedActionTargets(targets: ProtectedDerivativeTarget[]) {
+  return [
+    {
+      table: 'flowproperties' as const,
+      id: '44444444-4444-4444-8444-444444444441',
+      version: VERSION,
+    },
+    {
+      table: 'flowproperties' as const,
+      id: '44444444-4444-4444-8444-444444444442',
+      version: VERSION,
+    },
+    ...targets.map(({ table, id, version }) => ({ table, id, version })),
+  ];
+}
+
+function databaseJsonbHash(target: { table: string; id: string; version: string }): string {
+  return sha256Json({
+    hash_domain: 'postgres_jsonb_text',
+    table: target.table,
+    id: target.id,
+    version: target.version,
+  });
+}
+
+function primaryActionEvidence(executionIdentity: ProtectedExecutionIdentity): JsonObject[] {
+  return protectedActionTargets(executionIdentity.derivative_targets).map((target, index) => {
+    const databaseHash = databaseJsonbHash(target);
+    return {
+      batch_ordinality: index < 2 ? 1 : 2,
+      action_ordinality: index + 1,
+      dimension: index < 2 ? 'time' : 'length_time',
+      action_id: `action-${String(index + 1).padStart(2, '0')}`,
+      table: target.table,
+      id: target.id,
+      version: target.version,
+      row_found: true,
+      owner_matches: true,
+      state_code_matches: true,
+      json_matches: true,
+      json_ordered_matches: true,
+      desired_json_ordered_sha256: databaseHash,
+      live_json_sha256: databaseHash,
+      live_json_ordered_sha256: databaseHash,
+      valid: true,
+    };
+  });
+}
+
 function identity(targets = derivativeTargets()): ProtectedExecutionIdentity {
   return {
     request_id: '33333333-3333-4333-8333-333333333333',
@@ -167,17 +216,7 @@ function scenario() {
   const planDir = mkdtempSync(path.join(os.tmpdir(), 'protected-verify-'));
   mkdirSync(path.join(planDir, 'payloads'));
   const targets = derivativeTargets();
-  const actionTargets = [
-    {
-      table: 'flowproperties' as const,
-      id: '44444444-4444-4444-8444-444444444441',
-    },
-    {
-      table: 'flowproperties' as const,
-      id: '44444444-4444-4444-8444-444444444442',
-    },
-    ...targets.map(({ table, id }) => ({ table, id })),
-  ];
+  const actionTargets = protectedActionTargets(targets);
   const beforeRows: DatasetMaintenanceRemoteRow[] = [];
   const finalRows: DatasetMaintenanceRemoteRow[] = [];
   const actions = actionTargets.map((target, index) => {
@@ -283,7 +322,10 @@ function gateReceipts(): ProtectedExecutionStatusProof['gates'] {
   }));
 }
 
-function auditClosure(actorUserId = USER_ID): JsonObject {
+function auditClosure(
+  actorUserId = USER_ID,
+  executionIdentity: ProtectedExecutionIdentity = identity(),
+): JsonObject {
   const proofMaterial: JsonObject = {
     schema_version: 'dataset-alias-primary-closure.v1',
     actor_user_id: actorUserId,
@@ -299,7 +341,7 @@ function auditClosure(actorUserId = USER_ID): JsonObject {
     source_unitgroup_support_count: 2,
     invalid_action_count: 0,
     invalid_support_count: 0,
-    action_evidence: Array.from({ length: 52 }, (_, index) => ({ ordinal: index + 1 })),
+    action_evidence: primaryActionEvidence(executionIdentity),
     support_evidence: Array.from({ length: 6 }, (_, index) => ({ ordinal: index + 1 })),
     live_closure_proof: true,
   };
@@ -451,7 +493,7 @@ function proof(
             exchange_count: 59,
             alias_audit_count: 55,
             live_closure_proof: true,
-            closure: auditClosure(),
+            closure: auditClosure(USER_ID, executionIdentity),
           }
         : null,
     derivative_readback: derivativeReadback,
@@ -500,7 +542,8 @@ function liveRows(s: Scenario): DatasetMaintenanceDerivativeRemoteRow[] {
 function snapshots(s: Scenario): ProtectedDerivativeSnapshot[] {
   return s.identity.derivative_targets.map((target) => {
     const payload = desiredPayloadByTarget(s, target.table, target.id);
-    const payloadHash = sha256Json(payload);
+    const payloadHash = databaseJsonbHash(target);
+    assert.notEqual(payloadHash, sha256Json(payload));
     return {
       schema_version: 'dataset-derivative-snapshot.v1',
       table: target.table,
@@ -950,19 +993,27 @@ test('matchLiveTargets requires exact unique live/snapshot sets and completed sn
     const terminalProofs = terminalTargets(s.identity);
     const validLive = liveReadbacks(s);
     const validSnapshots = snapshots(s);
+    const validPrimaryClosure = auditClosure(USER_ID, s.identity);
     const verify = (
       live: ProtectedLiveDerivativeReadback[] = validLive,
       snapshotRows: ProtectedDerivativeSnapshot[] = validSnapshots,
       proofs: ProtectedTerminalTargetProof[] = terminalProofs,
       plan: DatasetMaintenancePlan = s.plan,
+      primaryClosure: unknown = validPrimaryClosure,
     ) =>
       __testInternals.matchLiveTargets({
         proofs,
         live,
         snapshots: snapshotRows,
+        primaryClosure,
         plan,
         identity: s.identity,
       });
+    assert.ok(
+      validLive.every(
+        (row, index) => row.json_ordered_sha256 !== validSnapshots[index]!.json_ordered_sha256,
+      ),
+    );
     assert.deepEqual(verify(), []);
 
     const setMutations: Array<[ProtectedLiveDerivativeReadback[], ProtectedDerivativeSnapshot[]]> =
@@ -1002,6 +1053,77 @@ test('matchLiveTargets requires exact unique live/snapshot sets and completed sn
       const rows = copy(validSnapshots);
       mutate(rows[0]!);
       assert.ok(issueCodes(verify(validLive, rows)).includes('PROTECTED_DERIVATIVE_LIVE_MISMATCH'));
+    }
+
+    const primaryClosureShapeMutations: Array<(closure: JsonObject) => void> = [
+      (closure) => (closure.action_evidence = {}),
+      (closure) => (closure.action_evidence = (closure.action_evidence as JsonObject[]).slice(1)),
+      (closure) => ((closure.action_evidence as unknown[])[2] = null),
+      (closure) => {
+        const evidence = closure.action_evidence as JsonObject[];
+        evidence[3] = copy(evidence[2]!);
+      },
+      (closure) => {
+        const evidence = closure.action_evidence as JsonObject[];
+        evidence[3]!.action_id = evidence[2]!.action_id;
+      },
+      (closure) =>
+        ((closure.action_evidence as JsonObject[])[2]!.id = '99999999-9999-4999-8999-999999999999'),
+      (closure) => ((closure.action_evidence as JsonObject[])[2]!.action_id = 'foreign-action'),
+    ];
+    for (const mutate of primaryClosureShapeMutations) {
+      const closure = copy(validPrimaryClosure);
+      mutate(closure);
+      assert.ok(
+        issueCodes(verify(validLive, validSnapshots, terminalProofs, s.plan, closure)).includes(
+          'PROTECTED_DERIVATIVE_LIVE_MISMATCH',
+        ),
+      );
+    }
+    assert.ok(
+      issueCodes(verify(validLive, validSnapshots, terminalProofs, s.plan, null)).includes(
+        'PROTECTED_DERIVATIVE_LIVE_MISMATCH',
+      ),
+    );
+
+    const invalidEvidenceValues: Array<[string, unknown]> = [
+      ['action_id', ''],
+      ['table', 'sources'],
+      ['id', ''],
+      ['version', ''],
+      ['row_found', false],
+      ['owner_matches', false],
+      ['state_code_matches', false],
+      ['json_matches', false],
+      ['json_ordered_matches', false],
+      ['desired_json_ordered_sha256', 'bad'],
+      ['live_json_sha256', 'bad'],
+      ['live_json_ordered_sha256', 'bad'],
+      ['valid', false],
+    ];
+    for (const [field, value] of invalidEvidenceValues) {
+      const closure = copy(validPrimaryClosure);
+      (closure.action_evidence as JsonObject[])[2]![field] = value;
+      assert.ok(
+        issueCodes(verify(validLive, validSnapshots, terminalProofs, s.plan, closure)).includes(
+          'PROTECTED_DERIVATIVE_LIVE_MISMATCH',
+        ),
+      );
+    }
+
+    const primaryHashMutations = [
+      'desired_json_ordered_sha256',
+      'live_json_sha256',
+      'live_json_ordered_sha256',
+    ];
+    for (const field of primaryHashMutations) {
+      const closure = copy(validPrimaryClosure);
+      (closure.action_evidence as JsonObject[])[2]![field] = HASH_F;
+      assert.ok(
+        issueCodes(verify(validLive, validSnapshots, terminalProofs, s.plan, closure)).includes(
+          'PROTECTED_DERIVATIVE_LIVE_MISMATCH',
+        ),
+      );
     }
 
     assert.ok(


### PR DESCRIPTION
Closes #182

## Summary
- Replace the invalid direct equality between CLI-canonical JSON and PostgreSQL jsonb::text hashes with an exact primary action-evidence bridge.
- Keep the independent RLS live-row-to-approved-plan check and the fresh-snapshot-to-terminal-proof check unchanged.
- Add production-shaped cross-domain regression coverage and fail-closed mutations for missing, duplicate, foreign, invalid, and drifting evidence.

## Key Decisions
- Use the already closure-SHA-validated primary_readback.closure.action_evidence as the database-domain bridge; do not implement a second PostgreSQL canonicalizer in the CLI.
- Validate all 52 action-evidence identities and action IDs as an exact unique set, even though only 50 actions have derivative targets.
- Keep the existing PROTECTED_DERIVATIVE_LIVE_MISMATCH output contract.

## Validation
- npm run prepush:gate passed: 926 tests, 922 passed, 4 skipped, 0 failed; statements, branches, functions, and lines all 100%.
- Docpact strict config and worktree lint passed with 13 changed paths, 13 matched rules, 11/11 fresh governed docs, and 0 diagnostics.
- Offline replay of the exact BAFU production artifacts found 50 targets, 0 cross-domain direct hash equalities, 0 issues with the fixed verifier, versus 50 issues in the prior CLI 0.0.27 terminal report.
- Independent review found no P0/P1/P2 issue and confirmed all 50 production action-evidence bridges match their fresh snapshots.

## Risks / Rollback
- The change never admits, mutates, rebuilds, rolls back, or reads production; it is verifier-only. Rollback is the single feature commit.
- The fix rejects malformed or incomplete bridge evidence and therefore remains fail-closed.

## Follow-ups
- After merge, create a separate patch-version release PR; verify tag, npm integrity, gitHead, and SLSA provenance.
- After exact root integration, run one status-only verification of existing request 26d8f820-5137-58fa-920e-fc171cdb813e. Never re-admit or reuse the approval.

## Workspace Integration
- Root integration is required only for the exact later patch release commit, not this unreleased feature commit.