### PR TITLE
feat: add crash-safe ordered dataset save-draft ledger

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -16,8 +16,9 @@ layout: repo
 # Review note, 2026-07-17: Issue #189 is the dedicated 0.0.29 package-version release for merged Issue #186 / PR #187. It changes only package metadata, the four live CLI-version fixtures, and governed review records; ownership, routing, dependencies, release authorization, tag automation, Trusted Publishing, and workspace-integration rules remain unchanged.
 # Review note, 2026-07-16: Issue #157 adds the native dataset-maintenance flow-identity capture/plan/freeze/seal/run/verify family inside existing command, remote-adapter, artifact, validation, and release routing. It adds no dependency, alternate auth, service-role, tag, or publishing path; the existing src/lib/dataset-*.ts, src/cli.ts, test/**, and governed-doc rules cover the implementation.
 # Review note, 2026-07-17: Issue #157 COMMON hardening remains inside the same flow-identity command, remote-adapter, artifact, validation, and release domains. Both Issue #29 derivative prerequisites require separate passed readbacks; HTTP-success `ok:false` envelopes are deterministic domain rejections; and verifier `pending` is limited to `derivatives_pending`. The protected runner now uses a database-enforced one-wrapper rotating permit as the cross-machine authority, a strict local approval claim as defense in depth, and a fresh exact recovery approval plus read-only scope lookup after permit or preflight-response loss. The remaining production gate is merge, Preview validation, and coordinated DB/CLI release, not an unresolved protocol design. No ownership, routing, dependency, auth, tag, or publishing rule changes are required.
-lastReviewedAt: '2026-07-17'
-lastReviewedCommit: '670acda2dd05a8ddae3d1968720c2ea176fb1b16'
+# Review note, 2026-07-23: Issue #194 adds an opt-in execution contract to the existing generic dataset save-draft family. Existing command/runtime, remote-adapter, artifact, test, and governed-doc wildcards cover ordered owner-draft actions, stable action-identity ledgers, exact readback recovery, and fail-closed dependency handling; no ownership, route, dependency, auth, package-release, or publication boundary changes.
+lastReviewedAt: '2026-07-23'
+lastReviewedCommit: '5c90ddd60328748ab6d8d89717e59dcaeca8cde7'
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-17
-lastReviewedCommit: 670acda2dd05a8ddae3d1968720c2ea176fb1b16
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 5c90ddd60328748ab6d8d89717e59dcaeca8cde7
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -88,6 +88,8 @@ Review note, 2026-07-16: Issue #186 adds the CLI-owned `release` transport for L
 Review note, 2026-07-17: Issue #191 changes only LCI/LCIA release tests so the four-platform matrix asserts POSIX mode bits and chmod-based cleanup failures only where those semantics exist. Runtime behavior, command ownership, credentials, release automation, and workspace-integration requirements are unchanged.
 
 Review note, 2026-07-17: Issue #189 is the dedicated 0.0.29 version-bump release for the merged LCI/LCIA release transport in Issue #186 / PR #187. It adds no command, runtime, dependency, credential, approval, database, or alternate publication path; automated tag creation, npm Trusted Publishing, provenance verification, and exact released-commit workspace integration remain mandatory.
