### PR TITLE
fix: bound ordered save-draft execution

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -19,8 +19,9 @@ layout: repo
 # Review note, 2026-07-23: Issue #194 adds an opt-in execution contract to the existing generic dataset save-draft family. Existing command/runtime, remote-adapter, artifact, test, and governed-doc wildcards cover ordered owner-draft actions, stable action-identity ledgers, exact readback recovery, and fail-closed dependency handling; no ownership, route, dependency, auth, package-release, or publication boundary changes.
 # Review note, 2026-07-23: Issue #196 is the dedicated 0.0.30 package-version release for merged Issue #194 / PR #195. Windows release-gate evidence also required a cross-platform durable-ledger repair: outcome appends now fsync the same write-capable descriptor before close instead of fsyncing a later read-only descriptor that Windows rejects. Ownership, routing, dependencies, release authorization, tag automation, Trusted Publishing, and workspace-integration rules remain unchanged.
 # Review note, 2026-07-23: Issue #198 releases 0.0.31 and isolates SDK validation on a deep clone so exact dataset save-draft inputs cannot be mutated before execution-contract binding or dispatch. Existing command/runtime, test, release, and integration routing already covers the change; ownership, dependencies, authentication, tag automation, Trusted Publishing, and publication boundaries remain unchanged.
-lastReviewedAt: '2026-07-23'
-lastReviewedCommit: '4daf99c1b0b0fe3e084b5903163cdf6b11fe4de2'
+# Review note, 2026-07-24: Issue #200 releases 0.0.32 and keeps bounded execution-contract scheduling plus owner-token renewal inside the existing dataset command/runtime, remote-session, test, release, and integration domains. Current wildcards already cover `src/cli.ts`, `src/lib/dataset-*.ts`, tests, and governed docs; no ownership, route, dependency, environment, authentication, tag, Trusted Publishing, or publication rule changes are required.
+lastReviewedAt: '2026-07-24'
+lastReviewedCommit: '0cbbf9cef373675ad39ae2b8103003d05b48ccb8'
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-23
-lastReviewedCommit: 4daf99c1b0b0fe3e084b5903163cdf6b11fe4de2
+lastReviewedAt: 2026-07-24
+lastReviewedCommit: 0cbbf9cef373675ad39ae2b8103003d05b48ccb8
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -94,6 +94,8 @@ Review note, 2026-07-23: Issue #194 extends `dataset save-draft` with an explici
 Review note, 2026-07-23: Issue #196 is the dedicated 0.0.30 release for merged Issue #194 / PR #195. Windows release-gate evidence exposed that `fsync` on a reopened read-only execution-ledger descriptor returns `EPERM`; the release now fsyncs create/append operations on their write-capable descriptors before close. Attempt-before-dispatch ordering, no-replay semantics, dependencies, authorization, tag automation, npm Trusted Publishing, provenance verification, and exact released-commit workspace integration remain unchanged.
 
 Review note, 2026-07-23: Issue #198 releases 0.0.31 and makes dataset save-draft validation side-effect free. SDK schema/entity validation receives a deep clone, while execution-contract hashing, dispatch, and readback remain bound to the original exact input payload. Owner/state/project fencing, attempt-before-dispatch ordering, no-replay semantics, command ownership, and publication boundaries remain unchanged.
