### PR TITLE
fix: bound all-visible delete preflight pagination

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -21,8 +21,9 @@ layout: repo
 # Review note, 2026-07-23: Issue #198 releases 0.0.31 and isolates SDK validation on a deep clone so exact dataset save-draft inputs cannot be mutated before execution-contract binding or dispatch. Existing command/runtime, test, release, and integration routing already covers the change; ownership, dependencies, authentication, tag automation, Trusted Publishing, and publication boundaries remain unchanged.
 # Review note, 2026-07-24: Issue #200 releases 0.0.32 and keeps bounded execution-contract scheduling plus owner-token renewal inside the existing dataset command/runtime, remote-session, test, release, and integration domains. Current wildcards already cover `src/cli.ts`, `src/lib/dataset-*.ts`, tests, and governed docs; no ownership, route, dependency, environment, authentication, tag, Trusted Publishing, or publication rule changes are required.
 # Review note, 2026-07-24: Issue #202 releases 0.0.33 and keeps bounded flow delete-only maintenance inside the existing dataset command/runtime, RLS remote-read, artifact, test, release, and integration domains. Current wildcards cover the visible-process inbound barrier, append-only dispatch ledger, tests, and governed docs; no ownership, route, dependency, environment, authentication, RPC/schema, tag, Trusted Publishing, or publication rule changes are required.
-lastReviewedAt: '2026-07-24'
-lastReviewedCommit: '0cbbf9cef373675ad39ae2b8103003d05b48ccb8'
+# Review note, 2026-07-24: Issue #204 keeps the parallel-delete all-visible process fence inside the existing maintenance runtime and exact-count paginator. Bounding only that scan to 250 rows per request changes no ownership, route, dependency, authentication, mutation, RPC/schema, release, or publication boundary.
+lastReviewedAt: "2026-07-25"
+lastReviewedCommit: "7c960cac3eab447a2a7d2b7c398ffd53c2de8fea"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-24
-lastReviewedCommit: 0cbbf9cef373675ad39ae2b8103003d05b48ccb8
+lastReviewedAt: 2026-07-25
+lastReviewedCommit: 7c960cac3eab447a2a7d2b7c398ffd53c2de8fea
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -98,6 +98,8 @@ Review note, 2026-07-23: Issue #198 releases 0.0.31 and makes dataset save-draft
 Review note, 2026-07-24: Issue #200 releases 0.0.32 and makes large ordered owner-draft contracts finish within the authenticated session window. `--max-parallel` remains opt-in and capped at 8: every action through the highest referenced dependency stays serial, and only the remaining unique-target suffix can overlap. The command resolves and revalidates the exact owner token immediately before each DML dispatch. Attempt-before-dispatch durability, exact readback, dependency blocking, UNKNOWN/success no-replay, and all public/foreign/publication/delete/state/schema/service-role prohibitions remain unchanged.
 
 Review note, 2026-07-24: Issue #202 releases 0.0.33 and keeps high-volume physical flow deletion inside the existing maintenance command boundary. Explicit `maintenance apply --max-parallel 1..8` accepts only unique owner-draft flow delete targets after zero current/projected impact and a fresh complete RLS-visible process inbound scan. Every protected delete remains an independent transaction with durable pre-dispatch evidence and exact absent readback; success/UNKNOWN are never automatically replayed and independent rows continue. No RPC, schema, dependency, alternate auth, publication, state, source, FP/UG, public, foreign-owner, direct-table, or service-role path is added.