+
+Review note, 2026-07-23: Issue #194 extends `dataset save-draft` with an explicit ordered owner-draft execution contract. The CLI binds project, owner, state 0, row identity, payload hashes, expected operations, before hashes, and earlier-action dependencies; it records each `action_id@desired_sha256` attempt in stable user state before dispatch and resolves ambiguous or orphaned attempts by exact owner readback without replay. This adds no service-role, direct-table, publication, delete, state/schema, or package-release path.
 
 ## Bootstrap Order
 

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -18,8 +18,8 @@ checkPaths:
   - src/**
   - scripts/**
   - .github/workflows/**
-lastReviewedAt: 2026-07-17
-lastReviewedCommit: 1aa9b58f7a62f50d2cb680f372452fe829686d75
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 5c90ddd60328748ab6d8d89717e59dcaeca8cde7
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -34,6 +34,8 @@ related:
 本项目是 TianGong 的统一 CLI 仓库，运行时基线固定为 Node 24，源码使用 TypeScript，但运行时执行 `dist/` 下的构建产物。
 
 Review note, 2026-06-04: `dataset curation-queue next/verify` extends the existing CLI-native dataset command family and does not change maintainer runtime, env, or release guidance.
+
+Review note, 2026-07-23: Issue #194 在既有 `dataset save-draft` 上增加可选的 ordered owner-draft execution contract。contract 精确绑定 project、owner、state 0、行顺序、before/desired hash、操作和依赖；稳定用户状态目录中的 action ledger 让复制 contract/out-dir 也不能重放成功或模糊 action。普通 save-draft、认证环境变量和 npm 发布流程不变。
 
 Review note, 2026-06-07: release 0.0.14 keeps maintainer runtime and release guidance unchanged. `dataset classification apply --type location` now supports explicit missing location targets for Foundry saturation workflows, and still rejects ambiguous target paths.
 
@@ -231,6 +233,7 @@ TIANGONG_LCA_UNSTRUCTURED_RETURN_TXT=true
 | `dataset classification children/path/audit/apply` | 无 |
 | `dataset curation-queue build` | 无 |
 | `dataset references rewrite` | 本地 rewrite 默认无；若 `--commit` 写入 patched rows，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` |
+| `dataset save-draft` | 本地 dry-run 默认无；`--commit`（包括 `--execution-contract` 模式）需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY`。execution ledger 默认写入平台用户状态目录，可由 `XDG_STATE_HOME` 改变根目录 |
 | `dataset maintenance plan/apply/freeze-protected/run-protected/verify` | 都需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY`；`plan`/`verify` 只读，`freeze-protected` 仅允许显式确认的 production project 只读冻结，`apply` 必须提供 plan hash 与当前账号邮箱；`run-protected` 的 commit 模式还必须提供 freeze、人工 approval 与 approved execution hash，恢复时使用 `--status-only` |
 | `dataset maintenance seal-protected-approval` | 无；完全离线，只读取 canonical freeze/request 与人类返回的原始 UTF-8 文本，并要求显式 freeze-file/request/text/account/timestamp 绑定 |
 | `lifecyclemodel auto-build \| validate-build \| publish-build \| graph \| orchestrate` | 无 |
@@ -293,6 +296,7 @@ npm exec tiangong-lca -- lifecyclemodel auto-build --input ./examples/lifecyclem
 npm exec tiangong-lca -- lifecyclemodel validate-build --run-dir /abs/path/to/lifecyclemodel-run --json
 npm exec tiangong-lca -- lifecyclemodel publish-build --run-dir /abs/path/to/lifecyclemodel-run --json
 npm exec tiangong-lca -- lifecyclemodel save-draft --input ./lifecyclemodels.jsonl --out-dir ./lifecyclemodel-save-draft --dry-run --json
+npm exec tiangong-lca -- dataset save-draft --input ./rows.jsonl --type auto --execution-contract ./execution-contract.json --out-dir ./dataset-save-draft --commit --json
 npm exec tiangong-lca -- lifecyclemodel graph --input ./lifecyclemodels.jsonl --out-dir ./lifecyclemodel-graph --format all --json
 npm exec tiangong-lca -- lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir /abs/path/to/lifecyclemodel-recursive-run --json
 npm exec tiangong-lca -- lifecyclemodel build-resulting-process --input ./request.json --json
@@ -372,6 +376,8 @@ Derivative rebuild 的 apply 成功只表示 guarded RPC 已返回 `accepted`/`q
 - 把 schema-invalid 或执行失败的行写入 `outputs/save-draft-rpc/failures.jsonl`
 
 这个命令当前只负责 current-user draft 的 save-draft/update 语义；`--target-user-id` 是批量导入时的账号/写入 guard，不能替代写后 readback verify，也不会替代 public `state_code=100` 的版本修订 publish 路径。
+
+`tiangong-lca dataset save-draft --execution-contract` 是另一条显式 opt-in 的通用批处理契约。`dataset-save-draft-execution-contract.v1` 必须给出 project、精确 owner（含 `state_code=0`）和有序 actions；每个 action 绑定 `action_id@desired_sha256`、table/id/version、expected operation、before hash 与只指向更早 action 的依赖。CLI 在调用受保护平台写入前把 attempt 持久化到稳定的 per-owner/project action ledger，随后只以精确 owner/state/payload readback 判定成功；transport 模糊、进程中断或既有 attempt 都不会自动重投。依赖失败只阻断其后继，无依赖 action 继续；任一 failed/unknown/blocked 都返回非零退出码。Unit Group / Flow Property 仍需额外显式 `--allow-account-local-support`，该模式不新增 direct-table、service-role、publication、delete 或 state/schema mutation 路径。
 
 `tiangong-lca process auto-build` 现在已经承担 `process_from_flow` 主链的第一个 CLI 切片，负责：
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ checkPaths:
   - src/main.ts
   - src/lib/lca-release.ts
   - test/lca-release*.test.ts
-lastReviewedAt: 2026-07-16
-lastReviewedCommit: 1aa9b58f7a62f50d2cb680f372452fe829686d75
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 5c90ddd60328748ab6d8d89717e59dcaeca8cde7
 ---
 
 # TianGong LCA CLI
@@ -40,6 +40,8 @@ Review note, 2026-07-15: `dataset maintenance freeze-protected` and `seal-protec
 Review note, 2026-07-16: `release ...` is the LCI/LCIA data-release command family, not the npm package release workflow. It uses the normal user-session bootstrap, requires the server to authorize `data_product_manager` for private and mutating operations, never accepts a service-role key, and keeps large Calculation Bundle or ZIP payloads in hash-verified files instead of stdout.
 
 Review note, 2026-07-17: `dataset maintenance flow-identity capture|plan|freeze|seal-approval|run|freeze-recovery|seal-recovery-approval|run-recovery|verify` is the dedicated Step 3 workflow for approved BAFU elementary-flow identity mappings. Capture performs one complete authenticated census and one database-attestation POST; plan rejects historical authorities and binds the exact 305-source request to its immutable receipt. The write path uses a database-minted one-wrapper permit that rotates after each successful process/finalize write and is never stored in proof artifacts; a create-only local approval claim is defense in depth. A lost permit or preflight response cannot be replayed: the operator must freeze and approve an exact recovery baseline, while status/recovery may locate only the same actor-owned scope through the exact read-only lookup. Terminal verification independently proves unchanged source/public/support rows, exact desired owner-draft processes, zero approved-source residue, unchanged pending/blocker/orphan closure, and causal derivative completion. Failed/stale derivatives still require a separate derivative-only plan, freeze, and approval and never replay the process mutation. Production use remains gated on merge, Preview validation, and coordinated database/CLI release.
+
+Review note, 2026-07-23: `dataset save-draft --execution-contract` adds an opt-in crash-safe ordered owner-draft batch. The contract binds the authenticated project/owner, state 0, exact input order and payloads, before hashes, expected insert/update operations, and dependencies. A stable per-owner/project `action_id@desired_sha256` ledger prevents replay even if the contract or output directory is copied; ambiguous attempts are recovered only by exact owner/state/payload readback. The ordinary save-draft mode is unchanged.
 
 ## Run
 
@@ -363,6 +365,7 @@ tiangong-lca dataset classification apply --type location --input ./rows/process
 tiangong-lca dataset curation-queue build --processes ./rows/processes.jsonl --flows ./rows/flows.jsonl --support ./rows/sources.jsonl --out-dir /abs/path/to/curation-queue --json
 tiangong-lca dataset curation-queue next --queue-dir /abs/path/to/curation-queue --type support --json
 tiangong-lca dataset curation-queue verify --queue-dir /abs/path/to/curation-queue --type process --json
+tiangong-lca dataset save-draft --input ./rows.jsonl --type auto --execution-contract ./execution-contract.json --out-dir /abs/path/to/dataset-save-draft --commit --json
 tiangong-lca dataset evidence-search plan --query "中国2026年电力结构数据" --out-dir /abs/path/to/evidence-search --json
 tiangong-lca dataset evidence-search run --input ./evidence-search.request.json --results ./search-results.json --out-dir /abs/path/to/evidence-search --json
 tiangong-lca dataset references rewrite --input ./rows.jsonl --from flow:<old-id>@<old-version> --to flow:<new-id>@<new-version> --out-dir /abs/path/to/dataset-rewrite --json
@@ -396,6 +399,8 @@ For `process identity-preflight` and `flow identity-preflight`, canonical TIDAS 
 For `process build-plan` and `flow build-plan`, canonical payloads embedded in the plan are schema-checked during `materialize`. Plan-only materialization now creates deterministic canonical `processDataSet` / `flowDataSet` wrappers from the build plan and validates them with the TIDAS SDK before reporting `passed`.
 
 For `process save-draft`, canonical process payloads are validated locally with `ProcessSchema` before any `--commit` write. Schema-invalid rows remain in `outputs/save-draft-rpc/failures.jsonl` instead of being persisted. Batch import callers should pass `--target-user-id`; the CLI then verifies the current auth session and any visible draft owner before writing, while downstream readback verification still proves the final owner and payload.
+
+For `dataset save-draft --execution-contract`, the JSON contract uses schema `dataset-save-draft-execution-contract.v1` and supplies `execution_id`, `project_ref`, an exact owner (`user_id`, lowercase `email`, `state_code: 0`), and ordered actions. Each action binds `action_id`, `desired_sha256`, `expected_operation` (`insert` or `save_draft`), table/id/version, `before_sha256`, and earlier `dependency_action_ids`. Contract mode requires `--commit`; account-local Unit Group or Flow Property support rows additionally require `--allow-account-local-support`. Attempts and outcomes are stored under the platform user-state directory (`$XDG_STATE_HOME/tiangong-lca-cli` when configured), not beside the contract or report. Any prior terminal or unresolved attempt is read back or retained without re-dispatch; exit status is nonzero unless every action has exact terminal success.
 
 For `flow publish-version`, canonical flow payloads are validated locally with `FlowSchema` before remote visibility planning or writes. The command always writes `flow-publish-version-gate-report.json`; blocked rows are written to the remote-failure JSONL without calling the remote service.
 

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - README.md
   - src/**
   - test/**
-lastReviewedAt: 2026-07-17
-lastReviewedCommit: e8a458c63a4c59d7ea1fcf4618cd5034ead6e836
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 5c90ddd60328748ab6d8d89717e59dcaeca8cde7
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -49,6 +49,8 @@ finalize request 绑定 fresh whole-scope proof，attempt/domain-rejection/proof
 Review note, 2026-07-16: Issue #182 修正 protected 终态验证中的 JSON hash 域混用。独立 RLS row 继续用 CLI canonical hash 对齐 approved plan；已经过 closure SHA 校验的 primary `action_evidence` 用 PostgreSQL `jsonb::text` hash 对齐 fresh derivative snapshot；snapshot SHA 再对齐 terminal completed proof。不同序列化域不直接比较，证据缺失、重复、身份/owner/state/JSON 标志错误或任一同域 hash 漂移仍 fail-closed；数据库/RPC 与一次性 admission 契约不变。
 
 Review note, 2026-07-16: Issue #186 将 LCI/LCIA 数据发布的远程执行面收口为 `release` 命令族，但不把 20-stage release workflow、TIDAS identity/version 规则或包闭包算法复制进 CLI。CLI 复用用户 API key 换 session，服务端检查 `data_product_manager`，本地严格校验 Unit Process 与 standalone LifecycleModel+Result 两类包的 TIDAS/ILCD 四个 ZIP，并对 Calculation Bundle/ZIP 下载执行 exact-path、byte-size 与 SHA-256 校验。service-role 不属于该命令契约。
+
+Review note, 2026-07-23: Issue #194 为通用 `dataset save-draft` 增加 opt-in execution contract。V1 将 session project/owner/state 0、有序 input rows、before/desired hashes、insert/update 操作和依赖绑定为一个离线 JSON 合同；每个 `action_id@desired_sha256` 使用稳定的用户状态 action ledger。首次 dispatch 前落盘 attempt，之后的模糊响应、孤立 attempt 或进程恢复只允许 exact owner readback，不允许自动重放；失败依赖不会阻止无依赖 action 继续。
 
 ## 1. 目标
 
@@ -186,6 +188,7 @@ tiangong-lca
 | `tiangong-lca dataset curation-queue build/next/verify` | 本地 Foundry external dataset import 的 entity-level curation queue 状态机；`build` 输出 manifest、tasks、locks、blockers、per-entity input/closure/run-plan artifacts，`next` 基于 checkpoint 返回下一条 runnable entity task，`verify` 校验 scoped checkpoint 完成度；不执行 AI、不写远端 |
 | `tiangong-lca dataset import-lca convert` | 外部 LCA 包转换入口；调用 `tidas-tools import_lca` 生成 TIDAS/ILCD/conversion report；tidas-tools >= 0.0.28 默认产出每个 process 的依赖子目录（可用 `--no-process-bundles` 关闭、`--process-bundles-dir` 自定义目录），便于后续 entity-level curation |
 | `tiangong-lca dataset references rewrite` | 本地 process / lifecyclemodel rows 的 flow reference rewrite、patch evidence 输出，并可选走 state-aware save-draft commit |
+| `tiangong-lca dataset save-draft` | 通用 canonical dataset dry-run/save-draft 入口；可选 `--execution-contract` 将 project/owner/state 0、输入顺序、before/desired hashes、预期 insert/update 与依赖绑定到稳定 action ledger，并以 exact owner readback 收口模糊响应且不重放 |
 | `tiangong-lca dataset maintenance clear-account` | 已实现的当前账号 draft 清理入口；先生成当前用户 RLS 可见 snapshot，默认 dry-run，只有显式 `--commit --confirm <当前账号邮箱>` 才按 `lifecyclemodels -> processes -> flows -> sources -> contacts` 顺序执行。普通 dataset rows 通过 `app_dataset_delete` / `cmd_dataset_delete` 删除，读回验证剩余行数；`unitgroups` / `flowproperties` 默认保护不删 |
 | `tiangong-lca dataset maintenance plan/apply/freeze-protected/seal-protected-approval/run-protected/verify` | 已实现的 row-level 维护入口。普通 V1 维护通过当前账号 RLS 冻结 exact draft rows 并走平台 `save_draft` / `delete`；固定 BAFU protected profile 先由 `freeze-protected` 直接读取 production owner-draft 状态并生成未批准请求，再由完全离线的 `seal-protected-approval` 记录人类逐字节批准，最后只能由服务器调度的 `run-protected` 以唯一 durable attempt/admission identity 执行和恢复。写入以 actor/user_id/state_code=0 与精确 plan/closure 栅栏保护，RLS 用于公开入口和独立读回；`rebuild-derivatives` V1 仍只允许一个 owner-draft process。所有路径共享不可变 plan、显式审批、durable proof 与独立 readback，且不发布 FP/UG |
 | `tiangong-lca lifecyclemodel auto-build` | 本地 lifecyclemodel local-run intake、graph 推断、reference process 选择、`json_ordered` artifact 输出 |
@@ -252,6 +255,7 @@ tiangong-lca
 - `tiangong-lca dataset curation-queue next` 已可执行
 - `tiangong-lca dataset curation-queue verify` 已可执行
 - `tiangong-lca dataset references rewrite` 已可执行
+- `tiangong-lca dataset save-draft` 已可执行；`--execution-contract` 为显式 opt-in 的 ordered owner-draft 模式
 - `tiangong-lca dataset maintenance plan` 已可执行
 - `tiangong-lca dataset maintenance apply` 已可执行
 - `tiangong-lca dataset maintenance freeze-protected` 已可执行（production 只读）
@@ -276,6 +280,7 @@ tiangong-lca
 - 已实现的 `dataset classification` 从 CLI bundled TIDAS schema 提供分类/位置编码治理：`children` 支持按 parent code 步进列子类，`path` 解析 code 的规范 path，`audit --type location` 按 bundled TIDAS schema 派生位置编码字段，并覆盖 TIDAS LCIA geography 和 lifecyclemodel connection location 字段，检查其值是否属于 `tidas_locations_category.json`；`apply --type location` 把 AI/human structured decision 确定性写回 rows 并输出 evidence，当 decision 明确给出 schema-derived location 字段的 `target_path`（如 `flowDataSet.flowInformation.geography.locationOfSupply`）时可创建缺失父对象和字段，缺少 target 或非 location 路径仍保持阻断
 - 已实现的 `dataset curation-queue build/next/verify` 把 Foundry external dataset import 的 support / flow / process rows 收口成 entity-level queue artifact contract：`build` 生成 `curation-queue-manifest.json`、`curation-queue-tasks.jsonl`、`curation-queue-locks.json`、`curation-queue-blockers.jsonl`，以及每个 entity 的 `input.jsonl`、`closure.json`、`entity-run-plan.json`；`next` 读取 task checkpoint 并返回下一条 runnable entity task；`verify` 确认目标 scope 的 checkpoint 完成且没有 build blocker。CLI 只负责稳定状态机、依赖闭包、锁和 blocker；AI authoring 仍必须通过 skill/Codex 输出 structured patch 或 build plan，并在 deterministic apply、schema/QA、prewrite verify、readback 后才允许进入远端写入。
 - 已实现的 `dataset references rewrite` 把 process / lifecyclemodel rows 中的 flow reference rewrite 收口到一个 deterministic 本地入口，默认只写 patch artifacts，只有显式 `--commit` 时才调用 state-aware save-draft 写入路径
+- 已实现的 `dataset save-draft --execution-contract` 读取 `dataset-save-draft-execution-contract.v1`，逐 action 校验 authenticated project/owner、state 0、input identity/order、desired payload hash、expected operation、before hash 与 earlier-only dependencies。账本不放在 contract/out-dir 旁，而放在稳定的 per-owner/project 用户状态根下，并以 `action_id@desired_sha256` 寻址；复制输入或输出目录不会获得新的 attempt。attempt 之后只做 exact owner/state/payload readback，terminal/unknown action 均永不重投；dependency 只阻断后继，independent unresolved actions 仍可继续。每个远端调用继续使用现有 protected platform dataset transaction，不新增 raw SQL/direct-table/service-role/publication/delete/state/schema 写面。
 - 已实现的 `dataset maintenance clear-account` 只覆盖当前认证账号的 draft 清空场景：CLI 必须先以 exact-count 分页证明五个可删除表的 RLS 可见快照完整，才写出 `rls-visible-snapshot.json` / `dry-run-report.json`；commit 时要求 `--confirm` 匹配当前账号邮箱，并逐行调用平台 `app_dataset_delete`。除逐表检查外，结束时必须重新扫描全部五表，只有完整 aggregate proof 且 `row_count=0` 才报告成功；若终检失败而之前已有删除，仍写出 `completed_with_failures` 审计报告。初始扫描不完整时不生成快照/approval，且零删除。该命令不绕过 RLS，不直接 REST DELETE，不删除默认保护的 `unitgroups` / `flowproperties`。
 - 已实现的 `dataset maintenance plan/apply/freeze-protected/seal-protected-approval/run-protected/verify` 是错误导入清理、redo 与受保护衍生重建的 row-level 归属面。`plan` 先证明当前用户 account scan 完整，再固化 scope manifest、RLS 可见快照、completeness proof、引用影响、保护行、不可变 plan 和 dry-run。普通 `apply` 只接受 plan SHA-256 与当前账号邮箱都匹配的显式 commit；固定 production alias profile 必须依次经过 production 只读 `freeze-protected`、人类逐字批准、完全离线 `seal-protected-approval`，然后才可进入 `run-protected`，其 `--status-only` 恢复不做 preflight 或 admission。`verify` 以新的完整 account readback 或 action-scoped DB readback 独立检查结果，不依赖 apply 的内存或报告结论。Foundry 只调用已发布 CLI、保存 task ledger/报告/产物，不读取数据库 env、直调 RPC 或重算 canonical hash。
 - `merge-support-aliases` 不是通用 alias 合并器：当前只接受 BAFU `time` 与 `length_time` 两个 batch。计划必须精确覆盖 25 + 27 行和 20 + 39 条 exchange，并保留受影响 process 中的 309 条其他 exchange。原 V1 adapter 只保留冻结请求/artifact 兼容契约，不能作为 seal 绑定 production 执行的 fallback；受保护路径绝不降级为旧 `cmd_dataset_alias_plan_guarded`、逐 dimension 或逐行 `save_draft`。
@@ -1100,6 +1105,7 @@ TIANGONG_LCA_COVERAGE=0
 | `dataset evidence-search` | 默认无；若使用 `--provider-url`，认证由 `--provider-key` 显式传入 |
 | `admin embedding-run` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY`（`TIANGONG_LCA_REGION` 可选） |
 | `process get` | `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY` |
+| `dataset save-draft` | 本地 dry-run 默认无；`--commit`（包括 `--execution-contract`）需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY`。execution ledger 默认使用平台用户状态目录，`XDG_STATE_HOME` 可改变根目录 |
 | `process identity-preflight` | 默认无；若启用 `--remote-candidates` 或输入 `remote_candidate_search.enabled=true`，则需要 `TIANGONG_LCA_API_BASE_URL`、`TIANGONG_LCA_API_KEY`、`TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY`（`TIANGONG_LCA_REGION` 可选） |
 | `process build-plan` | 无 |
 | `process auto-build | resume-build | publish-build | batch-build` | 无 |

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -17,8 +17,8 @@ checkPaths:
   - package.json
   - src/**
   - test/**
-lastReviewedAt: 2026-07-17
-lastReviewedCommit: 2fec4595262393fdf376a39a2c5e73a47f0c9b98
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 5c90ddd60328748ab6d8d89717e59dcaeca8cde7
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -55,6 +55,7 @@ related:
 - 2026-07-16 复核：Issue #182 只在 TypeScript protected verifier 内用既有 primary action evidence 修正 JSON hash 域桥接；不新增 Python、POSIX shell、MCP runtime、私有 skill runtime 或 npm 依赖，也不改变 skills 薄调用边界。
 - 2026-07-16 复核：`dataset maintenance flow-identity capture|plan|freeze|seal-approval|run|verify` 继续由 TypeScript / Node 原生 CLI 负责 305-source Step 3 单次 census/attestation、immutable plan、离线批准、guarded serial execution 与独立 readback；不新增 npm、Python、shell、MCP 或私有 skill runtime。Foundry/skills 不得复制哈希、数据库 receipt/scope、重试、derivative baseline 或补偿逻辑。
 - 2026-07-17 复核：Issue #157 COMMON 的双 #29 passed-readback、HTTP-success domain rejection、`derivatives_pending` 验证、数据库 one-wrapper rotating permit、本地 create-only claim，以及 fresh exact recovery approval + read-only lookup 均属于 DB/TypeScript CLI 契约。Foundry/skills 不得复制这些执行权限或恢复逻辑；尚余 merge、Preview 与 DB/CLI 发布门禁，不改变本迁移结论。
+- 2026-07-23 复核：Issue #194 的 ordered owner-draft execution contract 继续完全位于 TypeScript / Node 原生 CLI，复用现有用户 session、平台 dataset command 与 TIDAS SDK 校验；action ledger 使用 Node 原生文件能力，不新增 Python、POSIX shell、MCP、私有 skill runtime 或 npm 依赖。skills 若后续接入只能保持薄调用，不得复制 attempt/readback/replay 逻辑。
 
 这份文档记录的是：
 

--- a/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
+++ b/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
@@ -15,8 +15,8 @@ checkPaths:
   - src/lib/user-api-key.ts
   - src/lib/supabase-session.ts
   - src/lib/supabase-client.ts
-lastReviewedAt: 2026-07-17
-lastReviewedCommit: 2fec4595262393fdf376a39a2c5e73a47f0c9b98
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 5c90ddd60328748ab6d8d89717e59dcaeca8cde7
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -45,6 +45,7 @@ related:
 - 2026-07-16 复核：Issue #182 只调整同一已认证状态响应、RLS readback 与 snapshot proof 的本地 hash 域桥接，不改变用户 API key、publishable key、session cache、bearer、RLS、RPC 或 service-role 边界；本历史设计结论不变。
 - 2026-07-16 复核：Issue #157 的 flow-identity capture/run/verify 继续使用现有用户 API key 到 authenticated session、publishable key、RLS 表读取与受保护 RPC；freeze/seal 的离线边界不引入 service-role、alternate bearer 或新认证 env，本历史设计结论不变。
 - 2026-07-17 复核：Issue #157 COMMON 将已认证 RPC 的 HTTP-success `ok:false` 明确为数据库 domain rejection，并实现绑定现有 authenticated actor 的数据库 one-wrapper rotating permit、独立 fresh recovery approval 和 exact read-only scope lookup；create-only 本地 claim 只是纵深防御，不是 bearer 或新认证路径。access token、publishable key、session cache、RLS 与 service-role 边界不变；尚余 merge、Preview 与 DB/CLI 发布门禁。
+- 2026-07-23 复核：Issue #194 的 `dataset save-draft --execution-contract` 继续使用既有 user API key bootstrap、publishable key、access token、session cache 与 current-owner RLS 读回。稳定 action ledger 是本地非 bearer 状态，不保存 token；不新增认证 env、alternate bearer、service-role 或跨账号路径，本历史设计结论不变。
 
 ## 1. 已确认事实
 

--- a/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
+++ b/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - src/lib/supabase-client.ts
   - src/lib/tidas-sdk-package-validator.ts
   - test/**
-lastReviewedAt: 2026-07-17
-lastReviewedCommit: 2fec4595262393fdf376a39a2c5e73a47f0c9b98
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 5c90ddd60328748ab6d8d89717e59dcaeca8cde7
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -44,6 +44,8 @@ related:
 - 直到 repo 级验证、PR、workspace integration 全部完成，才算结束。
 
 当前状态：
+
+2026-07-23 复核：Issue #194 的 ordered owner-draft execution contract 复用现有 `@supabase/supabase-js` 用户 session/RLS 读取、平台 dataset command transport、`@tiangong-lca/tidas-sdk` 校验与 Node 原生文件/crypto 能力，不新增或改变直接依赖；本文件继续保持历史 TODO 记录用途。
 
 2026-07-17 复核：Issue #157 COMMON 的双 #29 readback、domain rejection、verify pending 收紧、DB one-wrapper rotating permit、create-only local claim 与 fresh exact recovery approval/read-only lookup 继续复用现有 TypeScript、Node `fs`/`crypto`、`@supabase/supabase-js` session/RPC 和 TIDAS SDK 校验，不新增或改变直接依赖。尚余 merge、Preview 与 DB/CLI 发布门禁；本文件继续保持历史 TODO 记录用途。
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-17
-lastReviewedCommit: 670acda2dd05a8ddae3d1968720c2ea176fb1b16
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 5c90ddd60328748ab6d8d89717e59dcaeca8cde7
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -81,6 +81,8 @@ Review note, 2026-07-16: Issue #186 introduces `src/lib/lca-release.ts` as the C
 Review note, 2026-07-17: Issue #191 changes only platform-specific assertions in `test/lca-release.test.ts`. The LCI/LCIA transport, artifact writer, command surface, filesystem architecture, and release workflow remain unchanged; POSIX mode and chmod failure semantics continue to be tested on platforms that implement them.
 
 Review note, 2026-07-17: Issue #189 changes the CLI package version to 0.0.29 and updates the four live CLI-version fixtures. No command family, launcher, session, artifact, dependency, authorization, tag, publication, or workspace-integration architecture changes.
+
+Review note, 2026-07-23: Issue #194 keeps ordered owner-draft execution inside `src/lib/dataset-save-draft-run.ts`. `src/cli.ts` owns the opt-in flag and all-success exit code; the runtime owns contract/session/before-state binding, stable per-owner/project action ledgers, dependency scheduling, exact owner readback, and no-replay recovery. It reuses the current platform dataset command transport and adds no new auth, direct-table, service-role, publication, delete, state/schema, or release architecture.
 
 ## Stable Path Map
 
@@ -178,6 +180,7 @@ These modules share one contract:
 Dataset-local governance now uses the same CLI-native command layer:
 
 - `src/lib/dataset-validate.ts`
+- `src/lib/dataset-save-draft-run.ts`
 - `src/lib/dataset-curation-queue.ts`
 - `src/lib/dataset-references-rewrite.ts`
 - `src/lib/dataset-maintenance-clear-account.ts`
@@ -200,6 +203,8 @@ Dataset-local governance now uses the same CLI-native command layer:
 - `src/lib/lifecyclemodel-graph.ts`
 
 These modules keep validation, entity-level curation queue build/next/verify state, reference rewrites, RLS-scoped account and exact-row maintenance, save-draft preparation, graph extraction, and local artifact reports inside the CLI instead of routing through skills or MCP transports.
+
+Execution-contract mode in `dataset-save-draft-run` is deliberately action-scoped rather than report-directory-scoped. The immutable input binds each ordered row to an `action_id@desired_sha256`, expected insert/update operation, before hash, and earlier-only dependencies. The append-only ledger is rooted in stable platform user state and names one file per owner/project/action identity, so copying a contract or output directory cannot create a replay path. A durable attempt without an outcome is recovered by exact current-owner state-0 payload readback only; terminal and unknown actions are never dispatched again, while unrelated actions may continue.
 
 The row-level maintenance family is deliberately split by responsibility:
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-17
-lastReviewedCommit: 670acda2dd05a8ddae3d1968720c2ea176fb1b16
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 5c90ddd60328748ab6d8d89717e59dcaeca8cde7
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -104,6 +104,8 @@ Review note, 2026-07-17: Issue #191 keeps the validation contract unchanged whil
 
 Review note, 2026-07-17: Issue #189 keeps the validation contract unchanged for the dedicated 0.0.29 release. In addition to the exact-coverage and pre-push gates, release proof requires unpublished-version and absent-tag checks, all four live CLI-version fixtures at 0.0.29, dry-run package inspection, AI Doc Lint, Docpact, and the release-time platform matrix before npm publication.
 
+Review note, 2026-07-23: Issue #194 adds focused proof for ordered contract binding, stable action-ledger replay exclusion across copied contract/output paths, exact insert/update before-state checks, crash/orphan recovery, ambiguous transport readback, dependency isolation, owner/project mismatch, ledger corruption, and zero-dispatch parser/preflight failures. The same exact 100% `src/**/*.ts`, lint, build, docpact, and pre-push gates remain authoritative.
+
 ## Validation Matrix
 
 | Change type | Minimum local proof | Additional proof when risk is higher | Notes |
@@ -125,7 +127,7 @@ Facts that matter:
 - `npm run prepush:gate` is the exact local test gate
 - the local `pre-push` hook runs docpact first and then `npm run prepush:gate`
 - `.github/workflows/quality-gate.yml` is manual-dispatch only for remote reproduction, not an ordinary push-triggered test runner
-- `process save-draft`, `lifecyclemodel save-draft`, dataset governance commands such as curation queue build/next/verify, BuildPlan gates, publish schema/verification gates, and the newer process maintenance commands are expected to preserve `100%` coverage even when they add schema-validation, rewrite, or fallback branches
+- `process save-draft`, `lifecyclemodel save-draft`, ordered `dataset save-draft --execution-contract`, dataset governance commands such as curation queue build/next/verify, BuildPlan gates, publish schema/verification gates, and the newer process maintenance commands are expected to preserve `100%` coverage even when they add schema-validation, rewrite, recovery, or fallback branches
 - LCI/LCIA release tests must cover all public actions and error branches without real credentials: user-session bootstrap is stubbed, remote error codes are preserved, upload request metadata is bound to local files, Calculation Bundle artifact selection is exact-path only, credentials stay masked, and no file becomes visible before size/hash verification succeeds. Live smoke tests, when explicitly authorized, use a disposable release identity and a real `data_product_manager` account through the public Edge/Database path; service-role or direct SQL evidence is invalid.
 - Dataset maintenance tests must prove exact `id` + `version`, expected state, and current-account ownership are enforced; rows outside the explicitly authorized owner-draft alias profile remain protected; no action runs after full-plan drift or approval mismatch; approval is persisted before the first mutation; each attempted action is appended durably to `apply-progress.jsonl` with plan/action/mode correlation, actor, timing, before/after hashes, result/error, and rollback fields; and `verify` performs its own remote readback instead of trusting `apply` output.
 - Exact-count pagination tests must prove that a requested page size such as 5000 still follows a 1000-row server cap with offsets `0,1000,2000...`; an exact multiple terminates without a speculative empty request; a true zero result accepts `*/0`; and missing/invalid/changing totals, early empty pages, range/body mismatch, page overflow, rows beyond total, missing/duplicate/out-of-order identities, foreign-owner rows, malformed/duplicate aggregate table proofs, or partial aggregate table sets fail closed. `plan`, apply preflight, and `verify` must not produce an accepted artifact or write after an incomplete scan. `clear-account` must execute zero deletes after an incomplete initial scan, re-read all five tables at the end, require aggregate `row_count=0` for success, and retain a failure audit if the final proof cannot complete after mutation starts. The evidence proves pagination completeness under stable filtered membership/order, not transaction-level/MVCC snapshot isolation.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-17
-lastReviewedCommit: 670acda2dd05a8ddae3d1968720c2ea176fb1b16
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 5c90ddd60328748ab6d8d89717e59dcaeca8cde7
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -60,6 +60,8 @@ Review note, 2026-07-17: Issue #189 is that separate 0.0.29 release. It must pro
 Review note, 2026-07-16: Issue #157 adds the Step 3 flow-identity feature without changing package metadata or release mechanics. Its feature PR must pass the exact DB contract, production-scale Preview capture timing, 100% CLI coverage, Docpact, and the full pre-push gate. A separate patch version-bump PR may begin only after database-engine #235 is promoted and deployed; production capture/plan/freeze still requires the released CLI plus a fresh exact human approval.
 
 Review note, 2026-07-17: Issue #157 COMMON hardening now includes the DB/CLI one-wrapper rotating permit, strict create-only local claim as defense in depth, fresh exact recovery approval, and exact read-only scope lookup after response loss. This closes the protocol design boundary without changing version, tag, or Trusted Publishing mechanics. The Step 3 patch release remains gated on feature merge, database Preview validation/promotion, focused cross-contract evidence, and the separate coordinated DB/CLI release; local publish and manual tag creation remain forbidden.
+
+Review note, 2026-07-23: Issue #194 adds the generic ordered owner-draft execution contract without changing package metadata or release mechanics. Its feature PR must pass focused ledger/recovery tests, exact 100% coverage, docpact, and the full pre-push gate. Any npm publication remains a separate version-bump PR through the existing merge-triggered tag and Trusted Publishing workflows; local publish and manual tag creation remain forbidden.
 
 Use this document for:
 

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -19,8 +19,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-17
-lastReviewedCommit: 670acda2dd05a8ddae3d1968720c2ea176fb1b16
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 5c90ddd60328748ab6d8d89717e59dcaeca8cde7
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -74,6 +74,8 @@ Review note, 2026-07-17: Issue #189 publishes 0.0.29 through the existing merge-
 Review note, 2026-07-16: Issue #157's flow-identity workflow requires no new npm secret, GitHub environment, Trusted Publisher setting, workflow filename, tag rule, service-role credential, or alternate CLI authentication variable. It follows the unchanged feature PR, separate version-bump PR, automated tag, and Trusted Publishing path.
 
 Review note, 2026-07-17: Issue #157 COMMON hardening still requires no new npm secret, GitHub environment, Trusted Publisher setting, workflow filename, tag rule, or release credential. The DB/CLI contract now supplies the cross-machine one-wrapper rotating permit, a create-only local claim as defense in depth, and a separately frozen and approved recovery path with read-only scope lookup. Production remains gated on merge, Preview validation, and coordinated DB/CLI release.
+
+Review note, 2026-07-23: Issue #194 requires no new npm secret, GitHub environment, Trusted Publisher setting, workflow filename, tag rule, service-role credential, or alternate CLI authentication variable. Its stable user-state execution ledger is local runtime state, not release infrastructure; the feature follows the unchanged feature PR, separate version-bump PR, automated tag, and Trusted Publishing path.
 
 Review note, 2026-07-13: exact-count maintenance pagination requires no repository secret, Trusted Publisher, environment, workflow filename, or tag-semantics change.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1415,6 +1415,10 @@ Options:
   --out-dir <dir>  Artifact directory
   --commit         Execute remote save-draft writes
   --dry-run        Validate and plan without remote writes (default)
+  --execution-contract <file>
+                   Execute a content-bound ordered owner-draft batch with append-only attempt/readback evidence (requires --commit)
+  --allow-account-local-support
+                   Explicitly permit account-local Unit Group / Flow Property rows in the execution contract
   --json           Print compact JSON
   -h, --help
 
@@ -1423,6 +1427,7 @@ Outputs written under --out-dir:
   - outputs/dataset-save-draft/progress.jsonl
   - outputs/dataset-save-draft/failures.jsonl
   - outputs/dataset-save-draft/summary.json
+  - $XDG_STATE_HOME/tiangong-lca-cli/execution-ledgers/dataset-save-draft/v1/<owner-scope-sha256>/<action-identity-sha256>.events.jsonl (execution-contract mode; platform state directory fallback applies)
 
 Contract:
   This generic dataset path writes only mutable rows such as contact/source/flow/process. Unit group and flow property rows are reference-only; select existing database rows and rewrite references instead of creating My Data support rows.
@@ -3063,6 +3068,7 @@ function parseDatasetSaveDraftFlags(args: string[]): {
   outDir: string | null;
   commit: boolean;
   allowReferenceOnlySupport: boolean;
+  executionContractPath: string | null;
 } {
   let values: ReturnType<typeof parseArgs>['values'];
   try {
@@ -3079,6 +3085,7 @@ function parseDatasetSaveDraftFlags(args: string[]): {
         commit: { type: 'boolean' },
         'dry-run': { type: 'boolean' },
         'allow-account-local-support': { type: 'boolean' },
+        'execution-contract': { type: 'string' },
       },
     }));
   } catch (error) {
@@ -3103,6 +3110,8 @@ function parseDatasetSaveDraftFlags(args: string[]): {
     outDir: typeof values['out-dir'] === 'string' ? values['out-dir'] : null,
     commit: Boolean(values.commit),
     allowReferenceOnlySupport: Boolean(values['allow-account-local-support']),
+    executionContractPath:
+      typeof values['execution-contract'] === 'string' ? values['execution-contract'] : null,
   };
 }
 
@@ -7341,12 +7350,13 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
         outDir: datasetFlags.outDir,
         commit: datasetFlags.commit,
         allowReferenceOnlySupport: datasetFlags.allowReferenceOnlySupport,
+        executionContractPath: datasetFlags.executionContractPath,
         env: deps.env,
         fetchImpl: deps.fetchImpl,
       });
 
       return {
-        exitCode: report.status === 'completed_with_failures' ? 1 : 0,
+        exitCode: report.status === 'completed' ? 0 : 1,
         stdout: stringifyJson(report, datasetFlags.json),
         stderr: '',
       };

--- a/src/lib/dataset-command.ts
+++ b/src/lib/dataset-command.ts
@@ -102,8 +102,17 @@ async function invokeDatasetCommand(options: {
   transport: DatasetCommandTransport;
   commandName: 'app_dataset_create' | 'app_dataset_save_draft' | 'app_dataset_delete';
   body: JsonObject;
+  beforeDispatch?: () => void;
 }): Promise<JsonObject> {
   const url = `${options.transport.functionsBaseUrl}/${options.commandName}`;
+  try {
+    options.beforeDispatch?.();
+  } catch {
+    throw new CliError('Dataset command was blocked before request dispatch.', {
+      code: 'DATASET_COMMAND_BEFORE_DISPATCH_FAILED',
+      exitCode: 1,
+    });
+  }
   return requireCommandSuccessPayload(
     await postJson({
       url,
@@ -162,6 +171,7 @@ export async function createDatasetRecord(options: {
   id: string;
   payload: JsonObject;
   extraData?: JsonObject;
+  beforeDispatch?: () => void;
 }): Promise<JsonObject> {
   const body: JsonObject = {
     table: options.table,
@@ -181,6 +191,7 @@ export async function createDatasetRecord(options: {
     transport: options.transport,
     commandName: 'app_dataset_create',
     body,
+    beforeDispatch: options.beforeDispatch,
   });
 }
 
@@ -191,6 +202,7 @@ export async function saveDraftDatasetRecord(options: {
   version: string;
   payload: JsonObject;
   extraData?: JsonObject;
+  beforeDispatch?: () => void;
 }): Promise<JsonObject> {
   const body: JsonObject = {
     table: options.table,
@@ -211,6 +223,7 @@ export async function saveDraftDatasetRecord(options: {
     transport: options.transport,
     commandName: 'app_dataset_save_draft',
     body,
+    beforeDispatch: options.beforeDispatch,
   });
 }
 

--- a/src/lib/dataset-save-draft-run.ts
+++ b/src/lib/dataset-save-draft-run.ts
@@ -1,3 +1,4 @@
+import { closeSync, chmodSync, fsyncSync, mkdirSync, openSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import * as tidasSdk from '@tiangong-lca/tidas-sdk';
 import { writeJsonArtifact, writeJsonLinesArtifact } from './artifacts.js';
@@ -35,6 +36,14 @@ import {
   type RemoteDatasetReference,
   type RemoteDatasetTable,
 } from './dataset-remote-verify.js';
+import {
+  appendStableJsonLine,
+  readJsonFile,
+  readJsonLinesIfPresent,
+  sha256Json,
+  stableJsonText,
+} from './dataset-maintenance-contract.js';
+import { resolveFlowIdentityApprovalClaimRoot } from './dataset-maintenance-flow-identity-approval-claim.js';
 
 type JsonObject = Record<string, unknown>;
 
@@ -97,7 +106,7 @@ export type DatasetSaveDraftRowReport = {
   version: string | null;
   type: ConcreteDatasetSaveDraftType | null;
   table: DatasetCommandTable | null;
-  status: 'prepared' | 'executed' | 'failed';
+  status: 'prepared' | 'executed' | 'failed' | 'unknown' | 'blocked';
   operation:
     | 'would_sync'
     | 'insert'
@@ -108,26 +117,36 @@ export type DatasetSaveDraftRowReport = {
     | 'identity_missing'
     | 'elementary_flow_insert_blocked'
     | 'remote_reference_unresolved'
+    | 'recovered_exact_readback'
+    | 'blocked_dependency'
     | null;
   validation: DatasetSaveDraftValidationResult | null;
   visible_row?: VisibleDatasetRow | null;
   error?: { message: string; details?: unknown };
+  action_id?: string;
+  desired_sha256?: string;
+  attempt_consumed?: boolean;
+  replayed?: false;
+  readback?: 'desired_exact' | 'not_desired' | 'not_performed';
 };
 
 export type DatasetSaveDraftReport = {
-  schema_version: 1;
+  schema_version: 1 | 2;
   generated_at_utc: string;
   input_path: string;
   requested_type: DatasetSaveDraftType;
   out_dir: string;
   commit: boolean;
   mode: 'dry_run' | 'commit';
-  status: 'completed' | 'completed_with_failures';
+  status: 'completed' | 'completed_with_failures' | 'completed_with_unknowns';
   counts: {
     selected: number;
     prepared: number;
     executed: number;
     failed: number;
+    unknown?: number;
+    blocked?: number;
+    attempts_consumed?: number;
     by_table: Partial<Record<DatasetCommandTable, number>>;
     operations: Record<string, number>;
   };
@@ -136,8 +155,15 @@ export type DatasetSaveDraftReport = {
     progress_jsonl: string;
     failures_jsonl: string;
     summary_json: string;
+    execution_ledger?: string;
   };
   rows: DatasetSaveDraftRowReport[];
+  execution_contract?: {
+    path: string;
+    sha256: string;
+    execution_id: string;
+    target_mode: 'owner_draft';
+  };
 };
 
 export type RunDatasetSaveDraftOptions = {
@@ -156,6 +182,53 @@ export type RunDatasetSaveDraftOptions = {
    * the CLI safe-by-default for interactive operators.
    */
   allowReferenceOnlySupport?: boolean | null;
+  executionContractPath?: string | null;
+};
+
+type DatasetSaveDraftExecutionAction = {
+  action_id: string;
+  desired_sha256: string;
+  expected_operation: 'insert' | 'save_draft';
+  table: DatasetCommandTable;
+  id: string;
+  version: string;
+  before_sha256: string | null;
+  dependency_action_ids: string[];
+};
+
+type DatasetSaveDraftExecutionContract = {
+  schema_version: 'dataset-save-draft-execution-contract.v1';
+  execution_id: string;
+  project_ref: string;
+  target_mode: 'owner_draft';
+  owner: {
+    user_id: string;
+    email: string;
+    state_code: 0;
+  };
+  actions: DatasetSaveDraftExecutionAction[];
+};
+
+type DatasetSaveDraftLedgerEvent = {
+  schema_version: 'dataset-save-draft-execution-event.v1';
+  sequence: number;
+  contract_sha256: string;
+  action_id: string;
+  desired_sha256: string;
+  action_binding_sha256: string;
+  event_type: 'attempt_emitted' | 'outcome';
+  operation: 'insert' | 'save_draft';
+  outcome: 'executed' | 'unknown' | null;
+  recovered: boolean;
+  recorded_at_utc: string;
+  previous_event_sha256: string | null;
+  event_sha256: string;
+};
+
+type ExecutionLedgerState = {
+  events: Map<string, DatasetSaveDraftLedgerEvent[]>;
+  attempts: Map<string, DatasetSaveDraftLedgerEvent>;
+  outcomes: Map<string, DatasetSaveDraftLedgerEvent>;
 };
 
 type PreparedDatasetRow = {
@@ -174,6 +247,10 @@ type VisibleDatasetRow = {
   version: string;
   user_id: string | null;
   state_code: number | null;
+};
+
+type ExecutionDatasetRow = VisibleDatasetRow & {
+  json_ordered: JsonObject | null;
 };
 
 type SupabaseDataClient = ReturnType<typeof createSupabaseDataClient>['client'];
@@ -242,6 +319,347 @@ const REFERENCE_ONLY_SAVE_DRAFT_TYPES = new Set<ConcreteDatasetSaveDraftType>([
   'unitgroup',
   'flowproperty',
 ]);
+
+const SHA256_PATTERN = /^[0-9a-f]{64}$/u;
+
+function executionContractError(message: string): never {
+  throw new CliError(message, {
+    code: 'DATASET_SAVE_DRAFT_EXECUTION_CONTRACT_INVALID',
+    exitCode: 2,
+  });
+}
+
+function requireExecutionToken(value: unknown, label: string): string {
+  const normalized = trimToken(value);
+  return normalized ?? executionContractError(`${label} must be a non-empty string.`);
+}
+
+function requireExecutionSha(value: unknown, label: string): string {
+  const normalized = requireExecutionToken(value, label);
+  return SHA256_PATTERN.test(normalized)
+    ? normalized
+    : executionContractError(`${label} must be a lowercase SHA-256 digest.`);
+}
+
+function parseExecutionContract(value: unknown): DatasetSaveDraftExecutionContract {
+  if (!isRecord(value)) {
+    executionContractError('Execution contract must be a JSON object.');
+  }
+  if (
+    value.schema_version !== 'dataset-save-draft-execution-contract.v1' ||
+    value.target_mode !== 'owner_draft' ||
+    !isRecord(value.owner) ||
+    value.owner.state_code !== 0 ||
+    !Array.isArray(value.actions) ||
+    value.actions.length === 0
+  ) {
+    executionContractError('Execution contract header is invalid.');
+  }
+  const executionId = requireExecutionToken(value.execution_id, 'execution_id');
+  const projectRef = requireExecutionToken(value.project_ref, 'project_ref');
+  const ownerUserId = requireExecutionToken(value.owner.user_id, 'owner.user_id');
+  const ownerEmail = requireExecutionToken(value.owner.email, 'owner.email').toLowerCase();
+  const actions: DatasetSaveDraftExecutionAction[] = [];
+  const seen = new Set<string>();
+  for (const [index, rawAction] of value.actions.entries()) {
+    if (!isRecord(rawAction) || !Array.isArray(rawAction.dependency_action_ids)) {
+      executionContractError(`actions[${index}] is invalid.`);
+    }
+    const actionId = requireExecutionToken(rawAction.action_id, `actions[${index}].action_id`);
+    if (seen.has(actionId)) {
+      executionContractError(`Duplicate action_id: ${actionId}`);
+    }
+    const table = requireExecutionToken(rawAction.table, `actions[${index}].table`);
+    if (!Object.values(DATASET_CONFIGS).some((config) => config.table === table)) {
+      executionContractError(`actions[${index}].table is unsupported.`);
+    }
+    const expectedOperation = rawAction.expected_operation;
+    if (expectedOperation !== 'insert' && expectedOperation !== 'save_draft') {
+      executionContractError(`actions[${index}].expected_operation is invalid.`);
+    }
+    const beforeSha =
+      rawAction.before_sha256 === null
+        ? null
+        : requireExecutionSha(rawAction.before_sha256, `actions[${index}].before_sha256`);
+    if (
+      (expectedOperation === 'insert' && beforeSha !== null) ||
+      (expectedOperation === 'save_draft' && beforeSha === null)
+    ) {
+      executionContractError(`actions[${index}].before_sha256 contradicts expected_operation.`);
+    }
+    const dependencies = rawAction.dependency_action_ids.map((dependency, dependencyIndex) =>
+      requireExecutionToken(
+        dependency,
+        `actions[${index}].dependency_action_ids[${dependencyIndex}]`,
+      ),
+    );
+    if (
+      new Set(dependencies).size !== dependencies.length ||
+      dependencies.some((id) => !seen.has(id))
+    ) {
+      executionContractError(
+        `actions[${index}].dependency_action_ids must be unique earlier actions.`,
+      );
+    }
+    actions.push({
+      action_id: actionId,
+      desired_sha256: requireExecutionSha(
+        rawAction.desired_sha256,
+        `actions[${index}].desired_sha256`,
+      ),
+      expected_operation: expectedOperation,
+      table: table as DatasetCommandTable,
+      id: requireExecutionToken(rawAction.id, `actions[${index}].id`),
+      version: requireExecutionToken(rawAction.version, `actions[${index}].version`),
+      before_sha256: beforeSha,
+      dependency_action_ids: dependencies,
+    });
+    seen.add(actionId);
+  }
+  return {
+    schema_version: 'dataset-save-draft-execution-contract.v1',
+    execution_id: executionId,
+    project_ref: projectRef,
+    target_mode: 'owner_draft',
+    owner: { user_id: ownerUserId, email: ownerEmail, state_code: 0 },
+    actions,
+  };
+}
+
+function bindExecutionContractRows(
+  contract: DatasetSaveDraftExecutionContract,
+  rows: PreparedDatasetRow[],
+): void {
+  if (contract.actions.length !== rows.length) {
+    executionContractError('Execution contract action count does not match selected rows.');
+  }
+  contract.actions.forEach((action, index) => {
+    const row = rows[index];
+    const payloadIdentity = row?.config
+      ? extractIdentity(row.payload, {}, row.config)
+      : { id: null, version: null };
+    if (
+      !row ||
+      row.config?.table !== action.table ||
+      row.id !== action.id ||
+      row.version !== action.version ||
+      payloadIdentity.id !== action.id ||
+      payloadIdentity.version !== action.version ||
+      sha256Json(row.payload) !== action.desired_sha256
+    ) {
+      executionContractError(
+        `Execution contract action ${action.action_id} does not bind row ${index}.`,
+      );
+    }
+  });
+}
+
+function executionActionBindingSha256(action: DatasetSaveDraftExecutionAction): string {
+  return sha256Json({
+    schema_version: 'dataset-save-draft-action-binding.v1',
+    action_id: action.action_id,
+    desired_sha256: action.desired_sha256,
+    expected_operation: action.expected_operation,
+    table: action.table,
+    id: action.id,
+    version: action.version,
+    before_sha256: action.before_sha256,
+  });
+}
+
+function executionLedgerRoot(
+  env: NodeJS.ProcessEnv,
+  contract: DatasetSaveDraftExecutionContract,
+): string {
+  const ownerScopeSha256 = sha256Json({
+    schema_version: 'dataset-save-draft-owner-scope.v1',
+    project_ref: contract.project_ref,
+    owner: contract.owner,
+  });
+  return path.join(
+    resolveFlowIdentityApprovalClaimRoot({ env }),
+    'execution-ledgers',
+    'dataset-save-draft',
+    'v1',
+    ownerScopeSha256,
+  );
+}
+
+function executionLedgerPath(ledgerRoot: string, action: DatasetSaveDraftExecutionAction): string {
+  const actionIdentitySha256 = sha256Json({
+    schema_version: 'dataset-save-draft-action-identity.v1',
+    action_id: action.action_id,
+    desired_sha256: action.desired_sha256,
+  });
+  return path.join(path.resolve(ledgerRoot), `${actionIdentitySha256}.events.jsonl`);
+}
+
+function eventWithoutSha(
+  event: DatasetSaveDraftLedgerEvent,
+): Omit<DatasetSaveDraftLedgerEvent, 'event_sha256'> {
+  const core: Partial<DatasetSaveDraftLedgerEvent> = { ...event };
+  delete core.event_sha256;
+  return core as Omit<DatasetSaveDraftLedgerEvent, 'event_sha256'>;
+}
+
+function parseLedgerEvent(value: unknown, index: number): DatasetSaveDraftLedgerEvent {
+  if (!isRecord(value)) {
+    executionContractError(`Execution ledger event ${index} is not an object.`);
+  }
+  const event = value as DatasetSaveDraftLedgerEvent;
+  if (
+    event.schema_version !== 'dataset-save-draft-execution-event.v1' ||
+    event.sequence !== index + 1 ||
+    !SHA256_PATTERN.test(event.contract_sha256) ||
+    !trimToken(event.action_id) ||
+    !SHA256_PATTERN.test(event.desired_sha256) ||
+    !SHA256_PATTERN.test(event.action_binding_sha256) ||
+    !['attempt_emitted', 'outcome'].includes(event.event_type) ||
+    !['insert', 'save_draft'].includes(event.operation) ||
+    !['executed', 'unknown', null].includes(event.outcome) ||
+    typeof event.recovered !== 'boolean' ||
+    !trimToken(event.recorded_at_utc) ||
+    !(event.previous_event_sha256 === null || SHA256_PATTERN.test(event.previous_event_sha256)) ||
+    !SHA256_PATTERN.test(event.event_sha256)
+  ) {
+    executionContractError(`Execution ledger event ${index} has an invalid shape.`);
+  }
+  if (
+    (event.event_type === 'attempt_emitted' && event.outcome !== null) ||
+    (event.event_type === 'outcome' && event.outcome === null)
+  ) {
+    executionContractError(`Execution ledger event ${index} has an invalid outcome.`);
+  }
+  return event;
+}
+
+function loadExecutionLedger(
+  ledgerRoot: string,
+  contract: DatasetSaveDraftExecutionContract,
+): ExecutionLedgerState {
+  const events = new Map<string, DatasetSaveDraftLedgerEvent[]>();
+  const attempts = new Map<string, DatasetSaveDraftLedgerEvent>();
+  const outcomes = new Map<string, DatasetSaveDraftLedgerEvent>();
+  for (const action of contract.actions) {
+    const actionEvents: DatasetSaveDraftLedgerEvent[] = [];
+    const rawEvents = readJsonLinesIfPresent(executionLedgerPath(ledgerRoot, action));
+    for (const [index, value] of rawEvents.entries()) {
+      const event = parseLedgerEvent(value, index);
+      const previous = actionEvents.at(-1) ?? null;
+      if (
+        event.action_id !== action.action_id ||
+        event.desired_sha256 !== action.desired_sha256 ||
+        event.action_binding_sha256 !== executionActionBindingSha256(action) ||
+        event.operation !== action.expected_operation ||
+        event.previous_event_sha256 !== (previous?.event_sha256 ?? null) ||
+        event.event_sha256 !== sha256Json(eventWithoutSha(event))
+      ) {
+        executionContractError(
+          `Execution ledger event ${index} failed its hash or action binding for ${action.action_id}.`,
+        );
+      }
+      if (event.event_type === 'attempt_emitted') {
+        if (attempts.has(event.action_id) || outcomes.has(event.action_id)) {
+          executionContractError(`Execution ledger repeats attempt for ${event.action_id}.`);
+        }
+        attempts.set(event.action_id, event);
+      } else {
+        if (!attempts.has(event.action_id) || outcomes.has(event.action_id)) {
+          executionContractError(
+            `Execution ledger outcome ordering is invalid for ${event.action_id}.`,
+          );
+        }
+        outcomes.set(event.action_id, event);
+      }
+      actionEvents.push(event);
+    }
+    events.set(action.action_id, actionEvents);
+  }
+  return { events, attempts, outcomes };
+}
+
+function appendExecutionEvent(options: {
+  ledgerRoot: string;
+  ledger: ExecutionLedgerState;
+  contractSha256: string;
+  action: DatasetSaveDraftExecutionAction;
+  eventType: 'attempt_emitted' | 'outcome';
+  outcome: 'executed' | 'unknown' | null;
+  recovered: boolean;
+  recordedAtUtc: string;
+}): DatasetSaveDraftLedgerEvent {
+  const actionEvents = options.ledger.events.get(
+    options.action.action_id,
+  ) as DatasetSaveDraftLedgerEvent[];
+  const core = {
+    schema_version: 'dataset-save-draft-execution-event.v1' as const,
+    sequence: actionEvents.length + 1,
+    contract_sha256: options.contractSha256,
+    action_id: options.action.action_id,
+    desired_sha256: options.action.desired_sha256,
+    action_binding_sha256: executionActionBindingSha256(options.action),
+    event_type: options.eventType,
+    operation: options.action.expected_operation,
+    outcome: options.outcome,
+    recovered: options.recovered,
+    recorded_at_utc: options.recordedAtUtc,
+    previous_event_sha256: actionEvents.at(-1)?.event_sha256 ?? null,
+  };
+  const event: DatasetSaveDraftLedgerEvent = { ...core, event_sha256: sha256Json(core) };
+  const ledgerPath = executionLedgerPath(options.ledgerRoot, options.action);
+  mkdirSync(path.dirname(ledgerPath), { recursive: true, mode: 0o700 });
+  chmodSync(path.dirname(ledgerPath), 0o700);
+  if (event.event_type === 'attempt_emitted') {
+    const createDescriptor = openSync(ledgerPath, 'wx', 0o600);
+    try {
+      writeFileSync(createDescriptor, `${stableJsonText(event)}\n`, 'utf8');
+      fsyncSync(createDescriptor);
+    } finally {
+      closeSync(createDescriptor);
+    }
+  } else {
+    appendStableJsonLine(ledgerPath, event);
+  }
+  chmodSync(ledgerPath, 0o600);
+  const descriptor = openSync(ledgerPath, 'r');
+  try {
+    fsyncSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+  actionEvents.push(event);
+  options.ledger.events.set(event.action_id, actionEvents);
+  if (event.event_type === 'attempt_emitted') {
+    options.ledger.attempts.set(event.action_id, event);
+  } else {
+    options.ledger.outcomes.set(event.action_id, event);
+  }
+  return event;
+}
+
+function projectRefFromApiBaseUrl(apiBaseUrl: string): string {
+  return new URL(apiBaseUrl).hostname.split('.')[0] as string;
+}
+
+function decodeExecutionActor(accessToken: string): { user_id: string; email: string } {
+  const payload = accessToken.split('.')[1];
+  if (!payload) {
+    executionContractError('Owner-session access token is not a JWT.');
+  }
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+  } catch {
+    executionContractError('Owner-session access token JWT payload is invalid.');
+  }
+  if (!isRecord(decoded)) {
+    executionContractError('Owner-session access token JWT payload is not an object.');
+  }
+  return {
+    user_id: requireExecutionToken(decoded.sub, 'owner-session sub'),
+    email: requireExecutionToken(decoded.email, 'owner-session email').toLowerCase(),
+  };
+}
 
 function isRecord(value: unknown): value is JsonObject {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -826,6 +1244,435 @@ async function exactVisibleRows(options: {
   return parseVisibleRows(payload, url);
 }
 
+function parseExecutionRows(payload: unknown, url: string): ExecutionDatasetRow[] {
+  const visible = parseVisibleRows(payload, url);
+  return visible.map((row, index) => {
+    const raw = (payload as unknown[])[index];
+    const jsonOrdered = isRecord(raw) && isRecord(raw.json_ordered) ? raw.json_ordered : null;
+    return { ...row, json_ordered: jsonOrdered };
+  });
+}
+
+async function exactExecutionRows(options: {
+  client: SupabaseDataClient;
+  restBaseUrl: string;
+  table: DatasetCommandTable;
+  id: string;
+  version: string;
+}): Promise<ExecutionDatasetRow[]> {
+  const url = new URL(
+    buildVisibleRowsUrl(options.restBaseUrl, options.table, options.id, options.version),
+  );
+  url.searchParams.set('select', 'id,version,user_id,state_code,json_ordered');
+  const payload = await runSupabaseArrayQuery(
+    options.client
+      .from(options.table)
+      .select('id,version,user_id,state_code,json_ordered')
+      .eq('id', options.id)
+      .eq('version', options.version),
+    url.toString(),
+  );
+  return parseExecutionRows(payload, url.toString());
+}
+
+function exactDesiredReadback(options: {
+  rows: ExecutionDatasetRow[];
+  action: DatasetSaveDraftExecutionAction;
+  contract: DatasetSaveDraftExecutionContract;
+}): boolean {
+  const row = options.rows[0];
+  return Boolean(
+    options.rows.length === 1 &&
+    row &&
+    row.id === options.action.id &&
+    row.version === options.action.version &&
+    row.user_id === options.contract.owner.user_id &&
+    row.state_code === 0 &&
+    row.json_ordered &&
+    sha256Json(row.json_ordered) === options.action.desired_sha256,
+  );
+}
+
+function contractRowReport(options: {
+  row: PreparedDatasetRow;
+  action: DatasetSaveDraftExecutionAction;
+  status: 'executed' | 'failed' | 'unknown' | 'blocked';
+  operation: DatasetSaveDraftRowReport['operation'];
+  attemptConsumed: boolean;
+  readback: DatasetSaveDraftRowReport['readback'];
+  error?: { message: string; details?: unknown };
+}): DatasetSaveDraftRowReport {
+  return {
+    index: options.row.index,
+    id: options.row.id,
+    version: options.row.version,
+    type: options.row.type,
+    table: options.action.table,
+    status: options.status,
+    operation: options.operation,
+    validation: options.row.validation,
+    action_id: options.action.action_id,
+    desired_sha256: options.action.desired_sha256,
+    attempt_consumed: options.attemptConsumed,
+    replayed: false,
+    readback: options.readback,
+    ...(options.error ? { error: options.error } : {}),
+  };
+}
+
+async function finalizeAttemptedAction(options: {
+  row: PreparedDatasetRow;
+  action: DatasetSaveDraftExecutionAction;
+  contract: DatasetSaveDraftExecutionContract;
+  contractSha256: string;
+  ledgerRoot: string;
+  ledger: ExecutionLedgerState;
+  client: SupabaseDataClient;
+  restBaseUrl: string;
+  now: () => string;
+  recovered: boolean;
+}): Promise<DatasetSaveDraftRowReport> {
+  const desiredExact = await readbackIsDesiredExact(options);
+  appendExecutionEvent({
+    ledgerRoot: options.ledgerRoot,
+    ledger: options.ledger,
+    contractSha256: options.contractSha256,
+    action: options.action,
+    eventType: 'outcome',
+    outcome: desiredExact ? 'executed' : 'unknown',
+    recovered: options.recovered,
+    recordedAtUtc: options.now(),
+  });
+  return contractRowReport({
+    row: options.row,
+    action: options.action,
+    status: desiredExact ? 'executed' : 'unknown',
+    operation:
+      desiredExact && options.recovered
+        ? 'recovered_exact_readback'
+        : options.action.expected_operation,
+    attemptConsumed: true,
+    readback: desiredExact ? 'desired_exact' : 'not_desired',
+    ...(desiredExact
+      ? {}
+      : {
+          error: {
+            message:
+              'A prior protected request was emitted without a terminal desired-exact readback; the action is UNKNOWN and will never be replayed.',
+          },
+        }),
+  });
+}
+
+async function readbackIsDesiredExact(options: {
+  client: SupabaseDataClient;
+  restBaseUrl: string;
+  action: DatasetSaveDraftExecutionAction;
+  contract: DatasetSaveDraftExecutionContract;
+}): Promise<boolean> {
+  try {
+    return exactDesiredReadback({
+      rows: await exactExecutionRows({
+        client: options.client,
+        restBaseUrl: options.restBaseUrl,
+        table: options.action.table,
+        id: options.action.id,
+        version: options.action.version,
+      }),
+      action: options.action,
+      contract: options.contract,
+    });
+  } catch {
+    return false;
+  }
+}
+
+async function runExecutionContractBatch(options: {
+  contractPath: string;
+  contract: DatasetSaveDraftExecutionContract;
+  preparedRows: PreparedDatasetRow[];
+  allowReferenceOnlySupport: boolean;
+  files: DatasetSaveDraftReport['files'];
+  inputPath: string;
+  requestedType: DatasetSaveDraftType;
+  outDir: string;
+  env: NodeJS.ProcessEnv;
+  runtime: SupabaseDataRuntime;
+  commandTransport: NonNullable<Awaited<ReturnType<typeof buildDatasetCommandTransport>>>;
+  dataClient: NonNullable<ReturnType<typeof createSupabaseDataClient>>;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+  now: () => string;
+}): Promise<DatasetSaveDraftReport> {
+  const contractSha256 = sha256Json(options.contract);
+  const ledgerRoot = executionLedgerRoot(options.env, options.contract);
+  const ledger = loadExecutionLedger(ledgerRoot, options.contract);
+  const actor = decodeExecutionActor(options.commandTransport.accessToken);
+  if (
+    projectRefFromApiBaseUrl(options.runtime.apiBaseUrl) !== options.contract.project_ref ||
+    actor.user_id !== options.contract.owner.user_id ||
+    actor.email !== options.contract.owner.email
+  ) {
+    executionContractError('Owner session or project does not match the execution contract.');
+  }
+  options.files.execution_ledger = ledgerRoot;
+  const reports: DatasetSaveDraftRowReport[] = [];
+  const statuses = new Map<string, DatasetSaveDraftRowReport['status']>();
+  const referenceOnlySupportCache = new Map<string, Promise<RemoteDatasetLookup>>();
+
+  for (const [index, action] of options.contract.actions.entries()) {
+    const row = options.preparedRows[index] as PreparedDatasetRow;
+    const preparedFailure = buildPreparedFailure(row, options.allowReferenceOnlySupport);
+    if (preparedFailure) {
+      const report = {
+        ...preparedFailure,
+        action_id: action.action_id,
+        desired_sha256: action.desired_sha256,
+        attempt_consumed: false,
+        replayed: false as const,
+        readback: 'not_performed' as const,
+      };
+      reports.push(report);
+      statuses.set(action.action_id, report.status);
+      continue;
+    }
+
+    const priorOutcome = ledger.outcomes.get(action.action_id);
+    if (priorOutcome) {
+      const desiredStillExact =
+        priorOutcome.outcome === 'executed' &&
+        (await readbackIsDesiredExact({
+          client: options.dataClient.client,
+          restBaseUrl: options.dataClient.restBaseUrl,
+          action,
+          contract: options.contract,
+        }));
+      const status = desiredStillExact ? 'executed' : 'unknown';
+      const report = contractRowReport({
+        row,
+        action,
+        status,
+        operation: action.expected_operation,
+        attemptConsumed: true,
+        readback: desiredStillExact ? 'desired_exact' : 'not_desired',
+        ...(status === 'unknown'
+          ? {
+              error: {
+                message:
+                  priorOutcome.outcome === 'unknown'
+                    ? 'Terminal UNKNOWN action retained; replay is forbidden.'
+                    : 'A terminal success no longer has exact desired owner readback; replay is forbidden.',
+              },
+            }
+          : {}),
+      });
+      reports.push(report);
+      statuses.set(action.action_id, status);
+      continue;
+    }
+
+    if (ledger.attempts.has(action.action_id)) {
+      const report = await finalizeAttemptedAction({
+        row,
+        action,
+        contract: options.contract,
+        contractSha256,
+        ledgerRoot,
+        ledger,
+        client: options.dataClient.client,
+        restBaseUrl: options.dataClient.restBaseUrl,
+        now: options.now,
+        recovered: true,
+      });
+      reports.push(report);
+      statuses.set(action.action_id, report.status);
+      continue;
+    }
+
+    const blockingDependencies = action.dependency_action_ids.filter(
+      (dependency) => statuses.get(dependency) !== 'executed',
+    );
+    if (blockingDependencies.length > 0) {
+      const report = contractRowReport({
+        row,
+        action,
+        status: 'blocked',
+        operation: 'blocked_dependency',
+        attemptConsumed: false,
+        readback: 'not_performed',
+        error: {
+          message: 'Action dependencies are not terminal successes; no request was emitted.',
+          details: { dependency_action_ids: blockingDependencies },
+        },
+      });
+      reports.push(report);
+      statuses.set(action.action_id, report.status);
+      continue;
+    }
+
+    let beforeRows: ExecutionDatasetRow[];
+    let transportFailed = false;
+    try {
+      beforeRows = await exactExecutionRows({
+        client: options.dataClient.client,
+        restBaseUrl: options.dataClient.restBaseUrl,
+        table: action.table,
+        id: action.id,
+        version: action.version,
+      });
+      const before = beforeRows[0];
+      const observedOperation = beforeRows.length === 0 ? 'insert' : 'save_draft';
+      const beforeExact = Boolean(
+        beforeRows.length === 1 &&
+        before &&
+        before.id === action.id &&
+        before.version === action.version &&
+        before.user_id === options.contract.owner.user_id &&
+        before.state_code === 0 &&
+        before.json_ordered &&
+        sha256Json(before.json_ordered) === action.before_sha256,
+      );
+      if (
+        beforeRows.length > 1 ||
+        observedOperation !== action.expected_operation ||
+        (observedOperation === 'save_draft' && !beforeExact)
+      ) {
+        throw new CliError('Execution action before-state or expected operation drifted.', {
+          code: 'DATASET_SAVE_DRAFT_EXECUTION_BEFORE_DRIFT',
+          exitCode: 1,
+        });
+      }
+      if (row.type === 'flow') {
+        const unresolvedReferences = await missingFlowRemoteReferences({
+          runtime: options.runtime,
+          fetchImpl: options.fetchImpl,
+          timeoutMs: options.timeoutMs,
+          cache: referenceOnlySupportCache,
+          payload: row.payload,
+        });
+        if (unresolvedReferences.length > 0) {
+          throw new CliError('Flow execution action has unresolved remote references.', {
+            code: 'DATASET_SAVE_DRAFT_REMOTE_REFERENCE_UNRESOLVED',
+            exitCode: 1,
+            details: { references: unresolvedReferences },
+          });
+        }
+      }
+    } catch (error) {
+      const report = contractRowReport({
+        row,
+        action,
+        status: 'failed',
+        operation: action.expected_operation,
+        attemptConsumed: false,
+        readback: 'not_performed',
+        error: serializeError(error),
+      });
+      reports.push(report);
+      statuses.set(action.action_id, report.status);
+      continue;
+    }
+
+    try {
+      const beforeDispatch = () => {
+        appendExecutionEvent({
+          ledgerRoot,
+          ledger,
+          contractSha256,
+          action,
+          eventType: 'attempt_emitted',
+          outcome: null,
+          recovered: false,
+          recordedAtUtc: options.now(),
+        });
+      };
+      if (action.expected_operation === 'insert') {
+        await createDatasetRecord({
+          transport: options.commandTransport,
+          table: action.table,
+          id: action.id,
+          payload: row.payload,
+          extraData: { ruleVerification: true },
+          beforeDispatch,
+        });
+      } else {
+        await saveDraftDatasetRecord({
+          transport: options.commandTransport,
+          table: action.table,
+          id: action.id,
+          version: action.version,
+          payload: row.payload,
+          extraData: { ruleVerification: true },
+          beforeDispatch,
+        });
+      }
+    } catch (error) {
+      if (error instanceof CliError && error.code === 'DATASET_COMMAND_BEFORE_DISPATCH_FAILED') {
+        throw error;
+      }
+      // Once emission is durably recorded, transport outcomes are resolved by readback only.
+      transportFailed = true;
+    }
+    const report = await finalizeAttemptedAction({
+      row,
+      action,
+      contract: options.contract,
+      contractSha256,
+      ledgerRoot,
+      ledger,
+      client: options.dataClient.client,
+      restBaseUrl: options.dataClient.restBaseUrl,
+      now: options.now,
+      recovered: transportFailed,
+    });
+    reports.push(report);
+    statuses.set(action.action_id, report.status);
+  }
+
+  const failures = reports.filter((row) => ['failed', 'unknown', 'blocked'].includes(row.status));
+  writeJsonLinesArtifact(options.files.progress_jsonl, reports);
+  writeJsonLinesArtifact(options.files.failures_jsonl, failures);
+  const unknown = reports.filter((row) => row.status === 'unknown').length;
+  const failed = reports.filter((row) => row.status === 'failed').length;
+  const blocked = reports.filter((row) => row.status === 'blocked').length;
+  const report: DatasetSaveDraftReport = {
+    schema_version: 2,
+    generated_at_utc: options.now(),
+    input_path: options.inputPath,
+    requested_type: options.requestedType,
+    out_dir: options.outDir,
+    commit: true,
+    mode: 'commit',
+    status:
+      unknown > 0
+        ? 'completed_with_unknowns'
+        : failed + blocked > 0
+          ? 'completed_with_failures'
+          : 'completed',
+    counts: {
+      selected: options.preparedRows.length,
+      prepared: 0,
+      executed: reports.filter((row) => row.status === 'executed').length,
+      failed,
+      unknown,
+      blocked,
+      attempts_consumed: ledger.attempts.size,
+      by_table: byTable(options.preparedRows),
+      operations: operationCount(reports),
+    },
+    files: options.files,
+    rows: reports,
+    execution_contract: {
+      path: path.resolve(options.contractPath),
+      sha256: contractSha256,
+      execution_id: options.contract.execution_id,
+      target_mode: 'owner_draft',
+    },
+  };
+  writeJsonArtifact(options.files.summary_json, report);
+  return report;
+}
+
 export async function runDatasetSaveDraft(
   options: RunDatasetSaveDraftOptions,
 ): Promise<DatasetSaveDraftReport> {
@@ -840,6 +1687,21 @@ export async function runDatasetSaveDraft(
   const files = buildFiles(outDir);
   const preparedRows = prepareRows(inputPath, options.rawInput, requestedType);
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const executionContractPath = options.executionContractPath
+    ? path.resolve(options.executionContractPath)
+    : null;
+  const executionContract = executionContractPath
+    ? parseExecutionContract(
+        readJsonFile(executionContractPath, 'Dataset save-draft execution contract'),
+      )
+    : null;
+
+  if (executionContract && !commit) {
+    executionContractError('Execution contract mode requires --commit.');
+  }
+  if (executionContract) {
+    bindExecutionContractRows(executionContract, preparedRows);
+  }
 
   if (commit && (!options.env || !options.fetchImpl)) {
     throw new CliError('Dataset save-draft commit requires env and fetch runtime bindings.', {
@@ -871,6 +1733,26 @@ export async function runDatasetSaveDraft(
       ? createSupabaseDataClient(runtime, options.fetchImpl, timeoutMs)
       : null;
   const referenceOnlySupportCache = new Map<string, Promise<RemoteDatasetLookup>>();
+
+  if (executionContract && executionContractPath) {
+    return runExecutionContractBatch({
+      contractPath: executionContractPath,
+      contract: executionContract,
+      preparedRows,
+      allowReferenceOnlySupport,
+      files,
+      inputPath,
+      requestedType,
+      outDir,
+      env: options.env!,
+      runtime: runtime!,
+      commandTransport: commandTransport!,
+      dataClient: dataClient!,
+      fetchImpl: options.fetchImpl!,
+      timeoutMs,
+      now: () => now.toISOString(),
+    });
+  }
 
   const reports: DatasetSaveDraftRowReport[] = [];
   for (const row of preparedRows) {
@@ -1025,6 +1907,13 @@ export const __testInternals = {
   compareVersions,
   defaultOutDir,
   detectType,
+  decodeExecutionActor,
+  bindExecutionContractRows,
+  executionLedgerRoot,
+  executionLedgerPath,
+  executionActionBindingSha256,
+  loadExecutionLedger,
+  exactDesiredReadback,
   extractIdentity,
   flowType,
   isElementaryFlowPayload,
@@ -1034,6 +1923,10 @@ export const __testInternals = {
   normalizeType,
   operationCount,
   parseVisibleRows,
+  parseExecutionContract,
+  parseExecutionRows,
+  parseLedgerEvent,
+  projectRefFromApiBaseUrl,
   prepareRows,
   remoteReferenceFallbackKey,
   selectedRow,

--- a/test/dataset-maintenance-flow-identity.test.ts
+++ b/test/dataset-maintenance-flow-identity.test.ts
@@ -1786,6 +1786,10 @@ test('planner rejects phantom orphans, target drift, incompatible directions, mi
     issue_count: 1,
     issues: [{ path: 'process', message: 'bad', code: 'custom' }],
   });
+  const schemaFailureNow = Date.now();
+  schemaFailure.capture.attestation.captured_at = new Date(schemaFailureNow - 60_000).toISOString();
+  schemaFailure.capture.attestation.expires_at = new Date(schemaFailureNow + 60_000).toISOString();
+  bindCaptureReceiptSemantics(schemaFailure.capture, schemaFailure.review);
   assert.throws(
     () =>
       buildFlowIdentityPlan({
@@ -1819,6 +1823,11 @@ test('contract parsers reject review, policy, and plan tampering', () => {
   duplicateReview.entries[304]!.source = { ...duplicateReview.entries[0]!.source };
   duplicateReview.ledger_sha256 = computeFlowIdentityReviewLedgerSha256(duplicateReview);
   assert.throws(() => parseFlowIdentityReviewLedger(duplicateReview), /305 unique/u);
+
+  const currentWindow = Date.now();
+  input.capture.attestation.captured_at = new Date(currentWindow - 60_000).toISOString();
+  input.capture.attestation.expires_at = new Date(currentWindow + 60_000).toISOString();
+  bindCaptureReceiptSemantics(input.capture, input.review);
 
   const bundle = buildFlowIdentityPlan({
     policy: input.policy,

--- a/test/dataset-save-draft-cli.test.ts
+++ b/test/dataset-save-draft-cli.test.ts
@@ -288,6 +288,8 @@ test('executeCli exposes generic dataset save-draft for support rows', async () 
       'contact',
       '--out-dir',
       'contact-save',
+      '--execution-contract',
+      'contract.json',
       '--commit',
     ],
     makeDeps({
@@ -307,6 +309,7 @@ test('executeCli exposes generic dataset save-draft for support rows', async () 
     outDir: 'contact-save',
     commit: true,
     allowReferenceOnlySupport: false,
+    executionContractPath: 'contract.json',
     env: {},
     fetchImpl: (observed[0] as { fetchImpl: unknown }).fetchImpl,
   });

--- a/test/dataset-save-draft-execution-contract.test.ts
+++ b/test/dataset-save-draft-execution-contract.test.ts
@@ -1,0 +1,976 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { runDatasetSaveDraft, __testInternals } from '../src/lib/dataset-save-draft-run.js';
+import { sha256Json, stableJsonText } from '../src/lib/dataset-maintenance-contract.js';
+import type { FetchLike } from '../src/lib/http.js';
+import {
+  buildSupabaseTestEnv,
+  isSupabaseAuthTokenUrl,
+  makeSupabaseAuthResponse,
+} from './helpers/supabase-auth.js';
+
+type JsonObject = Record<string, unknown>;
+
+function response(body: unknown): Awaited<ReturnType<FetchLike>> {
+  return {
+    ok: true,
+    status: 200,
+    headers: {
+      get: (name: string) => (name.toLowerCase() === 'content-type' ? 'application/json' : null),
+    },
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function localized(text: string): { '@xml:lang': 'en'; '#text': string } {
+  return { '@xml:lang': 'en', '#text': text };
+}
+
+function reference(type: string, id: string, version: string): JsonObject {
+  return {
+    '@type': type,
+    '@refObjectId': id,
+    '@version': version,
+    '@uri': `../datasets/${id}_${version}.xml`,
+    'common:shortDescription': localized(id),
+  };
+}
+
+function flow(id: string, name: string): JsonObject {
+  return {
+    flowDataSet: {
+      '@xmlns': 'http://lca.jrc.it/ILCD/Flow',
+      '@xmlns:common': 'http://lca.jrc.it/ILCD/Common',
+      '@xmlns:ecn': 'http://eplca.jrc.ec.europa.eu/ILCD/Extensions/2018/ECNumber',
+      '@xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+      '@version': '1.1',
+      '@locations': '../ILCDLocations.xml',
+      '@xsi:schemaLocation': 'http://lca.jrc.it/ILCD/Flow ../../schemas/ILCD_FlowDataSet.xsd',
+      flowInformation: {
+        dataSetInformation: {
+          'common:UUID': id,
+          name: {
+            baseName: localized(name),
+            treatmentStandardsRoutes: localized('not applicable'),
+            mixAndLocationTypes: localized('market'),
+          },
+          classificationInformation: {
+            'common:classification': {
+              'common:class': { '@level': '0', '@classId': '001', '#text': 'General' },
+            },
+          },
+        },
+        quantitativeReference: { referenceToReferenceFlowProperty: '0' },
+      },
+      modellingAndValidation: {
+        LCIMethod: { typeOfDataSet: 'Product flow' },
+        complianceDeclarations: {
+          compliance: {
+            'common:referenceToComplianceSystem': reference(
+              'source data set',
+              '22222222-2222-2222-2222-222222222222',
+              '00.00.001',
+            ),
+            'common:approvalOfOverallCompliance': 'Not defined',
+          },
+        },
+      },
+      administrativeInformation: {
+        dataEntryBy: {
+          'common:timeStamp': '2026-07-23T00:00:00.000Z',
+          'common:referenceToDataSetFormat': reference(
+            'source data set',
+            '33333333-3333-3333-3333-333333333333',
+            '00.00.001',
+          ),
+        },
+        publicationAndOwnership: {
+          'common:dataSetVersion': '00.00.001',
+          'common:referenceToOwnershipOfDataSet': reference(
+            'contact data set',
+            '44444444-4444-4444-4444-444444444444',
+            '00.00.001',
+          ),
+        },
+      },
+      flowProperties: {
+        flowProperty: {
+          '@dataSetInternalID': '0',
+          referenceToFlowPropertyDataSet: reference(
+            'flow property data set',
+            '55555555-5555-5555-5555-555555555555',
+            '00.00.001',
+          ),
+          meanValue: '1.0',
+        },
+      },
+    },
+  };
+}
+
+function jwt(userId = 'user-1', email = 'user@example.com'): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none' }), 'utf8').toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ sub: userId, email }), 'utf8').toString('base64url');
+  return `${header}.${payload}.signature`;
+}
+
+function jwtWithPayload(payloadValue: unknown): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none' }), 'utf8').toString('base64url');
+  const payload = Buffer.from(JSON.stringify(payloadValue), 'utf8').toString('base64url');
+  return `${header}.${payload}.signature`;
+}
+
+function identity(payload: JsonObject): { id: string; version: string } {
+  const root = payload.flowDataSet as JsonObject;
+  const information = root.flowInformation as JsonObject;
+  const dataSetInformation = information.dataSetInformation as JsonObject;
+  const admin = root.administrativeInformation as JsonObject;
+  const publication = admin.publicationAndOwnership as JsonObject;
+  return {
+    id: dataSetInformation['common:UUID'] as string,
+    version: publication['common:dataSetVersion'] as string,
+  };
+}
+
+type Behavior = 'success' | 'mutate_then_throw' | 'throw_without_mutation';
+
+function executionFetch(options: {
+  state: Map<string, JsonObject>;
+  writes: string[];
+  behavior?: Map<string, Behavior>;
+  userId?: string;
+  email?: string;
+  missingSources?: boolean;
+  rowIdentityOverride?: { id?: string; version?: string };
+}): FetchLike {
+  const userId = options.userId ?? 'user-1';
+  const email = options.email ?? 'user@example.com';
+  return async (input, init) => {
+    const url = String(input);
+    if (isSupabaseAuthTokenUrl(url)) {
+      return makeSupabaseAuthResponse({ accessToken: jwt(userId, email), userId, email });
+    }
+    const parsed = new URL(url);
+    const table = parsed.pathname.split('/').at(-1);
+    if (parsed.pathname.includes('/functions/v1/app_dataset_')) {
+      const body = JSON.parse(String(init?.body)) as {
+        id: string;
+        version?: string;
+        jsonOrdered: JsonObject;
+      };
+      options.writes.push(body.id);
+      const operation = parsed.pathname.endsWith('app_dataset_create') ? 'insert' : 'save_draft';
+      const behavior = options.behavior?.get(body.id) ?? 'success';
+      if (behavior !== 'throw_without_mutation') {
+        options.state.set(body.id, body.jsonOrdered);
+      }
+      if (behavior !== 'success') {
+        throw new Error(`simulated ${operation} response loss`);
+      }
+      return response({ ok: true, operation });
+    }
+    if (table === 'flows') {
+      const id = parsed.searchParams.get('id')?.replace(/^eq\./u, '') ?? '';
+      const payload = options.state.get(id);
+      return response(
+        payload
+          ? [
+              {
+                ...identity(payload),
+                ...options.rowIdentityOverride,
+                user_id: userId,
+                state_code: 0,
+                json_ordered: payload,
+              },
+            ]
+          : [],
+      );
+    }
+    if (table === 'flowproperties') {
+      return response([{ id: '55555555-5555-5555-5555-555555555555', version: '00.00.001' }]);
+    }
+    if (table === 'contacts') {
+      return response([{ id: '44444444-4444-4444-4444-444444444444', version: '00.00.001' }]);
+    }
+    if (table === 'sources') {
+      if (options.missingSources) {
+        return response([]);
+      }
+      const id = parsed.searchParams.get('id')?.replace(/^eq\./u, '') ?? '';
+      return response([{ id, version: '00.00.001' }]);
+    }
+    throw new Error(`Unexpected URL: ${url}`);
+  };
+}
+
+function contract(options: {
+  desired: JsonObject[];
+  before?: Array<JsonObject | null>;
+  dependencies?: string[][];
+}): JsonObject {
+  return {
+    schema_version: 'dataset-save-draft-execution-contract.v1',
+    execution_id: 'generic-owner-draft-batch-1',
+    project_ref: 'example',
+    target_mode: 'owner_draft',
+    owner: { user_id: 'user-1', email: 'user@example.com', state_code: 0 },
+    actions: options.desired.map((payload, index) => {
+      const rowIdentity = identity(payload);
+      const before = options.before?.[index] ?? null;
+      return {
+        action_id: `action-${index + 1}`,
+        desired_sha256: sha256Json(payload),
+        expected_operation: before ? 'save_draft' : 'insert',
+        table: 'flows',
+        ...rowIdentity,
+        before_sha256: before ? sha256Json(before) : null,
+        dependency_action_ids: options.dependencies?.[index] ?? [],
+      };
+    }),
+  };
+}
+
+function writeContract(dir: string, value: JsonObject): string {
+  const filePath = path.join(dir, 'execution-contract.json');
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+  return filePath;
+}
+
+function executionEnv(dir: string, apiKey: string): NodeJS.ProcessEnv {
+  return buildSupabaseTestEnv({
+    TIANGONG_LCA_API_KEY: apiKey,
+    XDG_STATE_HOME: path.join(dir, 'state'),
+  });
+}
+
+function ledgerEvent(options: {
+  contractSha256: string;
+  action: JsonObject;
+  sequence: number;
+  eventType: 'attempt_emitted' | 'outcome';
+  outcome: 'executed' | 'unknown' | null;
+  previousEventSha256?: string | null;
+}): JsonObject {
+  const core = {
+    schema_version: 'dataset-save-draft-execution-event.v1',
+    sequence: options.sequence,
+    contract_sha256: options.contractSha256,
+    action_id: options.action.action_id,
+    desired_sha256: options.action.desired_sha256,
+    action_binding_sha256: __testInternals.executionActionBindingSha256(options.action as never),
+    event_type: options.eventType,
+    operation: options.action.expected_operation,
+    outcome: options.outcome,
+    recovered: false,
+    recorded_at_utc: '2026-07-23T04:00:00.000Z',
+    previous_event_sha256: options.previousEventSha256 ?? null,
+  };
+  return { ...core, event_sha256: sha256Json(core) };
+}
+
+function writeLedgerEvents(filePath: string, events: JsonObject[]): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${events.map((event) => stableJsonText(event)).join('\n')}\n`, 'utf8');
+}
+
+test('execution contract runs ordered insert/update once and skips terminal rows across out dirs', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-execution-contract-success-'));
+  const created = flow('11111111-1111-1111-1111-111111111111', 'Created');
+  const before = flow('66666666-6666-6666-6666-666666666666', 'Before');
+  const desired = flow('66666666-6666-6666-6666-666666666666', 'Desired');
+  const state = new Map<string, JsonObject>([[identity(before).id, before]]);
+  const writes: string[] = [];
+  const fetchImpl = executionFetch({ state, writes });
+  const contractPath = writeContract(
+    dir,
+    contract({
+      desired: [created, desired],
+      before: [null, before],
+      dependencies: [[], ['action-1']],
+    }),
+  );
+  try {
+    const first = await runDatasetSaveDraft({
+      inputPath: path.join(dir, 'rows.json'),
+      rawInput: { rows: [created, desired] },
+      type: 'flow',
+      outDir: path.join(dir, 'out-1'),
+      commit: true,
+      executionContractPath: contractPath,
+      env: executionEnv(dir, 'success-1'),
+      fetchImpl,
+      now: new Date('2026-07-23T03:45:00.000Z'),
+    });
+    assert.equal(first.status, 'completed');
+    assert.deepEqual(writes, [identity(created).id, identity(desired).id]);
+    assert.deepEqual(
+      first.rows.map((row) => [row.status, row.operation]),
+      [
+        ['executed', 'insert'],
+        ['executed', 'save_draft'],
+      ],
+    );
+    assert.equal(first.counts.attempts_consumed, 2);
+    const ledgerRoot = first.files.execution_ledger as string;
+    const parsedContract = __testInternals.parseExecutionContract(
+      contract({
+        desired: [created, desired],
+        before: [null, before],
+        dependencies: [[], ['action-1']],
+      }),
+    );
+    const events = parsedContract.actions.flatMap((action) =>
+      readFileSync(__testInternals.executionLedgerPath(ledgerRoot, action), 'utf8')
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line)),
+    );
+    assert.deepEqual(
+      events.map((event) => [event.event_type, event.outcome]),
+      [
+        ['attempt_emitted', null],
+        ['outcome', 'executed'],
+        ['attempt_emitted', null],
+        ['outcome', 'executed'],
+      ],
+    );
+
+    const second = await runDatasetSaveDraft({
+      inputPath: path.join(dir, 'rows.json'),
+      rawInput: { rows: [created, desired] },
+      type: 'flow',
+      outDir: path.join(dir, 'out-2'),
+      commit: true,
+      executionContractPath: contractPath,
+      env: executionEnv(dir, 'success-2'),
+      fetchImpl,
+      now: new Date('2026-07-23T03:46:00.000Z'),
+    });
+    assert.equal(second.status, 'completed');
+    assert.deepEqual(writes, [identity(created).id, identity(desired).id]);
+    assert.equal(
+      parsedContract.actions.reduce(
+        (count, action) =>
+          count +
+          readFileSync(__testInternals.executionLedgerPath(ledgerRoot, action), 'utf8')
+            .trim()
+            .split('\n').length,
+        0,
+      ),
+      4,
+    );
+
+    const copiedDir = path.join(dir, 'copied-contract');
+    mkdirSync(copiedDir);
+    const copiedContractPath = writeContract(copiedDir, parsedContract as unknown as JsonObject);
+    await runDatasetSaveDraft({
+      inputPath: path.join(dir, 'rows.json'),
+      rawInput: { rows: [created, desired] },
+      type: 'flow',
+      outDir: path.join(dir, 'out-3'),
+      commit: true,
+      executionContractPath: copiedContractPath,
+      env: executionEnv(dir, 'success-3'),
+      fetchImpl,
+    });
+    assert.deepEqual(writes, [identity(created).id, identity(desired).id]);
+
+    state.set(identity(created).id, flow(identity(created).id, 'Later drift'));
+    const driftedTerminal = await runDatasetSaveDraft({
+      inputPath: path.join(dir, 'rows.json'),
+      rawInput: { rows: [created, desired] },
+      type: 'flow',
+      outDir: path.join(dir, 'out-4'),
+      commit: true,
+      executionContractPath: contractPath,
+      env: executionEnv(dir, 'success-4'),
+      fetchImpl,
+    });
+    assert.equal(driftedTerminal.status, 'completed_with_unknowns');
+    assert.equal(driftedTerminal.rows[0]?.status, 'unknown');
+    assert.match(driftedTerminal.rows[0]?.error?.message ?? '', /no longer has exact desired/u);
+    assert.equal(driftedTerminal.rows[1]?.status, 'executed');
+    assert.deepEqual(writes, [identity(created).id, identity(desired).id]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('execution contract recovers lost success, terminalizes unknown, blocks dependents, and continues independent rows', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-execution-contract-recovery-'));
+  const lostSuccess = flow('11111111-1111-1111-1111-111111111111', 'Lost success');
+  const unknown = flow('66666666-6666-6666-6666-666666666666', 'Unknown');
+  const dependent = flow('77777777-7777-7777-7777-777777777777', 'Dependent');
+  const independent = flow('88888888-8888-8888-8888-888888888888', 'Independent');
+  const state = new Map<string, JsonObject>();
+  const writes: string[] = [];
+  const behavior = new Map<string, Behavior>([
+    [identity(lostSuccess).id, 'mutate_then_throw'],
+    [identity(unknown).id, 'throw_without_mutation'],
+  ]);
+  const fetchImpl = executionFetch({ state, writes, behavior });
+  const contractPath = writeContract(
+    dir,
+    contract({
+      desired: [lostSuccess, unknown, dependent, independent],
+      dependencies: [[], [], ['action-2'], []],
+    }),
+  );
+  try {
+    const report = await runDatasetSaveDraft({
+      inputPath: path.join(dir, 'rows.json'),
+      rawInput: { rows: [lostSuccess, unknown, dependent, independent] },
+      type: 'flow',
+      outDir: path.join(dir, 'out'),
+      commit: true,
+      executionContractPath: contractPath,
+      env: executionEnv(dir, 'recovery-1'),
+      fetchImpl,
+      now: new Date('2026-07-23T03:47:00.000Z'),
+    });
+    assert.equal(report.status, 'completed_with_unknowns');
+    assert.deepEqual(
+      report.rows.map((row) => [row.status, row.operation]),
+      [
+        ['executed', 'recovered_exact_readback'],
+        ['unknown', 'insert'],
+        ['blocked', 'blocked_dependency'],
+        ['executed', 'insert'],
+      ],
+    );
+    assert.deepEqual(writes, [
+      identity(lostSuccess).id,
+      identity(unknown).id,
+      identity(independent).id,
+    ]);
+    assert.equal(report.counts.attempts_consumed, 3);
+
+    behavior.clear();
+    await runDatasetSaveDraft({
+      inputPath: path.join(dir, 'rows.json'),
+      rawInput: { rows: [lostSuccess, unknown, dependent, independent] },
+      type: 'flow',
+      outDir: path.join(dir, 'out-restart'),
+      commit: true,
+      executionContractPath: contractPath,
+      env: executionEnv(dir, 'recovery-2'),
+      fetchImpl,
+      now: new Date('2026-07-23T03:48:00.000Z'),
+    });
+    assert.deepEqual(writes, [
+      identity(lostSuccess).id,
+      identity(unknown).id,
+      identity(independent).id,
+    ]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('execution contract rejects local drift and owner/project mismatch before emission', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-execution-contract-drift-'));
+  const before = flow('11111111-1111-1111-1111-111111111111', 'Before');
+  const desired = flow('11111111-1111-1111-1111-111111111111', 'Desired');
+  const state = new Map<string, JsonObject>([
+    [identity(before).id, flow(identity(before).id, 'Drifted')],
+  ]);
+  const writes: string[] = [];
+  const contractPath = writeContract(dir, contract({ desired: [desired], before: [before] }));
+  try {
+    const drift = await runDatasetSaveDraft({
+      inputPath: path.join(dir, 'rows.json'),
+      rawInput: { rows: [desired] },
+      type: 'flow',
+      outDir: path.join(dir, 'out'),
+      commit: true,
+      executionContractPath: contractPath,
+      env: executionEnv(dir, 'drift-1'),
+      fetchImpl: executionFetch({ state, writes }),
+      now: new Date('2026-07-23T03:49:00.000Z'),
+    });
+    assert.equal(drift.status, 'completed_with_failures');
+    assert.equal(drift.rows[0]?.attempt_consumed, false);
+    assert.deepEqual(writes, []);
+
+    state.set(identity(before).id, before);
+    const wrongIdentity = await runDatasetSaveDraft({
+      inputPath: path.join(dir, 'rows.json'),
+      rawInput: { rows: [desired] },
+      type: 'flow',
+      outDir: path.join(dir, 'wrong-readback-identity'),
+      commit: true,
+      executionContractPath: contractPath,
+      env: executionEnv(dir, 'drift-identity'),
+      fetchImpl: executionFetch({
+        state,
+        writes,
+        rowIdentityOverride: { id: 'wrong-id' },
+      }),
+    });
+    assert.equal(wrongIdentity.status, 'completed_with_failures');
+    assert.equal(wrongIdentity.rows[0]?.attempt_consumed, false);
+    assert.deepEqual(writes, []);
+
+    const wrongVersion = await runDatasetSaveDraft({
+      inputPath: path.join(dir, 'rows.json'),
+      rawInput: { rows: [desired] },
+      type: 'flow',
+      outDir: path.join(dir, 'wrong-readback-version'),
+      commit: true,
+      executionContractPath: contractPath,
+      env: executionEnv(dir, 'drift-version'),
+      fetchImpl: executionFetch({
+        state,
+        writes,
+        rowIdentityOverride: { version: '99.99.999' },
+      }),
+    });
+    assert.equal(wrongVersion.status, 'completed_with_failures');
+    assert.equal(wrongVersion.rows[0]?.attempt_consumed, false);
+    assert.deepEqual(writes, []);
+
+    await assert.rejects(
+      () =>
+        runDatasetSaveDraft({
+          inputPath: path.join(dir, 'rows.json'),
+          rawInput: { rows: [desired] },
+          type: 'flow',
+          outDir: path.join(dir, 'wrong-owner'),
+          commit: true,
+          executionContractPath: contractPath,
+          env: executionEnv(dir, 'drift-2'),
+          fetchImpl: executionFetch({ state, writes, userId: 'other-user' }),
+        }),
+      /Owner session or project does not match/u,
+    );
+    assert.deepEqual(writes, []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('execution contract recovers an orphan attempt and terminalizes a readback failure without replay', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-execution-contract-orphan-'));
+  const desired = flow('11111111-1111-1111-1111-111111111111', 'Desired');
+  const state = new Map<string, JsonObject>([[identity(desired).id, desired]]);
+  const writes: string[] = [];
+  const contractValue = contract({ desired: [desired] });
+  const contractPath = writeContract(dir, contractValue);
+  const parsedContract = __testInternals.parseExecutionContract(contractValue);
+  const action = parsedContract.actions[0]!;
+  const env = executionEnv(dir, 'orphan-1');
+  const ledgerRoot = __testInternals.executionLedgerRoot(env, parsedContract);
+  const attempt = ledgerEvent({
+    contractSha256: sha256Json(parsedContract),
+    action: action as unknown as JsonObject,
+    sequence: 1,
+    eventType: 'attempt_emitted',
+    outcome: null,
+  });
+  writeLedgerEvents(__testInternals.executionLedgerPath(ledgerRoot, action), [attempt]);
+  try {
+    const recovered = await runDatasetSaveDraft({
+      inputPath: path.join(dir, 'rows.json'),
+      rawInput: { rows: [desired] },
+      type: 'flow',
+      outDir: path.join(dir, 'recovered'),
+      commit: true,
+      executionContractPath: contractPath,
+      env,
+      fetchImpl: executionFetch({ state, writes }),
+    });
+    assert.equal(recovered.status, 'completed');
+    assert.equal(recovered.rows[0]?.operation, 'recovered_exact_readback');
+    assert.deepEqual(writes, []);
+
+    const readbackDir = path.join(dir, 'readback-failure');
+    mkdirSync(readbackDir);
+    const readbackDesired = flow('66666666-6666-6666-6666-666666666666', 'Readback failure');
+    const readbackState = new Map<string, JsonObject>();
+    const readbackWrites: string[] = [];
+    const readbackContractPath = writeContract(
+      readbackDir,
+      contract({ desired: [readbackDesired] }),
+    );
+    const baseFetch = executionFetch({ state: readbackState, writes: readbackWrites });
+    let dispatched = false;
+    const fetchImpl: FetchLike = async (input, init) => {
+      const url = String(input);
+      if (url.includes('/functions/v1/app_dataset_')) {
+        const result = await baseFetch(input, init);
+        dispatched = true;
+        return result;
+      }
+      if (dispatched && new URL(url).pathname.endsWith('/flows')) {
+        throw new Error('simulated readback loss');
+      }
+      return baseFetch(input, init);
+    };
+    const unknown = await runDatasetSaveDraft({
+      inputPath: path.join(readbackDir, 'rows.json'),
+      rawInput: { rows: [readbackDesired] },
+      type: 'flow',
+      outDir: path.join(readbackDir, 'out'),
+      commit: true,
+      executionContractPath: readbackContractPath,
+      env: executionEnv(dir, 'readback-1'),
+      fetchImpl,
+    });
+    assert.equal(unknown.status, 'completed_with_unknowns');
+    assert.equal(unknown.rows[0]?.status, 'unknown');
+    assert.deepEqual(readbackWrites, [identity(readbackDesired).id]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('execution contract keeps preparation, reference, and dry-run failures at zero attempts', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-execution-contract-preflight-'));
+  const invalid = structuredClone(flow('11111111-1111-1111-1111-111111111111', 'Invalid'));
+  delete (invalid.flowDataSet as JsonObject).modellingAndValidation;
+  const valid = flow('66666666-6666-6666-6666-666666666666', 'Unresolved source');
+  const writes: string[] = [];
+  try {
+    __testInternals.prepareRows('invalid.json', { rows: [invalid] }, 'flow');
+    const invalidContractPath = writeContract(dir, contract({ desired: [invalid] }));
+    const invalidReport = await runDatasetSaveDraft({
+      inputPath: path.join(dir, 'invalid.json'),
+      rawInput: { rows: [invalid] },
+      type: 'flow',
+      outDir: path.join(dir, 'invalid-out'),
+      commit: true,
+      executionContractPath: invalidContractPath,
+      env: executionEnv(dir, 'invalid-1'),
+      fetchImpl: executionFetch({ state: new Map(), writes }),
+    });
+    assert.equal(invalidReport.status, 'completed_with_failures');
+    assert.equal(invalidReport.rows[0]?.attempt_consumed, false);
+
+    const unresolvedDir = path.join(dir, 'unresolved');
+    mkdirSync(unresolvedDir);
+    const unresolvedContractPath = writeContract(unresolvedDir, contract({ desired: [valid] }));
+    const unresolvedReport = await runDatasetSaveDraft({
+      inputPath: path.join(unresolvedDir, 'rows.json'),
+      rawInput: { rows: [valid] },
+      type: 'flow',
+      outDir: path.join(unresolvedDir, 'out'),
+      commit: true,
+      executionContractPath: unresolvedContractPath,
+      env: executionEnv(dir, 'unresolved-1'),
+      fetchImpl: executionFetch({ state: new Map(), writes, missingSources: true }),
+    });
+    assert.equal(unresolvedReport.status, 'completed_with_failures');
+    assert.match(unresolvedReport.rows[0]?.error?.message ?? '', /unresolved remote references/u);
+    assert.equal(unresolvedReport.rows[0]?.attempt_consumed, false);
+    assert.deepEqual(writes, []);
+
+    await assert.rejects(
+      () =>
+        runDatasetSaveDraft({
+          inputPath: path.join(unresolvedDir, 'rows.json'),
+          rawInput: { rows: [valid] },
+          type: 'flow',
+          outDir: path.join(unresolvedDir, 'dry-run'),
+          executionContractPath: unresolvedContractPath,
+        }),
+      /requires --commit/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('execution contract aborts before dispatch when its durable attempt marker cannot be created', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-execution-contract-ledger-failure-'));
+  const desired = flow('11111111-1111-1111-1111-111111111111', 'No marker');
+  const contractPath = writeContract(dir, contract({ desired: [desired] }));
+  const stateRootFile = path.join(dir, 'state-root-is-a-file');
+  writeFileSync(stateRootFile, 'not a directory\n', 'utf8');
+  const writes: string[] = [];
+  const env = buildSupabaseTestEnv({
+    TIANGONG_LCA_API_KEY: 'marker-failure',
+    TIANGONG_LCA_DISABLE_SESSION_CACHE: '1',
+    XDG_STATE_HOME: stateRootFile,
+  });
+  try {
+    await assert.rejects(
+      () =>
+        runDatasetSaveDraft({
+          inputPath: path.join(dir, 'rows.json'),
+          rawInput: { rows: [desired] },
+          type: 'flow',
+          outDir: path.join(dir, 'out'),
+          commit: true,
+          executionContractPath: contractPath,
+          env,
+          fetchImpl: executionFetch({ state: new Map(), writes }),
+        }),
+      /blocked before request dispatch/u,
+    );
+    assert.deepEqual(writes, []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('execution contract parsers reject malformed contracts, JWTs, rows, and ledger events', () => {
+  const valid = contract({
+    desired: [flow('11111111-1111-1111-1111-111111111111', 'One')],
+  });
+  assert.equal(__testInternals.parseExecutionContract(valid).actions.length, 1);
+  assert.throws(() => __testInternals.parseExecutionContract(null), /JSON object/u);
+  assert.throws(() => __testInternals.parseExecutionContract({}), /header is invalid/u);
+  assert.throws(
+    () => __testInternals.parseExecutionContract({ ...valid, execution_id: ' ' }),
+    /execution_id must be a non-empty string/u,
+  );
+  assert.throws(
+    () => __testInternals.parseExecutionContract({ ...valid, actions: [null] }),
+    /actions\[0\] is invalid/u,
+  );
+  assert.throws(
+    () =>
+      __testInternals.parseExecutionContract({
+        ...valid,
+        actions: [{ ...(valid.actions as JsonObject[])[0], desired_sha256: 'bad' }],
+      }),
+    /lowercase SHA-256/u,
+  );
+  const validAction = (valid.actions as JsonObject[])[0]!;
+  assert.throws(
+    () =>
+      __testInternals.parseExecutionContract({
+        ...valid,
+        actions: [{ ...validAction, table: 'unknown' }],
+      }),
+    /table is unsupported/u,
+  );
+  assert.throws(
+    () =>
+      __testInternals.parseExecutionContract({
+        ...valid,
+        actions: [{ ...validAction, expected_operation: 'delete' }],
+      }),
+    /expected_operation is invalid/u,
+  );
+  assert.throws(
+    () =>
+      __testInternals.parseExecutionContract({
+        ...valid,
+        actions: [{ ...validAction, before_sha256: '0'.repeat(64) }],
+      }),
+    /contradicts expected_operation/u,
+  );
+  assert.throws(
+    () =>
+      __testInternals.parseExecutionContract({
+        ...valid,
+        actions: [
+          validAction,
+          { ...validAction, action_id: 'action-2', dependency_action_ids: ['missing'] },
+        ],
+      }),
+    /unique earlier actions/u,
+  );
+  assert.throws(
+    () =>
+      __testInternals.parseExecutionContract({
+        ...valid,
+        actions: [validAction, validAction],
+      }),
+    /Duplicate action_id/u,
+  );
+  const parsed = __testInternals.parseExecutionContract(valid);
+  const parsedAction = parsed.actions[0]!;
+  const exactReadback = {
+    id: parsedAction.id,
+    version: parsedAction.version,
+    user_id: parsed.owner.user_id,
+    state_code: 0,
+    json_ordered: flow('11111111-1111-1111-1111-111111111111', 'One'),
+  };
+  assert.equal(
+    __testInternals.exactDesiredReadback({
+      rows: [exactReadback],
+      action: parsedAction,
+      contract: parsed,
+    }),
+    true,
+  );
+  assert.equal(
+    __testInternals.exactDesiredReadback({
+      rows: [{ ...exactReadback, id: 'wrong-id' }],
+      action: parsedAction,
+      contract: parsed,
+    }),
+    false,
+  );
+  assert.equal(
+    __testInternals.exactDesiredReadback({
+      rows: [{ ...exactReadback, version: '99.99.999' }],
+      action: parsedAction,
+      contract: parsed,
+    }),
+    false,
+  );
+  const prepared = __testInternals.prepareRows(
+    'rows.json',
+    { rows: [flow('11111111-1111-1111-1111-111111111111', 'One')] },
+    'flow',
+  );
+  assert.throws(() => __testInternals.bindExecutionContractRows(parsed, []), /action count/u);
+  assert.throws(
+    () =>
+      __testInternals.bindExecutionContractRows(parsed, [
+        ...__testInternals.prepareRows(
+          'rows.json',
+          { rows: [flow('11111111-1111-1111-1111-111111111111', 'Different')] },
+          'flow',
+        ),
+      ]),
+    /does not bind row/u,
+  );
+  assert.doesNotThrow(() => __testInternals.bindExecutionContractRows(parsed, prepared));
+  const wrapperIdentityContract = __testInternals.parseExecutionContract({
+    ...valid,
+    actions: [{ ...(valid.actions as JsonObject[])[0], id: 'wrapper-id' }],
+  });
+  const wrapperIdentityRows = __testInternals.prepareRows(
+    'rows.json',
+    { rows: [{ id: 'wrapper-id', json_ordered: prepared[0]?.payload }] },
+    'flow',
+  );
+  assert.throws(
+    () => __testInternals.bindExecutionContractRows(wrapperIdentityContract, wrapperIdentityRows),
+    /does not bind row/u,
+  );
+  assert.throws(
+    () =>
+      __testInternals.bindExecutionContractRows(
+        parsed,
+        __testInternals.prepareRows('rows.json', { rows: [{ unsupported: true }] }, 'auto'),
+      ),
+    /does not bind row/u,
+  );
+  assert.throws(() => __testInternals.decodeExecutionActor('plain'), /not a JWT/u);
+  assert.throws(() => __testInternals.decodeExecutionActor('x.bad!.x'), /payload is invalid/u);
+  assert.throws(() => __testInternals.decodeExecutionActor(jwtWithPayload([])), /not an object/u);
+  assert.deepEqual(__testInternals.decodeExecutionActor(jwt()), {
+    user_id: 'user-1',
+    email: 'user@example.com',
+  });
+  assert.deepEqual(
+    __testInternals.parseExecutionRows(
+      [{ id: 'a', version: 'v', user_id: 'u', state_code: 0, json_ordered: { a: 1 } }],
+      'https://example.test',
+    )[0]?.json_ordered,
+    { a: 1 },
+  );
+  assert.equal(
+    __testInternals.parseExecutionRows(
+      [{ id: 'a', version: 'v', user_id: 'u', state_code: 0 }],
+      'https://example.test',
+    )[0]?.json_ordered,
+    null,
+  );
+  assert.throws(() => __testInternals.parseLedgerEvent(null, 0), /not an object/u);
+  assert.throws(() => __testInternals.parseLedgerEvent({}, 0), /invalid shape/u);
+  const invalidOutcome = ledgerEvent({
+    contractSha256: '0'.repeat(64),
+    action: validAction,
+    sequence: 1,
+    eventType: 'attempt_emitted',
+    outcome: 'executed',
+  });
+  assert.throws(() => __testInternals.parseLedgerEvent(invalidOutcome, 0), /invalid outcome/u);
+  assert.equal(
+    __testInternals.projectRefFromApiBaseUrl('https://sample.supabase.co/functions/v1'),
+    'sample',
+  );
+});
+
+test('execution ledger rejects binding, repeated-attempt, and outcome-order corruption', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-execution-ledger-corruption-'));
+  const contractValue = contract({
+    desired: [flow('11111111-1111-1111-1111-111111111111', 'One')],
+  });
+  const parsed = __testInternals.parseExecutionContract(contractValue);
+  const action = parsed.actions[0]!;
+  const actionObject = action as unknown as JsonObject;
+  const contractSha256 = sha256Json(parsed);
+  try {
+    const bindingRoot = path.join(dir, 'binding');
+    const wrongBinding = ledgerEvent({
+      contractSha256,
+      action: { ...actionObject, action_id: 'wrong-action' },
+      sequence: 1,
+      eventType: 'attempt_emitted',
+      outcome: null,
+    });
+    writeLedgerEvents(__testInternals.executionLedgerPath(bindingRoot, action), [wrongBinding]);
+    assert.throws(
+      () => __testInternals.loadExecutionLedger(bindingRoot, parsed),
+      /failed its hash or action binding/u,
+    );
+
+    const targetBindingRoot = path.join(dir, 'target-binding');
+    const wrongTargetBinding = ledgerEvent({
+      contractSha256,
+      action: { ...actionObject, id: 'different-target' },
+      sequence: 1,
+      eventType: 'attempt_emitted',
+      outcome: null,
+    });
+    writeLedgerEvents(__testInternals.executionLedgerPath(targetBindingRoot, action), [
+      wrongTargetBinding,
+    ]);
+    assert.throws(
+      () => __testInternals.loadExecutionLedger(targetBindingRoot, parsed),
+      /failed its hash or action binding/u,
+    );
+
+    const repeatedRoot = path.join(dir, 'repeated');
+    const attempt = ledgerEvent({
+      contractSha256,
+      action: actionObject,
+      sequence: 1,
+      eventType: 'attempt_emitted',
+      outcome: null,
+    });
+    const repeatedAttempt = ledgerEvent({
+      contractSha256,
+      action: actionObject,
+      sequence: 2,
+      eventType: 'attempt_emitted',
+      outcome: null,
+      previousEventSha256: attempt.event_sha256 as string,
+    });
+    writeLedgerEvents(__testInternals.executionLedgerPath(repeatedRoot, action), [
+      attempt,
+      repeatedAttempt,
+    ]);
+    assert.throws(
+      () => __testInternals.loadExecutionLedger(repeatedRoot, parsed),
+      /repeats attempt/u,
+    );
+
+    const orderingRoot = path.join(dir, 'ordering');
+    const orphanOutcome = ledgerEvent({
+      contractSha256,
+      action: actionObject,
+      sequence: 1,
+      eventType: 'outcome',
+      outcome: 'unknown',
+    });
+    writeLedgerEvents(__testInternals.executionLedgerPath(orderingRoot, action), [orphanOutcome]);
+    assert.throws(
+      () => __testInternals.loadExecutionLedger(orderingRoot, parsed),
+      /outcome ordering is invalid/u,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #194

## Summary
- Add a generic content-bound owner-draft execution-contract mode for ordered insert/save_draft batches.
- Persist append-only per-action attempt/outcome evidence before protected dispatch and recover ambiguous transport results by exact readback only.
- Continue dependency-independent actions while permanently excluding successful or UNKNOWN actions from replay.

## Key Decisions
- Bind each ledger to owner/project scope and action_id@desired_sha256, with an additional full target/action binding digest.
- Require exact owner, state_code=0, id, version, payload and expected operation for terminal success; prepared is never success.

## Validation
- npm run prepush:gate: PASS; lint, TypeScript, full tests, and 100% statements/branches/functions/lines.
- Strict Docpact validation and enforced changed-path/freshness lint: PASS for all 18 changed paths.
- Focused crash, response-loss, recovery, dependency, malformed-ledger, identity, and zero-dispatch tests: PASS.

## Risks / Rollback
- No production data execution, deployment, schema change, package release, direct SQL/table write, service-role path, publication/delete/state transition, or public/foreign-owner write.

## Follow-ups
- Independent review and merge require the current SHA-bound BAFU authority to be explicitly superseded or separately authorized.

## Workspace Integration
- After an authorized merge and release eligibility, integrate the exact child main commit into lca-workspace in a separate root integration change.