+
+Review note, 2026-07-24: Issue #200 releases 0.0.32 and makes large ordered owner-draft contracts finish within the authenticated session window. `--max-parallel` remains opt-in and capped at 8: every action through the highest referenced dependency stays serial, and only the remaining unique-target suffix can overlap. The command resolves and revalidates the exact owner token immediately before each DML dispatch. Attempt-before-dispatch durability, exact readback, dependency blocking, UNKNOWN/success no-replay, and all public/foreign/publication/delete/state/schema/service-role prohibitions remain unchanged.
 
 ## Bootstrap Order
 

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -18,8 +18,8 @@ checkPaths:
   - src/**
   - scripts/**
   - .github/workflows/**
-lastReviewedAt: 2026-07-23
-lastReviewedCommit: 5c90ddd60328748ab6d8d89717e59dcaeca8cde7
+lastReviewedAt: 2026-07-24
+lastReviewedCommit: 0cbbf9cef373675ad39ae2b8103003d05b48ccb8
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -40,6 +40,8 @@ Review note, 2026-07-23: Issue #194 在既有 `dataset save-draft` 上增加可�
 Review note, 2026-07-23: Issue #196 在 0.0.30 发布门禁中修复 Windows execution-ledger 持久化：创建与追加均在可写 descriptor 上写入、`fsync`、关闭。运行环境、认证变量、合同格式、attempt-before-dispatch 与 npm Trusted Publishing 路径均不变。
 
 Review note, 2026-07-23: Issue #198 发布 0.0.31；`dataset save-draft` 只在深拷贝上运行 SDK 校验，原始 payload 继续作为 execution-contract hash、受保护写请求与精确 readback 的唯一目标。认证、owner/state/project 护栏、attempt-before-dispatch、无重放和 Trusted Publishing 路径均不变。
+
+Review note, 2026-07-24: Issue #200 发布 0.0.32；`dataset save-draft --execution-contract` 新增显式 `--max-parallel 1..8`，完整 dependency prefix 仍串行，只有 table/id/version 唯一的 suffix 可有界并发。每次 DML 前通过既有 session runtime 取得当前 token 并重新核对 exact user/email，foreign renewal 在 attempt=0 阻断。环境变量、每行独立事务、durable ledger、成功/UNKNOWN 不重放和 Trusted Publishing 路径均不变。
 
 Review note, 2026-06-07: release 0.0.14 keeps maintainer runtime and release guidance unchanged. `dataset classification apply --type location` now supports explicit missing location targets for Foundry saturation workflows, and still rejects ambiguous target paths.
 
@@ -300,7 +302,7 @@ npm exec tiangong-lca -- lifecyclemodel auto-build --input ./examples/lifecyclem
 npm exec tiangong-lca -- lifecyclemodel validate-build --run-dir /abs/path/to/lifecyclemodel-run --json
 npm exec tiangong-lca -- lifecyclemodel publish-build --run-dir /abs/path/to/lifecyclemodel-run --json
 npm exec tiangong-lca -- lifecyclemodel save-draft --input ./lifecyclemodels.jsonl --out-dir ./lifecyclemodel-save-draft --dry-run --json
-npm exec tiangong-lca -- dataset save-draft --input ./rows.jsonl --type auto --execution-contract ./execution-contract.json --out-dir ./dataset-save-draft --commit --json
+npm exec tiangong-lca -- dataset save-draft --input ./rows.jsonl --type auto --execution-contract ./execution-contract.json --max-parallel 8 --out-dir ./dataset-save-draft --commit --json
 npm exec tiangong-lca -- lifecyclemodel graph --input ./lifecyclemodels.jsonl --out-dir ./lifecyclemodel-graph --format all --json
 npm exec tiangong-lca -- lifecyclemodel orchestrate plan --input ./lifecyclemodel-orchestrate.request.json --out-dir /abs/path/to/lifecyclemodel-recursive-run --json
 npm exec tiangong-lca -- lifecyclemodel build-resulting-process --input ./request.json --json
@@ -381,7 +383,7 @@ Derivative rebuild 的 apply 成功只表示 guarded RPC 已返回 `accepted`/`q
 
 这个命令当前只负责 current-user draft 的 save-draft/update 语义；`--target-user-id` 是批量导入时的账号/写入 guard，不能替代写后 readback verify，也不会替代 public `state_code=100` 的版本修订 publish 路径。
 
-`tiangong-lca dataset save-draft --execution-contract` 是另一条显式 opt-in 的通用批处理契约。`dataset-save-draft-execution-contract.v1` 必须给出 project、精确 owner（含 `state_code=0`）和有序 actions；每个 action 绑定 `action_id@desired_sha256`、table/id/version、expected operation、before hash 与只指向更早 action 的依赖。CLI 在调用受保护平台写入前把 attempt 持久化到稳定的 per-owner/project action ledger，随后只以精确 owner/state/payload readback 判定成功；transport 模糊、进程中断或既有 attempt 都不会自动重投。依赖失败只阻断其后继，无依赖 action 继续；任一 failed/unknown/blocked 都返回非零退出码。Unit Group / Flow Property 仍需额外显式 `--allow-account-local-support`，该模式不新增 direct-table、service-role、publication、delete 或 state/schema mutation 路径。
+`tiangong-lca dataset save-draft --execution-contract` 是另一条显式 opt-in 的通用批处理契约。`dataset-save-draft-execution-contract.v1` 必须给出 project、精确 owner（含 `state_code=0`）和有序 actions；每个 action 绑定 `action_id@desired_sha256`、table/id/version、expected operation、before hash 与只指向更早 action 的依赖。`--max-parallel` 默认 1、上限 8；调度器把所有被 dependency 引用的 action 收进一个完整串行前缀，只有其后 table/id/version 唯一的 suffix 可以并发。每次 DML 前都会从既有 session runtime 取得当前 token 并再次核对 exact user/email。CLI 在调用受保护平台写入前把 attempt 持久化到稳定的 per-owner/project action ledger，随后只以精确 owner/state/payload readback 判定成功；transport 模糊、进程中断或既有 attempt 都不会自动重投。依赖失败只阻断其后继，无依赖 action 继续；任一 failed/unknown/blocked 都返回非零退出码。Unit Group / Flow Property 仍需额外显式 `--allow-account-local-support`，该模式不新增 direct-table、service-role、publication、delete 或 state/schema mutation 路径。
 
 `tiangong-lca process auto-build` 现在已经承担 `process_from_flow` 主链的第一个 CLI 切片，负责：
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Review note, 2026-07-17: `dataset maintenance flow-identity capture|plan|freeze|
 
 Review note, 2026-07-23: `dataset save-draft --execution-contract` adds an opt-in crash-safe ordered owner-draft batch. The contract binds the authenticated project/owner, state 0, exact input order and payloads, before hashes, expected insert/update operations, and dependencies. A stable per-owner/project `action_id@desired_sha256` ledger prevents replay even if the contract or output directory is copied; ambiguous attempts are recovered only by exact owner/state/payload readback. The ordinary save-draft mode is unchanged.
 
+Review note, 2026-07-24: CLI 0.0.32 adds bounded execution-contract concurrency without changing the sealed payload or replay model. `--max-parallel 1..8` keeps the complete dependency prefix serial and exact-read-back, then overlaps only the unique-target suffix. The current owner token is renewed and revalidated before each DML dispatch so long batches do not turn token expiry into an avoidable UNKNOWN.
+
 ## Run
 
 One-off published run:
@@ -365,7 +367,7 @@ tiangong-lca dataset classification apply --type location --input ./rows/process
 tiangong-lca dataset curation-queue build --processes ./rows/processes.jsonl --flows ./rows/flows.jsonl --support ./rows/sources.jsonl --out-dir /abs/path/to/curation-queue --json
 tiangong-lca dataset curation-queue next --queue-dir /abs/path/to/curation-queue --type support --json
 tiangong-lca dataset curation-queue verify --queue-dir /abs/path/to/curation-queue --type process --json
-tiangong-lca dataset save-draft --input ./rows.jsonl --type auto --execution-contract ./execution-contract.json --out-dir /abs/path/to/dataset-save-draft --commit --json
+tiangong-lca dataset save-draft --input ./rows.jsonl --type auto --execution-contract ./execution-contract.json --max-parallel 8 --out-dir /abs/path/to/dataset-save-draft --commit --json
 tiangong-lca dataset evidence-search plan --query "中国2026年电力结构数据" --out-dir /abs/path/to/evidence-search --json
 tiangong-lca dataset evidence-search run --input ./evidence-search.request.json --results ./search-results.json --out-dir /abs/path/to/evidence-search --json
 tiangong-lca dataset references rewrite --input ./rows.jsonl --from flow:<old-id>@<old-version> --to flow:<new-id>@<new-version> --out-dir /abs/path/to/dataset-rewrite --json
@@ -400,7 +402,7 @@ For `process build-plan` and `flow build-plan`, canonical payloads embedded in t
 
 For `process save-draft`, canonical process payloads are validated locally with `ProcessSchema` before any `--commit` write. Schema-invalid rows remain in `outputs/save-draft-rpc/failures.jsonl` instead of being persisted. Batch import callers should pass `--target-user-id`; the CLI then verifies the current auth session and any visible draft owner before writing, while downstream readback verification still proves the final owner and payload.
 
-For `dataset save-draft --execution-contract`, the JSON contract uses schema `dataset-save-draft-execution-contract.v1` and supplies `execution_id`, `project_ref`, an exact owner (`user_id`, lowercase `email`, `state_code: 0`), and ordered actions. Each action binds `action_id`, `desired_sha256`, `expected_operation` (`insert` or `save_draft`), table/id/version, `before_sha256`, and earlier `dependency_action_ids`. Contract mode requires `--commit`; account-local Unit Group or Flow Property support rows additionally require `--allow-account-local-support`. Attempts and outcomes are stored under the platform user-state directory (`$XDG_STATE_HOME/tiangong-lca-cli` when configured), not beside the contract or report. Any prior terminal or unresolved attempt is read back or retained without re-dispatch; exit status is nonzero unless every action has exact terminal success.
+For `dataset save-draft --execution-contract`, the JSON contract uses schema `dataset-save-draft-execution-contract.v1` and supplies `execution_id`, `project_ref`, an exact owner (`user_id`, lowercase `email`, `state_code: 0`), and ordered actions. Each action binds `action_id`, `desired_sha256`, `expected_operation` (`insert` or `save_draft`), table/id/version, `before_sha256`, and earlier `dependency_action_ids`. Contract mode requires `--commit`; account-local Unit Group or Flow Property support rows additionally require `--allow-account-local-support`. `--max-parallel` defaults to 1 and is capped at 8. When it is greater than 1, every action through the highest referenced dependency remains serial; only the later table/id/version-unique suffix may overlap. The exact owner token is renewed and checked before each DML dispatch. Attempts and outcomes are stored under the platform user-state directory (`$XDG_STATE_HOME/tiangong-lca-cli` when configured), not beside the contract or report. Any prior terminal or unresolved attempt is read back or retained without re-dispatch; exit status is nonzero unless every action has exact terminal success.
 
 For `flow publish-version`, canonical flow payloads are validated locally with `FlowSchema` before remote visibility planning or writes. The command always writes `flow-publish-version-gate-report.json`; blocked rows are written to the remote-failure JSONL without calling the remote service.
 

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - README.md
   - src/**
   - test/**
-lastReviewedAt: 2026-07-23
-lastReviewedCommit: 5c90ddd60328748ab6d8d89717e59dcaeca8cde7
+lastReviewedAt: 2026-07-24
+lastReviewedCommit: 0cbbf9cef373675ad39ae2b8103003d05b48ccb8
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -55,6 +55,8 @@ Review note, 2026-07-23: Issue #194 为通用 `dataset save-draft` 增加 opt-in
 Review note, 2026-07-23: Issue #196 在发布 0.0.30 前补齐 Windows 持久化兼容性。execution ledger 的首次创建和后续追加均在可写文件描述符上完成写入与 `fsync` 后再关闭，不再重新以只读方式打开后执行 Windows 会拒绝的 `fsync`。attempt-before-dispatch、每行事件顺序、exact readback 恢复及成功行不重放语义保持不变。
 
 Review note, 2026-07-23: Issue #198 发布 0.0.31 并将 SDK schema/entity 校验隔离到 payload 深拷贝。原始 JSON 不再被校验器隐式补默认值，execution-contract SHA、受保护 command dispatch 与 exact owner readback 始终引用同一输入；无效行仍在 prepared failure 阶段被拦截，owner/state/project、attempt-before-dispatch 与不重放语义不变。
+
+Review note, 2026-07-24: Issue #200 发布 0.0.32，为大规模 execution contract 增加显式 `--max-parallel 1..8`。调度器先找出所有 dependency 所引用 action 的最大序号，该序号及其之前的完整前缀严格串行并完成 exact readback；只有后续 table/id/version 唯一的 suffix 可以有界并发。每次 DML 前通过既有 session runtime 取得当前 token，并再次核对 user/email；续期成 foreign owner 时在 attempt=0 阻断。每行独立 protected transaction、ledger、UNKNOWN/成功不重放与全部写入禁止项不变。
 
 ## 1. 目标
 
@@ -284,7 +286,7 @@ tiangong-lca
 - 已实现的 `dataset classification` 从 CLI bundled TIDAS schema 提供分类/位置编码治理：`children` 支持按 parent code 步进列子类，`path` 解析 code 的规范 path，`audit --type location` 按 bundled TIDAS schema 派生位置编码字段，并覆盖 TIDAS LCIA geography 和 lifecyclemodel connection location 字段，检查其值是否属于 `tidas_locations_category.json`；`apply --type location` 把 AI/human structured decision 确定性写回 rows 并输出 evidence，当 decision 明确给出 schema-derived location 字段的 `target_path`（如 `flowDataSet.flowInformation.geography.locationOfSupply`）时可创建缺失父对象和字段，缺少 target 或非 location 路径仍保持阻断
 - 已实现的 `dataset curation-queue build/next/verify` 把 Foundry external dataset import 的 support / flow / process rows 收口成 entity-level queue artifact contract：`build` 生成 `curation-queue-manifest.json`、`curation-queue-tasks.jsonl`、`curation-queue-locks.json`、`curation-queue-blockers.jsonl`，以及每个 entity 的 `input.jsonl`、`closure.json`、`entity-run-plan.json`；`next` 读取 task checkpoint 并返回下一条 runnable entity task；`verify` 确认目标 scope 的 checkpoint 完成且没有 build blocker。CLI 只负责稳定状态机、依赖闭包、锁和 blocker；AI authoring 仍必须通过 skill/Codex 输出 structured patch 或 build plan，并在 deterministic apply、schema/QA、prewrite verify、readback 后才允许进入远端写入。
 - 已实现的 `dataset references rewrite` 把 process / lifecyclemodel rows 中的 flow reference rewrite 收口到一个 deterministic 本地入口，默认只写 patch artifacts，只有显式 `--commit` 时才调用 state-aware save-draft 写入路径
-- 已实现的 `dataset save-draft --execution-contract` 读取 `dataset-save-draft-execution-contract.v1`，逐 action 校验 authenticated project/owner、state 0、input identity/order、desired payload hash、expected operation、before hash 与 earlier-only dependencies。账本不放在 contract/out-dir 旁，而放在稳定的 per-owner/project 用户状态根下，并以 `action_id@desired_sha256` 寻址；复制输入或输出目录不会获得新的 attempt。attempt 之后只做 exact owner/state/payload readback，terminal/unknown action 均永不重投；dependency 只阻断后继，independent unresolved actions 仍可继续。每个远端调用继续使用现有 protected platform dataset transaction，不新增 raw SQL/direct-table/service-role/publication/delete/state/schema 写面。
+- 已实现的 `dataset save-draft --execution-contract` 读取 `dataset-save-draft-execution-contract.v1`，逐 action 校验 authenticated project/owner、state 0、input identity/order、desired payload hash、expected operation、before hash 与 earlier-only dependencies。账本不放在 contract/out-dir 旁，而放在稳定的 per-owner/project 用户状态根下，并以 `action_id@desired_sha256` 寻址；复制输入或输出目录不会获得新的 attempt。`--max-parallel` 默认 1、上限 8：dependency prefix 保持串行，只有 target 唯一的 suffix 可并发；每次 DML 前重新取得并核对 exact owner token。attempt 之后只做 exact owner/state/payload readback，terminal/unknown action 均永不重投；dependency 只阻断后继，independent unresolved actions 仍可继续。每个远端调用继续使用现有 protected platform dataset transaction，不新增 raw SQL/direct-table/service-role/publication/delete/state/schema 写面。
 - 已实现的 `dataset maintenance clear-account` 只覆盖当前认证账号的 draft 清空场景：CLI 必须先以 exact-count 分页证明五个可删除表的 RLS 可见快照完整，才写出 `rls-visible-snapshot.json` / `dry-run-report.json`；commit 时要求 `--confirm` 匹配当前账号邮箱，并逐行调用平台 `app_dataset_delete`。除逐表检查外，结束时必须重新扫描全部五表，只有完整 aggregate proof 且 `row_count=0` 才报告成功；若终检失败而之前已有删除，仍写出 `completed_with_failures` 审计报告。初始扫描不完整时不生成快照/approval，且零删除。该命令不绕过 RLS，不直接 REST DELETE，不删除默认保护的 `unitgroups` / `flowproperties`。
 - 已实现的 `dataset maintenance plan/apply/freeze-protected/seal-protected-approval/run-protected/verify` 是错误导入清理、redo 与受保护衍生重建的 row-level 归属面。`plan` 先证明当前用户 account scan 完整，再固化 scope manifest、RLS 可见快照、completeness proof、引用影响、保护行、不可变 plan 和 dry-run。普通 `apply` 只接受 plan SHA-256 与当前账号邮箱都匹配的显式 commit；固定 production alias profile 必须依次经过 production 只读 `freeze-protected`、人类逐字批准、完全离线 `seal-protected-approval`，然后才可进入 `run-protected`，其 `--status-only` 恢复不做 preflight 或 admission。`verify` 以新的完整 account readback 或 action-scoped DB readback 独立检查结果，不依赖 apply 的内存或报告结论。Foundry 只调用已发布 CLI、保存 task ledger/报告/产物，不读取数据库 env、直调 RPC 或重算 canonical hash。
 - `merge-support-aliases` 不是通用 alias 合并器：当前只接受 BAFU `time` 与 `length_time` 两个 batch。计划必须精确覆盖 25 + 27 行和 20 + 39 条 exchange，并保留受影响 process 中的 309 条其他 exchange。原 V1 adapter 只保留冻结请求/artifact 兼容契约，不能作为 seal 绑定 production 执行的 fallback；受保护路径绝不降级为旧 `cmd_dataset_alias_plan_guarded`、逐 dimension 或逐行 `save_draft`。

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -17,8 +17,8 @@ checkPaths:
   - package.json
   - src/**
   - test/**
-lastReviewedAt: 2026-07-23
-lastReviewedCommit: 5c90ddd60328748ab6d8d89717e59dcaeca8cde7
+lastReviewedAt: 2026-07-24
+lastReviewedCommit: 0cbbf9cef373675ad39ae2b8103003d05b48ccb8
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -58,6 +58,7 @@ related:
 - 2026-07-23 复核：Issue #194 的 ordered owner-draft execution contract 继续完全位于 TypeScript / Node 原生 CLI，复用现有用户 session、平台 dataset command 与 TIDAS SDK 校验；action ledger 使用 Node 原生文件能力，不新增 Python、POSIX shell、MCP、私有 skill runtime 或 npm 依赖。skills 若后续接入只能保持薄调用，不得复制 attempt/readback/replay 逻辑。
 - 2026-07-23 复核：Issue #196 仅把 execution ledger 的 `fsync` 固定在同一可写 descriptor 上以通过 Windows release gate，不新增 Python、POSIX shell、MCP、私有 skill runtime 或 npm 依赖，也不改变 skills 薄调用边界。
 - 2026-07-23 复核：Issue #198 仅使用 Node 原生 `structuredClone` 隔离 dataset save-draft 的 SDK 校验副作用并发布 0.0.31，不新增 Python、shell、MCP、私有 skill runtime 或 npm 依赖，也不改变 skills 只负责薄调用的边界。
+- 2026-07-24 复核：Issue #200 在原生 CLI 内发布 0.0.32，使用 Node Promise worker pool 实现 dependency prefix 串行、unique-target suffix 最多 8 路并发，并复用既有 Supabase owner session 续期；不新增 Python、shell、MCP、私有 skill runtime 或 npm 依赖，skills 仍只能传入已审计 contract 与并发上限。
 
 这份文档记录的是：
 

--- a/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
+++ b/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
@@ -15,8 +15,8 @@ checkPaths:
   - src/lib/user-api-key.ts
   - src/lib/supabase-session.ts
   - src/lib/supabase-client.ts
-lastReviewedAt: 2026-07-23
-lastReviewedCommit: 5c90ddd60328748ab6d8d89717e59dcaeca8cde7
+lastReviewedAt: 2026-07-24
+lastReviewedCommit: 0cbbf9cef373675ad39ae2b8103003d05b48ccb8
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -48,6 +48,7 @@ related:
 - 2026-07-23 复核：Issue #194 的 `dataset save-draft --execution-contract` 继续使用既有 user API key bootstrap、publishable key、access token、session cache 与 current-owner RLS 读回。稳定 action ledger 是本地非 bearer 状态，不保存 token；不新增认证 env、alternate bearer、service-role 或跨账号路径，本历史设计结论不变。
 - 2026-07-23 复核：Issue #196 只修复 Windows 本地 execution-ledger 文件的 durable append，不读取或持久化 bearer，不改变 user API key、session cache、RLS、service-role 或跨账号边界；本历史设计结论不变。
 - 2026-07-23 复核：Issue #198 只隔离本地 payload 校验的内存副作用，不读取、复制或持久化 bearer，不改变 user API key、session cache、RLS、owner/project/state 校验、service-role 或跨账号边界；本历史设计结论不变。
+- 2026-07-24 复核：Issue #200 在每个 execution-contract DML 前调用既有 session runtime 获取当前 access token，并重新解码核对 exact user/email；token 仍不写入 action ledger/report，foreign renewal 在 attempt=0 拒绝，不新增认证 env、service-role、跨账号或 blind retry 路径。本历史设计结论不变。
 
 ## 1. 已确认事实
 

--- a/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
+++ b/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - src/lib/supabase-client.ts
   - src/lib/tidas-sdk-package-validator.ts
   - test/**
-lastReviewedAt: 2026-07-23
-lastReviewedCommit: 5c90ddd60328748ab6d8d89717e59dcaeca8cde7
+lastReviewedAt: 2026-07-24
+lastReviewedCommit: 0cbbf9cef373675ad39ae2b8103003d05b48ccb8
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -50,6 +50,8 @@ related:
 2026-07-23 复核：Issue #198 只使用 Node 原生 `structuredClone` 在现有 TIDAS SDK 校验边界内复制 JSON，不新增或升级 Supabase JS、TIDAS SDK 或其他直接依赖；本文件继续保持历史 TODO 记录用途。
 
 2026-07-23 复核：Issue #194 的 ordered owner-draft execution contract 复用现有 `@supabase/supabase-js` 用户 session/RLS 读取、平台 dataset command transport、`@tiangong-lca/tidas-sdk` 校验与 Node 原生文件/crypto 能力，不新增或改变直接依赖；本文件继续保持历史 TODO 记录用途。
+
+2026-07-24 复核：Issue #200 的有界 scheduler 使用 Node 原生 Promise，并通过现有 `SupabaseDataRuntime.getAccessToken()` 续期同一 owner session；0.0.32 不新增、删除或升级任何直接依赖，本文件继续保持历史 TODO 记录用途。
 
 2026-07-17 复核：Issue #157 COMMON 的双 #29 readback、domain rejection、verify pending 收紧、DB one-wrapper rotating permit、create-only local claim 与 fresh exact recovery approval/read-only lookup 继续复用现有 TypeScript、Node `fs`/`crypto`、`@supabase/supabase-js` session/RPC 和 TIDAS SDK 校验，不新增或改变直接依赖。尚余 merge、Preview 与 DB/CLI 发布门禁；本文件继续保持历史 TODO 记录用途。
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-23
-lastReviewedCommit: 4daf99c1b0b0fe3e084b5903163cdf6b11fe4de2
+lastReviewedAt: 2026-07-24
+lastReviewedCommit: 0cbbf9cef373675ad39ae2b8103003d05b48ccb8
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -87,6 +87,8 @@ Review note, 2026-07-23: Issue #194 keeps ordered owner-draft execution inside `
 Review note, 2026-07-23: Issue #196 changes the CLI package version to 0.0.30, updates the four live CLI-version fixtures, and makes execution-ledger durability portable by fsyncing the active write descriptor rather than reopening the ledger read-only. No command family, launcher, session, artifact shape, dependency, authorization, tag, publication, or workspace-integration architecture changes.
 
 Review note, 2026-07-23: Issue #198 changes the package version to 0.0.31 and confines SDK schema/entity mutation to a validation clone. The original dataset save-draft payload remains the single source for contract hashing, protected command dispatch, and exact owner readback. No command family, session, artifact schema, dependency, authorization, publication, or integration architecture changes.
+
+Review note, 2026-07-24: Issue #200 releases 0.0.32 and extends the existing execution-contract scheduler without adding a second write path. The scheduler derives one serial prefix ending at the highest action referenced by any dependency, verifies that the remaining suffix has unique table/id/version targets, and runs that suffix with explicit concurrency 1..8. Each action still owns its independent protected transaction and ledger file. The existing session runtime supplies a current token immediately before dispatch, and the runner rejects any renewed user/email mismatch before attempt consumption.
 
 ## Stable Path Map
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-23
-lastReviewedCommit: 4daf99c1b0b0fe3e084b5903163cdf6b11fe4de2
+lastReviewedAt: 2026-07-24
+lastReviewedCommit: 0cbbf9cef373675ad39ae2b8103003d05b48ccb8
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -109,6 +109,8 @@ Review note, 2026-07-23: Issue #194 adds focused proof for ordered contract bind
 Review note, 2026-07-23: Issue #196 keeps the validation contract unchanged for the dedicated 0.0.30 release. The manually dispatched Windows gate is required to prove durable attempt/outcome ledger writes no longer fail on read-only-descriptor `fsync`; all execution-contract recovery/no-replay tests, all four live CLI-version fixtures, exact 100% coverage, dry-run package inspection, Docpact, tag/publish workflows, and exact npm provenance remain required.
 
 Review note, 2026-07-23: Issue #198 adds a regression proving SDK validation cannot mutate the execution-contract input payload, its desired SHA, or the eventual dispatch target, and releases the repair as 0.0.31. Focused execution-contract coverage, all four live CLI-version fixtures, exact 100% coverage, Docpact, the full pre-push gate, the four-platform quality gate, package inspection, and exact npm provenance remain required.
+
+Review note, 2026-07-24: Issue #200 releases 0.0.32 and adds focused proof for serial dependency-prefix completion, bounded suffix concurrency, stable report ordering, repeated-target rejection before DML, owner-token rollover, foreign renewed-session rejection at zero attempts, and unchanged success/UNKNOWN no-replay. Exact 100% coverage, Docpact, pre-push, four-platform quality, package inspection, and npm provenance gates remain required.
 
 ## Validation Matrix
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-23
-lastReviewedCommit: 4daf99c1b0b0fe3e084b5903163cdf6b11fe4de2
+lastReviewedAt: 2026-07-24
+lastReviewedCommit: 0cbbf9cef373675ad39ae2b8103003d05b48ccb8
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -66,6 +66,8 @@ Review note, 2026-07-23: Issue #194 adds the generic ordered owner-draft executi
 Review note, 2026-07-23: Issue #196 is the separate 0.0.30 release for merged Issue #194 / PR #195. It must prove the version and tag are absent, retain exact coverage, pass Docpact and the four-platform quality gate, including Windows durable-ledger creation/append/recovery, and use only the merge-triggered tag plus tag-triggered npm Trusted Publishing workflows. Local publish and manual tag creation remain forbidden; npm provenance and `gitHead` must match the immutable release merge commit before workspace integration.
 
 Review note, 2026-07-23: Issue #198 is the 0.0.31 hotfix release for side-effect-free dataset save-draft validation. It must prove the exact input remains unchanged through contract binding and dispatch preparation, keep exact coverage, pass Docpact and the four-platform quality gate, and use only the merge-triggered tag plus tag-triggered npm Trusted Publishing workflows. Local publish and manual tag creation remain forbidden; npm provenance and `gitHead` must match the immutable release merge commit before workspace integration.
+
+Review note, 2026-07-24: Issue #200 is the 0.0.32 hotfix release for bounded ordered-batch concurrency and current-owner token renewal. It must prove serial dependency-prefix completion, unique-target suffix concurrency no greater than 8, exact owner revalidation before dispatch, and unchanged durable attempt/no-replay behavior. Publication remains merge-triggered tag creation plus npm Trusted Publishing; local publish/manual tags remain forbidden, and npm provenance plus `gitHead` must match the release merge before workspace integration.
 
 Use this document for:
 

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -19,8 +19,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-23
-lastReviewedCommit: 4daf99c1b0b0fe3e084b5903163cdf6b11fe4de2
+lastReviewedAt: 2026-07-24
+lastReviewedCommit: 0cbbf9cef373675ad39ae2b8103003d05b48ccb8
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -80,6 +80,8 @@ Review note, 2026-07-23: Issue #194 requires no new npm secret, GitHub environme
 Review note, 2026-07-23: Issue #196 publishes 0.0.30 through the existing merge-triggered tag and npm Trusted Publishing workflows. Its Windows-compatible write-descriptor `fsync` repair requires no new secret, environment, runner, Trusted Publisher setting, workflow filename, tag rule, service-role credential, or alternate CLI authentication variable.
 
 Review note, 2026-07-23: Issue #198 publishes 0.0.31 through the same merge-triggered tag and npm Trusted Publishing workflows. Isolating SDK validation on a deep clone requires no new secret, environment, runner, Trusted Publisher setting, workflow filename, tag rule, service-role credential, or alternate CLI authentication variable.
+
+Review note, 2026-07-24: Issue #200 publishes 0.0.32 through the unchanged merge-triggered tag and npm Trusted Publishing workflows. Bounded execution-contract concurrency and owner-token renewal reuse the existing CLI session runtime and add no dependency, secret, environment variable, runner, Trusted Publisher setting, workflow filename, service-role credential, or alternate authentication surface.
 
 Review note, 2026-07-13: exact-count maintenance pagination requires no repository secret, Trusted Publisher, environment, workflow filename, or tag-semantics change.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/cli",
-      "version": "0.0.31",
+      "version": "0.0.32",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.101.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/cli",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "Unified TianGong LCA CLI with direct REST adapters and low-entropy command surface.",
   "repository": {
     "type": "git",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1417,6 +1417,8 @@ Options:
   --dry-run        Validate and plan without remote writes (default)
   --execution-contract <file>
                    Execute a content-bound ordered owner-draft batch with append-only attempt/readback evidence (requires --commit)
+  --max-parallel <1-8>
+                   Keep the dependency prefix serial, then run only the target-unique suffix with this concurrency (default: 1)
   --allow-account-local-support
                    Explicitly permit account-local Unit Group / Flow Property rows in the execution contract
   --json           Print compact JSON
@@ -3069,6 +3071,7 @@ function parseDatasetSaveDraftFlags(args: string[]): {
   commit: boolean;
   allowReferenceOnlySupport: boolean;
   executionContractPath: string | null;
+  maxParallel: number;
 } {
   let values: ReturnType<typeof parseArgs>['values'];
   try {
@@ -3086,6 +3089,7 @@ function parseDatasetSaveDraftFlags(args: string[]): {
         'dry-run': { type: 'boolean' },
         'allow-account-local-support': { type: 'boolean' },
         'execution-contract': { type: 'string' },
+        'max-parallel': { type: 'string' },
       },
     }));
   } catch (error) {
@@ -3102,6 +3106,20 @@ function parseDatasetSaveDraftFlags(args: string[]): {
     });
   }
 
+  const maxParallelValue = values['max-parallel'];
+  const maxParallel =
+    typeof maxParallelValue === 'string' && /^\d+$/u.test(maxParallelValue)
+      ? Number.parseInt(maxParallelValue, 10)
+      : maxParallelValue === undefined
+        ? 1
+        : Number.NaN;
+  if (!Number.isInteger(maxParallel) || maxParallel < 1 || maxParallel > 8) {
+    throw new CliError('--max-parallel must be an integer from 1 to 8.', {
+      code: 'INVALID_ARGS',
+      exitCode: 2,
+    });
+  }
+
   return {
     help: Boolean(values.help),
     json: Boolean(values.json),
@@ -3112,6 +3130,7 @@ function parseDatasetSaveDraftFlags(args: string[]): {
     allowReferenceOnlySupport: Boolean(values['allow-account-local-support']),
     executionContractPath:
       typeof values['execution-contract'] === 'string' ? values['execution-contract'] : null,
+    maxParallel,
   };
 }
 
@@ -7351,6 +7370,7 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
         commit: datasetFlags.commit,
         allowReferenceOnlySupport: datasetFlags.allowReferenceOnlySupport,
         executionContractPath: datasetFlags.executionContractPath,
+        maxParallel: datasetFlags.maxParallel,
         env: deps.env,
         fetchImpl: deps.fetchImpl,
       });

--- a/src/lib/dataset-save-draft-run.ts
+++ b/src/lib/dataset-save-draft-run.ts
@@ -162,6 +162,9 @@ export type DatasetSaveDraftReport = {
     sha256: string;
     execution_id: string;
     target_mode: 'owner_draft';
+    max_parallel: number;
+    serial_prefix_actions: number;
+    parallel_suffix_actions: number;
   };
 };
 
@@ -182,6 +185,7 @@ export type RunDatasetSaveDraftOptions = {
    */
   allowReferenceOnlySupport?: boolean | null;
   executionContractPath?: string | null;
