### PR TITLE
fix: use indexed ordering for visible maintenance scans

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -22,8 +22,9 @@ layout: repo
 # Review note, 2026-07-24: Issue #200 releases 0.0.32 and keeps bounded execution-contract scheduling plus owner-token renewal inside the existing dataset command/runtime, remote-session, test, release, and integration domains. Current wildcards already cover `src/cli.ts`, `src/lib/dataset-*.ts`, tests, and governed docs; no ownership, route, dependency, environment, authentication, tag, Trusted Publishing, or publication rule changes are required.
 # Review note, 2026-07-24: Issue #202 releases 0.0.33 and keeps bounded flow delete-only maintenance inside the existing dataset command/runtime, RLS remote-read, artifact, test, release, and integration domains. Current wildcards cover the visible-process inbound barrier, append-only dispatch ledger, tests, and governed docs; no ownership, route, dependency, environment, authentication, RPC/schema, tag, Trusted Publishing, or publication rule changes are required.
 # Review note, 2026-07-24: Issue #204 keeps the parallel-delete all-visible process fence inside the existing maintenance runtime and exact-count paginator. Bounding only that scan to 250 rows per request changes no ownership, route, dependency, authentication, mutation, RPC/schema, release, or publication boundary.
+# Review note, 2026-07-25: Issue #206 keeps that complete RLS-visible fence on the globally unique `(id, version)` primary-key order so Postgres can use the existing index instead of sorting redundant owner/state keys. Completeness, ownership, mutation, retry, RPC/schema, release, and publication boundaries are unchanged.
 lastReviewedAt: "2026-07-25"
-lastReviewedCommit: "7c960cac3eab447a2a7d2b7c398ffd53c2de8fea"
+lastReviewedCommit: "473ad5b54d099ae0584c4d188968446ca0c48409"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-25
-lastReviewedCommit: 7c960cac3eab447a2a7d2b7c398ffd53c2de8fea
+lastReviewedCommit: 473ad5b54d099ae0584c4d188968446ca0c48409
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -100,6 +100,8 @@ Review note, 2026-07-24: Issue #200 releases 0.0.32 and makes large ordered owne
 Review note, 2026-07-24: Issue #202 releases 0.0.33 and keeps high-volume physical flow deletion inside the existing maintenance command boundary. Explicit `maintenance apply --max-parallel 1..8` accepts only unique owner-draft flow delete targets after zero current/projected impact and a fresh complete RLS-visible process inbound scan. Every protected delete remains an independent transaction with durable pre-dispatch evidence and exact absent readback; success/UNKNOWN are never automatically replayed and independent rows continue. No RPC, schema, dependency, alternate auth, publication, state, source, FP/UG, public, foreign-owner, direct-table, or service-role path is added.
 
 Review note, 2026-07-24: Issue #204 bounds each page of the parallel-delete all-visible process inbound preflight at 250 rows so large process JSON cannot exhaust the production statement timeout. The scan still omits a `user_id` predicate, follows exact-count pagination to completion, and blocks every mutation after an incomplete scan or any visible inbound reference. Delete scope, authorization, attempt-before-dispatch, no-replay, RPC/schema, and all protected-row boundaries are unchanged.
