### PR TITLE
feat: cut LCA imports over to Rust tidas

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -24,8 +24,9 @@ layout: repo
 # Review note, 2026-07-24: Issue #204 keeps the parallel-delete all-visible process fence inside the existing maintenance runtime and exact-count paginator. Bounding only that scan to 250 rows per request changes no ownership, route, dependency, authentication, mutation, RPC/schema, release, or publication boundary.
 # Review note, 2026-07-25: Issue #206 keeps that complete RLS-visible fence on the globally unique `(id, version)` primary-key order so Postgres can use the existing index instead of sorting redundant owner/state keys. Completeness, ownership, mutation, retry, RPC/schema, release, and publication boundaries are unchanged.
 # Review note, 2026-07-25: Issue #208 optionally replaces that expensive owner-session fence with a fresh, SHA-approved, plan/actor/project/target-bound SELECT-only proof over all process rows. The default RLS scan remains unchanged; the proof path is delete-only, adds no database write or raw-SQL execution to the CLI, and changes no ownership, route, dependency, authentication, RPC/schema, release, or publication boundary.
-lastReviewedAt: "2026-07-25"
-lastReviewedCommit: "0b0cd23104088ee477acb7c7be12bccdb5719331"
+# Review note, 2026-07-27: Issue #210 replaces the dataset import-lca Python/checkout discovery path with the external Rust `tidas import` machine contract. Existing dataset command, runtime, test, documentation, validation, and release routes cover binary discovery, the compatible 0.1.x/version-and-schema handshake, stable exit/report mapping, packaged smoke evidence, and supported-platform guidance; no ownership, npm dependency, authentication, tag, Trusted Publishing, or workspace-integration rule changes are required.
+lastReviewedAt: "2026-07-27"
+lastReviewedCommit: "e35a3de9fb44ea2f3aa0ec83654a640c09348c39"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-25
-lastReviewedCommit: 0b0cd23104088ee477acb7c7be12bccdb5719331
+lastReviewedAt: 2026-07-27
+lastReviewedCommit: e35a3de9fb44ea2f3aa0ec83654a640c09348c39
+lastReviewedNote: 'Reviewed for Issue #210: dataset import-lca now delegates only to the contract-compatible Rust tidas 0.1.x binary.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -56,6 +57,8 @@ Review note, 2026-06-05: release 0.0.12 only updates CLI package version metadat
 Review note, 2026-06-07: release 0.0.14 keeps the CLI-owned dataset classification command family and release workflow boundaries unchanged. `dataset classification apply --type location` may create an explicit missing location field such as `locationOfSupply`, but path ambiguity still blocks.
 
 Review note, 2026-06-11: release 0.0.15 keeps command nouns/verbs, repo ownership, and release workflow boundaries unchanged. `dataset import-lca convert` now matches the tidas-tools 0.0.28 import_lca CLI surface: the wrapper no longer passes a bare `--process-bundles` flag, forwards `--no-process-bundles` when bundles are disabled, and derives report bundle/mapping file fields from on-disk state.