+
+Review note, 2026-07-24: Issue #204 bounds each page of the parallel-delete all-visible process inbound preflight at 250 rows so large process JSON cannot exhaust the production statement timeout. The scan still omits a `user_id` predicate, follows exact-count pagination to completion, and blocks every mutation after an incomplete scan or any visible inbound reference. Delete scope, authorization, attempt-before-dispatch, no-replay, RPC/schema, and all protected-row boundaries are unchanged.
 
 ## Bootstrap Order
 

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -18,8 +18,8 @@ checkPaths:
   - src/**
   - scripts/**
   - .github/workflows/**
-lastReviewedAt: 2026-07-24
-lastReviewedCommit: 0cbbf9cef373675ad39ae2b8103003d05b48ccb8
+lastReviewedAt: 2026-07-25
+lastReviewedCommit: 7c960cac3eab447a2a7d2b7c398ffd53c2de8fea
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - README.md
   - src/**
   - test/**
-lastReviewedAt: 2026-07-24
-lastReviewedCommit: 0cbbf9cef373675ad39ae2b8103003d05b48ccb8
+lastReviewedAt: 2026-07-25
+lastReviewedCommit: 7c960cac3eab447a2a7d2b7c398ffd53c2de8fea
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -59,6 +59,8 @@ Review note, 2026-07-23: Issue #198 发布 0.0.31 并将 SDK schema/entity 校�
 Review note, 2026-07-24: Issue #200 发布 0.0.32，为大规模 execution contract 增加显式 `--max-parallel 1..8`。调度器先找出所有 dependency 所引用 action 的最大序号，该序号及其之前的完整前缀严格串行并完成 exact readback；只有后续 table/id/version 唯一的 suffix 可以有界并发。每次 DML 前通过既有 session runtime 取得当前 token，并再次核对 user/email；续期成 foreign owner 时在 attempt=0 阻断。每行独立 protected transaction、ledger、UNKNOWN/成功不重放与全部写入禁止项不变。
 
 Review note, 2026-07-24: Issue #202 发布 0.0.33，为 BAFU flow 物理收敛增加显式 `maintenance apply --max-parallel 1..8`。该模式只接受 flow delete-only、目标唯一、current/projected impact 为零的计划；dispatch 前完成全部 RLS 可见 process 的 fresh SELECT-only 入边复核。`PREPARED/DISPATCHED/COMMITTED/UNKNOWN` 逐行留痕，exact absent 才成功，成功和 UNKNOWN 均不自动重放，独立行继续。
+
+Review note, 2026-07-24: Issue #204 将上述全可见 process 入边复核固定为每页 250 行，以避免大 JSON 页触发生产语句超时；查询仍不带 `user_id` 过滤，必须完成 exact-count 全量分页后才允许 dispatch。
 
 ## 1. 目标
 

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -17,8 +17,8 @@ checkPaths:
   - package.json
   - src/**
   - test/**
-lastReviewedAt: 2026-07-24
-lastReviewedCommit: 0cbbf9cef373675ad39ae2b8103003d05b48ccb8
+lastReviewedAt: 2026-07-25
+lastReviewedCommit: 7c960cac3eab447a2a7d2b7c398ffd53c2de8fea
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
+++ b/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
@@ -15,8 +15,8 @@ checkPaths:
   - src/lib/user-api-key.ts
   - src/lib/supabase-session.ts
   - src/lib/supabase-client.ts
-lastReviewedAt: 2026-07-24
-lastReviewedCommit: 0cbbf9cef373675ad39ae2b8103003d05b48ccb8
+lastReviewedAt: 2026-07-25
+lastReviewedCommit: 7c960cac3eab447a2a7d2b7c398ffd53c2de8fea
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
+++ b/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
@@ -16,8 +16,8 @@ checkPaths:
   - src/lib/supabase-client.ts
   - src/lib/tidas-sdk-package-validator.ts
   - test/**
-lastReviewedAt: 2026-07-24
-lastReviewedCommit: 0cbbf9cef373675ad39ae2b8103003d05b48ccb8
+lastReviewedAt: 2026-07-25
+lastReviewedCommit: 7c960cac3eab447a2a7d2b7c398ffd53c2de8fea
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-24
-lastReviewedCommit: 0cbbf9cef373675ad39ae2b8103003d05b48ccb8
+lastReviewedAt: 2026-07-25
+lastReviewedCommit: 7c960cac3eab447a2a7d2b7c398ffd53c2de8fea
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -91,6 +91,8 @@ Review note, 2026-07-23: Issue #198 changes the package version to 0.0.31 and co
 Review note, 2026-07-24: Issue #200 releases 0.0.32 and extends the existing execution-contract scheduler without adding a second write path. The scheduler derives one serial prefix ending at the highest action referenced by any dependency, verifies that the remaining suffix has unique table/id/version targets, and runs that suffix with explicit concurrency 1..8. Each action still owns its independent protected transaction and ledger file. The existing session runtime supplies a current token immediately before dispatch, and the runner rejects any renewed user/email mismatch before attempt consumption.
 
 Review note, 2026-07-24: Issue #202 releases 0.0.33 and extends only ordinary dataset-maintenance apply. Explicit bounded mode is restricted to flow delete-only plans, reuses owner-session RLS reads and `cmd_dataset_delete`, adds a complete all-visible-process inbound barrier, and records append-only action dispatch/outcome events beside the immutable plan. It adds no RPC, schema, dependency, service-role, direct-table, publication, or cross-owner architecture.
+
+Review note, 2026-07-24: Issue #204 keeps the same all-visible-process inbound barrier but requests it in exact-count pages of at most 250 rows. The query still has no `user_id` predicate, and an incomplete scan still prevents approval or dispatch; only the per-request payload size changes.
 
 ## Stable Path Map
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-24
-lastReviewedCommit: 0cbbf9cef373675ad39ae2b8103003d05b48ccb8
+lastReviewedAt: 2026-07-25
+lastReviewedCommit: 7c960cac3eab447a2a7d2b7c398ffd53c2de8fea
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -113,6 +113,8 @@ Review note, 2026-07-23: Issue #198 adds a regression proving SDK validation can
 Review note, 2026-07-24: Issue #200 releases 0.0.32 and adds focused proof for serial dependency-prefix completion, bounded suffix concurrency, stable report ordering, repeated-target rejection before DML, owner-token rollover, foreign renewed-session rejection at zero attempts, and unchanged success/UNKNOWN no-replay. Exact 100% coverage, Docpact, pre-push, four-platform quality, package inspection, and npm provenance gates remain required.
 
 Review note, 2026-07-24: Issue #202 releases 0.0.33 and adds focused proof for flow delete-only admission, unique targets, complete RLS-visible process inbound scans, bounded concurrency, PREPARED-before-DISPATCHED durability, exact absent commit proof, lost-response recovery, success/UNKNOWN no-replay, independent-row continuation, and public/foreign/non-draft rejection. Exact 100% coverage, Docpact, pre-push, four-platform quality, package inspection, and npm provenance gates remain required.
+
+Review note, 2026-07-24: Issue #204 adds a production-scale regression for the all-visible process fence: more than 250 visible rows must traverse offsets `0,250,...` with `limit=250`, no `user_id` predicate, exact-count completeness, and zero dispatch on scan or inbound-reference failure.
 
 ## Validation Matrix
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-24
-lastReviewedCommit: 0cbbf9cef373675ad39ae2b8103003d05b48ccb8
+lastReviewedAt: 2026-07-25
+lastReviewedCommit: 7c960cac3eab447a2a7d2b7c398ffd53c2de8fea
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -70,6 +70,8 @@ Review note, 2026-07-23: Issue #198 is the 0.0.31 hotfix release for side-effect
 Review note, 2026-07-24: Issue #200 is the 0.0.32 hotfix release for bounded ordered-batch concurrency and current-owner token renewal. It must prove serial dependency-prefix completion, unique-target suffix concurrency no greater than 8, exact owner revalidation before dispatch, and unchanged durable attempt/no-replay behavior. Publication remains merge-triggered tag creation plus npm Trusted Publishing; local publish/manual tags remain forbidden, and npm provenance plus `gitHead` must match the release merge before workspace integration.
 
 Review note, 2026-07-24: Issue #202 is the 0.0.33 release for bounded delete-only flow convergence. It must prove a complete visible-process inbound barrier, target uniqueness, owner/state exactness, durable dispatch-before-request evidence, exact absent readback, ambiguity no-replay, and independent-row continuation at concurrency no greater than 8. Publication remains merge-triggered tag creation plus npm Trusted Publishing; local publish/manual tags remain forbidden, and npm provenance plus `gitHead` must match the release merge before workspace integration or production deletion.
+
+Review note, 2026-07-24: Issue #204 is a main-commit operational fix for the all-visible process preflight page size. The BAFU topology run binds the exact merged commit and built-file fingerprint; no package version, manual tag, local publish, or alternate release path is introduced by this fix.
 
 Use this document for:
 

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -19,8 +19,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-24
-lastReviewedCommit: 0cbbf9cef373675ad39ae2b8103003d05b48ccb8
+lastReviewedAt: 2026-07-25
+lastReviewedCommit: 7c960cac3eab447a2a7d2b7c398ffd53c2de8fea
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -84,6 +84,8 @@ Review note, 2026-07-23: Issue #198 publishes 0.0.31 through the same merge-trig
 Review note, 2026-07-24: Issue #200 publishes 0.0.32 through the unchanged merge-triggered tag and npm Trusted Publishing workflows. Bounded execution-contract concurrency and owner-token renewal reuse the existing CLI session runtime and add no dependency, secret, environment variable, runner, Trusted Publisher setting, workflow filename, service-role credential, or alternate authentication surface.
 
 Review note, 2026-07-24: Issue #202 publishes 0.0.33 through the unchanged merge-triggered tag and npm Trusted Publishing workflows. Bounded flow delete-only maintenance reuses the existing user session, RLS REST reads, and protected delete RPC and adds no dependency, secret, environment variable, runner, Trusted Publisher setting, workflow filename, service-role credential, or alternate authentication surface.
+
+Review note, 2026-07-24: Issue #204 changes only the main-commit all-visible preflight page size and requires no new secret, environment variable, runner, Trusted Publisher setting, workflow, tag rule, service-role credential, or alternate authentication surface.
 
 Review note, 2026-07-13: exact-count maintenance pagination requires no repository secret, Trusted Publisher, environment, workflow filename, or tag-semantics change.
 

--- a/src/lib/dataset-maintenance-apply.ts
+++ b/src/lib/dataset-maintenance-apply.ts
@@ -126,6 +126,11 @@ export type RunDatasetMaintenanceApplyOptions = {
 
 type ParallelDeleteExecutionStatus = 'PREPARED' | 'DISPATCHED' | 'COMMITTED' | 'UNKNOWN';
 
+// Process payloads can be large enough for the default 1,000-row page to exceed
+// the database statement timeout. Keep the destructive all-visible RLS fence,
+// but bound each SELECT-only page so admission can complete without weakening it.
+const PARALLEL_DELETE_VISIBLE_PROCESS_PAGE_SIZE = 250;
+
 type ParallelDeleteExecutionEntry = {
   schema_version: 1;
   plan_sha256: string;
@@ -2346,7 +2351,11 @@ export async function runDatasetMaintenanceApply(
           userId: plan.account.user_id,
         }),
         parallelDeleteMode
-          ? fetchMaintenanceVisibleTableRows({ context, table: 'processes' })
+          ? fetchMaintenanceVisibleTableRows({
+              context,
+              table: 'processes',
+              pageSize: PARALLEL_DELETE_VISIBLE_PROCESS_PAGE_SIZE,
+            })
           : Promise.resolve(null),
       ]);
       assertApplyPreconditions({

--- a/test/dataset-maintenance-row-level.test.ts
+++ b/test/dataset-maintenance-row-level.test.ts
@@ -1525,7 +1525,24 @@ test('parallel flow delete apply is bounded, durable, globally fenced, and never
       }),
       { user_id: null, state_code: null },
     );
+    for (let index = 3; index <= 253; index += 1) {
+      const suffix = String(index).padStart(12, '0');
+      scenario.remote.add(
+        'processes',
+        `81000000-0000-4000-8000-${suffix}`,
+        processFlowReferencePayload({
+          processId: `81000000-0000-4000-8000-${suffix}`,
+          flowId: `82000000-0000-4000-8000-${suffix}`,
+        }),
+        { user_id: '99999999-9999-4999-8999-999999999999', state_code: 100 },
+      );
+    }
     scenario.remote.deleteDelayMs = 20;
+    const requestedUrls: string[] = [];
+    const fetchImpl: FetchLike = async (input, init) => {
+      requestedUrls.push(String(input));
+      return scenario.remote.fetch(input, init);
+    };
     const report = await runDatasetMaintenanceApply({
       planPath: scenario.planPath,
       commit: true,
@@ -1533,7 +1550,7 @@ test('parallel flow delete apply is bounded, durable, globally fenced, and never
       confirm: scenario.remote.email,
       maxParallel: 4,
       env: scenario.remote.env,
-      fetchImpl: scenario.remote.fetch,
+      fetchImpl,
       now: new Date('2026-07-24T10:01:00.000Z'),
     });
     assert.equal(report.status, 'completed');
@@ -1561,8 +1578,21 @@ test('parallel flow delete apply is bounded, durable, globally fenced, and never
     assert.ok(isJsonObject(barrier));
     assert.equal(barrier.inbound_reference_count, 0);
     assert.equal(barrier.target_count, 4);
-    assert.equal(barrier.process_rows, 2);
-    assert.equal(barrier.process_references, 2);
+    assert.equal(barrier.process_rows, 253);
+    assert.equal(barrier.process_references, 253);
+    const visibleProcessUrls = requestedUrls
+      .filter((requestedUrl) => requestedUrl.includes('/rest/v1/processes'))
+      .map((requestedUrl) => new URL(requestedUrl))
+      .filter((requestedUrl) => !requestedUrl.searchParams.has('user_id'));
+    assert.ok(visibleProcessUrls.length > 0);
+    assert.deepEqual(
+      visibleProcessUrls.map((requestedUrl) => requestedUrl.searchParams.get('offset')),
+      ['0', '250'],
+    );
+    for (const requestedUrl of visibleProcessUrls) {
+      assert.equal(requestedUrl.searchParams.get('limit'), '250');
+      assert.equal(requestedUrl.searchParams.get('user_id'), null);
+    }
 
     const rpcCount = scenario.remote.rpcOrder.length;
     const resumed = await runDatasetMaintenanceApply({


### PR DESCRIPTION
Closes #204

## Summary
- Bound the parallel-delete all-visible process census to exact-count pages of 250 rows.
- Preserve the complete RLS-visible safety fence and its no-user-filter semantics.
- Add a 253-row regression that proves offsets 0 and 250 before delete dispatch.

## Key Decisions
- Keep the change internal to maintenance apply; no new flag, RPC, schema, authentication, or mutation path.

## Validation
- Docpact strict validation and enforce lint passed.
- npm run prepush:gate passed: 1,055 tests, 1,051 passed, 4 skipped, and 100 percent statements, branches, functions, and lines.
- npm run build passed.

## Risks / Rollback
- If the visible census is incomplete or sees any inbound reference, apply still fails before approval and dispatch.

## Workspace Integration
- After merge, pin the exact CLI main merge commit and built-file fingerprint in lca-workspace and BAFU successor authority before Phase D resumes.