### PR TITLE
chore: release cli 0.0.28

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -10,8 +10,9 @@ layout: repo
 # Review note, 2026-07-16: Issue #177 removes Windows-only assumptions from existing CLI tests. The same test and validation wildcards cover native path handling, deterministic spawn doubles, and platform-appropriate permission assertions; no runtime, ownership, routing, dependency, auth, database, protected-execution, or release-rule change is required.
 # Review note, 2026-07-16: Issue #178 is the dedicated 0.0.27 package-version release after Issues #175 and #177. It changes only package metadata, the package-version dispatch fixture, and governed review records; ownership, routing, dependencies, protected execution, database behavior, tag automation, Trusted Publishing, and workspace-integration rules remain unchanged.
 # Review note, 2026-07-16: Issue #182 corrects the protected verifier's cross-hash-domain comparison inside the existing dataset-maintenance runtime and tests. Existing wildcards and ownership cover the CLI-plan, database action-evidence, derivative-snapshot, and terminal-proof bridge; no routing, dependency, auth, database, release, or integration rule changes are required.
+# Review note, 2026-07-16: Issue #184 is the dedicated 0.0.28 package-version release for merged Issue #182. It changes only package metadata, the live package-version fixture, and governed review records; ownership, routing, dependencies, protected execution, database behavior, tag automation, Trusted Publishing, and workspace-integration rules remain unchanged.
 lastReviewedAt: "2026-07-16"
-lastReviewedCommit: "e8a458c63a4c59d7ea1fcf4618cd5034ead6e836"
+lastReviewedCommit: "497ac46bba02297b46cee255429371bf20074487"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: e8a458c63a4c59d7ea1fcf4618cd5034ead6e836
+lastReviewedCommit: 497ac46bba02297b46cee255429371bf20074487
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -76,6 +76,8 @@ Review note, 2026-07-16: Issue #177 changes tests only: native path helpers repl
 Review note, 2026-07-16: Issue #178 is the dedicated 0.0.27 version-bump release for the merged protected clock-skew fix and Windows-portable validation suite. It adds no command, runtime, dependency, approval, database, or alternate publication path; automated tag creation, Trusted Publishing, and exact released-commit workspace integration remain mandatory.
 
 Review note, 2026-07-16: Issue #182 corrects only the terminal protected verifier's JSON hash-domain bridge. Independent RLS rows remain bound to the approved plan with the CLI canonical hash; the already closure-hash-validated primary action evidence binds PostgreSQL `jsonb::text` hashes to the fresh derivative snapshot; and the snapshot SHA remains bound to the terminal completion proof. Cross-domain hashes are never compared directly. Missing, duplicate, foreign, invalid, or drifting evidence still fails closed, and admission, ownership, database, release, and workspace-integration boundaries are unchanged.
+
+Review note, 2026-07-16: Issue #184 is the dedicated 0.0.28 version-bump release for merged verifier fix #182. It adds no command, runtime, dependency, approval, database, or alternate publication path; automated tag creation, Trusted Publishing, provenance verification, and exact released-commit workspace integration remain mandatory before production status-only verification.
 
 ## Bootstrap Order
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: e8a458c63a4c59d7ea1fcf4618cd5034ead6e836
+lastReviewedCommit: 497ac46bba02297b46cee255429371bf20074487
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -69,6 +69,8 @@ Review note, 2026-07-16: Issue #177 modifies only `test/**` portability assumpti
 Review note, 2026-07-16: Issue #178 changes the package version to 0.0.27 and updates the one package-version dispatch fixture. No command family, launcher, session, artifact, protected-maintenance, dependency, tag, publication, or workspace-integration architecture changes.
 
 Review note, 2026-07-16: Issue #182 remains entirely inside `dataset-maintenance-protected-verify`. It replaces one invalid cross-serialization equality with an exact three-part proof bridge: CLI-canonical RLS row to approved plan, PostgreSQL-domain primary action evidence to fresh derivative snapshot, and snapshot SHA to terminal completion proof. It adds no runtime, adapter, artifact schema, RPC, database, dependency, or command surface.
+
+Review note, 2026-07-16: Issue #184 changes the package version to 0.0.28 and updates the one live package-version dispatch fixture. No command family, launcher, session, artifact, protected-maintenance, dependency, tag, publication, or workspace-integration architecture changes.
 
 ## Stable Path Map
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: e8a458c63a4c59d7ea1fcf4618cd5034ead6e836
+lastReviewedCommit: 497ac46bba02297b46cee255429371bf20074487
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -89,6 +89,8 @@ Review note, 2026-07-16: Issue #175 proof requires a fixed five-second allowance
 Review note, 2026-07-16: Issue #177 keeps the validation contract unchanged while making existing tests portable across the four-platform quality matrix. Tests use native path helpers and deterministic spawn doubles; POSIX permission-bit checks remain required on non-Windows platforms, while byte preservation, immutability, hashing, and overwrite rejection remain required everywhere.
 
 Review note, 2026-07-16: Issue #182 adds a production-shaped protected-verifier regression in which the CLI canonical payload hash deliberately differs from the PostgreSQL `jsonb::text` hash. Passing proof must bind RLS live row to the approved plan in the CLI domain, exact unique valid primary `action_evidence` to the fresh snapshot in the database domain, and snapshot SHA to terminal completion. Missing, duplicate, foreign, wrong-action, false owner/state/JSON flags, malformed or unequal hashes, and snapshot/terminal drift must all remain fail-closed. Exact `src/**/*.ts` coverage remains 100%.