+
+Review note, 2026-07-27: Issue #210 removes the remaining Python import runtime. `dataset import-lca convert` resolves an explicit or PATH-installed Rust `tidas`, requires `tidas.operation-report.v1` plus a stable `0.1.x` version handshake, forwards only native import controls, and preserves native exit classes and atomic publication. The CLI does not bundle a platform binary or copy import domain logic; the npm package carries only a small smoke fixture. Supported artifact targets are Linux x86_64/ARM64, macOS Intel/Apple Silicon, and Windows x86_64; Windows ARM64 fails closed.
 
 Review note, 2026-07-11: `dataset maintenance plan/apply/verify` is now the CLI-owned v1 row-level maintenance contract. It freezes exact current-user RLS scope and audit artifacts before any write, executes only approved `save_draft` / `delete` actions through platform command paths, and verifies the result with an independent readback.
 

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -18,8 +18,9 @@ checkPaths:
   - src/**
   - scripts/**
   - .github/workflows/**
-lastReviewedAt: 2026-07-25
-lastReviewedCommit: 0b0cd23104088ee477acb7c7be12bccdb5719331
+lastReviewedAt: 2026-07-27
+lastReviewedCommit: e35a3de9fb44ea2f3aa0ec83654a640c09348c39
+lastReviewedNote: 'Reviewed for Issue #210: LCA import runtime and maintainer setup now use unified Rust tidas 0.1.x only.'
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -50,6 +51,8 @@ Review note, 2026-07-25: Issue #208 为同一 delete-only 模式增加可选 `--
 Review note, 2026-06-07: release 0.0.14 keeps maintainer runtime and release guidance unchanged. `dataset classification apply --type location` now supports explicit missing location targets for Foundry saturation workflows, and still rejects ambiguous target paths.
 
 Review note, 2026-06-11: release 0.0.15 keeps maintainer runtime and release guidance unchanged. `dataset import-lca convert` now adapts to the tidas-tools 0.0.28 process-bundle flags (no bare `--process-bundles`, `--no-process-bundles` only when disabled) and reports bundle/mapping files from actual on-disk state.
+
+Review note, 2026-07-27: Issue #210 已删除最后一个 active Python import 路径。`dataset import-lca convert` 只调用统一 Rust `tidas import`，按 `--tidas-bin`、`TIDAS_BIN`、PATH 的顺序定位 binary，并要求 `tidas.operation-report.v1` 与稳定 `0.1.x` 握手。npm 包不内置平台 binary，只包含可用于 clean-machine 验证的 SimaPro smoke fixture；binary 应来自带 checksum/provenance 的 tidas release 或 `cargo install tidas`。支持 Linux x86_64/ARM64、macOS Intel/Apple Silicon、Windows x86_64，不支持 Windows ARM64。
 
 Review note, 2026-07-11: `dataset maintenance plan/apply/verify` is now an implemented current-user RLS command family. It adds no environment variables or release-path changes; commit remains bound to an immutable plan hash, current account confirmation, append-only per-action logs, and independent readback verification.
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ checkPaths:
   - src/main.ts
   - src/lib/lca-release.ts
   - test/lca-release*.test.ts
-lastReviewedAt: 2026-07-23
-lastReviewedCommit: 5c90ddd60328748ab6d8d89717e59dcaeca8cde7
+lastReviewedAt: 2026-07-27
+lastReviewedCommit: e35a3de9fb44ea2f3aa0ec83654a640c09348c39
+lastReviewedNote: 'Reviewed for Issue #210: public LCA import guidance now uses unified Rust tidas 0.1.x only.'
 ---
 
 # TianGong LCA CLI
@@ -373,6 +374,7 @@ tiangong-lca dataset classification apply --type location --input ./rows/process
 tiangong-lca dataset curation-queue build --processes ./rows/processes.jsonl --flows ./rows/flows.jsonl --support ./rows/sources.jsonl --out-dir /abs/path/to/curation-queue --json
 tiangong-lca dataset curation-queue next --queue-dir /abs/path/to/curation-queue --type support --json
 tiangong-lca dataset curation-queue verify --queue-dir /abs/path/to/curation-queue --type process --json
+tiangong-lca dataset import-lca convert --input ./external/simapro.csv --output-dir /abs/path/to/imported --from-format simapro-csv --target both --write-mapping --json
 tiangong-lca dataset save-draft --input ./rows.jsonl --type auto --execution-contract ./execution-contract.json --max-parallel 8 --out-dir /abs/path/to/dataset-save-draft --commit --json
 tiangong-lca dataset evidence-search plan --query "中国2026年电力结构数据" --out-dir /abs/path/to/evidence-search --json
 tiangong-lca dataset evidence-search run --input ./evidence-search.request.json --results ./search-results.json --out-dir /abs/path/to/evidence-search --json
@@ -426,6 +428,8 @@ For `dataset evidence-search`, `plan` creates the field-level query matrix and s
 For `dataset validate`, `--type auto` supports mixed support scopes containing contact/source/unitgroup/flowproperty rows as well as flow/process/lifecyclemodel rows. For `dataset classification`, `children` and `path` navigate the bundled TIDAS category schemas copied from `tidas-tools`. `audit --type location` scans local rows for schema-derived location-code fields, plus TIDAS LCIA geography and lifecyclemodel connection location fields, whose values are not in `tidas_locations_category.json`; `apply --type location` applies structured decisions to a specific `target_path` when a row has multiple location fields. When `target_path` explicitly points at a schema-derived location field such as `flowDataSet.flowInformation.geography.locationOfSupply`, location apply may create the missing parent object and field; ambiguous or non-location paths still block.
 
 For `dataset curation-queue build/next/verify`, the CLI owns entity-level Foundry import queue state. `build` writes `outputs/curation-queue-manifest.json`, `outputs/curation-queue-tasks.jsonl`, `outputs/curation-queue-locks.json`, `outputs/curation-queue-blockers.jsonl`, and per-entity `input.jsonl`, `closure.json`, and `entity-run-plan.json`. `next` returns one runnable support/flow/process task based on checkpoint state. `verify` passes only when scoped checkpoints are complete and build blockers are absent. AI authoring must return structured patches or build plans, and remote writes remain gated by deterministic apply, schema/QA, prewrite verify, and readback.
+
+For `dataset import-lca convert`, the CLI delegates all format detection, conversion, validation, bounded spooling, cancellation, and atomic publication to unified Rust `tidas import`; it does not reproduce import logic in TypeScript. Binary selection is `--tidas-bin`, then `TIDAS_BIN`, then `tidas` on PATH. Optional `--tidas-config` maps to native `--config`. Every run first requires a successful `tidas version --format json --progress never` handshake with `tidas.operation-report.v1` and a stable `0.1.x` binary version, then validates the native `tidas.import-execution-report.v1` summary and exact exit-class/code mapping. Native controls include explicit or automatic source format, target, mapping output, process-bundle disablement, warning failure, maximum entry size, memory budget, and queue capacity. The supported release matrix is Linux x86_64/ARM64, macOS Intel/Apple Silicon, and Windows x86_64; Windows ARM64 is unsupported. The npm package includes `assets/import-smoke/simapro.csv` for clean-machine proof but does not bundle a platform binary or require Python.
 
 For `dataset references rewrite`, `--commit` executes the state-aware save-draft path for patched process and lifecyclemodel rows; without `--commit`, the command only writes local rewrite artifacts.
 

--- a/assets/import-smoke/simapro.csv
+++ b/assets/import-smoke/simapro.csv
@@ -1,0 +1,20 @@
+{SimaPro 8.0}
+{processes}
+{CSV separator: Semicolon}
+{Decimal separator: ,}
+
+Process
+
+Process name
+Test process
+
+Products
+my product;kg;0,5;100;not defined;Agricultural;
+
+Materials/fuels
+Soy oil, refined, at plant/kg/RNA;kg;0,2;Undefined;0;0;0;
+
+Emissions to air
+carbon dioxide;low. pop.;kg;1,5;Undefined;0;0;0;
+
+End

--- a/docs/IMPLEMENTATION_GUIDE_CN.md
+++ b/docs/IMPLEMENTATION_GUIDE_CN.md
@@ -16,8 +16,9 @@ checkPaths:
   - README.md
   - src/**
   - test/**
-lastReviewedAt: 2026-07-25
-lastReviewedCommit: 0b0cd23104088ee477acb7c7be12bccdb5719331
+lastReviewedAt: 2026-07-27
+lastReviewedCommit: e35a3de9fb44ea2f3aa0ec83654a640c09348c39
+lastReviewedNote: 'Reviewed for Issue #210: external LCA imports now use only unified Rust tidas 0.1.x machine contracts.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -200,7 +201,7 @@ tiangong-lca
 | `tiangong-lca dataset validate` | 本地 support / flow / process / lifecyclemodel rows 的统一 TIDAS SDK validation 与稳定报告输出 |
 | `tiangong-lca dataset classification` | 本地 TIDAS 分类/位置编码治理入口；从 bundled schema 步进列子类、解析 path、审计 `tidas_locations_category.json` 位置编码，并可 deterministic apply AI/human decision |
 | `tiangong-lca dataset curation-queue build/next/verify` | 本地 Foundry external dataset import 的 entity-level curation queue 状态机；`build` 输出 manifest、tasks、locks、blockers、per-entity input/closure/run-plan artifacts，`next` 基于 checkpoint 返回下一条 runnable entity task，`verify` 校验 scoped checkpoint 完成度；不执行 AI、不写远端 |
-| `tiangong-lca dataset import-lca convert` | 外部 LCA 包转换入口；调用 `tidas-tools import_lca` 生成 TIDAS/ILCD/conversion report；tidas-tools >= 0.0.28 默认产出每个 process 的依赖子目录（可用 `--no-process-bundles` 关闭、`--process-bundles-dir` 自定义目录），便于后续 entity-level curation |
+| `tiangong-lca dataset import-lca convert` | 外部 LCA 包导入入口；只调用统一 Rust `tidas import`，先验证 `tidas.operation-report.v1` 与稳定 `0.1.x` 版本，再消费 `tidas.import-execution-report.v1`。格式检测、转换、validation、bounded spool、cancellation 与 atomic publish 均属于 Rust；TypeScript 只做 binary/config 发现、参数翻译和稳定 exit/report 适配 |
 | `tiangong-lca dataset references rewrite` | 本地 process / lifecyclemodel rows 的 flow reference rewrite、patch evidence 输出，并可选走 state-aware save-draft commit |
 | `tiangong-lca dataset save-draft` | 通用 canonical dataset dry-run/save-draft 入口；可选 `--execution-contract` 将 project/owner/state 0、输入顺序、before/desired hashes、预期 insert/update 与依赖绑定到稳定 action ledger，并以 exact owner readback 收口模糊响应且不重放 |
 | `tiangong-lca dataset maintenance clear-account` | 已实现的当前账号 draft 清理入口；先生成当前用户 RLS 可见 snapshot，默认 dry-run，只有显式 `--commit --confirm <当前账号邮箱>` 才按 `lifecyclemodels -> processes -> flows -> sources -> contacts` 顺序执行。普通 dataset rows 通过 `app_dataset_delete` / `cmd_dataset_delete` 删除，读回验证剩余行数；`unitgroups` / `flowproperties` 默认保护不删 |

--- a/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
+++ b/docs/SKILLS_TO_CLI_MIGRATION_CHECKLIST_CN.md
@@ -17,8 +17,9 @@ checkPaths:
   - package.json
   - src/**
   - test/**
-lastReviewedAt: 2026-07-25
-lastReviewedCommit: 0b0cd23104088ee477acb7c7be12bccdb5719331
+lastReviewedAt: 2026-07-27
+lastReviewedCommit: e35a3de9fb44ea2f3aa0ec83654a640c09348c39
+lastReviewedNote: 'Reviewed for Issue #210: the final Python LCA import exception is replaced by unified Rust tidas.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -48,6 +49,7 @@ related:
 - 2026-06-06 复核：release 0.0.13 发布路径澄清为 PR merge 到 upstream `main` 后由 GitHub Actions / npm Trusted Publishing 执行，不重新引入 Python、POSIX shell、MCP runtime 或本地发布脚本前提
 - 2026-06-07 复核：release 0.0.14 的 `dataset classification apply --type location` 修复仍在 TypeScript CLI-native 路径内完成，不重新引入 Python、POSIX shell、MCP runtime 或本地发布脚本前提
 - 2026-06-11 复核：release 0.0.15 的 `dataset import-lca convert` 适配仍通过 TypeScript CLI 包装 tidas-tools Python CLI 完成，不重新引入 Python、POSIX shell、MCP runtime 或本地发布脚本前提
+- 2026-07-27 复核：Issue #210 已关闭上述最后一个 import 例外；`dataset import-lca convert` 只调用统一 Rust `tidas import`，删除 Python executable、checkout/venv 与 `src/tidas_tools` 发现面。skills 若调用该命令只能传递公开 Rust/CLI 参数并保存机器报告，不得复制 import domain logic。
 - 2026-07-14 复核：`dataset maintenance rebuild-derivatives` 继续作为 TypeScript / Node 原生命令通过既有用户 session 和受保护 RPC 执行，不新增 Python、POSIX shell、MCP runtime 或私有 skill runtime 前提
 - 2026-07-15 复核：`dataset maintenance run-protected` 继续由 TypeScript / Node 原生 CLI 负责 sealed request、一次 admission、本地 immutable evidence 与只读恢复；不新增 Python、POSIX shell、MCP runtime、私有 skill runtime 或新 npm 依赖，skills 仍只能薄编排 CLI。
 - 2026-07-15 复核：`dataset maintenance freeze-protected` 与 `seal-protected-approval` 继续由 TypeScript / Node 原生 CLI 分别负责生产只读冻结和完全离线的人类批准记录；不新增 Python、POSIX shell、MCP runtime、私有 skill runtime 或 npm 依赖。Foundry/skills 只能调用已发布 CLI 并保留其产物，不得读取数据库 env、直调 RPC、重算 canonical JSON/hash 或复制 freeze/seal 逻辑。

--- a/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
+++ b/docs/TEMP_CLI_AUTH_SESSION_REDESIGN_CN.md
@@ -50,6 +50,7 @@ related:
 - 2026-07-23 复核：Issue #198 只隔离本地 payload 校验的内存副作用，不读取、复制或持久化 bearer，不改变 user API key、session cache、RLS、owner/project/state 校验、service-role 或跨账号边界；本历史设计结论不变。
 - 2026-07-24 复核：Issue #200 在每个 execution-contract DML 前调用既有 session runtime 获取当前 access token，并重新解码核对 exact user/email；token 仍不写入 action ledger/report，foreign renewal 在 attempt=0 拒绝，不新增认证 env、service-role、跨账号或 blind retry 路径。本历史设计结论不变。
 - 2026-07-24 复核：Issue #202 的 bounded maintenance delete 继续只使用当前用户 session 和 RLS，所有目标必须匹配计划 owner/state，且不接受 target-user、service-role、alternate bearer 或 blind retry。该变更不新增认证 env，也不改变本历史设计结论。
+- 2026-07-27 复核：Issue #210 的 `dataset import-lca` 仅发现并调用本地 Rust `tidas` binary，通过进程级 JSON contract 交换版本、报告与退出状态；`TIDAS_BIN` / `--tidas-bin` 是 executable location 配置，不是认证信息。该命令不读取用户 API key、session cache、bearer、service-role 或数据库凭据，本历史认证边界不变。
 
 ## 1. 已确认事实
 

--- a/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
+++ b/docs/TEMP_ISSUE_55_DIRECT_DEPS_TODO_CN.md
@@ -57,6 +57,8 @@ related:
 
 2026-07-25 复核：Issue #208 的外部证明只使用现有文件、JSON 与 SHA 工具进行本地 admission 校验，不新增、删除或升级任何直接依赖。
 
+2026-07-27 复核：Issue #210 使用 Node 原生进程/文件能力调用单独安装的 Rust `tidas` binary，并通过版本与 machine-contract 握手 fail closed；binary 不作为 npm dependency 或 package asset 捆绑，`package.json` / lockfile 无变化，本文件继续保持历史 TODO 记录用途。
+
 2026-07-17 复核：Issue #157 COMMON 的双 #29 readback、domain rejection、verify pending 收紧、DB one-wrapper rotating permit、create-only local claim 与 fresh exact recovery approval/read-only lookup 继续复用现有 TypeScript、Node `fs`/`crypto`、`@supabase/supabase-js` session/RPC 和 TIDAS SDK 校验，不新增或改变直接依赖。尚余 merge、Preview 与 DB/CLI 发布门禁；本文件继续保持历史 TODO 记录用途。
 
 2026-07-16 复核：Issue #157 的 flow-identity 工作流复用现有 `@supabase/supabase-js` 用户 session、authenticated RPC 和 `@tiangong-lca/tidas-sdk` ProcessSchema 校验，不新增或改变直接依赖；本文件继续保持历史 TODO 记录用途。

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-25
-lastReviewedCommit: 0b0cd23104088ee477acb7c7be12bccdb5719331
+lastReviewedAt: 2026-07-27
+lastReviewedCommit: e35a3de9fb44ea2f3aa0ec83654a640c09348c39
+lastReviewedNote: 'Reviewed for Issue #210: dataset-import-lca is now a thin Rust tidas process-contract adapter.'
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -49,6 +50,8 @@ Review note, 2026-06-06: release 0.0.13 keeps the release architecture unchanged
 Review note, 2026-06-07: release 0.0.14 keeps the architecture in the existing TypeScript dataset classification command family. The location apply helper now creates only explicit schema-derived missing location targets and does not introduce a new orchestration layer or release path.
 
 Review note, 2026-06-11: release 0.0.15 keeps the import-lca wrapper inside the existing TypeScript dataset command family. Only the tidas-tools spawn argument construction and report file derivation changed to match tidas-tools 0.0.28; no new orchestration layer or release path.
+
+Review note, 2026-07-27: Issue #210 keeps `src/lib/dataset-import-lca.ts` as a thin process adapter but replaces the Python module/check-out boundary with unified Rust `tidas import`. The adapter owns only platform/binary/config discovery, `0.1.x` plus operation-report handshake, native flag translation, and exit/report validation. Rust owns format semantics, bounded runtime, cancellation, validation, spool artifacts, and atomic output publication. The npm package carries a cross-platform text fixture, not native executables.
 
 Review note, 2026-07-11: row-level dataset maintenance is implemented in the native CLI as `dataset maintenance plan/apply/verify`. The architecture keeps scope freezing, current-user RLS reads, protected-row classification, approved platform-command writes, append-only action logging, and independent verification in separate maintenance modules.
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-25
-lastReviewedCommit: 0b0cd23104088ee477acb7c7be12bccdb5719331
+lastReviewedAt: 2026-07-27
+lastReviewedCommit: e35a3de9fb44ea2f3aa0ec83654a640c09348c39
+lastReviewedNote: 'Reviewed for Issue #210: Rust import proof includes machine-contract, package, platform, and Python-unavailable smoke gates.'
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -71,6 +72,8 @@ Review note, 2026-06-06: release 0.0.13 keeps local validation separate from pub
 Review note, 2026-06-07: release 0.0.14 requires the same local proof plus focused dataset classification coverage for explicit missing location target creation. Publication remains PR merge to upstream `main`, tag workflow, and npm Trusted Publishing.
 
 Review note, 2026-06-11: release 0.0.15 requires the same local proof plus focused dataset import-lca coverage for the tidas-tools 0.0.28 bundle-flag adaptation and disk-derived report fields. Publication remains PR merge to upstream `main`, tag workflow, and npm Trusted Publishing.
+
+Review note, 2026-07-27: Issue #210 proof must cover binary-discovery precedence, the five supported release targets and Windows ARM64 rejection, compatible `0.1.x` patch versions, protocol/version/report/exit mismatch rejection, native runtime flag translation, cancellation exit 130, and absence of active Python/check-out discovery. Run the packaged SimaPro fixture through the checksum-verified v0.1.0 artifact with Python unavailable, inspect `npm pack --dry-run` for the fixture, then run the complete `npm run prepush:gate` and docpact gates.
 
 Review note, 2026-07-11: `dataset maintenance plan/apply/verify` adds focused proof for exact-row scope freezing, current-user RLS guards, immutable plan hashing, protected-row classification, full-plan drift preflight, approval-before-write, per-action logs, platform audit correlation, failure/resume behavior, and independent readback verification.
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -22,8 +22,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-25
-lastReviewedCommit: 0b0cd23104088ee477acb7c7be12bccdb5719331
+lastReviewedAt: 2026-07-27
+lastReviewedCommit: e35a3de9fb44ea2f3aa0ec83654a640c09348c39
+lastReviewedNote: 'Reviewed for Issue #210: npm packaging includes a Rust import smoke fixture but never a native tidas binary.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -111,6 +112,8 @@ Release 0.0.13 note, 2026-06-06: prechecks are `node ./scripts/ci/release-versio
 Release 0.0.14 note, 2026-06-07: prechecks are `node ./scripts/ci/release-version.cjs assert-unpublished --version 0.0.14`, `npm run prepush:gate`, and `npm pack --dry-run`; this release lets `dataset classification apply --type location` create explicit missing location fields such as flow `locationOfSupply` while keeping ambiguous paths blocked.
 
 Release 0.0.15 note, 2026-06-11: prechecks are `node ./scripts/ci/release-version.cjs assert-unpublished --version 0.0.15`, `npm run prepush:gate`, and `npm pack --dry-run`; this release adapts `dataset import-lca convert` to the tidas-tools 0.0.28 process-bundle CLI surface (no bare `--process-bundles` flag, `--no-process-bundles` forwarded when disabled) and derives report bundle/mapping file fields from on-disk state.
+
+Issue #210 packaging note, 2026-07-27: feature PRs do not bump or publish the CLI package. Before the later release PR, verify `npm pack --dry-run` includes `assets/import-smoke/simapro.csv` and does not include a Python package, tidas-tools checkout, venv, or native executable. Run a clean installed-package smoke with Python unavailable and an explicit checksum-verified Rust `tidas` artifact. Native artifacts remain distributed by tidas-tools for Linux x86_64/ARM64, macOS Intel/Apple Silicon, and Windows x86_64; the CLI npm release must not invent a Windows ARM64 artifact.
 
 Useful commands:
 

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -19,8 +19,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-25
-lastReviewedCommit: 0b0cd23104088ee477acb7c7be12bccdb5719331
+lastReviewedAt: 2026-07-27
+lastReviewedCommit: e35a3de9fb44ea2f3aa0ec83654a640c09348c39
+lastReviewedNote: 'Reviewed for Issue #210: tidas remains an external verified runtime artifact, not an npm secret or bundled binary.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -122,6 +123,8 @@ Release 0.0.13 note, 2026-06-06: package version and lockfile bump only; no repo
 Release 0.0.14 note, 2026-06-07: package version and lockfile bump only; no repository secret, Trusted Publisher, tag, workflow filename, or GitHub environment setup change is required. The release includes a deterministic location apply fix and uses the same PR merge to upstream `main`, tag, and npm Trusted Publishing path.
 
 Release 0.0.15 note, 2026-06-11: package version and lockfile bump only; no repository secret, Trusted Publisher, tag, workflow filename, or GitHub environment setup change is required. The release includes the `dataset import-lca convert` adaptation to tidas-tools 0.0.28 process-bundle flags and uses the same PR merge to upstream `main`, tag, and npm Trusted Publishing path.
+
+Issue #210 setup note, 2026-07-27: unified Rust import adds no npm secret, Trusted Publisher setting, tag rule, or release workflow. Operators install `tidas` separately from a checksum/provenance-verified release artifact or crates.io and select it with `--tidas-bin`, `TIDAS_BIN`, or PATH. The npm tarball intentionally contains the smoke fixture but no platform executable.
 
 The publish workflow file is fixed at:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -787,7 +787,7 @@ Implemented Subcommands:
   curation-queue build Build entity-level AI curation queue artifacts for Foundry imports
   curation-queue next  Return the next runnable support/flow/process queue task
   curation-queue verify Verify queue task checkpoints for a scope
-  import-lca convert  Convert supported external LCA packages through tidas-tools
+  import-lca convert  Import supported external LCA packages through the unified Rust tidas binary
   author              Extract source evidence and prepare TIDAS context packs for AI authoring
   patch apply          Apply AI-authored structured dataset patches deterministically
   save-draft           Save contact/source/support or other canonical dataset rows through the platform dataset command path
@@ -1301,30 +1301,33 @@ function renderDatasetImportLcaHelp(): string {
 
 Options:
   --input <path>          Source file, directory, or package to import
-  --output-dir <dir>      Output directory for generated package and reports
+  --output-dir <dir>      Output directory atomically published by tidas
   --from-format <format>  auto, ecospold1, ecospold2, openlca-jsonld, openlca-process-xlsx, simapro-csv, ilcd
   --target <target>       tidas | ilcd | both (default: tidas)
-  --report <file>         Conversion report path (default: <output-dir>/conversion-report.json)
-  --mapping-dir <dir>     Optional custom mapping/reference data directory
-  --language <lang>       Default language for generated text (default: en)
-  --validation-jobs <n>   Parallel validation jobs passed to tidas-tools (default: 1)
-  --process-bundles       Write per-process dependency bundles (default: enabled by tidas-tools)
-  --process-bundles-dir <dir>
-                           Custom per-process bundle directory (default: <output-dir>/process-bundles)
+  --report <file>         Persist the native operation report atomically instead of using tidas stdout
+  --write-mapping         Write deterministic mapping.csv.gz
   --no-process-bundles    Disable per-process dependency bundle generation
-  --detect-only           Only detect the input format and write the report
   --fail-on-warning       Return non-zero when converter warnings are present
-  --python <bin>          Python executable (default: python3)
-  --tidas-tools-dir <dir> Explicit tidas-tools checkout path
+  --max-entry-mib <n>     Maximum source-entry size in MiB (tidas default: 128)
+  --memory-budget-mib <n> Maximum accounted in-flight memory in MiB (tidas default: 512)
+  --queue-capacity <n>    Maximum items in each bounded queue (tidas default: 256)
+  --tidas-bin <path>      Rust tidas executable (default: TIDAS_BIN, then tidas on PATH)
+  --tidas-config <path>   Explicit tidas config file (otherwise TIDAS_CONFIG is honored)
   --json                  Print compact JSON
   -h, --help
 
 Outputs written under --output-dir:
-  - conversion-report.json
-  - tidas/ when target includes TIDAS and not detect-only
-  - ilcd/ when target includes ILCD and not detect-only
-  - process-bundles/ when not detect-only and process bundles are enabled
-  - outputs/import-lca-report.json
+  - import-report.json and issues.jsonl
+  - tidas/ when target includes TIDAS
+  - ilcd/ when target includes ILCD
+  - process-bundles/ by default
+  - mapping.csv.gz when --write-mapping is used
+
+Runtime contract:
+  - Linux x86_64/ARM64, macOS Intel/Apple Silicon, and Windows x86_64 are supported.
+  - Windows ARM64 is unsupported.
+  - The binary must report tidas.operation-report.v1 and a stable 0.1.x version.
+  - Import publication, cancellation cleanup, and domain validation remain owned by Rust tidas.
 `.trim();
 }
 
@@ -3535,15 +3538,14 @@ function parseDatasetImportLcaConvertFlags(args: string[]): {
   fromFormat: string | undefined;
   target: string | undefined;
   reportPath: string | undefined;
-  mappingDir: string | undefined;
-  language: string | undefined;
-  validationJobs: number | undefined;
+  writeMapping: boolean;
   processBundles: boolean | undefined;
-  processBundlesDir: string | undefined;
-  detectOnly: boolean;
   failOnWarning: boolean;
-  pythonBin: string | undefined;
-  tidasToolsDir: string | undefined;
+  maxEntryMib: number | undefined;
+  memoryBudgetMib: number | undefined;
+  queueCapacity: number | undefined;
+  tidasBin: string | undefined;
+  tidasConfig: string | undefined;
 } {
   let values: ReturnType<typeof parseArgs>['values'];
   try {
@@ -3559,16 +3561,14 @@ function parseDatasetImportLcaConvertFlags(args: string[]): {
         'from-format': { type: 'string' },
         target: { type: 'string' },
         report: { type: 'string' },
-        'mapping-dir': { type: 'string' },
-        language: { type: 'string' },
-        'validation-jobs': { type: 'string' },
-        'process-bundles': { type: 'boolean' },
-        'process-bundles-dir': { type: 'string' },
+        'write-mapping': { type: 'boolean' },
         'no-process-bundles': { type: 'boolean' },
-        'detect-only': { type: 'boolean' },
         'fail-on-warning': { type: 'boolean' },
-        python: { type: 'string' },
-        'tidas-tools-dir': { type: 'string' },
+        'max-entry-mib': { type: 'string' },
+        'memory-budget-mib': { type: 'string' },
+        'queue-capacity': { type: 'string' },
+        'tidas-bin': { type: 'string' },
+        'tidas-config': { type: 'string' },
       },
     }));
   } catch (error) {
@@ -3578,26 +3578,12 @@ function parseDatasetImportLcaConvertFlags(args: string[]): {
     });
   }
 
-  const validationJobs =
-    typeof values['validation-jobs'] === 'string' ? Number(values['validation-jobs']) : undefined;
-  if (validationJobs !== undefined && (!Number.isInteger(validationJobs) || validationJobs < 0)) {
-    throw new CliError('--validation-jobs must be a non-negative integer.', {
-      code: 'DATASET_IMPORT_LCA_VALIDATION_JOBS_INVALID',
-      exitCode: 2,
-    });
-  }
-  if (values['process-bundles'] && values['no-process-bundles']) {
-    throw new CliError('--process-bundles and --no-process-bundles cannot both be set.', {
-      code: 'DATASET_IMPORT_LCA_PROCESS_BUNDLES_INVALID',
-      exitCode: 2,
-    });
-  }
-  if (values['no-process-bundles'] && typeof values['process-bundles-dir'] === 'string') {
-    throw new CliError('--process-bundles-dir cannot be used with --no-process-bundles.', {
-      code: 'DATASET_IMPORT_LCA_PROCESS_BUNDLES_INVALID',
-      exitCode: 2,
-    });
-  }
+  const maxEntryMib = parsePositiveIntegerFlag(values['max-entry-mib'], '--max-entry-mib');
+  const memoryBudgetMib = parsePositiveIntegerFlag(
+    values['memory-budget-mib'],
+    '--memory-budget-mib',
+  );
+  const queueCapacity = parsePositiveIntegerFlag(values['queue-capacity'], '--queue-capacity');
 
   return {
     help: Boolean(values.help),
@@ -3607,22 +3593,29 @@ function parseDatasetImportLcaConvertFlags(args: string[]): {
     fromFormat: typeof values['from-format'] === 'string' ? values['from-format'] : undefined,
     target: typeof values.target === 'string' ? values.target : undefined,
     reportPath: typeof values.report === 'string' ? values.report : undefined,
-    mappingDir: typeof values['mapping-dir'] === 'string' ? values['mapping-dir'] : undefined,
-    language: typeof values.language === 'string' ? values.language : undefined,
-    validationJobs,
-    processBundles: values['no-process-bundles']
-      ? false
-      : values['process-bundles']
-        ? true
-        : undefined,
-    processBundlesDir:
-      typeof values['process-bundles-dir'] === 'string' ? values['process-bundles-dir'] : undefined,
-    detectOnly: Boolean(values['detect-only']),
+    writeMapping: Boolean(values['write-mapping']),
+    processBundles: values['no-process-bundles'] ? false : undefined,
     failOnWarning: Boolean(values['fail-on-warning']),
-    pythonBin: typeof values.python === 'string' ? values.python : undefined,
-    tidasToolsDir:
-      typeof values['tidas-tools-dir'] === 'string' ? values['tidas-tools-dir'] : undefined,
+    maxEntryMib,
+    memoryBudgetMib,
+    queueCapacity,
+    tidasBin: typeof values['tidas-bin'] === 'string' ? values['tidas-bin'] : undefined,
+    tidasConfig: typeof values['tidas-config'] === 'string' ? values['tidas-config'] : undefined,
   };
+}
+
+function parsePositiveIntegerFlag(value: unknown, flag: string): number | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new CliError(`${flag} must be a positive integer.`, {
+      code: 'DATASET_IMPORT_LCA_RUNTIME_BOUND_INVALID',
+      exitCode: 2,
+    });
+  }
+  return parsed;
 }
 
 function parseDatasetAuthorFlags(args: string[]): {
@@ -7283,19 +7276,18 @@ export async function executeCli(argv: string[], deps: CliDeps): Promise<CliResu
         fromFormat: datasetFlags.fromFormat,
         target: datasetFlags.target,
         reportPath: datasetFlags.reportPath,
-        mappingDir: datasetFlags.mappingDir,
-        language: datasetFlags.language,
-        validationJobs: datasetFlags.validationJobs,
+        writeMapping: datasetFlags.writeMapping,
         processBundles: datasetFlags.processBundles,
-        processBundlesDir: datasetFlags.processBundlesDir,
-        detectOnly: datasetFlags.detectOnly,
         failOnWarning: datasetFlags.failOnWarning,
-        pythonBin: datasetFlags.pythonBin,
-        tidasToolsDir: datasetFlags.tidasToolsDir,
+        maxEntryMib: datasetFlags.maxEntryMib,
+        memoryBudgetMib: datasetFlags.memoryBudgetMib,
+        queueCapacity: datasetFlags.queueCapacity,
+        tidasBin: datasetFlags.tidasBin,
+        tidasConfig: datasetFlags.tidasConfig,
         env: deps.env,
       });
       return {
-        exitCode: report.status === 'completed' ? 0 : 1,
+        exitCode: report.exit_code,
         stdout: stringifyJson(report, datasetFlags.json),
         stderr: '',
       };

--- a/src/lib/dataset-import-lca.ts
+++ b/src/lib/dataset-import-lca.ts
@@ -1,39 +1,98 @@
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
-import { writeJsonArtifact } from './artifacts.js';
 import { CliError } from './errors.js';
 
+const OPERATION_REPORT_SCHEMA = 'tidas.operation-report.v1';
+const INVOCATION_CONTEXT_SCHEMA = 'tidas.invocation-context.v1';
+const IMPORT_REPORT_SCHEMA = 'tidas.import-execution-report.v1';
+const SUPPORTED_TIDAS_VERSION = /^0\.1\.\d+$/u;
+
+const EXIT_CODES = {
+  success: 0,
+  'data-issues': 2,
+  usage: 64,
+  unavailable: 69,
+  internal: 70,
+  io: 74,
+  cancelled: 130,
+} as const;
+
+const OPERATION_STATUSES = ['succeeded', 'completed-with-issues', 'failed', 'cancelled'] as const;
+const COMPLETENESS_VALUES = ['complete', 'partial', 'not-started'] as const;
+const SOURCE_FORMATS = [
+  'ecospold1',
+  'ecospold2',
+  'simapro-csv',
+  'openlca-jsonld',
+  'openlca-process-xlsx',
+  'ilcd',
+] as const;
+
+type TidasExitClass = keyof typeof EXIT_CODES;
+type TidasOperationStatus = (typeof OPERATION_STATUSES)[number];
+type TidasCompleteness = (typeof COMPLETENESS_VALUES)[number];
 export type DatasetImportLcaTarget = 'tidas' | 'ilcd' | 'both';
+export type DatasetImportLcaSourceFormat = (typeof SOURCE_FORMATS)[number];
+
+type TidasOperationReport = {
+  schema_version: typeof OPERATION_REPORT_SCHEMA;
+  command: 'version' | 'import';
+  status: TidasOperationStatus;
+  exit_class: TidasExitClass;
+  completeness: TidasCompleteness;
+  invocation: {
+    schema_version: typeof INVOCATION_CONTEXT_SCHEMA;
+    input_policy: 'explicit-path-or-dash';
+    report_destination: 'stdout' | 'file';
+    diagnostic_destination: 'stderr';
+    [key: string]: unknown;
+  };
+  summary: Record<string, unknown>;
+  diagnostics: unknown[];
+  artifacts: unknown[];
+  next_actions: unknown[];
+};
 
 export type DatasetImportLcaReport = {
-  schema_version: 1;
-  status: 'completed' | 'blocked';
+  schema_version: 'tiangong-lca.dataset-import-lca-report.v2';
+  status: TidasOperationStatus;
+  exit_class: TidasExitClass;
+  exit_code: number;
   generated_at_utc: string;
   input_path: string;
   output_dir: string;
-  from_format: string;
+  from_format: DatasetImportLcaSourceFormat | 'auto';
   target: DatasetImportLcaTarget;
-  detect_only: boolean;
-  command: {
+  tidas: {
     executable: string;
+    version: string;
+    operation_report_schema: typeof OPERATION_REPORT_SCHEMA;
+    import_report_schema: typeof IMPORT_REPORT_SCHEMA;
+  };
+  command: {
     args: string[];
     cwd: string;
-    exit_code: number | null;
-    stdout: string;
     stderr: string;
   };
-  conversion_report: unknown | null;
+  operation_report: TidasOperationReport;
   files: {
-    report: string;
-    conversion_report: string;
+    report: string | null;
+    native_import_report: string;
+    issues: string;
     tidas_dir: string | null;
     ilcd_dir: string | null;
     mapping_csv: string | null;
     process_bundles_dir: string | null;
-    process_bundles_index: string | null;
   };
+};
+
+export type TidasProcessResult = {
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  error?: Error | undefined;
 };
 
 export type RunDatasetImportLcaConvertOptions = {
@@ -41,130 +100,318 @@ export type RunDatasetImportLcaConvertOptions = {
   outputDir: string;
   fromFormat?: string | undefined;
   target?: string | undefined;
-  language?: string | undefined;
   reportPath?: string | undefined;
-  mappingDir?: string | undefined;
-  failOnWarning?: boolean | undefined;
-  validationJobs?: number | undefined;
+  writeMapping?: boolean | undefined;
   processBundles?: boolean | undefined;
-  processBundlesDir?: string | undefined;
-  detectOnly?: boolean | undefined;
-  pythonBin?: string | undefined;
-  tidasToolsDir?: string | undefined;
+  failOnWarning?: boolean | undefined;
+  maxEntryMib?: number | undefined;
+  memoryBudgetMib?: number | undefined;
+  queueCapacity?: number | undefined;
+  tidasBin?: string | undefined;
+  tidasConfig?: string | undefined;
   env?: NodeJS.ProcessEnv | undefined;
+  cwd?: string | undefined;
+  platform?: NodeJS.Platform | undefined;
+  arch?: string | undefined;
   now?: Date | undefined;
   spawnImpl?: typeof spawnSync | undefined;
 };
 
-export function runDatasetImportLcaConvert(
+export async function runDatasetImportLcaConvert(
   options: RunDatasetImportLcaConvertOptions,
-): DatasetImportLcaReport {
+): Promise<DatasetImportLcaReport> {
   const inputPath = requireInputPath(options.inputPath);
   const outputDir = requireOutputDir(options.outputDir);
+  const fromFormat = normalizeSourceFormat(options.fromFormat);
   const target = normalizeTarget(options.target);
-  const fromFormat = options.fromFormat?.trim() || 'auto';
-  const pythonBin = options.pythonBin?.trim() || 'python3';
-  const tidasToolsRoot = resolveTidasToolsRoot(options.tidasToolsDir, options.env ?? process.env);
-  const processBundlesDir = options.processBundlesDir
-    ? path.resolve(options.processBundlesDir)
-    : path.join(outputDir, 'process-bundles');
-  if (options.processBundles === false && options.processBundlesDir?.trim()) {
-    throw new CliError('--process-bundles-dir cannot be used with --no-process-bundles.', {
-      code: 'DATASET_IMPORT_LCA_PROCESS_BUNDLES_INVALID',
-      exitCode: 2,
-    });
-  }
-  const reportPath = path.resolve(
-    options.reportPath ?? path.join(outputDir, 'conversion-report.json'),
-  );
-  const commandArgs = [
-    '-m',
-    'tidas_tools.import_lca.cli',
-    '--input',
-    inputPath,
-    '--output-dir',
-    outputDir,
-    '--from-format',
-    fromFormat,
-    '--target',
-    target,
-    '--report',
-    reportPath,
-    '--language',
-    options.language?.trim() || 'en',
-    '--validation-jobs',
-    String(options.validationJobs ?? 1),
-  ];
-  if (options.mappingDir) {
-    commandArgs.push('--mapping-dir', path.resolve(options.mappingDir));
-  }
-  if (options.failOnWarning) {
-    commandArgs.push('--fail-on-warning');
-  }
-  // tidas-tools >= 0.0.28 enables process bundles by default and only accepts
-  // --no-process-bundles / --process-bundles-dir; a bare --process-bundles flag
-  // gets prefix-matched by argparse to --process-bundles-dir and aborts.
-  if (!options.detectOnly && options.processBundles === false) {
-    commandArgs.push('--no-process-bundles');
-  }
-  if (!options.detectOnly && options.processBundlesDir?.trim()) {
-    commandArgs.push('--process-bundles-dir', processBundlesDir);
-  }
-  if (options.detectOnly) {
-    commandArgs.push('--detect-only');
-  }
+  const env = options.env ?? process.env;
+  const executable = resolveTidasBinary(options.tidasBin, env);
+  const cwd = path.resolve(options.cwd ?? process.cwd());
+  const reportPath = options.reportPath?.trim() ? path.resolve(options.reportPath) : null;
+  const configPath = options.tidasConfig?.trim() ? path.resolve(options.tidasConfig) : null;
+  const spawnImpl = [spawnSync, options.spawnImpl].filter(Boolean).at(-1) as typeof spawnSync;
 
-  const run = (options.spawnImpl ?? spawnSync)(pythonBin, commandArgs, {
-    cwd: tidasToolsRoot,
-    env: {
-      ...(options.env ?? process.env),
-      PYTHONPATH: buildPythonPath(tidasToolsRoot, options.env ?? process.env),
-    },
-    encoding: 'utf8',
-  }) as SpawnSyncReturns<string>;
-  const conversionReport = readOptionalJson(reportPath);
-  // Mapping CSV is opt-in in tidas-tools >= 0.0.28 (mapping.csv.gz) and bundle
-  // output depends on converter defaults, so report what is actually on disk.
-  const mappingCsv = firstExistingPath([
-    path.join(outputDir, 'mapping.csv.gz'),
-    path.join(outputDir, 'mapping.csv'),
-  ]);
-  const processBundlesIndexPath = path.join(processBundlesDir, 'index.json');
-  const files = {
-    report: path.join(outputDir, 'outputs', 'import-lca-report.json'),
-    conversion_report: reportPath,
-    tidas_dir: options.detectOnly ? null : path.join(outputDir, 'tidas'),
-    ilcd_dir:
-      !options.detectOnly && (target === 'ilcd' || target === 'both')
-        ? path.join(outputDir, 'ilcd')
-        : null,
-    mapping_csv: mappingCsv,
-    process_bundles_dir: existsSync(processBundlesDir) ? processBundlesDir : null,
-    process_bundles_index: existsSync(processBundlesIndexPath) ? processBundlesIndexPath : null,
-  };
-  const report: DatasetImportLcaReport = {
-    schema_version: 1,
-    status: run.status === 0 ? 'completed' : 'blocked',
+  assertSupportedPlatform(options.platform ?? process.platform, options.arch ?? process.arch);
+  requirePositiveInteger('--max-entry-mib', options.maxEntryMib);
+  requirePositiveInteger('--memory-budget-mib', options.memoryBudgetMib);
+  requirePositiveInteger('--queue-capacity', options.queueCapacity);
+
+  const versionArgs = ['version', '--format', 'json', '--progress', 'never'];
+  const versionRun = runTidas(spawnImpl, executable, versionArgs, cwd, env);
+  const versionReport = parseOperationReport(readProcessReport(versionRun, null), 'version');
+  assertExitContract(versionRun, versionReport);
+  const version = readCompatibleVersion(versionReport);
+
+  const commandArgs = buildImportArgs({
+    inputPath,
+    outputDir,
+    fromFormat,
+    target,
+    reportPath,
+    configPath,
+    writeMapping: Boolean(options.writeMapping),
+    processBundles: options.processBundles !== false,
+    failOnWarning: Boolean(options.failOnWarning),
+    maxEntryMib: options.maxEntryMib,
+    memoryBudgetMib: options.memoryBudgetMib,
+    queueCapacity: options.queueCapacity,
+  });
+  const importRun = runTidas(spawnImpl, executable, commandArgs, cwd, env);
+  const operationReport = parseOperationReport(readProcessReport(importRun, reportPath), 'import');
+  assertExitContract(importRun, operationReport);
+  assertImportContract(operationReport);
+
+  return {
+    schema_version: 'tiangong-lca.dataset-import-lca-report.v2',
+    status: operationReport.status,
+    exit_class: operationReport.exit_class,
+    exit_code: EXIT_CODES[operationReport.exit_class],
     generated_at_utc: (options.now ?? new Date()).toISOString(),
     input_path: inputPath,
     output_dir: outputDir,
     from_format: fromFormat,
     target,
-    detect_only: Boolean(options.detectOnly),
-    command: {
-      executable: pythonBin,
-      args: commandArgs,
-      cwd: tidasToolsRoot,
-      exit_code: run.status,
-      stdout: run.stdout ?? '',
-      stderr: run.stderr ?? '',
+    tidas: {
+      executable,
+      version,
+      operation_report_schema: OPERATION_REPORT_SCHEMA,
+      import_report_schema: IMPORT_REPORT_SCHEMA,
     },
-    conversion_report: conversionReport,
-    files,
+    command: {
+      args: commandArgs,
+      cwd,
+      stderr: importRun.stderr,
+    },
+    operation_report: operationReport,
+    files: {
+      report: reportPath,
+      native_import_report: path.join(outputDir, 'import-report.json'),
+      issues: path.join(outputDir, 'issues.jsonl'),
+      tidas_dir:
+        operationReport.completeness === 'complete' && (target === 'tidas' || target === 'both')
+          ? path.join(outputDir, 'tidas')
+          : null,
+      ilcd_dir:
+        operationReport.completeness === 'complete' && (target === 'ilcd' || target === 'both')
+          ? path.join(outputDir, 'ilcd')
+          : null,
+      mapping_csv:
+        operationReport.completeness === 'complete' && options.writeMapping
+          ? path.join(outputDir, 'mapping.csv.gz')
+          : null,
+      process_bundles_dir:
+        operationReport.completeness === 'complete' && options.processBundles !== false
+          ? path.join(outputDir, 'process-bundles')
+          : null,
+    },
   };
+}
 
-  writeJsonArtifact(files.report, report);
-  return report;
+function buildImportArgs(options: {
+  inputPath: string;
+  outputDir: string;
+  fromFormat: DatasetImportLcaSourceFormat | 'auto';
+  target: DatasetImportLcaTarget;
+  reportPath: string | null;
+  configPath: string | null;
+  writeMapping: boolean;
+  processBundles: boolean;
+  failOnWarning: boolean;
+  maxEntryMib: number | undefined;
+  memoryBudgetMib: number | undefined;
+  queueCapacity: number | undefined;
+}): string[] {
+  const args = [
+    'import',
+    options.inputPath,
+    '--output',
+    options.outputDir,
+    '--target',
+    options.target,
+    '--format',
+    'json',
+    '--progress',
+    'never',
+  ];
+  if (options.fromFormat !== 'auto') {
+    args.push('--from-format', options.fromFormat);
+  }
+  if (options.reportPath) {
+    args.push('--report', options.reportPath);
+  }
+  if (options.configPath) {
+    args.push('--config', options.configPath);
+  }
+  if (options.writeMapping) {
+    args.push('--write-mapping');
+  }
+  if (!options.processBundles) {
+    args.push('--no-process-bundles');
+  }
+  if (options.failOnWarning) {
+    args.push('--fail-on-warning');
+  }
+  if (options.maxEntryMib !== undefined) {
+    args.push('--max-entry-mib', String(options.maxEntryMib));
+  }
+  if (options.memoryBudgetMib !== undefined) {
+    args.push('--memory-budget-mib', String(options.memoryBudgetMib));
+  }
+  if (options.queueCapacity !== undefined) {
+    args.push('--queue-capacity', String(options.queueCapacity));
+  }
+  return args;
+}
+
+function runTidas(
+  spawnImpl: typeof spawnSync,
+  executable: string,
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+): TidasProcessResult {
+  const run = spawnImpl(executable, args, {
+    cwd,
+    env,
+    encoding: 'utf8',
+    windowsHide: true,
+  }) as SpawnSyncReturns<string>;
+  if (run.error) {
+    throw new CliError(`Could not execute the Rust tidas binary: ${run.error.message}`, {
+      code: 'DATASET_IMPORT_LCA_TIDAS_EXEC_FAILED',
+      exitCode: 69,
+      details: { executable },
+    });
+  }
+  return {
+    status: run.status,
+    signal: run.signal,
+    stdout: run.stdout ?? '',
+    stderr: run.stderr ?? '',
+  };
+}
+
+function readProcessReport(run: TidasProcessResult, reportPath: string | null): string {
+  const cancelled = run.status === 130 || run.signal === 'SIGINT';
+  if (reportPath) {
+    if (!existsSync(reportPath)) {
+      if (cancelled) {
+        throw new CliError(
+          'tidas import was cancelled before a complete machine report was available.',
+          {
+            code: 'DATASET_IMPORT_LCA_CANCELLED',
+            exitCode: 130,
+            details: { signal: run.signal, stderr: run.stderr },
+          },
+        );
+      }
+      throw new CliError(`tidas did not write the requested machine report: ${reportPath}`, {
+        code: 'DATASET_IMPORT_LCA_TIDAS_REPORT_MISSING',
+        exitCode: 70,
+      });
+    }
+    return readFileSync(reportPath, 'utf8');
+  }
+  if (!run.stdout.trim()) {
+    throw new CliError(
+      cancelled
+        ? 'tidas import was cancelled before a complete machine report was available.'
+        : 'tidas did not emit a machine-readable operation report.',
+      {
+        code: cancelled
+          ? 'DATASET_IMPORT_LCA_CANCELLED'
+          : 'DATASET_IMPORT_LCA_TIDAS_REPORT_MISSING',
+        exitCode: cancelled ? 130 : 70,
+        details: { signal: run.signal, stderr: run.stderr },
+      },
+    );
+  }
+  return run.stdout;
+}
+
+function parseOperationReport(text: string, command: 'version' | 'import'): TidasOperationReport {
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch (error) {
+    throw new CliError('tidas emitted invalid JSON instead of its machine operation report.', {
+      code: 'DATASET_IMPORT_LCA_TIDAS_REPORT_INVALID',
+      exitCode: 70,
+      details: String(error),
+    });
+  }
+  if (
+    !isRecord(value) ||
+    value.schema_version !== OPERATION_REPORT_SCHEMA ||
+    value.command !== command ||
+    !includesValue(OPERATION_STATUSES, value.status) ||
+    !isExitClass(value.exit_class) ||
+    !includesValue(COMPLETENESS_VALUES, value.completeness) ||
+    !isRecord(value.invocation) ||
+    value.invocation.schema_version !== INVOCATION_CONTEXT_SCHEMA ||
+    value.invocation.input_policy !== 'explicit-path-or-dash' ||
+    !['stdout', 'file'].includes(String(value.invocation.report_destination)) ||
+    value.invocation.diagnostic_destination !== 'stderr' ||
+    !isRecord(value.summary) ||
+    !Array.isArray(value.diagnostics) ||
+    !Array.isArray(value.artifacts) ||
+    !Array.isArray(value.next_actions)
+  ) {
+    throw new CliError(
+      `Incompatible tidas ${command} machine contract; expected ${OPERATION_REPORT_SCHEMA}.`,
+      {
+        code: 'DATASET_IMPORT_LCA_TIDAS_CONTRACT_INCOMPATIBLE',
+        exitCode: 69,
+      },
+    );
+  }
+  return value as TidasOperationReport;
+}
+
+function assertExitContract(run: TidasProcessResult, report: TidasOperationReport): void {
+  const expected = EXIT_CODES[report.exit_class];
+  if (run.status !== expected) {
+    throw new CliError(
+      `tidas exit status ${String(run.status)} disagrees with report exit class ${report.exit_class} (${expected}).`,
+      {
+        code: 'DATASET_IMPORT_LCA_TIDAS_EXIT_MISMATCH',
+        exitCode: 70,
+      },
+    );
+  }
+}
+
+function readCompatibleVersion(report: TidasOperationReport): string {
+  if (
+    report.status !== 'succeeded' ||
+    report.exit_class !== 'success' ||
+    report.completeness !== 'complete' ||
+    report.summary.operation_report_schema !== OPERATION_REPORT_SCHEMA ||
+    typeof report.summary.binary_version !== 'string' ||
+    !SUPPORTED_TIDAS_VERSION.test(report.summary.binary_version)
+  ) {
+    throw new CliError(
+      'Incompatible tidas binary: dataset import requires a stable contract-compatible 0.1.x release.',
+      {
+        code: 'DATASET_IMPORT_LCA_TIDAS_VERSION_INCOMPATIBLE',
+        exitCode: 69,
+        details: { binary_version: report.summary.binary_version ?? null },
+      },
+    );
+  }
+  return report.summary.binary_version;
+}
+
+function assertImportContract(report: TidasOperationReport): void {
+  if (report.status === 'succeeded' || report.status === 'completed-with-issues') {
+    const importSummary = report.summary.import;
+    if (!isRecord(importSummary) || importSummary.schema_version !== IMPORT_REPORT_SCHEMA) {
+      throw new CliError(`Incompatible tidas import summary; expected ${IMPORT_REPORT_SCHEMA}.`, {
+        code: 'DATASET_IMPORT_LCA_TIDAS_IMPORT_CONTRACT_INCOMPATIBLE',
+        exitCode: 69,
+      });
+    }
+  }
 }
 
 function requireInputPath(value: string): string {
@@ -194,6 +441,17 @@ function requireOutputDir(value: string): string {
   return path.resolve(value);
 }
 
+function normalizeSourceFormat(value: string | undefined): DatasetImportLcaSourceFormat | 'auto' {
+  const format = value?.trim() || 'auto';
+  if (format === 'auto' || includesValue(SOURCE_FORMATS, format)) {
+    return format;
+  }
+  throw new CliError(`--from-format must be auto or one of: ${SOURCE_FORMATS.join(', ')}.`, {
+    code: 'DATASET_IMPORT_LCA_SOURCE_FORMAT_INVALID',
+    exitCode: 2,
+  });
+}
+
 function normalizeTarget(value: string | undefined): DatasetImportLcaTarget {
   const target = value?.trim() || 'tidas';
   if (target === 'tidas' || target === 'ilcd' || target === 'both') {
@@ -205,76 +463,67 @@ function normalizeTarget(value: string | undefined): DatasetImportLcaTarget {
   });
 }
 
-function resolveTidasToolsRoot(
-  explicitValue: string | undefined,
-  env: NodeJS.ProcessEnv,
-  defaultCandidate?: string,
-): string {
-  const cliRepoRoot = resolveCliRepoRoot();
-  if (explicitValue?.trim()) {
-    const resolved = path.resolve(explicitValue);
-    if (existsSync(path.join(resolved, 'src/tidas_tools/import_lca/cli.py'))) {
-      return resolved;
+function resolveTidasBinary(explicitValue: string | undefined, env: NodeJS.ProcessEnv): string {
+  const candidate = explicitValue?.trim() || env.TIDAS_BIN?.trim() || 'tidas';
+  if (path.isAbsolute(candidate) || candidate.includes('/') || candidate.includes('\\')) {
+    const resolved = path.resolve(candidate);
+    if (!existsSync(resolved)) {
+      throw new CliError(`Rust tidas binary not found: ${resolved}`, {
+        code: 'DATASET_IMPORT_LCA_TIDAS_NOT_FOUND',
+        exitCode: 69,
+      });
     }
-    throw new CliError('Could not resolve a tidas-tools checkout for dataset import.', {
-      code: 'DATASET_IMPORT_LCA_TIDAS_TOOLS_NOT_FOUND',
-      exitCode: 2,
-      details: { candidates: [explicitValue] },
+    return resolved;
+  }
+  return candidate;
+}
+
+function assertSupportedPlatform(platform: NodeJS.Platform, arch: string): void {
+  const supported =
+    (platform === 'linux' && (arch === 'x64' || arch === 'arm64')) ||
+    (platform === 'darwin' && (arch === 'x64' || arch === 'arm64')) ||
+    (platform === 'win32' && arch === 'x64');
+  if (!supported) {
+    throw new CliError(`No supported Rust tidas artifact exists for ${platform}/${arch}.`, {
+      code: 'DATASET_IMPORT_LCA_PLATFORM_UNSUPPORTED',
+      exitCode: 69,
+      details: {
+        supported: ['linux/x64', 'linux/arm64', 'darwin/x64', 'darwin/arm64', 'win32/x64'],
+      },
     });
   }
+}
 
-  const candidates = [
-    env.TIDAS_TOOLS_DIR,
-    env.TIDAS_TOOLS_PATH,
-    defaultCandidate ?? path.resolve(cliRepoRoot, '../tidas-tools'),
-  ].filter((candidate): candidate is string => Boolean(candidate?.trim()));
-
-  for (const candidate of candidates) {
-    const resolved = path.resolve(candidate);
-    if (existsSync(path.join(resolved, 'src/tidas_tools/import_lca/cli.py'))) {
-      return resolved;
-    }
+function requirePositiveInteger(flag: string, value: number | undefined): void {
+  if (value !== undefined && (!Number.isSafeInteger(value) || value <= 0)) {
+    throw new CliError(`${flag} must be a positive integer.`, {
+      code: 'DATASET_IMPORT_LCA_RUNTIME_BOUND_INVALID',
+      exitCode: 2,
+    });
   }
-
-  throw new CliError('Could not resolve a tidas-tools checkout for dataset import.', {
-    code: 'DATASET_IMPORT_LCA_TIDAS_TOOLS_NOT_FOUND',
-    exitCode: 2,
-    details: { candidates },
-  });
 }
 
-function resolveCliRepoRoot(candidatesOverride?: string[]): string {
-  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
-  const candidates = candidatesOverride ?? [
-    path.resolve(moduleDir, '../..'),
-    path.resolve(moduleDir, '../../..'),
-  ];
-  return (
-    candidates.find(
-      (candidate) =>
-        existsSync(path.join(candidate, 'package.json')) &&
-        existsSync(path.join(candidate, 'src/cli.ts')),
-    ) ?? candidates[0]
-  );
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
-function buildPythonPath(tidasToolsRoot: string, env: NodeJS.ProcessEnv): string {
-  return [path.join(tidasToolsRoot, 'src'), env.PYTHONPATH].filter(Boolean).join(path.delimiter);
+function includesValue<T extends readonly string[]>(values: T, value: unknown): value is T[number] {
+  return typeof value === 'string' && values.includes(value);
 }
 
-function firstExistingPath(candidates: string[]): string | null {
-  return candidates.find((candidate) => existsSync(candidate)) ?? null;
-}
-
-function readOptionalJson(filePath: string): unknown | null {
-  if (!existsSync(filePath)) {
-    return null;
-  }
-  return JSON.parse(readFileSync(filePath, 'utf8'));
+function isExitClass(value: unknown): value is TidasExitClass {
+  return typeof value === 'string' && Object.hasOwn(EXIT_CODES, value);
 }
 
 export const __testInternals = {
+  assertImportContract,
+  assertSupportedPlatform,
+  buildImportArgs,
+  normalizeSourceFormat,
   normalizeTarget,
-  resolveCliRepoRoot,
-  resolveTidasToolsRoot,
+  parseOperationReport,
+  readCompatibleVersion,
+  readProcessReport,
+  requirePositiveInteger,
+  resolveTidasBinary,
 };

--- a/test/dataset-import-lca.test.ts
+++ b/test/dataset-import-lca.test.ts
@@ -1,502 +1,593 @@
 import assert from 'node:assert/strict';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import test from 'node:test';
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { test } from 'node:test';
 import { executeCli } from '../src/cli.js';
 import { __testInternals, runDatasetImportLcaConvert } from '../src/lib/dataset-import-lca.js';
-import type { spawnSync, SpawnSyncReturns } from 'node:child_process';
-import type { DotEnvLoadResult } from '../src/lib/dotenv.js';
-import type { FetchLike } from '../src/lib/http.js';
-
-const dotEnvStatus: DotEnvLoadResult = {
-  loaded: false,
-  path: '/tmp/.env',
-  count: 0,
-};
 
 const deps = {
   env: {},
-  dotEnvStatus,
-  fetchImpl: (async () => ({
-    ok: true,
-    status: 200,
-    headers: { get: () => 'application/json' },
-    text: async () => JSON.stringify({ ok: true }),
-  })) as FetchLike,
+  dotEnvStatus: { loaded: false, path: '/tmp/.env', count: 0 },
+  fetchImpl: async () => new Response('{}', { status: 200 }),
 };
 
-function readJson(filePath: string): unknown {
-  return JSON.parse(readFileSync(filePath, 'utf8'));
+type JsonRecord = Record<string, unknown>;
+
+function operationReport(
+  command: 'version' | 'import',
+  options: {
+    status?: string;
+    exitClass?: string;
+    completeness?: string;
+    summary?: JsonRecord;
+    reportDestination?: string;
+  } = {},
+): JsonRecord {
+  return {
+    schema_version: 'tidas.operation-report.v1',
+    command,
+    status: options.status ?? 'succeeded',
+    exit_class: options.exitClass ?? 'success',
+    completeness: options.completeness ?? 'complete',
+    invocation: {
+      schema_version: 'tidas.invocation-context.v1',
+      input_policy: 'explicit-path-or-dash',
+      report_destination: options.reportDestination ?? 'stdout',
+      diagnostic_destination: 'stderr',
+    },
+    summary:
+      options.summary ??
+      (command === 'version'
+        ? {
+            binary_version: '0.1.0',
+            operation_report_schema: 'tidas.operation-report.v1',
+          }
+        : {
+            import: {
+              schema_version: 'tidas.import-execution-report.v1',
+              detected_format: 'simapro-csv',
+            },
+          }),
+    diagnostics: [],
+    artifacts: [],
+    next_actions: [],
+  };
 }
 
-test('runDatasetImportLcaConvert wraps tidas-tools and writes a report', () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-import-lca-'));
-  const inputPath = path.join(dir, 'package.zip');
-  const outDir = path.join(dir, 'out');
-  const toolsDir = path.join(dir, 'tidas-tools');
-  const cliPath = path.join(toolsDir, 'src/tidas_tools/import_lca/cli.py');
-  writeFileSync(inputPath, 'fixture', 'utf8');
-  mkdirSync(path.dirname(cliPath), { recursive: true });
-  writeFileSync(cliPath, '', { encoding: 'utf8', flag: 'w' });
-  const spawnImpl = ((_bin: string, args: readonly string[] = []): SpawnSyncReturns<string> => {
-    const reportIndex = args.indexOf('--report');
-    const reportPath = String(args[reportIndex + 1]);
-    mkdirSync(path.dirname(reportPath), { recursive: true });
-    writeFileSync(
-      reportPath,
-      JSON.stringify({
-        detected_format: 'ecospold2',
-        validation: { tidas: { ok: true } },
-      }),
-      'utf8',
-    );
-    // tidas-tools >= 0.0.28 writes process bundles by default and only writes
-    // mapping.csv.gz when --write-mapping-csv is passed.
-    const bundlesDir = path.join(outDir, 'process-bundles');
-    mkdirSync(bundlesDir, { recursive: true });
-    writeFileSync(path.join(bundlesDir, 'index.json'), '{}', 'utf8');
-    return {
-      status: 0,
-      signal: null,
-      output: [],
-      pid: 1,
-      stdout: 'converted',
-      stderr: '',
-    };
-  }) as typeof spawnSync;
+function spawnResult(
+  report: JsonRecord,
+  status = 0,
+  overrides: Partial<SpawnSyncReturns<string>> = {},
+): SpawnSyncReturns<string> {
+  return {
+    pid: 1,
+    output: [],
+    stdout: `${JSON.stringify(report)}\n`,
+    stderr: '',
+    status,
+    signal: null,
+    ...overrides,
+  };
+}
 
+function successfulSpawn(
+  calls: Array<{ executable: string; args: string[]; cwd: string | undefined }>,
+  importReport = operationReport('import'),
+): typeof spawnSync {
+  return ((executable: string, args?: readonly string[], options?: { cwd?: string }) => {
+    const commandArgs = [...(args ?? [])];
+    calls.push({ executable, args: commandArgs, cwd: options?.cwd });
+    return commandArgs[0] === 'version'
+      ? spawnResult(operationReport('version'))
+      : spawnResult(importReport);
+  }) as unknown as typeof spawnSync;
+}
+
+function tempInput(): { dir: string; input: string; output: string } {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-rust-import-'));
+  const input = path.join(dir, 'source.csv');
+  writeFileSync(input, 'fixture', 'utf8');
+  return { dir, input, output: path.join(dir, 'output') };
+}
+
+test('dataset import-lca invokes the Rust binary with native defaults and stable report mapping', async () => {
+  const fixture = tempInput();
+  const calls: Array<{ executable: string; args: string[]; cwd: string | undefined }> = [];
   try {
-    const report = runDatasetImportLcaConvert({
-      inputPath,
-      outputDir: outDir,
-      fromFormat: 'auto',
-      target: 'both',
-      mappingDir: path.join(dir, 'mapping'),
-      failOnWarning: true,
-      tidasToolsDir: toolsDir,
-      spawnImpl,
-      now: new Date('2026-06-01T00:00:00.000Z'),
+    const report = await runDatasetImportLcaConvert({
+      inputPath: fixture.input,
+      outputDir: fixture.output,
+      env: { TIDAS_BIN: 'tidas-from-env' },
+      cwd: fixture.dir,
+      now: new Date('2026-07-27T00:00:00.000Z'),
+      spawnImpl: successfulSpawn(calls),
     });
 
-    assert.equal(report.status, 'completed');
-    assert.equal(report.target, 'both');
-    assert.notEqual(report.files.ilcd_dir, null);
-    assert.ok(report.command.args.includes('--mapping-dir'));
-    assert.ok(report.command.args.includes('--fail-on-warning'));
-    // Bundles are on by default in tidas-tools >= 0.0.28; a bare
-    // --process-bundles flag is no longer a valid argument.
-    assert.equal(report.command.args.includes('--process-bundles'), false);
-    assert.equal(report.command.args.includes('--no-process-bundles'), false);
-    assert.equal(report.command.args.includes('--process-bundles-dir'), false);
-    assert.equal(report.files.process_bundles_dir, path.join(outDir, 'process-bundles'));
-    assert.equal(
-      report.files.process_bundles_index,
-      path.join(outDir, 'process-bundles', 'index.json'),
-    );
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0]?.executable, 'tidas-from-env');
+    assert.deepEqual(calls[0]?.args, ['version', '--format', 'json', '--progress', 'never']);
+    assert.deepEqual(calls[1]?.args, [
+      'import',
+      fixture.input,
+      '--output',
+      fixture.output,
+      '--target',
+      'tidas',
+      '--format',
+      'json',
+      '--progress',
+      'never',
+    ]);
+    assert.equal(report.schema_version, 'tiangong-lca.dataset-import-lca-report.v2');
+    assert.equal(report.status, 'succeeded');
+    assert.equal(report.exit_class, 'success');
+    assert.equal(report.exit_code, 0);
+    assert.equal(report.generated_at_utc, '2026-07-27T00:00:00.000Z');
+    assert.equal(report.from_format, 'auto');
+    assert.equal(report.tidas.version, '0.1.0');
+    assert.equal(report.files.tidas_dir, path.join(fixture.output, 'tidas'));
+    assert.equal(report.files.ilcd_dir, null);
     assert.equal(report.files.mapping_csv, null);
-    assert.equal(report.conversion_report && typeof report.conversion_report, 'object');
-    assert.equal(existsSync(report.files.report), true);
-    assert.deepEqual(readJson(report.files.report), report);
+    assert.equal(report.files.process_bundles_dir, path.join(fixture.output, 'process-bundles'));
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmSync(fixture.dir, { recursive: true, force: true });
   }
 });
 
-test('executeCli exposes dataset import-lca convert command', async () => {
-  const result = await executeCli(['dataset', 'import-lca', 'convert', '--help'], deps);
-  assert.equal(result.exitCode, 0);
-  assert.match(result.stdout, /dataset import-lca convert/u);
+test('dataset import-lca forwards every supported native control and reads file reports', async () => {
+  const fixture = tempInput();
+  const tidasBin = path.join(fixture.dir, 'tidas');
+  const config = path.join(fixture.dir, 'tidas.toml');
+  const nativeReport = path.join(fixture.dir, 'native-report.json');
+  writeFileSync(tidasBin, 'binary', 'utf8');
+  writeFileSync(config, 'config', 'utf8');
+  const calls: Array<{ executable: string; args: string[]; cwd: string | undefined }> = [];
+  const importReport = operationReport('import', { reportDestination: 'file' });
+  const spawnImpl = ((executable: string, args?: readonly string[], options?: { cwd?: string }) => {
+    const commandArgs = [...(args ?? [])];
+    calls.push({ executable, args: commandArgs, cwd: options?.cwd });
+    if (commandArgs[0] === 'version') {
+      return spawnResult(
+        operationReport('version', {
+          summary: {
+            binary_version: '0.1.91',
+            operation_report_schema: 'tidas.operation-report.v1',
+          },
+        }),
+      );
+    }
+    writeFileSync(nativeReport, JSON.stringify(importReport), 'utf8');
+    return spawnResult(importReport, 0, { stdout: '' });
+  }) as unknown as typeof spawnSync;
+
+  try {
+    const report = await runDatasetImportLcaConvert({
+      inputPath: fixture.input,
+      outputDir: fixture.output,
+      fromFormat: 'simapro-csv',
+      target: 'both',
+      reportPath: nativeReport,
+      writeMapping: true,
+      processBundles: false,
+      failOnWarning: true,
+      maxEntryMib: 64,
+      memoryBudgetMib: 128,
+      queueCapacity: 8,
+      tidasBin,
+      tidasConfig: config,
+      cwd: fixture.dir,
+      platform: 'linux',
+      arch: 'x64',
+      spawnImpl,
+    });
+
+    assert.equal(report.tidas.executable, tidasBin);
+    assert.equal(report.tidas.version, '0.1.91');
+    assert.equal(report.files.report, nativeReport);
+    assert.equal(report.files.tidas_dir, path.join(fixture.output, 'tidas'));
+    assert.equal(report.files.ilcd_dir, path.join(fixture.output, 'ilcd'));
+    assert.equal(report.files.mapping_csv, path.join(fixture.output, 'mapping.csv.gz'));
+    assert.equal(report.files.process_bundles_dir, null);
+    const args = calls[1]?.args ?? [];
+    for (const expected of [
+      '--from-format',
+      'simapro-csv',
+      '--report',
+      nativeReport,
+      '--config',
+      config,
+      '--write-mapping',
+      '--no-process-bundles',
+      '--fail-on-warning',
+      '--max-entry-mib',
+      '64',
+      '--memory-budget-mib',
+      '128',
+      '--queue-capacity',
+      '8',
+    ]) {
+      assert.ok(args.includes(expected), expected);
+    }
+  } finally {
+    rmSync(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test('dataset import-lca CLI exposes only the native Rust surface and preserves tidas exits', async () => {
+  const help = await executeCli(['dataset', 'import-lca', 'convert', '--help'], deps);
+  assert.equal(help.exitCode, 0);
+  assert.match(help.stdout, /--tidas-bin/u);
+  assert.match(help.stdout, /--memory-budget-mib/u);
+  assert.match(help.stdout, /Windows ARM64 is unsupported/u);
+  assert.doesNotMatch(help.stdout, /--python|--tidas-tools-dir|--detect-only/u);
 
   const namespaceHelp = await executeCli(['dataset', 'import-lca'], deps);
   assert.equal(namespaceHelp.exitCode, 0);
-  assert.match(namespaceHelp.stdout, /dataset import-lca convert/u);
-
   const invalidAction = await executeCli(['dataset', 'import-lca', 'detect'], deps);
   assert.equal(invalidAction.exitCode, 2);
-  assert.match(invalidAction.stderr, /dataset import-lca action must be 'convert'/u);
 
-  const converted = await executeCli(
-    ['dataset', 'import-lca', 'convert', '--input', 'in.zip', '--output-dir', 'out', '--json'],
-    {
-      ...deps,
-      runDatasetImportLcaConvertImpl: (options) => ({
-        schema_version: 1,
-        status: 'completed',
-        generated_at_utc: '2026-06-01T00:00:00.000Z',
-        input_path: options.inputPath,
-        output_dir: options.outputDir,
-        from_format: options.fromFormat ?? 'auto',
-        target: 'tidas',
-        detect_only: false,
-        command: {
-          executable: 'python3',
-          args: [],
-          cwd: '/tmp/tidas-tools',
-          exit_code: 0,
-          stdout: '',
-          stderr: '',
-        },
-        conversion_report: null,
-        files: {
-          report: '/tmp/report.json',
-          conversion_report: '/tmp/conversion-report.json',
-          tidas_dir: '/tmp/tidas',
-          ilcd_dir: null,
-          mapping_csv: '/tmp/mapping.csv',
-          process_bundles_dir: '/tmp/process-bundles',
-          process_bundles_index: '/tmp/process-bundles/index.json',
-        },
-      }),
-    },
-  );
-  assert.equal(converted.exitCode, 0);
-  assert.equal(JSON.parse(converted.stdout).input_path, 'in.zip');
-
-  const blocked = await executeCli(
+  const result = await executeCli(
     [
       'dataset',
       'import-lca',
       'convert',
       '--input',
-      'in.zip',
+      'fixture.csv',
       '--output-dir',
       'out',
       '--from-format',
-      'ecospold2',
+      'simapro-csv',
       '--target',
-      'both',
+      'ilcd',
       '--report',
-      'conversion.json',
-      '--mapping-dir',
-      'mapping',
-      '--language',
-      'zh',
-      '--validation-jobs',
-      '2',
-      '--process-bundles-dir',
-      'bundles',
-      '--detect-only',
+      'native-report.json',
+      '--write-mapping',
+      '--no-process-bundles',
       '--fail-on-warning',
-      '--python',
-      'python-custom',
-      '--tidas-tools-dir',
-      '/tmp/tidas-tools',
+      '--max-entry-mib',
+      '4',
+      '--memory-budget-mib',
+      '16',
+      '--queue-capacity',
+      '2',
+      '--tidas-bin',
+      '/opt/tidas',
+      '--tidas-config',
+      'tidas.toml',
       '--json',
     ],
     {
       ...deps,
-      runDatasetImportLcaConvertImpl: (options) => ({
-        schema_version: 1,
-        status: 'blocked',
-        generated_at_utc: '2026-06-01T00:00:00.000Z',
-        input_path: `${options.inputPath}:${options.fromFormat}:${options.target}:${options.reportPath}:${options.mappingDir}:${options.language}:${options.validationJobs}:${options.processBundles}:${options.processBundlesDir}:${options.detectOnly}:${options.failOnWarning}:${options.pythonBin}:${options.tidasToolsDir}`,
-        output_dir: options.outputDir,
-        from_format: options.fromFormat ?? 'auto',
-        target: 'both',
-        detect_only: true,
-        command: {
-          executable: 'python-custom',
-          args: [],
-          cwd: '/tmp/tidas-tools',
-          exit_code: 1,
-          stdout: '',
-          stderr: '',
-        },
-        conversion_report: null,
-        files: {
-          report: '/tmp/report.json',
-          conversion_report: '/tmp/conversion-report.json',
-          tidas_dir: null,
-          ilcd_dir: null,
-          mapping_csv: null,
-          process_bundles_dir: null,
-          process_bundles_index: null,
-        },
-      }),
+      runDatasetImportLcaConvertImpl: async (options) => {
+        assert.deepEqual(options, {
+          inputPath: 'fixture.csv',
+          outputDir: 'out',
+          fromFormat: 'simapro-csv',
+          target: 'ilcd',
+          reportPath: 'native-report.json',
+          writeMapping: true,
+          processBundles: false,
+          failOnWarning: true,
+          maxEntryMib: 4,
+          memoryBudgetMib: 16,
+          queueCapacity: 2,
+          tidasBin: '/opt/tidas',
+          tidasConfig: 'tidas.toml',
+          env: {},
+        });
+        return {
+          schema_version: 'tiangong-lca.dataset-import-lca-report.v2',
+          status: 'completed-with-issues',
+          exit_class: 'data-issues',
+          exit_code: 2,
+        } as never;
+      },
     },
   );
-  assert.equal(blocked.exitCode, 1);
-  assert.match(
-    JSON.parse(blocked.stdout).input_path,
-    /ecospold2:both:conversion\.json:mapping:zh:2:undefined:bundles:true:true:python-custom/u,
-  );
-});
+  assert.equal(result.exitCode, 2);
+  assert.match(result.stdout, /completed-with-issues/u);
 
-test('runDatasetImportLcaConvert records missing conversion report as null', () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-import-lca-no-report-'));
-  const inputPath = path.join(dir, 'package.zip');
-  const outDir = path.join(dir, 'out');
-  const toolsDir = path.join(dir, 'tidas-tools');
-  const cliPath = path.join(toolsDir, 'src/tidas_tools/import_lca/cli.py');
-  writeFileSync(inputPath, 'fixture', 'utf8');
-  mkdirSync(path.dirname(cliPath), { recursive: true });
-  writeFileSync(cliPath, '', 'utf8');
-
-  try {
-    const report = runDatasetImportLcaConvert({
-      inputPath,
-      outputDir: outDir,
-      target: 'both',
-      detectOnly: true,
-      tidasToolsDir: toolsDir,
-      spawnImpl: (() => ({
-        status: 0,
-        signal: null,
-        output: [],
-        pid: 1,
-        stdout: '',
-        stderr: '',
-      })) as unknown as typeof spawnSync,
-    });
-
-    assert.equal(report.conversion_report, null);
-    assert.equal(report.files.tidas_dir, null);
-    assert.equal(report.files.ilcd_dir, null);
-    assert.equal(report.files.mapping_csv, null);
-    assert.equal(report.files.process_bundles_dir, null);
-    assert.equal(report.files.process_bundles_index, null);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
+  for (const args of [
+    ['dataset', 'import-lca', 'convert', '--python', 'python3'],
+    ['dataset', 'import-lca', 'convert', '--tidas-tools-dir', '../tidas-tools'],
+    ['dataset', 'import-lca', 'convert', '--detect-only'],
+    ['dataset', 'import-lca', 'convert', '--max-entry-mib', '0'],
+    ['dataset', 'import-lca', 'convert', '--memory-budget-mib', 'nope'],
+    ['dataset', 'import-lca', 'convert', '--queue-capacity', '-1'],
+  ]) {
+    const invalid = await executeCli(args, deps);
+    assert.equal(invalid.exitCode, 2, args.join(' '));
   }
 });
 
-test('runDatasetImportLcaConvert records blocked commands and default spawn output', () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-import-lca-blocked-'));
-  const inputPath = path.join(dir, 'package.zip');
-  const outDir = path.join(dir, 'out');
-  const toolsDir = path.join(dir, 'tidas-tools');
-  const cliPath = path.join(toolsDir, 'src/tidas_tools/import_lca/cli.py');
-  writeFileSync(inputPath, 'fixture', 'utf8');
-  mkdirSync(path.dirname(cliPath), { recursive: true });
-  writeFileSync(cliPath, '', 'utf8');
-
+test('discovery, platform, source, target, and runtime bounds fail closed', async () => {
+  const fixture = tempInput();
   try {
-    const blocked = runDatasetImportLcaConvert({
-      inputPath,
-      outputDir: outDir,
-      target: 'ilcd',
-      language: 'zh',
-      pythonBin: 'python-custom',
-      tidasToolsDir: toolsDir,
-      spawnImpl: (() => ({
-        status: 1,
-        signal: null,
-        output: [],
-        pid: 1,
-      })) as unknown as typeof spawnSync,
-    });
-    assert.equal(blocked.status, 'blocked');
-    assert.equal(blocked.command.executable, 'python-custom');
-    assert.equal(blocked.command.stdout, '');
-    assert.equal(blocked.command.stderr, '');
-    assert.equal(blocked.files.tidas_dir, path.join(outDir, 'tidas'));
-    assert.equal(blocked.files.ilcd_dir, path.join(outDir, 'ilcd'));
-    assert.equal(blocked.command.args.includes('--process-bundles'), false);
-    assert.equal(blocked.command.args.includes('--no-process-bundles'), false);
-    // The blocked run produced no bundle output, so the report must not claim any.
-    assert.equal(blocked.files.process_bundles_dir, null);
-    assert.equal(blocked.files.process_bundles_index, null);
-
-    const missingPython = path.join(dir, 'missing-python-executable');
-    const defaultSpawnBlocked = runDatasetImportLcaConvert({
-      inputPath,
-      outputDir: path.join(dir, 'missing-python-out'),
-      pythonBin: missingPython,
-      tidasToolsDir: toolsDir,
-      processBundles: false,
-    });
-    assert.equal(defaultSpawnBlocked.status, 'blocked');
-    assert.equal(defaultSpawnBlocked.command.executable, missingPython);
-
-    const completed = runDatasetImportLcaConvert({
-      inputPath,
-      outputDir: path.join(dir, 'completed-out'),
-      pythonBin: 'python-custom',
-      tidasToolsDir: toolsDir,
-      processBundles: false,
-      spawnImpl: (() => ({
-        status: 0,
-        signal: null,
-        output: [],
-        pid: 1,
-        stdout: '',
-        stderr: '',
-      })) as unknown as typeof spawnSync,
-    });
-    assert.equal(completed.status, 'completed');
-    assert.equal(completed.command.executable, 'python-custom');
-    assert.equal(completed.command.args.includes('--no-process-bundles'), true);
-    assert.equal(completed.command.args.includes('--process-bundles'), false);
-    assert.equal(completed.files.process_bundles_dir, null);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test('runDatasetImportLcaConvert forwards a custom process bundles directory', () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-import-lca-bundles-dir-'));
-  const inputPath = path.join(dir, 'package.zip');
-  const outDir = path.join(dir, 'out');
-  const bundlesDir = path.join(dir, 'custom-bundles');
-  const toolsDir = path.join(dir, 'tidas-tools');
-  const cliPath = path.join(toolsDir, 'src/tidas_tools/import_lca/cli.py');
-  writeFileSync(inputPath, 'fixture', 'utf8');
-  mkdirSync(path.dirname(cliPath), { recursive: true });
-  writeFileSync(cliPath, '', 'utf8');
-
-  try {
-    const report = runDatasetImportLcaConvert({
-      inputPath,
-      outputDir: outDir,
-      processBundlesDir: bundlesDir,
-      tidasToolsDir: toolsDir,
-      spawnImpl: ((): SpawnSyncReturns<string> => {
-        mkdirSync(bundlesDir, { recursive: true });
-        writeFileSync(path.join(bundlesDir, 'index.json'), '{}', 'utf8');
-        return {
-          status: 0,
-          signal: null,
-          output: [],
-          pid: 1,
-          stdout: '',
-          stderr: '',
-        };
-      }) as unknown as typeof spawnSync,
-    });
-
-    const dirFlagIndex = report.command.args.indexOf('--process-bundles-dir');
-    assert.notEqual(dirFlagIndex, -1);
-    assert.equal(report.command.args[dirFlagIndex + 1], bundlesDir);
-    assert.equal(report.command.args.includes('--process-bundles'), false);
-    assert.equal(report.command.args.includes('--no-process-bundles'), false);
-    assert.equal(report.files.process_bundles_dir, bundlesDir);
-    assert.equal(report.files.process_bundles_index, path.join(bundlesDir, 'index.json'));
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test('dataset import-lca internals reject missing tidas-tools checkout', () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-import-lca-missing-tools-'));
-  try {
-    assert.throws(
-      () => __testInternals.resolveTidasToolsRoot(path.join(dir, 'missing'), {}),
-      /Could not resolve a tidas-tools checkout/u,
+    assert.equal(__testInternals.resolveTidasBinary(undefined, {}), 'tidas');
+    assert.equal(
+      __testInternals.resolveTidasBinary(undefined, { TIDAS_BIN: 'custom-tidas' }),
+      'custom-tidas',
     );
+    assert.equal(__testInternals.resolveTidasBinary(' explicit-tidas ', {}), 'explicit-tidas');
     assert.throws(
-      () => __testInternals.resolveTidasToolsRoot(undefined, {}, path.join(dir, 'also-missing')),
-      /Could not resolve a tidas-tools checkout/u,
+      () => __testInternals.resolveTidasBinary(path.join(fixture.dir, 'missing'), {}),
+      /not found/u,
     );
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
 
-test('dataset import-lca validates required inputs and target values', () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'tg-cli-import-lca-validation-'));
-  const inputPath = path.join(dir, 'package.zip');
-  const toolsDir = path.join(dir, 'tidas-tools');
-  const cliPath = path.join(toolsDir, 'src/tidas_tools/import_lca/cli.py');
-  writeFileSync(inputPath, 'fixture', 'utf8');
-  mkdirSync(path.dirname(cliPath), { recursive: true });
-  writeFileSync(cliPath, '', 'utf8');
+    for (const [platform, arch] of [
+      ['linux', 'x64'],
+      ['linux', 'arm64'],
+      ['darwin', 'x64'],
+      ['darwin', 'arm64'],
+      ['win32', 'x64'],
+    ] as const) {
+      assert.doesNotThrow(() => __testInternals.assertSupportedPlatform(platform, arch));
+    }
+    assert.throws(() => __testInternals.assertSupportedPlatform('win32', 'arm64'), /No supported/u);
+    assert.throws(() => __testInternals.assertSupportedPlatform('freebsd', 'x64'), /No supported/u);
 
-  try {
+    assert.equal(__testInternals.normalizeSourceFormat(undefined), 'auto');
+    assert.equal(__testInternals.normalizeSourceFormat(' ilcd '), 'ilcd');
+    assert.throws(() => __testInternals.normalizeSourceFormat('zolca'), /--from-format/u);
+    assert.equal(__testInternals.normalizeTarget(undefined), 'tidas');
+    assert.equal(__testInternals.normalizeTarget(' both '), 'both');
+    assert.throws(() => __testInternals.normalizeTarget('invalid'), /--target/u);
+
+    assert.doesNotThrow(() => __testInternals.requirePositiveInteger('--limit', undefined));
+    assert.doesNotThrow(() => __testInternals.requirePositiveInteger('--limit', 1));
+    assert.throws(() => __testInternals.requirePositiveInteger('--limit', 0), /positive/u);
+    assert.throws(() => __testInternals.requirePositiveInteger('--limit', 1.5), /positive/u);
     assert.throws(
+      () => __testInternals.requirePositiveInteger('--limit', Number.MAX_VALUE),
+      /positive/u,
+    );
+
+    await assert.rejects(
       () =>
         runDatasetImportLcaConvert({
           inputPath: '',
-          outputDir: path.join(dir, 'out'),
-          tidasToolsDir: toolsDir,
+          outputDir: fixture.output,
+          spawnImpl: successfulSpawn([]),
         }),
       /Missing required --input/u,
     );
-    assert.throws(
+    await assert.rejects(
       () =>
         runDatasetImportLcaConvert({
-          inputPath: path.join(dir, 'missing.zip'),
-          outputDir: path.join(dir, 'out'),
-          tidasToolsDir: toolsDir,
+          inputPath: path.join(fixture.dir, 'missing'),
+          outputDir: fixture.output,
+          spawnImpl: successfulSpawn([]),
         }),
       /Input path not found/u,
     );
-    assert.throws(
+    await assert.rejects(
       () =>
         runDatasetImportLcaConvert({
-          inputPath,
+          inputPath: fixture.input,
           outputDir: '',
-          tidasToolsDir: toolsDir,
+          spawnImpl: successfulSpawn([]),
         }),
       /Missing required --output-dir/u,
     );
-    assert.throws(
-      () =>
-        runDatasetImportLcaConvert({
-          inputPath,
-          outputDir: path.join(dir, 'out'),
-          target: 'invalid',
-          tidasToolsDir: toolsDir,
-        }),
-      /--target must be/u,
-    );
-    assert.throws(
-      () =>
-        runDatasetImportLcaConvert({
-          inputPath,
-          outputDir: path.join(dir, 'out'),
-          processBundles: false,
-          processBundlesDir: path.join(dir, 'bundles'),
-          tidasToolsDir: toolsDir,
-        }),
-      /--process-bundles-dir cannot be used/u,
-    );
-    assert.equal(
-      __testInternals.resolveTidasToolsRoot(undefined, { TIDAS_TOOLS_DIR: toolsDir }),
-      toolsDir,
-    );
-    assert.equal(__testInternals.normalizeTarget(undefined), 'tidas');
-
-    const repoRoot = path.join(dir, 'cli-root');
-    mkdirSync(path.join(repoRoot, 'src'), { recursive: true });
-    writeFileSync(path.join(repoRoot, 'package.json'), '{}', 'utf8');
-    writeFileSync(path.join(repoRoot, 'src/cli.ts'), '', 'utf8');
-    assert.equal(
-      __testInternals.resolveCliRepoRoot([path.join(dir, 'missing-root'), repoRoot]),
-      repoRoot,
-    );
-    assert.equal(
-      __testInternals.resolveCliRepoRoot([path.join(dir, 'missing-root')]),
-      path.join(dir, 'missing-root'),
-    );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmSync(fixture.dir, { recursive: true, force: true });
   }
 });
 
-test('dataset import-lca CLI validates parser-only errors', async () => {
-  const invalidUnknown = await executeCli(['dataset', 'import-lca', 'convert', '--unknown'], deps);
-  assert.equal(invalidUnknown.exitCode, 2);
-  assert.match(invalidUnknown.stderr, /INVALID_ARGS/u);
-
-  const invalidJobs = await executeCli(
-    ['dataset', 'import-lca', 'convert', '--validation-jobs=-1'],
-    deps,
+test('machine contract parser rejects malformed and incompatible reports', () => {
+  assert.throws(() => __testInternals.parseOperationReport('{', 'version'), /invalid JSON/u);
+  const valid = operationReport('version');
+  assert.equal(
+    __testInternals.parseOperationReport(JSON.stringify(valid), 'version').command,
+    'version',
   );
-  assert.equal(invalidJobs.exitCode, 2);
-  assert.match(invalidJobs.stderr, /validation-jobs/u);
 
-  const invalidProcessBundles = await executeCli(
-    [
-      'dataset',
-      'import-lca',
-      'convert',
-      '--no-process-bundles',
-      '--process-bundles-dir',
-      'bundles',
-    ],
-    deps,
+  const invalidReports: JsonRecord[] = [];
+  const mutate = (key: string, value: unknown): void => {
+    invalidReports.push({ ...valid, [key]: value });
+  };
+  mutate('schema_version', 'tidas.operation-report.v2');
+  mutate('command', 'import');
+  mutate('status', 'unknown');
+  mutate('exit_class', 'unknown');
+  mutate('completeness', 'unknown');
+  mutate('invocation', null);
+  mutate('invocation', { ...(valid.invocation as JsonRecord), schema_version: 'v2' });
+  mutate('invocation', { ...(valid.invocation as JsonRecord), input_policy: 'implicit' });
+  mutate('invocation', { ...(valid.invocation as JsonRecord), report_destination: 'other' });
+  mutate('invocation', { ...(valid.invocation as JsonRecord), diagnostic_destination: 'stdout' });
+  mutate('summary', null);
+  mutate('diagnostics', null);
+  mutate('artifacts', null);
+  mutate('next_actions', null);
+  for (const report of invalidReports) {
+    assert.throws(
+      () => __testInternals.parseOperationReport(JSON.stringify(report), 'version'),
+      /Incompatible/u,
+    );
+  }
+});
+
+test('version and import handshakes accept compatible patches and reject drift', () => {
+  const validVersion = __testInternals.parseOperationReport(
+    JSON.stringify(operationReport('version')),
+    'version',
   );
-  assert.equal(invalidProcessBundles.exitCode, 2);
-  assert.match(invalidProcessBundles.stderr, /process-bundles-dir/u);
+  assert.equal(__testInternals.readCompatibleVersion(validVersion), '0.1.0');
+
+  for (const mutation of [
+    { status: 'failed' },
+    { exit_class: 'data-issues' },
+    { completeness: 'partial' },
+    { summary: { binary_version: '0.1.0', operation_report_schema: 'v2' } },
+    {
+      summary: {
+        binary_version: '0.2.0',
+        operation_report_schema: 'tidas.operation-report.v1',
+      },
+    },
+    { summary: { operation_report_schema: 'tidas.operation-report.v1' } },
+  ]) {
+    const report = { ...validVersion, ...mutation } as never;
+    assert.throws(() => __testInternals.readCompatibleVersion(report), /0\.1\.x/u);
+  }
+
+  const successfulImport = __testInternals.parseOperationReport(
+    JSON.stringify(operationReport('import')),
+    'import',
+  );
+  assert.doesNotThrow(() => __testInternals.assertImportContract(successfulImport));
+  assert.doesNotThrow(() =>
+    __testInternals.assertImportContract({
+      ...successfulImport,
+      status: 'completed-with-issues',
+      exit_class: 'data-issues',
+    }),
+  );
+  assert.doesNotThrow(() =>
+    __testInternals.assertImportContract({
+      ...successfulImport,
+      status: 'failed',
+      summary: {},
+    }),
+  );
+  assert.throws(
+    () =>
+      __testInternals.assertImportContract({
+        ...successfulImport,
+        summary: { import: { schema_version: 'v2' } },
+      }),
+    /import summary/u,
+  );
+});
+
+test('process report handling covers stdout, file, missing, invalid exit, spawn, and cancellation', async () => {
+  const fixture = tempInput();
+  const reportPath = path.join(fixture.dir, 'report.json');
+  try {
+    const reportText = JSON.stringify(operationReport('import'));
+    assert.equal(
+      __testInternals.readProcessReport(
+        { status: 0, signal: null, stdout: reportText, stderr: '' },
+        null,
+      ),
+      reportText,
+    );
+    writeFileSync(reportPath, reportText, 'utf8');
+    assert.equal(
+      __testInternals.readProcessReport(
+        { status: 0, signal: null, stdout: '', stderr: '' },
+        reportPath,
+      ),
+      reportText,
+    );
+    assert.throws(
+      () =>
+        __testInternals.readProcessReport(
+          { status: 70, signal: null, stdout: '', stderr: 'failed' },
+          path.join(fixture.dir, 'missing-report'),
+        ),
+      /did not write/u,
+    );
+    for (const run of [
+      { status: 130, signal: null, stdout: '', stderr: '' },
+      { status: null, signal: 'SIGINT' as const, stdout: '', stderr: '' },
+    ]) {
+      assert.throws(() => __testInternals.readProcessReport(run, null), /cancelled/u);
+      assert.throws(
+        () =>
+          __testInternals.readProcessReport(
+            run,
+            path.join(fixture.dir, `cancelled-${String(run.status)}-${String(run.signal)}.json`),
+          ),
+        /cancelled/u,
+      );
+    }
+    assert.throws(
+      () =>
+        __testInternals.readProcessReport(
+          { status: 70, signal: null, stdout: '', stderr: 'failed' },
+          null,
+        ),
+      /machine-readable/u,
+    );
+
+    await assert.rejects(
+      () =>
+        runDatasetImportLcaConvert({
+          inputPath: fixture.input,
+          outputDir: fixture.output,
+          platform: 'darwin',
+          arch: 'arm64',
+          spawnImpl: (() =>
+            spawnResult(operationReport('version'), 0, {
+              error: new Error('ENOENT'),
+            })) as unknown as typeof spawnSync,
+        }),
+      /Could not execute/u,
+    );
+
+    const calls: unknown[] = [];
+    const mismatchSpawn = ((_: string, args?: readonly string[]) => {
+      calls.push(args);
+      return args?.[0] === 'version'
+        ? spawnResult(operationReport('version'))
+        : spawnResult(operationReport('import'), 2);
+    }) as unknown as typeof spawnSync;
+    await assert.rejects(
+      () =>
+        runDatasetImportLcaConvert({
+          inputPath: fixture.input,
+          outputDir: fixture.output,
+          platform: 'darwin',
+          arch: 'arm64',
+          spawnImpl: mismatchSpawn,
+        }),
+      /disagrees/u,
+    );
+    assert.equal(calls.length, 2);
+
+    const ilcdOnly = await runDatasetImportLcaConvert({
+      inputPath: fixture.input,
+      outputDir: fixture.output,
+      target: 'ilcd',
+      platform: 'darwin',
+      arch: 'arm64',
+      spawnImpl: successfulSpawn([]),
+    });
+    assert.equal(ilcdOnly.files.tidas_dir, null);
+    assert.equal(ilcdOnly.files.ilcd_dir, path.join(fixture.output, 'ilcd'));
+
+    await assert.rejects(
+      () =>
+        runDatasetImportLcaConvert({
+          inputPath: fixture.input,
+          outputDir: fixture.output,
+          platform: 'darwin',
+          arch: 'arm64',
+          spawnImpl: (() => ({
+            pid: 1,
+            output: [],
+            stdout: undefined,
+            stderr: undefined,
+            status: 70,
+            signal: null,
+          })) as unknown as typeof spawnSync,
+        }),
+      /machine-readable/u,
+    );
+  } finally {
+    rmSync(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test('packaged smoke fixture is the frozen SimaPro parity input', () => {
+  const fixture = new URL('../assets/import-smoke/simapro.csv', import.meta.url);
+  assert.equal(existsSync(fixture), true);
+  const text = readFileSync(fixture, 'utf8');
+  assert.match(text, /\{SimaPro 8\.0\}/u);
+  assert.match(text, /Test process/u);
+  assert.match(text, /carbon dioxide/u);
 });

--- a/test/dataset-maintenance-row-level.test.ts
+++ b/test/dataset-maintenance-row-level.test.ts
@@ -2421,7 +2421,7 @@ test('parallel delete internals reject duplicate targets, corrupt ledgers, and f
           maxParallel: 1,
           now: () => '2026-07-24T10:00:00.000Z',
         }),
-      /EISDIR|illegal operation on a directory/u,
+      /EISDIR|EPERM|illegal operation on a directory/u,
     );
 
     const unversioned = processFlowReferencePayload({

--- a/test/prepush-coverage-edges.test.ts
+++ b/test/prepush-coverage-edges.test.ts
@@ -23,7 +23,6 @@ import {
   __testInternals as curationInternals,
   runDatasetCurationQueueBuild,
 } from '../src/lib/dataset-curation-queue.js';
-import { runDatasetImportLcaConvert } from '../src/lib/dataset-import-lca.js';
 import {
   __testInternals as maintenanceInternals,
   runDatasetMaintenanceClearAccount,
@@ -131,16 +130,9 @@ test('prepush coverage covers CLI parser error and help branches', async () => {
     ['dataset', 'classification', 'bad-action'],
     ['dataset', 'curation-queue', 'next', '--bad-flag'],
     ['dataset', 'curation-queue', 'next', '--type', 'bad'],
-    ['dataset', 'import-lca', 'convert', '--validation-jobs', '-1'],
-    ['dataset', 'import-lca', 'convert', '--process-bundles', '--no-process-bundles'],
-    [
-      'dataset',
-      'import-lca',
-      'convert',
-      '--no-process-bundles',
-      '--process-bundles-dir',
-      'bundles',
-    ],
+    ['dataset', 'import-lca', 'convert', '--max-entry-mib', '0'],
+    ['dataset', 'import-lca', 'convert', '--memory-budget-mib', '-1'],
+    ['dataset', 'import-lca', 'convert', '--queue-capacity', 'invalid'],
     ['dataset', 'patch', 'apply', '--bad-flag'],
     ['dataset', 'verify-remote', '--state-code=bad'],
     ['dataset', 'maintenance', 'clear-account', '--bad-flag'],
@@ -294,59 +286,15 @@ test('prepush coverage covers CLI parser error and help branches', async () => {
       runDatasetImportLcaConvertImpl: async (options) => {
         assert.equal(options.processBundles, false);
         return {
-          schema_version: 1,
-          generated_at_utc: '2026-06-04T00:00:00.000Z',
-          status: 'completed',
-          input_path: options.inputPath,
-          output_dir: options.outputDir,
-          from_format: 'ecospold1',
-          target: 'tidas',
-          command: [],
-          exit_status: 0,
-          stdout: '',
-          stderr: '',
-          report: null,
-          files: { report: options.reportPath ?? null },
+          schema_version: 'tiangong-lca.dataset-import-lca-report.v2',
+          status: 'succeeded',
+          exit_class: 'success',
+          exit_code: 0,
         } as never;
       },
     },
   );
   assert.equal(importNoBundles.exitCode, 0);
-
-  const importBundles = await executeCli(
-    [
-      'dataset',
-      'import-lca',
-      'convert',
-      '--input',
-      'in.zip',
-      '--output-dir',
-      'out',
-      '--process-bundles',
-    ],
-    {
-      ...makeDeps(),
-      runDatasetImportLcaConvertImpl: async (options) => {
-        assert.equal(options.processBundles, true);
-        return {
-          schema_version: 1,
-          generated_at_utc: '2026-06-04T00:00:00.000Z',
-          status: 'completed',
-          input_path: options.inputPath,
-          output_dir: options.outputDir,
-          from_format: 'ecospold1',
-          target: 'tidas',
-          command: [],
-          exit_status: 0,
-          stdout: '',
-          stderr: '',
-          report: null,
-          files: { report: options.reportPath ?? null },
-        } as never;
-      },
-    },
-  );
-  assert.equal(importBundles.exitCode, 0);
 
   const classificationChildrenBlocked = await executeCli(
     [
@@ -1329,61 +1277,6 @@ test('prepush coverage covers save-draft and import-lca edge branches', async ()
       now: new Date('2026-06-04T00:00:00.000Z'),
     });
     assert.equal(preparedFailure.rows[0]?.operation, 'type_unknown');
-
-    const tidasToolsDir = path.join(dir, 'tidas-tools');
-    const cliPath = path.join(tidasToolsDir, 'src/tidas_tools/import_lca/cli.py');
-    mkdirSync(path.dirname(cliPath), { recursive: true });
-    writeFileSync(cliPath, '# cli\n', 'utf8');
-    const inputPath = path.join(dir, 'input.zip');
-    writeFileSync(inputPath, 'zip', 'utf8');
-    const reportPath = path.join(dir, 'report.json');
-    const observedArgs: string[][] = [];
-    await runDatasetImportLcaConvert({
-      inputPath,
-      outputDir: path.join(dir, 'out'),
-      reportPath,
-      processBundlesDir: path.join(dir, 'bundles'),
-      tidasToolsDir,
-      spawnImpl: ((_command: string, args?: readonly string[]) => {
-        observedArgs.push([...(args ?? [])]);
-        writeJson(reportPath, { ok: true });
-        return { status: 0, stdout: '', stderr: '' };
-      }) as never,
-    });
-    assert.ok(observedArgs[0]?.includes('--process-bundles-dir'));
-
-    observedArgs.length = 0;
-    await runDatasetImportLcaConvert({
-      inputPath,
-      outputDir: path.join(dir, 'detect-only'),
-      reportPath,
-      processBundles: true,
-      processBundlesDir: path.join(dir, 'bundles'),
-      detectOnly: true,
-      tidasToolsDir,
-      spawnImpl: ((_command: string, args?: readonly string[]) => {
-        observedArgs.push([...(args ?? [])]);
-        writeJson(reportPath, { ok: true });
-        return { status: 0, stdout: '', stderr: '' };
-      }) as never,
-    });
-    assert.equal(observedArgs[0]?.includes('--process-bundles'), false);
-
-    observedArgs.length = 0;
-    await runDatasetImportLcaConvert({
-      inputPath,
-      outputDir: path.join(dir, 'no-bundles'),
-      reportPath,
-      processBundles: false,
-      processBundlesDir: '',
-      tidasToolsDir,
-      spawnImpl: ((_command: string, args?: readonly string[]) => {
-        observedArgs.push([...(args ?? [])]);
-        writeJson(reportPath, { ok: true });
-        return { status: 0, stdout: '', stderr: '' };
-      }) as never,
-    });
-    assert.equal(observedArgs[0]?.includes('--process-bundles'), false);
 
     const contract = await runDatasetContract({
       type: 'contact',


### PR DESCRIPTION
Closes #210

## Summary
- Replace the Python tidas_tools import path with the unified Rust tidas import process contract.
- Package a small SimaPro smoke fixture while keeping native binaries outside the npm package.

## Key Decisions
- Discover tidas through --tidas-bin, TIDAS_BIN, then PATH, with optional native config forwarding.
- Require tidas.operation-report.v1 and contract-compatible stable 0.1.x versions; reject protocol or major/minor drift.
- Preserve Rust-owned format logic, bounded queues/spooling, cancellation cleanup, atomic publication, reports, and exit classes without duplicating domain behavior in TypeScript.

## Validation
- npm run prepush:gate: 1057 tests, 0 failures, and 100% statements/branches/functions/lines.
- Checksum-verified v0.1.0 source-tree and installed-tarball smoke passed with Python unavailable.
- npm pack --dry-run includes assets/import-smoke/simapro.csv and excludes Python/venv/native-binary payloads.
- Strict docpact config plus staged enforce lint passed with all 18 changed paths covered.

## Risks / Rollback
- The adapter intentionally rejects Windows ARM64, non-0.1.x binaries, incompatible operation-report schemas, and exit/report disagreement.
- Rollback is a PR revert;/ outputs remain native atomic tidas publications, and this PR changes no package version, tag, publish workflow, dependency lock, or workspace pointer.

## Follow-ups
- tiangong-lca/tidas-tools#142 will publish the qualified v0.1.1 fidelity release; the compatible 0.1.x handshake means it is not a review blocker.

## Workspace Integration
- Workspace Integration stays Pending; this feature PR does not update the lca-workspace submodule pointer.