### PR TITLE
chore: upgrade actions/checkout to v7

### DIFF
--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -105,7 +105,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.release-context.outputs.release_head }}
           fetch-depth: 0
@@ -152,7 +152,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.release-context.outputs.release_head }}
 

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -21,7 +21,7 @@ jobs:
             arch: arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node 24
         uses: actions/setup-node@v6

--- a/.github/workflows/tag-release-from-merge.yml
+++ b/.github/workflows/tag-release-from-merge.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Closes tiangong-lca/tiangong-cli#220

## Summary
- Upgrade every active workflow checkout reference to actions/checkout@v7.

## Validation
- Workflow YAML parse passed.
- Docpact lint passed.
- git diff --check passed.

## Workspace Integration
- Requires an exact-SHA workspace pointer update after merge.