+
+Review note, 2026-07-25: Issue #206 orders that complete RLS-visible process scan only by the globally unique `(id, version)` primary key. This preserves deterministic exact-count completeness and every visible-row safety check while avoiding a redundant full-result owner/state sort; filtering, delete scope, authorization, retry, mutation, RPC/schema, and protected-row boundaries remain unchanged.
 
 ## Bootstrap Order
 

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -19,7 +19,7 @@ checkPaths:
   - scripts/**
   - .github/workflows/**
 lastReviewedAt: 2026-07-25
-lastReviewedCommit: 7c960cac3eab447a2a7d2b7c398ffd53c2de8fea
+lastReviewedCommit: 473ad5b54d099ae0584c4d188968446ca0c48409
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Review note, 2026-07-24: CLI 0.0.32 adds bounded execution-contract concurrency 
 
 Review note, 2026-07-24: CLI 0.0.33 adds an explicit `dataset maintenance apply --max-parallel 1..8` profile for large owner-draft flow convergence. It accepts only unique flow delete-only plans with zero frozen and fresh visible-process inbound references, persists `PREPARED` and `DISPATCHED` before each protected RPC, requires exact absent readback for `COMMITTED`, never automatically replays success or UNKNOWN, and continues independent rows.
 
+Review note, 2026-07-25: The complete RLS-visible process fence now paginates in the strict `(id, version)` primary-key order. It still has no `user_id` filter and retains exact-count completeness, while avoiding a redundant owner/state sort before any deletion can dispatch.
+
 ## Run
 
 One-off published run:

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -17,7 +17,7 @@ checkPaths:
   - src/**
   - test/**
 lastReviewedAt: 2026-07-25
-lastReviewedCommit: 7c960cac3eab447a2a7d2b7c398ffd53c2de8fea
+lastReviewedCommit: 473ad5b54d099ae0584c4d188968446ca0c48409
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -61,6 +61,8 @@ Review note, 2026-07-24: Issue #200 发布 0.0.32，为大规模 execution contr
 Review note, 2026-07-24: Issue #202 发布 0.0.33，为 BAFU flow 物理收敛增加显式 `maintenance apply --max-parallel 1..8`。该模式只接受 flow delete-only、目标唯一、current/projected impact 为零的计划；dispatch 前完成全部 RLS 可见 process 的 fresh SELECT-only 入边复核。`PREPARED/DISPATCHED/COMMITTED/UNKNOWN` 逐行留痕，exact absent 才成功，成功和 UNKNOWN 均不自动重放，独立行继续。
 
 Review note, 2026-07-24: Issue #204 将上述全可见 process 入边复核固定为每页 250 行，以避免大 JSON 页触发生产语句超时；查询仍不带 `user_id` 过滤，必须完成 exact-count 全量分页后才允许 dispatch。
+
+Review note, 2026-07-25: Issue #206 将该完整 RLS 可见 process 扫描的稳定顺序收敛为全局唯一主键 `(id, version)`，让数据库直接走既有索引，避免冗余 owner/state 全结果排序；无 `user_id` 过滤、exact-count 完整性和首写前全局入边阻断均不变。
 
 ## 1. 目标
 

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -18,7 +18,7 @@ checkPaths:
   - src/**
   - test/**
 lastReviewedAt: 2026-07-25
-lastReviewedCommit: 7c960cac3eab447a2a7d2b7c398ffd53c2de8fea
+lastReviewedCommit: 473ad5b54d099ae0584c4d188968446ca0c48409
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
+++ b/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
@@ -16,7 +16,7 @@ checkPaths:
   - src/lib/supabase-session.ts
   - src/lib/supabase-client.ts
 lastReviewedAt: 2026-07-25
-lastReviewedCommit: 7c960cac3eab447a2a7d2b7c398ffd53c2de8fea
+lastReviewedCommit: 473ad5b54d099ae0584c4d188968446ca0c48409
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
+++ b/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
@@ -17,7 +17,7 @@ checkPaths:
   - src/lib/tidas-sdk-package-validator.ts
   - test/**
 lastReviewedAt: 2026-07-25
-lastReviewedCommit: 7c960cac3eab447a2a7d2b7c398ffd53c2de8fea
+lastReviewedCommit: 473ad5b54d099ae0584c4d188968446ca0c48409
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-25
-lastReviewedCommit: 7c960cac3eab447a2a7d2b7c398ffd53c2de8fea
+lastReviewedCommit: 473ad5b54d099ae0584c4d188968446ca0c48409
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -93,6 +93,8 @@ Review note, 2026-07-24: Issue #200 releases 0.0.32 and extends the existing exe
 Review note, 2026-07-24: Issue #202 releases 0.0.33 and extends only ordinary dataset-maintenance apply. Explicit bounded mode is restricted to flow delete-only plans, reuses owner-session RLS reads and `cmd_dataset_delete`, adds a complete all-visible-process inbound barrier, and records append-only action dispatch/outcome events beside the immutable plan. It adds no RPC, schema, dependency, service-role, direct-table, publication, or cross-owner architecture.
 
 Review note, 2026-07-24: Issue #204 keeps the same all-visible-process inbound barrier but requests it in exact-count pages of at most 250 rows. The query still has no `user_id` predicate, and an incomplete scan still prevents approval or dispatch; only the per-request payload size changes.
+
+Review note, 2026-07-25: Issue #206 keeps the same barrier and exact-count paginator but uses only the globally unique `(id, version)` primary-key order. The database can now satisfy stable pagination through its existing index without a redundant owner/state sort; visibility, filtering, mutation, authorization, and fail-closed semantics do not change.
 
 ## Stable Path Map
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-25
-lastReviewedCommit: 7c960cac3eab447a2a7d2b7c398ffd53c2de8fea
+lastReviewedCommit: 473ad5b54d099ae0584c4d188968446ca0c48409
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -115,6 +115,8 @@ Review note, 2026-07-24: Issue #200 releases 0.0.32 and adds focused proof for s
 Review note, 2026-07-24: Issue #202 releases 0.0.33 and adds focused proof for flow delete-only admission, unique targets, complete RLS-visible process inbound scans, bounded concurrency, PREPARED-before-DISPATCHED durability, exact absent commit proof, lost-response recovery, success/UNKNOWN no-replay, independent-row continuation, and public/foreign/non-draft rejection. Exact 100% coverage, Docpact, pre-push, four-platform quality, package inspection, and npm provenance gates remain required.
 
 Review note, 2026-07-24: Issue #204 adds a production-scale regression for the all-visible process fence: more than 250 visible rows must traverse offsets `0,250,...` with `limit=250`, no `user_id` predicate, exact-count completeness, and zero dispatch on scan or inbound-reference failure.
+
+Review note, 2026-07-25: Issue #206 extends that regression to require the exact `id.asc,version.asc` primary-key order on every all-visible page while retaining the no-`user_id` and exact-count assertions. The test continues to prove that incomplete scans or inbound references dispatch zero mutations.
 
 ## Validation Matrix
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-25
-lastReviewedCommit: 7c960cac3eab447a2a7d2b7c398ffd53c2de8fea
+lastReviewedCommit: 473ad5b54d099ae0584c4d188968446ca0c48409
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -72,6 +72,8 @@ Review note, 2026-07-24: Issue #200 is the 0.0.32 hotfix release for bounded ord
 Review note, 2026-07-24: Issue #202 is the 0.0.33 release for bounded delete-only flow convergence. It must prove a complete visible-process inbound barrier, target uniqueness, owner/state exactness, durable dispatch-before-request evidence, exact absent readback, ambiguity no-replay, and independent-row continuation at concurrency no greater than 8. Publication remains merge-triggered tag creation plus npm Trusted Publishing; local publish/manual tags remain forbidden, and npm provenance plus `gitHead` must match the release merge before workspace integration or production deletion.
 
 Review note, 2026-07-24: Issue #204 is a main-commit operational fix for the all-visible process preflight page size. The BAFU topology run binds the exact merged commit and built-file fingerprint; no package version, manual tag, local publish, or alternate release path is introduced by this fix.
+
+Review note, 2026-07-25: Issue #206 is a main-commit operational fix that changes only the stable order of the same all-visible preflight to `(id, version)`. The BAFU topology run must bind the exact merged commit and built-file fingerprint; no package version, tag, publish, credential, or alternate release path is introduced.
 
 Use this document for:
 

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-25
-lastReviewedCommit: 7c960cac3eab447a2a7d2b7c398ffd53c2de8fea
+lastReviewedCommit: 473ad5b54d099ae0584c4d188968446ca0c48409
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -86,6 +86,8 @@ Review note, 2026-07-24: Issue #200 publishes 0.0.32 through the unchanged merge
 Review note, 2026-07-24: Issue #202 publishes 0.0.33 through the unchanged merge-triggered tag and npm Trusted Publishing workflows. Bounded flow delete-only maintenance reuses the existing user session, RLS REST reads, and protected delete RPC and adds no dependency, secret, environment variable, runner, Trusted Publisher setting, workflow filename, service-role credential, or alternate authentication surface.
 
 Review note, 2026-07-24: Issue #204 changes only the main-commit all-visible preflight page size and requires no new secret, environment variable, runner, Trusted Publisher setting, workflow, tag rule, service-role credential, or alternate authentication surface.
+
+Review note, 2026-07-25: Issue #206 changes only that preflight's indexed ordering and requires no new secret, environment variable, runner, Trusted Publisher setting, workflow, tag rule, service-role credential, or alternate authentication surface.
 
 Review note, 2026-07-13: exact-count maintenance pagination requires no repository secret, Trusted Publisher, environment, workflow filename, or tag-semantics change.
 

--- a/src/lib/dataset-maintenance-remote.ts
+++ b/src/lib/dataset-maintenance-remote.ts
@@ -426,17 +426,14 @@ export async function fetchMaintenanceVisibleTableRows(options: {
   return fetchCompletePostgrestPages({
     table: options.table,
     requestedPageSize: pageSize,
-    rowIdentity: (row: DatasetMaintenanceRemoteRow) =>
-      `${row.id}\u0000${row.version}\u0000${row.user_id ?? ''}\u0000${
-        row.state_code === null ? '' : String(row.state_code).padStart(12, '0')
-      }`,
+    // Every maintenance table is keyed by the globally unique (id, version)
+    // pair. Keep the visible scan on that strict primary-key order so Postgres
+    // can paginate through the index without a redundant full-result sort.
+    rowIdentity: (row: DatasetMaintenanceRemoteRow) => `${row.id}\u0000${row.version}`,
     fetchPage: async (offset) => {
       const url = new URL(`${options.context.rest_base_url}/${options.table}`);
       url.searchParams.set('select', selectForTable(options.table, options.includeJson));
-      url.searchParams.set(
-        'order',
-        'id.asc,version.asc,user_id.asc.nullsfirst,state_code.asc.nullsfirst',
-      );
+      url.searchParams.set('order', 'id.asc,version.asc');
       url.searchParams.set('limit', String(pageSize));
       url.searchParams.set('offset', String(offset));
       const sourceUrl = url.toString();

--- a/test/dataset-maintenance-row-level.test.ts
+++ b/test/dataset-maintenance-row-level.test.ts
@@ -1592,6 +1592,7 @@ test('parallel flow delete apply is bounded, durable, globally fenced, and never
     for (const requestedUrl of visibleProcessUrls) {
       assert.equal(requestedUrl.searchParams.get('limit'), '250');
       assert.equal(requestedUrl.searchParams.get('user_id'), null);
+      assert.equal(requestedUrl.searchParams.get('order'), 'id.asc,version.asc');
     }
 
     const rpcCount = scenario.remote.rpcOrder.length;


### PR DESCRIPTION
Closes #206

## Summary
- Order complete RLS-visible maintenance pagination by the strict (id, version) primary key.
- Retain the no-user filter, exact-count completeness proof, fixed 250-row pages, and pre-dispatch inbound barrier.

## Key Decisions
- Remove redundant user_id/state_code sort keys because (id, version) is already globally unique and indexed.

## Validation
- Focused parallel-delete regression passed and now asserts order=id.asc,version.asc on every all-visible page.
- Pre-push gate: 1,055 tests; 1,051 pass, 4 skip; 100% statements, branches, functions, and lines; lint and TypeScript build passed.
- Docpact strict config and changed-path lint passed.

## Risks / Rollback
- No mutation, retry, RPC, schema, authentication, package-version, or semantic-plan behavior changes; rollback is the single runtime commit.

## Workspace Integration
- After merge, integrate the exact CLI main merge commit into lca-workspace before publishing the Phase D successor authority.