+
+Review note, 2026-07-16: Issue #184 keeps the validation contract unchanged for the dedicated 0.0.28 release. In addition to the existing exact-coverage and pre-push gates, release proof requires an unpublished-version check, absent-tag check, dry-run package inspection, a fresh four-platform matrix, AI Doc Lint, and Docpact with no diagnostics before merge.
 
 Review note, 2026-07-16: Issue #178 keeps the validation contract unchanged for the dedicated 0.0.27 release. In addition to the existing exact-coverage and pre-push gates, release proof requires an unpublished-version check, tag-name check, dry-run package inspection, a fresh four-platform matrix, and Docpact with no diagnostics before merge.
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: e8a458c63a4c59d7ea1fcf4618cd5034ead6e836
+lastReviewedCommit: 497ac46bba02297b46cee255429371bf20074487
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -48,6 +48,8 @@ Review note, 2026-07-16: Issue #177 changes only cross-platform tests needed to 
 Review note, 2026-07-16: Issue #178 is that separate 0.0.27 release PR. It must prove the version is unpublished, retain exact coverage and all four platform results, and use the existing merge-triggered tag plus tag-triggered Trusted Publishing workflows. Local publish or manual tag creation remains forbidden; npm provenance and `gitHead` must match the immutable release merge commit before workspace integration starts.
 
 Review note, 2026-07-16: Issue #182 fixes the protected terminal verifier without changing package metadata or release mechanics. Its feature PR must pass the production-shaped cross-hash-domain regression, exact coverage, docpact, and the full pre-push gate. Only after it merges may a separate patch version-bump PR use the existing tag and Trusted Publishing workflows; npm provenance and exact root-workspace integration must be verified before the existing protected request receives one status-only readback.
+
+Review note, 2026-07-16: Issue #184 is that separate 0.0.28 release. It must prove the version and tag are absent, retain exact coverage and all four platform results, pass AI Doc Lint and Docpact, and use only the existing merge-triggered tag plus tag-triggered Trusted Publishing workflows. Local publish or manual tag creation remains forbidden; npm provenance and `gitHead` must match the immutable release merge commit before workspace integration and status-only verification.
 
 Use this document for:
 

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: e8a458c63a4c59d7ea1fcf4618cd5034ead6e836
+lastReviewedCommit: 497ac46bba02297b46cee255429371bf20074487
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -62,6 +62,8 @@ Review note, 2026-07-16: Issue #177's test-only Windows portability changes requ
 Review note, 2026-07-16: Issue #178 publishes 0.0.27 through the existing merge-triggered tag and npm Trusted Publishing workflows. It requires no new secret, environment, runner, Trusted Publisher setting, workflow, tag rule, credential, or database change.
 
 Review note, 2026-07-16: Issue #182's protected-verifier hash-domain fix requires no new secret, environment, runner, Trusted Publisher setting, workflow, tag rule, credential, or database change. It follows the unchanged feature-then-patch-release path.
+
+Review note, 2026-07-16: Issue #184 publishes 0.0.28 through the existing merge-triggered tag and npm Trusted Publishing workflows. It requires no new secret, environment, runner, Trusted Publisher setting, workflow, tag rule, credential, or database change.
 
 Review note, 2026-07-13: exact-count maintenance pagination requires no repository secret, Trusted Publisher, environment, workflow filename, or tag-semantics change.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/cli",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.101.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "Unified TianGong LCA CLI with direct REST adapters and low-entropy command surface.",
   "repository": {
     "type": "git",

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1064,7 +1064,7 @@ test('executeCli separates production read-only freeze from offline approval sea
     outDir: './protected-freeze',
     expectedProjectRef: 'production-ref',
     confirm: 'bafudata@126.com',
-    cliVersion: '0.0.27',
+    cliVersion: '0.0.28',
     pageSize: 250,
     timeoutMs: 12000,
     env: deps.env,


### PR DESCRIPTION
Closes #184

## Summary

- bump `@tiangong-lca/cli` from 0.0.27 to 0.0.28
- update the one live package-version dispatch fixture
- record the Docpact-required release review against feature merge `497ac46bba02297b46cee255429371bf20074487`

## Key decisions

- keep the release diff to exactly nine files
- leave source, dependencies, workflows, database behavior, approvals, and protected execution unchanged
- rely only on the existing merge-triggered tag and Trusted Publishing workflows; never publish or create the tag locally
- require exact released-commit workspace integration before the existing BAFU request receives one status-only readback

## Validation

- 0.0.28 unpublished check: passed; npm latest remains 0.0.27
- release tag-name check: passed; remote `cli-v0.0.28` absent
- `npm ci`: passed
- `npm run prepush:gate`: passed
- tests: 926 total, 922 passed, 4 skipped, 0 failed
- exact coverage: 100% statements, branches, functions, and lines
- Docpact strict/enforce and repository gate: zero diagnostics
- `npm pack --dry-run --json`: 1,443,884 bytes, 238 entries

A fresh four-platform quality matrix and AI Doc Lint run are required before merge.

## Risks / rollback

If npm 0.0.28 or `cli-v0.0.28` appears before merge, stop; do not move a tag or overwrite a package. Before merge, rollback is simply closing this PR. After merge, release evidence must be verified rather than republishing locally.

## Follow-ups

- verify `cli-v0.0.28`, Trusted Publishing, npm `latest`, `gitHead`, integrity, and provenance
- pin the exact release commit through a tracked `lca-workspace` integration Issue/PR
- only then run one released-CLI `status-only` readback for production request `26d8f820-5137-58fa-920e-fc171cdb813e`, with no admission or mutation

## Workspace integration

Pending; create the tracked root integration record after the immutable release commit exists.