+  maxParallel?: number | null;
 };
 
 type DatasetSaveDraftExecutionAction = {
@@ -1392,6 +1396,62 @@ async function readbackIsDesiredExact(options: {
   }
 }
 
+function normalizeExecutionMaxParallel(value: number | null | undefined): number {
+  const normalized = value ?? 1;
+  if (!Number.isInteger(normalized) || normalized < 1 || normalized > 8) {
+    executionContractError('Execution contract --max-parallel must be an integer from 1 to 8.');
+  }
+  return normalized;
+}
+
+function executionSerialPrefixLength(contract: DatasetSaveDraftExecutionContract): number {
+  const actionIndexes = new Map(
+    contract.actions.map((action, index) => [action.action_id, index] as const),
+  );
+  let highestDependencyIndex = -1;
+  for (const action of contract.actions) {
+    for (const dependencyActionId of action.dependency_action_ids) {
+      highestDependencyIndex = Math.max(
+        highestDependencyIndex,
+        actionIndexes.get(dependencyActionId) as number,
+      );
+    }
+  }
+  return highestDependencyIndex + 1;
+}
+
+function assertParallelSuffixTargetsAreUnique(
+  contract: DatasetSaveDraftExecutionContract,
+  serialPrefixLength: number,
+): void {
+  const targets = new Set<string>();
+  for (const action of contract.actions.slice(serialPrefixLength)) {
+    const target = `${action.table}\u0000${action.id}\u0000${action.version}`;
+    if (targets.has(target)) {
+      executionContractError(
+        'Execution contract parallel suffix contains a repeated table/id/version target.',
+      );
+    }
+    targets.add(target);
+  }
+}
+
+async function renewExecutionOwnerToken(options: {
+  runtime: SupabaseDataRuntime;
+  commandTransport: NonNullable<Awaited<ReturnType<typeof buildDatasetCommandTransport>>>;
+  contract: DatasetSaveDraftExecutionContract;
+}): Promise<void> {
+  const accessToken = await options.runtime.getAccessToken();
+  const actor = decodeExecutionActor(accessToken);
+  if (
+    actor.user_id !== options.contract.owner.user_id ||
+    actor.email !== options.contract.owner.email
+  ) {
+    executionContractError('Renewed owner session does not match the execution contract.');
+  }
+  options.commandTransport.accessToken = accessToken;
+}
+
 async function runExecutionContractBatch(options: {
   contractPath: string;
   contract: DatasetSaveDraftExecutionContract;
@@ -1408,6 +1468,7 @@ async function runExecutionContractBatch(options: {
   fetchImpl: FetchLike;
   timeoutMs: number;
   now: () => string;
+  maxParallel: number;
 }): Promise<DatasetSaveDraftReport> {
   const contractSha256 = sha256Json(options.contract);
   const ledgerRoot = executionLedgerRoot(options.env, options.contract);
@@ -1421,12 +1482,23 @@ async function runExecutionContractBatch(options: {
     executionContractError('Owner session or project does not match the execution contract.');
   }
   options.files.execution_ledger = ledgerRoot;
-  const reports: DatasetSaveDraftRowReport[] = [];
+  const serialPrefixLength = executionSerialPrefixLength(options.contract);
+  if (options.maxParallel > 1) {
+    assertParallelSuffixTargetsAreUnique(options.contract, serialPrefixLength);
+  }
+  const reports: Array<DatasetSaveDraftRowReport | undefined> = new Array(
+    options.contract.actions.length,
+  );
   const statuses = new Map<string, DatasetSaveDraftRowReport['status']>();
   const referenceOnlySupportCache = new Map<string, Promise<RemoteDatasetLookup>>();
 
-  for (const [index, action] of options.contract.actions.entries()) {
+  const executeAction = async (index: number): Promise<void> => {
+    const action = options.contract.actions[index] as DatasetSaveDraftExecutionAction;
     const row = options.preparedRows[index] as PreparedDatasetRow;
+    const storeReport = (report: DatasetSaveDraftRowReport): void => {
+      reports[index] = report;
+      statuses.set(action.action_id, report.status);
+    };
     const preparedFailure = buildPreparedFailure(row, options.allowReferenceOnlySupport);
     if (preparedFailure) {
       const report = {
@@ -1437,9 +1509,8 @@ async function runExecutionContractBatch(options: {
         replayed: false as const,
         readback: 'not_performed' as const,
       };
-      reports.push(report);
-      statuses.set(action.action_id, report.status);
-      continue;
+      storeReport(report);
+      return;
     }
 
     const priorOutcome = ledger.outcomes.get(action.action_id);
@@ -1471,9 +1542,8 @@ async function runExecutionContractBatch(options: {
             }
           : {}),
       });
-      reports.push(report);
-      statuses.set(action.action_id, status);
-      continue;
+      storeReport(report);
+      return;
     }
 
     if (ledger.attempts.has(action.action_id)) {
@@ -1489,9 +1559,8 @@ async function runExecutionContractBatch(options: {
         now: options.now,
         recovered: true,
       });
-      reports.push(report);
-      statuses.set(action.action_id, report.status);
-      continue;
+      storeReport(report);
+      return;
     }
 
     const blockingDependencies = action.dependency_action_ids.filter(
@@ -1510,9 +1579,8 @@ async function runExecutionContractBatch(options: {
           details: { dependency_action_ids: blockingDependencies },
         },
       });
-      reports.push(report);
-      statuses.set(action.action_id, report.status);
-      continue;
+      storeReport(report);
+      return;
     }
 
     let beforeRows: ExecutionDatasetRow[];
@@ -1563,6 +1631,11 @@ async function runExecutionContractBatch(options: {
           });
         }
       }
+      await renewExecutionOwnerToken({
+        runtime: options.runtime,
+        commandTransport: options.commandTransport,
+        contract: options.contract,
+      });
     } catch (error) {
       const report = contractRowReport({
         row,
@@ -1573,9 +1646,8 @@ async function runExecutionContractBatch(options: {
         readback: 'not_performed',
         error: serializeError(error),
       });
-      reports.push(report);
-      statuses.set(action.action_id, report.status);
-      continue;
+      storeReport(report);
+      return;
     }
 
     try {
@@ -1630,16 +1702,47 @@ async function runExecutionContractBatch(options: {
       now: options.now,
       recovered: transportFailed,
     });
-    reports.push(report);
-    statuses.set(action.action_id, report.status);
+    storeReport(report);
+  };
+
+  for (let index = 0; index < serialPrefixLength; index += 1) {
+    await executeAction(index);
   }
 
-  const failures = reports.filter((row) => ['failed', 'unknown', 'blocked'].includes(row.status));
-  writeJsonLinesArtifact(options.files.progress_jsonl, reports);
+  let nextParallelIndex = serialPrefixLength;
+  let fatalWorkerError: unknown = null;
+  const runParallelWorker = async (): Promise<void> => {
+    while (fatalWorkerError === null) {
+      const index = nextParallelIndex;
+      nextParallelIndex += 1;
+      if (index >= options.contract.actions.length) {
+        return;
+      }
+      try {
+        await executeAction(index);
+      } catch (error) {
+        fatalWorkerError ??= error;
+      }
+    }
+  };
+  const parallelWorkerCount = Math.min(
+    options.maxParallel,
+    options.contract.actions.length - serialPrefixLength,
+  );
+  await Promise.all(Array.from({ length: parallelWorkerCount }, () => runParallelWorker()));
+  if (fatalWorkerError !== null) {
+    throw fatalWorkerError;
+  }
+
+  const completedReports = reports as DatasetSaveDraftRowReport[];
+  const failures = completedReports.filter((row) =>
+    ['failed', 'unknown', 'blocked'].includes(row.status),
+  );
+  writeJsonLinesArtifact(options.files.progress_jsonl, completedReports);
   writeJsonLinesArtifact(options.files.failures_jsonl, failures);
-  const unknown = reports.filter((row) => row.status === 'unknown').length;
-  const failed = reports.filter((row) => row.status === 'failed').length;
-  const blocked = reports.filter((row) => row.status === 'blocked').length;
+  const unknown = completedReports.filter((row) => row.status === 'unknown').length;
+  const failed = completedReports.filter((row) => row.status === 'failed').length;
+  const blocked = completedReports.filter((row) => row.status === 'blocked').length;
   const report: DatasetSaveDraftReport = {
     schema_version: 2,
     generated_at_utc: options.now(),
@@ -1657,21 +1760,24 @@ async function runExecutionContractBatch(options: {
     counts: {
       selected: options.preparedRows.length,
       prepared: 0,
-      executed: reports.filter((row) => row.status === 'executed').length,
+      executed: completedReports.filter((row) => row.status === 'executed').length,
       failed,
       unknown,
       blocked,
       attempts_consumed: ledger.attempts.size,
       by_table: byTable(options.preparedRows),
-      operations: operationCount(reports),
+      operations: operationCount(completedReports),
     },
     files: options.files,
-    rows: reports,
+    rows: completedReports,
     execution_contract: {
       path: path.resolve(options.contractPath),
       sha256: contractSha256,
       execution_id: options.contract.execution_id,
       target_mode: 'owner_draft',
+      max_parallel: options.maxParallel,
+      serial_prefix_actions: serialPrefixLength,
+      parallel_suffix_actions: options.contract.actions.length - serialPrefixLength,
     },
   };
   writeJsonArtifact(options.files.summary_json, report);
@@ -1692,6 +1798,7 @@ export async function runDatasetSaveDraft(
   const files = buildFiles(outDir);
   const preparedRows = prepareRows(inputPath, options.rawInput, requestedType);
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxParallel = normalizeExecutionMaxParallel(options.maxParallel);
   const executionContractPath = options.executionContractPath
     ? path.resolve(options.executionContractPath)
     : null;
@@ -1703,6 +1810,9 @@ export async function runDatasetSaveDraft(
 
   if (executionContract && !commit) {
     executionContractError('Execution contract mode requires --commit.');
+  }
+  if (!executionContract && maxParallel !== 1) {
+    executionContractError('--max-parallel greater than 1 requires --execution-contract.');
   }
   if (executionContract) {
     bindExecutionContractRows(executionContract, preparedRows);
@@ -1756,6 +1866,7 @@ export async function runDatasetSaveDraft(
       fetchImpl: options.fetchImpl!,
       timeoutMs,
       now: () => now.toISOString(),
+      maxParallel,
     });
   }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1064,7 +1064,7 @@ test('executeCli separates production read-only freeze from offline approval sea
     outDir: './protected-freeze',
     expectedProjectRef: 'production-ref',
     confirm: 'bafudata@126.com',
-    cliVersion: '0.0.31',
+    cliVersion: '0.0.32',
     pageSize: 250,
     timeoutMs: 12000,
     env: deps.env,
@@ -1266,7 +1266,7 @@ test('executeCli exposes the dedicated flow-identity capture/plan/freeze/seal/ru
     operationId: 'flow-identity-v2-capture',
     expectedProjectRef: 'prod',
     confirm: 'owner@example.com',
-    cliVersion: '0.0.31',
+    cliVersion: '0.0.32',
     sdkVersion: '0.1.45',
     outDir: 'capture-out',
     pageSize: 1000,
@@ -1343,7 +1343,7 @@ test('executeCli exposes the dedicated flow-identity capture/plan/freeze/seal/ru
     approvedAtUtc: '2026-07-16T05:00:00Z',
     expectedProjectRef: 'prod',
     confirm: 'owner@example.com',
-    cliVersion: '0.0.31',
+    cliVersion: '0.0.32',
     outDir: 'freeze-out',
   });
 

--- a/test/dataset-maintenance-flow-identity-coverage-cli-remote.test.ts
+++ b/test/dataset-maintenance-flow-identity-coverage-cli-remote.test.ts
@@ -627,7 +627,7 @@ test('flow-identity CLI dispatches all recovery actions with exact options', asy
     confirm: 'owner@example.com',
     approvedAtUtc: '2026-07-16T05:20:00.000Z',
     recoveryReason: 'process_response_ambiguous',
-    cliVersion: '0.0.31',
+    cliVersion: '0.0.32',
     outDir: 'recovery-freeze-out',
     timeoutMs: 5000,
     env: {},

--- a/test/dataset-save-draft-cli.test.ts
+++ b/test/dataset-save-draft-cli.test.ts
@@ -275,6 +275,7 @@ test('executeCli exposes generic dataset save-draft for support rows', async () 
   assert.equal(help.exitCode, 0);
   assert.match(help.stdout, /tiangong-lca dataset save-draft --input <file>/u);
   assert.match(help.stdout, /auto, contact, source, flow, process/u);
+  assert.match(help.stdout, /--max-parallel <1-8>/u);
   assert.match(help.stdout, /Unit group and flow property rows are reference-only/u);
 
   const result = await executeCli(
@@ -290,6 +291,8 @@ test('executeCli exposes generic dataset save-draft for support rows', async () 
       'contact-save',
       '--execution-contract',
       'contract.json',
+      '--max-parallel',
+      '8',
       '--commit',
     ],
     makeDeps({
@@ -310,6 +313,7 @@ test('executeCli exposes generic dataset save-draft for support rows', async () 
     commit: true,
     allowReferenceOnlySupport: false,
     executionContractPath: 'contract.json',
+    maxParallel: 8,
     env: {},
     fetchImpl: (observed[0] as { fetchImpl: unknown }).fetchImpl,
   });
@@ -339,6 +343,25 @@ test('executeCli maps generic dataset save-draft failures and rejects mode confl
   );
   assert.equal(conflict.exitCode, 2);
   assert.match(conflict.stderr, /Cannot pass both --commit and --dry-run/u);
+
+  for (const invalid of ['0', '9', '1.5', 'nope']) {
+    const invalidParallel = await executeCli(
+      [
+        'dataset',
+        'save-draft',
+        '--input',
+        'contacts.jsonl',
+        '--execution-contract',
+        'contract.json',
+        '--max-parallel',
+        invalid,
+        '--commit',
+      ],
+      makeDeps(),
+    );
+    assert.equal(invalidParallel.exitCode, 2);
+    assert.match(invalidParallel.stderr, /integer from 1 to 8/u);
+  }
 });
 
 test('dataset save-draft rejects explicit reference-only support types', () => {

--- a/test/dataset-save-draft-execution-contract.test.ts
+++ b/test/dataset-save-draft-execution-contract.test.ts
@@ -399,6 +399,227 @@ test('execution contract runs ordered insert/update once and skips terminal rows
   }
 });
 
+test('execution contract keeps the dependency prefix serial and bounds the unique suffix', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-execution-contract-parallel-'));
+  const desired = [
+    flow('10000000-0000-0000-0000-000000000001', 'Prefix one'),
+    flow('10000000-0000-0000-0000-000000000002', 'Prefix two'),
+    flow('10000000-0000-0000-0000-000000000003', 'Suffix three'),
+    flow('10000000-0000-0000-0000-000000000004', 'Suffix four'),
+    flow('10000000-0000-0000-0000-000000000005', 'Suffix five'),
+    flow('10000000-0000-0000-0000-000000000006', 'Suffix six'),
+  ];
+  const state = new Map<string, JsonObject>();
+  const writes: string[] = [];
+  const baseFetch = executionFetch({ state, writes });
+  const starts: string[] = [];
+  const prefixActive: number[] = [];
+  let active = 0;
+  let maxActive = 0;
+  const fetchImpl: FetchLike = async (input, init) => {
+    if (String(input).includes('/functions/v1/app_dataset_')) {
+      const body = JSON.parse(String(init?.body)) as { id: string };
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      starts.push(body.id);
+      if (
+        body.id === identity(desired[0] as JsonObject).id ||
+        body.id === identity(desired[1] as JsonObject).id
+      ) {
+        prefixActive.push(active);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 15));
+      try {
+        return await baseFetch(input, init);
+      } finally {
+        active -= 1;
+      }
+    }
+    return baseFetch(input, init);
+  };
+  const contractPath = writeContract(
+    dir,
+    contract({
+      desired,
+      dependencies: [[], [], ['action-2'], [], [], []],
+    }),
+  );
+
+  try {
+    const report = await runDatasetSaveDraft({
+      inputPath: path.join(dir, 'rows.json'),
+      rawInput: { rows: desired },
+      type: 'flow',
+      outDir: path.join(dir, 'out'),
+      commit: true,
+      executionContractPath: contractPath,
+      maxParallel: 3,
+      env: executionEnv(dir, 'parallel'),
+      fetchImpl,
+    });
+
+    assert.equal(report.status, 'completed');
+    assert.deepEqual(prefixActive, [1, 1]);
+    assert.equal(maxActive, 3);
+    assert.deepEqual(
+      starts.slice(0, 2),
+      desired.slice(0, 2).map((row) => identity(row).id),
+    );
+    assert.deepEqual(
+      report.rows.map((row) => row.id),
+      desired.map((row) => identity(row).id),
+    );
+    assert.deepEqual(report.execution_contract, {
+      path: path.resolve(contractPath),
+      sha256: sha256Json(
+        __testInternals.parseExecutionContract(
+          contract({ desired, dependencies: [[], [], ['action-2'], [], [], []] }),
+        ),
+      ),
+      execution_id: 'generic-owner-draft-batch-1',
+      target_mode: 'owner_draft',
+      max_parallel: 3,
+      serial_prefix_actions: 2,
+      parallel_suffix_actions: 4,
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('execution contract renews the exact owner token before DML and rejects a foreign renewal', async () => {
+  const runCase = async (
+    foreignRenewal: boolean,
+  ): Promise<{
+    report: Awaited<ReturnType<typeof runDatasetSaveDraft>>;
+    authCalls: number;
+    edgeTokens: Array<string | null>;
+    writes: string[];
+  }> => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-execution-contract-renew-'));
+    const desired = flow(
+      foreignRenewal
+        ? '20000000-0000-0000-0000-000000000002'
+        : '20000000-0000-0000-0000-000000000001',
+      foreignRenewal ? 'Foreign renewal' : 'Exact renewal',
+    );
+    const state = new Map<string, JsonObject>();
+    const writes: string[] = [];
+    const edgeTokens: Array<string | null> = [];
+    const baseFetch = executionFetch({ state, writes });
+    const firstToken = jwtWithPayload({ sub: 'user-1', email: 'user@example.com', seq: 1 });
+    const renewedToken = jwtWithPayload({
+      sub: foreignRenewal ? 'foreign-user' : 'user-1',
+      email: foreignRenewal ? 'foreign@example.com' : 'user@example.com',
+      seq: 2,
+    });
+    let authCalls = 0;
+    const fetchImpl: FetchLike = async (input, init) => {
+      const url = String(input);
+      if (isSupabaseAuthTokenUrl(url)) {
+        authCalls += 1;
+        return makeSupabaseAuthResponse({
+          accessToken: authCalls === 1 ? firstToken : renewedToken,
+          refreshToken: 'renew-owner-session',
+          expiresAt: authCalls === 1 ? Math.floor(Date.now() / 1000) + 60 : 4_102_444_800,
+          userId: foreignRenewal && authCalls > 1 ? 'foreign-user' : 'user-1',
+          email: foreignRenewal && authCalls > 1 ? 'foreign@example.com' : 'user@example.com',
+        });
+      }
+      if (url.includes('/functions/v1/app_dataset_')) {
+        edgeTokens.push(new Headers(init?.headers).get('authorization'));
+      }
+      return baseFetch(input, init);
+    };
+    const contractPath = writeContract(dir, contract({ desired: [desired] }));
+    try {
+      const report = await runDatasetSaveDraft({
+        inputPath: path.join(dir, 'rows.json'),
+        rawInput: { rows: [desired] },
+        type: 'flow',
+        outDir: path.join(dir, 'out'),
+        commit: true,
+        executionContractPath: contractPath,
+        env: executionEnv(dir, foreignRenewal ? 'foreign-renewal' : 'exact-renewal'),
+        fetchImpl,
+      });
+      return { report, authCalls, edgeTokens, writes };
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  };
+
+  const exact = await runCase(false);
+  assert.equal(exact.report.status, 'completed');
+  assert.ok(exact.authCalls >= 2);
+  assert.deepEqual(exact.edgeTokens, [
+    `Bearer ${jwtWithPayload({ sub: 'user-1', email: 'user@example.com', seq: 2 })}`,
+  ]);
+  assert.equal(exact.writes.length, 1);
+
+  const foreign = await runCase(true);
+  assert.equal(foreign.report.status, 'completed_with_failures');
+  assert.equal(foreign.report.counts.attempts_consumed, 0);
+  assert.match(foreign.report.rows[0]?.error?.message ?? '', /Renewed owner session/u);
+  assert.deepEqual(foreign.edgeTokens, []);
+  assert.deepEqual(foreign.writes, []);
+});
+
+test('execution contract rejects unsafe parallel configuration before DML', async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-execution-contract-parallel-guard-'));
+  const first = flow('30000000-0000-0000-0000-000000000001', 'First');
+  const repeated = flow('30000000-0000-0000-0000-000000000001', 'Repeated target');
+  const state = new Map<string, JsonObject>();
+  const writes: string[] = [];
+  const fetchImpl = executionFetch({ state, writes });
+  const contractPath = writeContract(dir, contract({ desired: [first, repeated] }));
+  const invalidContractDir = path.join(dir, 'invalid-contract');
+  mkdirSync(invalidContractDir);
+  try {
+    await assert.rejects(
+      runDatasetSaveDraft({
+        inputPath: path.join(dir, 'rows.json'),
+        rawInput: { rows: [first, repeated] },
+        type: 'flow',
+        outDir: path.join(dir, 'duplicate-out'),
+        commit: true,
+        executionContractPath: contractPath,
+        maxParallel: 2,
+        env: executionEnv(dir, 'duplicate-target'),
+        fetchImpl,
+      }),
+      /parallel suffix contains a repeated/u,
+    );
+    await assert.rejects(
+      runDatasetSaveDraft({
+        inputPath: path.join(dir, 'rows.json'),
+        rawInput: { rows: [first] },
+        type: 'flow',
+        outDir: path.join(dir, 'invalid-out'),
+        commit: true,
+        executionContractPath: writeContract(invalidContractDir, contract({ desired: [first] })),
+        maxParallel: 0,
+        env: executionEnv(dir, 'invalid-parallel'),
+        fetchImpl,
+      }),
+      /integer from 1 to 8/u,
+    );
+    await assert.rejects(
+      runDatasetSaveDraft({
+        inputPath: path.join(dir, 'rows.json'),
+        rawInput: { rows: [first] },
+        type: 'flow',
+        outDir: path.join(dir, 'ordinary-out'),
+        maxParallel: 2,
+      }),
+      /requires --execution-contract/u,
+    );
+    assert.deepEqual(writes, []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('execution contract recovers lost success, terminalizes unknown, blocks dependents, and continues independent rows', async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-execution-contract-recovery-'));
   const lostSuccess = flow('11111111-1111-1111-1111-111111111111', 'Lost success');


### PR DESCRIPTION
Closes #200

## Summary
- Add dataset save-draft --max-parallel 1..8 while preserving contract order, per-row protected transactions, stable reporting, and no-replay attempt semantics.
- Renew and revalidate the exact owner access token immediately before each production DML dispatch so long campaigns do not inherit an expired startup session.
- Release the backward-compatible CLI as 0.0.32 with updated operator and governance documentation.

## Key Decisions
- Serialize the full dependency-referenced prefix; allow overlap only for the suffix after proving table/id/version targets are unique, and reject duplicate suffix targets before any DML.
- Keep max-parallel=1 as the default and leave attempt accounting, exact owner readback, UNKNOWN handling, and success no-replay rules unchanged.

## Validation
- npm test: 1048/1048 passed.
- npm run test:coverage: 1044 passed, 4 expected skips, 100% statements/branches/functions/lines.
- npm run prepush:gate and npm pack --dry-run passed; docpact strict validation and staged lint passed.

## Risks / Rollback
- Concurrency is bounded at 8 and only reaches dependency-closed unique targets; rollback is a revert of this PR and max-parallel=1 remains the serial fallback.

## Workspace Integration
- After merge and cli-v0.0.32 publication, pin the exact child main commit in lca-workspace and refresh the data-foundry toolchain admission before the first BAFU production DML.